### PR TITLE
Pass physical tenant id to backup and exporting services

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.management.backups.BackupInfo;
 import io.camunda.management.backups.BackupType;
 import io.camunda.management.backups.CheckpointState;
@@ -89,7 +91,7 @@ public final class BackupEndpoint {
       if (backupId <= 0) {
         return incorrectBackupIdErrorResponse();
       }
-      api.takeBackup(backupId).toCompletableFuture().join();
+      api.takeBackup(DEFAULT_PHYSICAL_TENANT_ID, backupId).toCompletableFuture().join();
       return successfullyScheduledBackupResponse(backupId);
     } catch (final Exception e) {
       return mapErrorResponse(e);
@@ -103,7 +105,7 @@ public final class BackupEndpoint {
     }
 
     try {
-      final var backupId = api.takeBackup().toCompletableFuture().join();
+      final var backupId = api.takeBackup(DEFAULT_PHYSICAL_TENANT_ID).toCompletableFuture().join();
       return successfullyScheduledBackupResponse(backupId);
     } catch (final Exception e) {
       return mapErrorResponse(e);
@@ -114,8 +116,10 @@ public final class BackupEndpoint {
   public WebEndpointResponse<?> write(@Selector(match = Match.ALL_REMAINING) final String[] path) {
     if (path.length == 2 && BackupApi.STATE.equals(path[0]) && BackupApi.SYNC.equals(path[1])) {
       try {
-        final var updatedRangesFuture = api.syncMetadata().toCompletableFuture();
-        final var checkpointStateFuture = api.getCheckpointState().toCompletableFuture();
+        final var updatedRangesFuture =
+            api.syncMetadata(DEFAULT_PHYSICAL_TENANT_ID).toCompletableFuture();
+        final var checkpointStateFuture =
+            api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID).toCompletableFuture();
         final var checkpointState = checkpointStateFuture.join();
         final var ranges = updatedRangesFuture.join();
         return new WebEndpointResponse<>(toCheckpointState(checkpointState, ranges));
@@ -174,7 +178,7 @@ public final class BackupEndpoint {
 
   private WebEndpointResponse<?> deleteBackup(final long id) {
     try {
-      api.deleteBackup(id).toCompletableFuture().join();
+      api.deleteBackup(DEFAULT_PHYSICAL_TENANT_ID, id).toCompletableFuture().join();
       return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
     } catch (final Exception e) {
       return mapErrorResponse(e);
@@ -183,7 +187,7 @@ public final class BackupEndpoint {
 
   private WebEndpointResponse<?> deleteState() {
     try {
-      api.deleteRuntimeState().toCompletableFuture().join();
+      api.deleteRuntimeState(DEFAULT_PHYSICAL_TENANT_ID).toCompletableFuture().join();
       return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
     } catch (final Exception e) {
       return mapErrorResponse(e);
@@ -192,8 +196,11 @@ public final class BackupEndpoint {
 
   private WebEndpointResponse<?> state() {
     final var checkpointStateFuture =
-        api.getCheckpointState().toCompletableFuture().handle((v, e) -> v);
-    final var rangesFuture = api.getBackupRanges().toCompletableFuture().handle((v, e) -> v);
+        api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID)
+            .toCompletableFuture()
+            .handle((v, e) -> v);
+    final var rangesFuture =
+        api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID).toCompletableFuture().handle((v, e) -> v);
     final var checkpointState = checkpointStateFuture.join();
     final var ranges = rangesFuture.join();
     return new WebEndpointResponse<>(toCheckpointState(checkpointState, ranges));
@@ -306,7 +313,8 @@ public final class BackupEndpoint {
 
   private WebEndpointResponse<?> status(final long id) {
     try {
-      final BackupStatus status = api.getStatus(id).toCompletableFuture().join();
+      final BackupStatus status =
+          api.getStatus(DEFAULT_PHYSICAL_TENANT_ID, id).toCompletableFuture().join();
       if (status.status() == State.DOES_NOT_EXIST) {
         return doestNotExistResponse(status.backupId());
       }
@@ -319,7 +327,8 @@ public final class BackupEndpoint {
 
   private WebEndpointResponse<?> listPrefix(final String prefix) {
     try {
-      final var backups = api.listBackups(prefix).toCompletableFuture().join();
+      final var backups =
+          api.listBackups(DEFAULT_PHYSICAL_TENANT_ID, prefix).toCompletableFuture().join();
       final var response = backups.stream().map(this::getBackupInfoFromBackupStatus).toList();
       return new WebEndpointResponse<>(response);
     } catch (final Exception e) {

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.gateway.admin.exporting.ExportingControlApi;
 import java.util.concurrent.CompletionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,11 +40,11 @@ public final class ExportingEndpoint {
       final boolean softPause = soft;
       final var result =
           switch (operationKey) {
-            case RESUME -> exportingService.resumeExporting();
+            case RESUME -> exportingService.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID);
             case PAUSE ->
                 softPause
-                    ? exportingService.softPauseExporting()
-                    : exportingService.pauseExporting();
+                    ? exportingService.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID)
+                    : exportingService.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID);
             default -> throw new UnsupportedOperationException();
           };
       result.join();

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -119,7 +121,7 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var failure = new RuntimeException("failure");
-      doThrow(failure).when(api).takeBackup(anyLong());
+      doThrow(failure).when(api).takeBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final WebEndpointResponse<?> response = endpoint.take(1);
@@ -141,7 +143,9 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var failure = new BackupAlreadyExistException(2, 1);
-      doReturn(CompletableFuture.failedFuture(failure)).when(api).takeBackup(anyLong());
+      doReturn(CompletableFuture.failedFuture(failure))
+          .when(api)
+          .takeBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final WebEndpointResponse<?> response = endpoint.take(1);
@@ -161,7 +165,9 @@ final class BackupEndpointTest {
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.failedFuture(error)).when(api).takeBackup(anyLong());
+      doReturn(CompletableFuture.failedFuture(error))
+          .when(api)
+          .takeBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final var response = endpoint.take(1);
@@ -285,12 +291,12 @@ final class BackupEndpointTest {
 
       doAnswer(
               invocation -> {
-                final Long backupId = invocation.getArgument(0);
+                final Long backupId = invocation.getArgument(1);
                 return CompletableFuture.completedFuture(backupId);
               })
           .when(requestHandler)
-          .takeBackup(anyLong());
-      when(requestHandler.takeBackup()).thenCallRealMethod();
+          .takeBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
+      when(requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID)).thenCallRealMethod();
 
       // when
       final var now = Instant.now();
@@ -299,7 +305,7 @@ final class BackupEndpointTest {
       final WebEndpointResponse<?> secondBackup = endpoint.take();
 
       // then
-      verify(requestHandler, times(2)).takeBackup();
+      verify(requestHandler, times(2)).takeBackup(DEFAULT_PHYSICAL_TENANT_ID);
       assertThat(firstBackup.getStatus()).isEqualTo(202);
       final var firstBody = (TakeBackupRuntimeResponse) firstBackup.getBody();
       final var backupId1 = firstBody.getBackupId();
@@ -331,21 +337,21 @@ final class BackupEndpointTest {
       when(config.getOffset()).thenReturn(offset);
       final var endpoint = new BackupEndpoint(requestHandler, config);
 
-      when(requestHandler.takeBackup()).thenCallRealMethod();
+      when(requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID)).thenCallRealMethod();
       doAnswer(
               invocation -> {
-                final var backupId = invocation.getArgument(0);
+                final var backupId = invocation.getArgument(1);
                 return CompletableFuture.completedFuture(backupId);
               })
           .when(requestHandler)
-          .takeBackup(anyLong());
+          .takeBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final var now = Instant.now();
       final WebEndpointResponse<?> response = endpoint.take();
 
       // then
-      verify(requestHandler, times(1)).takeBackup(anyLong());
+      verify(requestHandler, times(1)).takeBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
       assertThat(response.getStatus()).isEqualTo(202);
       final var body = (TakeBackupRuntimeResponse) response.getBody();
       final var backupId = body.getBackupId();
@@ -365,7 +371,8 @@ final class BackupEndpointTest {
       when(config.isContinuous()).thenReturn(true);
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
-      when(api.takeBackup()).thenReturn(CompletableFuture.completedFuture(1L));
+      when(api.takeBackup(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(1L));
       final var endpoint = new BackupEndpoint(api, config);
 
       // when
@@ -384,7 +391,8 @@ final class BackupEndpointTest {
       when(config.isContinuous()).thenReturn(false);
       when(config.getSchedule()).thenReturn(new IntervalSchedule(Duration.ofSeconds(1)));
       when(config.getCheckpointInterval()).thenReturn(null);
-      when(api.takeBackup()).thenReturn(CompletableFuture.completedFuture(1L));
+      when(api.takeBackup(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(1L));
       final var endpoint = new BackupEndpoint(api, config);
 
       // when
@@ -403,7 +411,8 @@ final class BackupEndpointTest {
       when(config.isContinuous()).thenReturn(false);
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(Duration.ofSeconds(1));
-      when(api.takeBackup()).thenReturn(CompletableFuture.completedFuture(1L));
+      when(api.takeBackup(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(1L));
       final var endpoint = new BackupEndpoint(api, config);
 
       // when
@@ -422,7 +431,8 @@ final class BackupEndpointTest {
       when(config.isContinuous()).thenReturn(true);
       when(config.getSchedule()).thenReturn(new IntervalSchedule(Duration.ofSeconds(1)));
       when(config.getCheckpointInterval()).thenReturn(Duration.ofSeconds(1));
-      when(api.takeBackup()).thenReturn(CompletableFuture.completedFuture(1L));
+      when(api.takeBackup(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(1L));
       final var endpoint = new BackupEndpoint(api, config);
 
       // when
@@ -445,7 +455,7 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var failure = new RuntimeException("failure");
-      doThrow(failure).when(api).getStatus(anyLong());
+      doThrow(failure).when(api).getStatus(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final WebEndpointResponse<?> response = endpoint.query("1");
@@ -467,7 +477,9 @@ final class BackupEndpointTest {
       final var endpoint = new BackupEndpoint(api, config);
       final var backupStatus =
           new BackupStatus(1, State.DOES_NOT_EXIST, Optional.empty(), List.of());
-      doReturn(CompletableFuture.completedFuture(backupStatus)).when(api).getStatus(anyLong());
+      doReturn(CompletableFuture.completedFuture(backupStatus))
+          .when(api)
+          .getStatus(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final WebEndpointResponse<?> response = endpoint.query("1");
@@ -489,7 +501,9 @@ final class BackupEndpointTest {
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.failedFuture(error)).when(api).getStatus(anyLong());
+      doReturn(CompletableFuture.failedFuture(error))
+          .when(api)
+          .getStatus(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final var response = endpoint.query("1");
@@ -513,7 +527,9 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var status = createPartitionBackupStatus();
-      doReturn(CompletableFuture.completedFuture(status)).when(api).getStatus(anyLong());
+      doReturn(CompletableFuture.completedFuture(status))
+          .when(api)
+          .getStatus(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       final String expectedJson =
           """
@@ -569,7 +585,9 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var status = createFailedBackupStatus();
-      doReturn(CompletableFuture.completedFuture(status)).when(api).getStatus(anyLong());
+      doReturn(CompletableFuture.completedFuture(status))
+          .when(api)
+          .getStatus(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       final String expectedJson =
           """
@@ -668,7 +686,7 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var failure = new RuntimeException("failure");
-      doThrow(failure).when(api).listBackups("*");
+      doThrow(failure).when(api).listBackups(DEFAULT_PHYSICAL_TENANT_ID, "*");
 
       // when
       final WebEndpointResponse<?> response = endpoint.listAll();
@@ -689,7 +707,9 @@ final class BackupEndpointTest {
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.failedFuture(error)).when(api).listBackups("*");
+      doReturn(CompletableFuture.failedFuture(error))
+          .when(api)
+          .listBackups(DEFAULT_PHYSICAL_TENANT_ID, "*");
 
       // when
       final var response = endpoint.listAll();
@@ -726,7 +746,7 @@ final class BackupEndpointTest {
               List.of(createPartialPartitionStatus(BackupStatusCode.IN_PROGRESS)));
       doReturn(CompletableFuture.completedFuture(List.of(backup1, backup2)))
           .when(api)
-          .listBackups("*");
+          .listBackups(DEFAULT_PHYSICAL_TENANT_ID, "*");
 
       final String expectedJson =
           """
@@ -782,7 +802,9 @@ final class BackupEndpointTest {
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.completedFuture(List.of())).when(api).listBackups("*");
+      doReturn(CompletableFuture.completedFuture(List.of()))
+          .when(api)
+          .listBackups(DEFAULT_PHYSICAL_TENANT_ID, "*");
 
       // when
       final WebEndpointResponse<?> response = endpoint.listAll();
@@ -821,7 +843,7 @@ final class BackupEndpointTest {
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
       final var failure = new RuntimeException("failure");
-      doThrow(failure).when(api).deleteBackup(1);
+      doThrow(failure).when(api).deleteBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
       // when
       final WebEndpointResponse<?> response = endpoint.delete("1");
@@ -842,7 +864,9 @@ final class BackupEndpointTest {
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.failedFuture(error)).when(api).deleteBackup(anyLong());
+      doReturn(CompletableFuture.failedFuture(error))
+          .when(api)
+          .deleteBackup(eq(DEFAULT_PHYSICAL_TENANT_ID), anyLong());
 
       // when
       final var response = endpoint.delete("1");
@@ -865,7 +889,9 @@ final class BackupEndpointTest {
       when(config.getSchedule()).thenReturn(Schedule.none());
       when(config.getCheckpointInterval()).thenReturn(null);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.completedFuture(null)).when(api).deleteBackup(1);
+      doReturn(CompletableFuture.completedFuture(null))
+          .when(api)
+          .deleteBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
       // when
       final WebEndpointResponse<?> response = endpoint.delete("1");
@@ -884,7 +910,9 @@ final class BackupEndpointTest {
       final var api = mock(BackupApi.class);
       final var config = mock(BackupCfg.class);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.completedFuture(null)).when(api).deleteRuntimeState();
+      doReturn(CompletableFuture.completedFuture(null))
+          .when(api)
+          .deleteRuntimeState(DEFAULT_PHYSICAL_TENANT_ID);
 
       // when
       final WebEndpointResponse<?> response = endpoint.delete("state");
@@ -900,7 +928,9 @@ final class BackupEndpointTest {
       final var api = mock(BackupApi.class);
       final var config = mock(BackupCfg.class);
       final var endpoint = new BackupEndpoint(api, config);
-      doReturn(CompletableFuture.failedFuture(error)).when(api).deleteRuntimeState();
+      doReturn(CompletableFuture.failedFuture(error))
+          .when(api)
+          .deleteRuntimeState(DEFAULT_PHYSICAL_TENANT_ID);
 
       // when
       final var response = endpoint.delete("state");
@@ -921,7 +951,7 @@ final class BackupEndpointTest {
       final var config = mock(BackupCfg.class);
       final var endpoint = new BackupEndpoint(api, config);
       final var failure = new RuntimeException("failure");
-      doThrow(failure).when(api).deleteRuntimeState();
+      doThrow(failure).when(api).deleteRuntimeState(DEFAULT_PHYSICAL_TENANT_ID);
 
       // when
       final WebEndpointResponse<?> response = endpoint.delete("state");
@@ -958,8 +988,10 @@ final class BackupEndpointTest {
                   new CheckpointInfo(
                       10, 100L, 150L, CheckpointType.SCHEDULED_BACKUP, endTimestamp))));
 
-      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
-      when(api.getBackupRanges()).thenReturn(CompletableFuture.completedFuture(rangesResponse));
+      when(api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(rangesResponse));
 
       // when
       final WebEndpointResponse<?> response = endpoint.query(BackupApi.STATE);
@@ -1015,8 +1047,9 @@ final class BackupEndpointTest {
           Set.of(
               new CheckpointStateResponse.PartitionCheckpointState(
                   1, 1L, CheckpointType.MANUAL_BACKUP, 20L, 10L, 5L)));
-      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
-      when(api.getBackupRanges())
+      when(api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID))
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
@@ -1056,8 +1089,9 @@ final class BackupEndpointTest {
           Set.of(
               new CheckpointStateResponse.PartitionCheckpointState(
                   1, 2L, CheckpointType.MARKER, 30L, 50L)));
-      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
-      when(api.getBackupRanges())
+      when(api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID))
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
@@ -1101,8 +1135,9 @@ final class BackupEndpointTest {
 
       final var stateResponse = new CheckpointStateResponse();
 
-      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
-      when(api.getBackupRanges())
+      when(api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID))
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
@@ -1146,8 +1181,9 @@ final class BackupEndpointTest {
       stateResponse.setCheckpointStates(Set.of(p1State, p2State, p3State));
       stateResponse.setBackupStates(Set.of(p1BackupState, p2BackupState, p3BackupState));
 
-      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
-      when(api.getBackupRanges())
+      when(api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID))
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when
@@ -1228,8 +1264,9 @@ final class BackupEndpointTest {
       stateResponse.setBackupStates(
           Set.of(new CheckpointStateResponse.PartitionCheckpointState(1, 1L, null, 20L, 10L)));
 
-      when(api.getCheckpointState()).thenReturn(CompletableFuture.completedFuture(stateResponse));
-      when(api.getBackupRanges())
+      when(api.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
+          .thenReturn(CompletableFuture.completedFuture(stateResponse));
+      when(api.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID))
           .thenReturn(CompletableFuture.completedFuture(new BackupRangesResponse()));
 
       // when

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.from;
 import static org.mockito.Mockito.mock;
@@ -27,9 +28,9 @@ final class ExportingEndpointTest {
     final var endpoint = new ExportingEndpoint(service);
 
     // when
-    when(service.pauseExporting()).thenThrow(new RuntimeException());
-    when(service.resumeExporting()).thenThrow(new RuntimeException());
-    when(service.softPauseExporting()).thenThrow(new RuntimeException());
+    when(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID)).thenThrow(new RuntimeException());
+    when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID)).thenThrow(new RuntimeException());
+    when(service.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID)).thenThrow(new RuntimeException());
 
     // then
     assertThat(endpoint.post(operation, false))
@@ -45,11 +46,11 @@ final class ExportingEndpointTest {
     final var endpoint = new ExportingEndpoint(service);
 
     // when
-    when(service.pauseExporting())
+    when(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
-    when(service.resumeExporting())
+    when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
-    when(service.softPauseExporting())
+    when(service.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
 
     // then
@@ -66,9 +67,12 @@ final class ExportingEndpointTest {
     final var endpoint = new ExportingEndpoint(service);
 
     // when
-    when(service.pauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
-    when(service.resumeExporting()).thenReturn(CompletableFuture.completedFuture(null));
-    when(service.softPauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
+    when(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(service.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.completedFuture(null));
 
     // then
     assertThat(endpoint.post(operation, false))

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupApi.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupApi.java
@@ -18,26 +18,28 @@ public interface BackupApi {
   String SYNC = "sync";
 
   /**
-   * Triggers backup on all partitions. Returned future is completed successfully after all
-   * partitions have processed the request. Returned future fails if the request was not processed
-   * by at least one partition.
+   * Triggers backup on all partitions of the given physical tenant. Returned future is completed
+   * successfully after all partitions have processed the request. Returned future fails if the
+   * request was not processed by at least one partition.
    *
    * <p>TODO: check if it makes more sense to return a {@link java.util.concurrent.Future} if we're
    * always blocking on the result and never combining.
    *
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @param backupId the id of the backup to be taken
    * @return the backupId
    */
-  CompletionStage<Long> takeBackup(long backupId);
+  CompletionStage<Long> takeBackup(String physicalTenantId, long backupId);
 
   /**
-   * Triggers backup on all partitions using the current timestamp as the backupId. An optional
-   * offset may be added to the timestamp to maintain consistency with existing backup ID schemes
-   * (e.g., if migrating from a different timestamp format).
+   * Triggers backup on all partitions of the given physical tenant using the current timestamp as
+   * the backupId. An optional offset may be added to the timestamp to maintain consistency with
+   * existing backup ID schemes (e.g., if migrating from a different timestamp format).
    *
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @return the generated backupId (current timestamp + offset)
    */
-  CompletionStage<Long> takeBackup();
+  CompletionStage<Long> takeBackup(String physicalTenantId);
 
   /**
    * Returns the status of the backup. The future fails if the request was not processed by at least
@@ -46,47 +48,60 @@ public interface BackupApi {
    * <p>TODO: check if it makes more sense to return a {@link java.util.concurrent.Future} if we're
    * always blocking on the result and never combining.
    *
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @return the status of the backup
    */
-  CompletionStage<BackupStatus> getStatus(long backupId);
+  CompletionStage<BackupStatus> getStatus(String physicalTenantId, long backupId);
 
   /**
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @return the latest checkpoint and state for all partitions
    */
-  CompletionStage<CheckpointStateResponse> getCheckpointState();
+  CompletionStage<CheckpointStateResponse> getCheckpointState(String physicalTenantId);
 
   /**
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @return all backup ranges for all partitions
    */
-  CompletionStage<BackupRangesResponse> getBackupRanges();
+  CompletionStage<BackupRangesResponse> getBackupRanges(String physicalTenantId);
 
   /**
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @return a list of available backups
    */
-  default CompletionStage<List<BackupStatus>> listBackups() {
-    return listBackups(WILDCARD);
+  default CompletionStage<List<BackupStatus>> listBackups(final String physicalTenantId) {
+    return listBackups(physicalTenantId, WILDCARD);
   }
 
   /**
    * Returns a list of backups with ids matching the prefix.
    *
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @param prefix A string that backup ids must match. Must end in a single `*`.
    */
-  CompletionStage<List<BackupStatus>> listBackups(String prefix);
+  CompletionStage<List<BackupStatus>> listBackups(String physicalTenantId, String prefix);
 
   /**
    * Deletes the backup with the given id
    *
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @param backupId id of the backup to delete
    */
-  CompletionStage<Void> deleteBackup(long backupId);
-
-  /** Force-write backup metadata for all partitions. */
-  CompletionStage<BackupRangesResponse> syncMetadata();
+  CompletionStage<Void> deleteBackup(String physicalTenantId, long backupId);
 
   /**
-   * Resets the backup runtime state on all partitions. Clears all checkpoint info, backup info,
-   * checkpoint metadata, and backup ranges. Used when switching backup stores.
+   * Force-write backup metadata for all partitions of the given physical tenant.
+   *
+   * @param physicalTenantId the physical tenant (partition group) to target
    */
-  CompletionStage<Void> deleteRuntimeState();
+  CompletionStage<BackupRangesResponse> syncMetadata(String physicalTenantId);
+
+  /**
+   * Resets the backup runtime state on all partitions of the given physical tenant. Clears all
+   * checkpoint info, backup info, checkpoint metadata, and backup ranges. Used when switching
+   * backup stores.
+   *
+   * @param physicalTenantId the physical tenant (partition group) to target
+   */
+  CompletionStage<Void> deleteRuntimeState(String physicalTenantId);
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/client/api/BackupRequestHandler.java
@@ -55,72 +55,82 @@ public final class BackupRequestHandler implements BackupApi {
   }
 
   @Override
-  public CompletionStage<Long> takeBackup(final long backupId) {
-    return takeBackup(backupId, CheckpointType.MANUAL_BACKUP);
+  public CompletionStage<Long> takeBackup(final String physicalTenantId, final long backupId) {
+    return takeBackup(physicalTenantId, backupId, CheckpointType.MANUAL_BACKUP);
   }
 
   @Override
-  public CompletionStage<Long> takeBackup() {
+  public CompletionStage<Long> takeBackup(final String physicalTenantId) {
     final var backupId = checkpointIdGenerator.generateCheckpointId();
-    return takeBackup(backupId);
+    return takeBackup(physicalTenantId, backupId);
   }
 
   @Override
-  public CompletionStage<BackupStatus> getStatus(final long backupId) {
-    return broadcastRequest(partitionId -> createStatusQueryRequest(backupId, partitionId))
+  public CompletionStage<BackupStatus> getStatus(
+      final String physicalTenantId, final long backupId) {
+    return broadcastRequest(
+            physicalTenantId, partitionId -> createStatusQueryRequest(backupId, partitionId))
         .thenApply(responses -> responses.stream().map(PartitionBackupStatus::from).toList())
         .thenApply(responses -> aggregatePartitionStatus(backupId, responses));
   }
 
   @Override
-  public CompletionStage<CheckpointStateResponse> getCheckpointState() {
-    return broadcastRequest(this::createCheckpointRequest)
+  public CompletionStage<CheckpointStateResponse> getCheckpointState(
+      final String physicalTenantId) {
+    return broadcastRequest(physicalTenantId, this::createCheckpointRequest)
         .thenApply(this::aggregateCheckpointResponses);
   }
 
   @Override
-  public CompletionStage<BackupRangesResponse> getBackupRanges() {
-    return broadcastRequest(this::createRangesRequest).thenApply(this::aggregateRangesResponses);
-  }
-
-  @Override
-  public CompletionStage<List<BackupStatus>> listBackups(final String prefix) {
-    return broadcastRequest(partitionId -> createListRequest(partitionId, prefix))
-        .thenApply(this::aggregateBackupList);
-  }
-
-  @Override
-  public CompletionStage<Void> deleteBackup(final long backupId) {
-    return broadcastRequest(partitionId -> createDeleteRequest(backupId, partitionId))
-        .thenApply(ignored -> null);
-  }
-
-  @Override
-  public CompletionStage<BackupRangesResponse> syncMetadata() {
-    return broadcastRequest(this::createMetadataSyncRequest)
+  public CompletionStage<BackupRangesResponse> getBackupRanges(final String physicalTenantId) {
+    return broadcastRequest(physicalTenantId, this::createRangesRequest)
         .thenApply(this::aggregateRangesResponses);
   }
 
   @Override
-  public CompletionStage<Void> deleteRuntimeState() {
-    return broadcastRequest(this::createClearStateRequest).thenApply(ignored -> null);
+  public CompletionStage<List<BackupStatus>> listBackups(
+      final String physicalTenantId, final String prefix) {
+    return broadcastRequest(physicalTenantId, partitionId -> createListRequest(partitionId, prefix))
+        .thenApply(responses -> aggregateBackupList(physicalTenantId, responses));
+  }
+
+  @Override
+  public CompletionStage<Void> deleteBackup(final String physicalTenantId, final long backupId) {
+    return broadcastRequest(
+            physicalTenantId, partitionId -> createDeleteRequest(backupId, partitionId))
+        .thenApply(ignored -> null);
+  }
+
+  @Override
+  public CompletionStage<BackupRangesResponse> syncMetadata(final String physicalTenantId) {
+    return broadcastRequest(physicalTenantId, this::createMetadataSyncRequest)
+        .thenApply(this::aggregateRangesResponses);
+  }
+
+  @Override
+  public CompletionStage<Void> deleteRuntimeState(final String physicalTenantId) {
+    return broadcastRequest(physicalTenantId, this::createClearStateRequest)
+        .thenApply(ignored -> null);
   }
 
   /**
-   * Trigger a checkpoint of the given type across all partitions
+   * Trigger a checkpoint of the given type across all partitions of the given physical tenant
    *
+   * @param physicalTenantId the physical tenant (partition group) to target
    * @param checkpointType {@link CheckpointType} type of checkpoint to create
    * @return the checkpoint id created
    */
-  public CompletionStage<Long> checkpoint(final CheckpointType checkpointType) {
+  public CompletionStage<Long> checkpoint(
+      final String physicalTenantId, final CheckpointType checkpointType) {
     final var checkpointId = checkpointIdGenerator.generateCheckpointId();
-    return takeBackup(checkpointId, checkpointType);
+    return takeBackup(physicalTenantId, checkpointId, checkpointType);
   }
 
   @VisibleForTesting
   public CompletionStage<Long> takeBackup(
-      final long backupId, final CheckpointType checkpointType) {
+      final String physicalTenantId, final long backupId, final CheckpointType checkpointType) {
     return broadcastRequest(
+            physicalTenantId,
             partitionId -> createBackupRequest(backupId, partitionId, checkpointType))
         .thenApply(
             responses -> {
@@ -155,13 +165,14 @@ public final class BackupRequestHandler implements BackupApi {
   }
 
   private <R> CompletionStage<Set<R>> broadcastRequest(
-      final Function<Integer, BrokerRequest<R>> requestCreator) {
-    return checkTopologyComplete()
+      final String physicalTenantId, final Function<Integer, BrokerRequest<R>> requestCreator) {
+    return checkTopologyComplete(physicalTenantId)
         .thenCompose(
             topology -> {
               final var responses =
                   topology.getPartitions().stream()
                       .map(requestCreator)
+                      .map(request -> stampPhysicalTenant(request, physicalTenantId))
                       .map(brokerClient::sendRequestWithRetry)
                       .toList();
               return CompletableFuture.allOf(responses.toArray(CompletableFuture[]::new))
@@ -174,8 +185,14 @@ public final class BackupRequestHandler implements BackupApi {
             });
   }
 
+  private static <R> BrokerRequest<R> stampPhysicalTenant(
+      final BrokerRequest<R> request, final String physicalTenantId) {
+    request.setPartitionGroup(physicalTenantId);
+    return request;
+  }
+
   private List<BackupStatus> aggregateBackupList(
-      final Collection<BackupListResponse> backupsReceived) {
+      final String physicalTenantId, final Collection<BackupListResponse> backupsReceived) {
     // backupId -> [partitiondId -> partitionBackupStatus]
     final var statusByBackupAndPartition =
         backupsReceived.stream()
@@ -188,7 +205,7 @@ public final class BackupRequestHandler implements BackupApi {
                         Function.identity(),
                         this::mergeDuplicatePartitionBackupStatus)));
 
-    final var partitions = topologyManager.getTopology().getPartitions();
+    final var partitions = topologyManager.getTopology(physicalTenantId).getPartitions();
     // calculate status of each backup from the status of each partition
     return statusByBackupAndPartition.entrySet().stream()
         .map(
@@ -253,8 +270,8 @@ public final class BackupRequestHandler implements BackupApi {
             Comparator.comparingInt(comparingOrder::indexOf)));
   }
 
-  private CompletionStage<BrokerClusterState> checkTopologyComplete() {
-    final BrokerClusterState topology = topologyManager.getTopology();
+  private CompletionStage<BrokerClusterState> checkTopologyComplete(final String physicalTenantId) {
+    final BrokerClusterState topology = topologyManager.getTopology(physicalTenantId);
     if (topology == null) {
       return CompletableFuture.failedFuture(new NoTopologyAvailableException());
     }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/schedule/CheckpointScheduler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.backup.schedule;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse;
 import io.camunda.zeebe.protocol.impl.encoding.CheckpointStateResponse.PartitionCheckpointState;
@@ -104,7 +106,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
       final Function<CheckpointStateResponse, Set<PartitionCheckpointState>> stateFilter) {
     final ActorFuture<Set<PartitionCheckpointState>> future = createFuture();
     backupRequestHandler
-        .getCheckpointState()
+        .getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID)
         .thenApplyAsync(stateFilter, this)
         .whenCompleteAsync(future, this);
     return future;
@@ -154,7 +156,7 @@ public class CheckpointScheduler extends Actor implements AutoCloseable {
     final CompletableActorFuture<ExecutionResult> future = new CompletableActorFuture<>();
     if (nextExecution.isBefore(now) || nextExecution.equals(now)) {
       backupRequestHandler
-          .checkpoint(type)
+          .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, type)
           .toCompletableFuture()
           .thenApplyAsync(
               id -> {

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/schedule/CheckpointScheduleTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.backup.schedule;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.LAST_CHECKPOINT_GAUGE_NAME;
 import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.LAST_CHECKPOINT_ID_GAUGE_NAME;
 import static io.camunda.zeebe.backup.schedule.SchedulerMetrics.NEXT_CHECKPOINT_GAUGE_NAME;
@@ -16,6 +17,7 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -66,18 +68,20 @@ public class CheckpointScheduleTest {
     final var topologyManager = mock(BrokerTopologyManager.class);
     final var clusterState = mock(BrokerClusterState.class);
     lenient().when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
-    lenient().when(topologyManager.getTopology()).thenReturn(clusterState);
+    lenient()
+        .when(topologyManager.getTopology(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(clusterState);
     lenient().when(clusterState.getPartitionsCount()).thenReturn(1);
     lenient().when(clusterState.getPartitions()).thenReturn(List.of(1));
     backupRequestHandler = spy(new BackupRequestHandler(brokerClient));
 
     doAnswer(
             (ctx) -> {
-              final Object backupId = ctx.getArgument(0);
+              final Object backupId = ctx.getArgument(1);
               return CompletableFuture.completedFuture(backupId);
             })
         .when(backupRequestHandler)
-        .takeBackup(anyLong(), any(CheckpointType.class));
+        .takeBackup(any(), anyLong(), any(CheckpointType.class));
 
     actorScheduler.getClock().reset();
     actorScheduler.getClock().pinCurrentTime();
@@ -89,7 +93,7 @@ public class CheckpointScheduleTest {
     final var now = actorScheduler.getClock().getCurrentTime();
     checkpointScheduler =
         createScheduler(new Schedule.IntervalSchedule(Duration.ofSeconds(5)), null);
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.completedStage(checkpointState(now.toEpochMilli(), 0L)));
 
     // when
@@ -99,10 +103,11 @@ public class CheckpointScheduleTest {
     actorScheduler.workUntilDone();
 
     // then
-    verify(backupRequestHandler, times(2)).getCheckpointState();
-    verify(backupRequestHandler, times(1)).checkpoint(CheckpointType.MARKER);
+    verify(backupRequestHandler, times(2)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
     verify(backupRequestHandler, times(1))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.MARKER));
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.MARKER);
+    verify(backupRequestHandler, times(1))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.MARKER));
     verifyNoMoreInteractions(backupRequestHandler);
 
     final var recordedTimestampValue =
@@ -127,7 +132,7 @@ public class CheckpointScheduleTest {
     checkpointScheduler =
         createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.completedStage(checkpointState(0L, now.toEpochMilli())));
 
     // when
@@ -137,11 +142,12 @@ public class CheckpointScheduleTest {
     actorScheduler.workUntilDone();
 
     // then
-    verify(backupRequestHandler, times(2)).getCheckpointState();
+    verify(backupRequestHandler, times(2)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
 
-    verify(backupRequestHandler, times(1)).checkpoint(CheckpointType.SCHEDULED_BACKUP);
     verify(backupRequestHandler, times(1))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.SCHEDULED_BACKUP);
+    verify(backupRequestHandler, times(1))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
     verifyNoMoreInteractions(backupRequestHandler);
 
     var recordedTimestampValue = getGaugeValue(LAST_CHECKPOINT_GAUGE_NAME, CheckpointType.MARKER);
@@ -173,7 +179,7 @@ public class CheckpointScheduleTest {
             new Schedule.IntervalSchedule(Duration.ofSeconds(5)),
             new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(
                 checkpointState(now.toEpochMilli(), now.toEpochMilli())));
@@ -185,12 +191,14 @@ public class CheckpointScheduleTest {
     actorScheduler.workUntilDone();
 
     // then – both loops fire independently
-    verify(backupRequestHandler, times(1)).checkpoint(CheckpointType.MARKER);
     verify(backupRequestHandler, times(1))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.MARKER));
-    verify(backupRequestHandler, times(1)).checkpoint(CheckpointType.SCHEDULED_BACKUP);
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.MARKER);
     verify(backupRequestHandler, times(1))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.MARKER));
+    verify(backupRequestHandler, times(1))
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.SCHEDULED_BACKUP);
+    verify(backupRequestHandler, times(1))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
   }
 
   @Test
@@ -200,21 +208,21 @@ public class CheckpointScheduleTest {
     checkpointScheduler =
         createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.completedStage(checkpointState(0L, now.toEpochMilli())));
 
     // when
     actorScheduler.submitActor(checkpointScheduler);
     actorScheduler.workUntilDone();
-    verify(backupRequestHandler, times(1)).getCheckpointState();
+    verify(backupRequestHandler, times(1)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
     actorScheduler.updateClock(Duration.ofSeconds(5));
     checkpointScheduler.closeAsync();
     actorScheduler.workUntilDone();
 
     // then
 
-    verify(backupRequestHandler, times(0)).checkpoint(any());
-    verify(backupRequestHandler, times(0)).takeBackup(anyLong(), any());
+    verify(backupRequestHandler, times(0)).checkpoint(eq(DEFAULT_PHYSICAL_TENANT_ID), any());
+    verify(backupRequestHandler, times(0)).takeBackup(any(), anyLong(), any());
     verifyNoMoreInteractions(backupRequestHandler);
   }
 
@@ -223,7 +231,7 @@ public class CheckpointScheduleTest {
     // given
     final int iterations = 10;
     var now = actorScheduler.getClock().getCurrentTime();
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.completedStage(checkpointState(now.toEpochMilli(), 0L)));
     checkpointScheduler =
         createScheduler(new Schedule.IntervalSchedule(Duration.ofSeconds(5)), null);
@@ -235,16 +243,17 @@ public class CheckpointScheduleTest {
       actorScheduler.updateClock(Duration.ofSeconds(5));
       actorScheduler.workUntilDone();
       now = actorScheduler.getClock().getCurrentTime();
-      when(backupRequestHandler.getCheckpointState())
+      when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
           .thenReturn(CompletableFuture.completedStage(checkpointState(now.toEpochMilli(), 0L)));
     }
     // 1 for the initial plus the 10 iterations
-    verify(backupRequestHandler, times(11)).getCheckpointState();
+    verify(backupRequestHandler, times(11)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
-    verify(backupRequestHandler, times(iterations)).checkpoint(CheckpointType.MARKER);
     verify(backupRequestHandler, times(iterations))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.MARKER));
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.MARKER);
+    verify(backupRequestHandler, times(iterations))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.MARKER));
     verifyNoMoreInteractions(backupRequestHandler);
   }
 
@@ -252,7 +261,7 @@ public class CheckpointScheduleTest {
   void shouldTakeDifferentCheckpointsInSuccession() {
     // given
     final var initTime = actorScheduler.getClock().getCurrentTime();
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(
                 checkpointState(initTime.toEpochMilli(), initTime.toEpochMilli())));
@@ -267,7 +276,7 @@ public class CheckpointScheduleTest {
     final var latestBackupCheckpoint = initTime.toEpochMilli();
     final AtomicInteger callCount = new AtomicInteger(0);
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenAnswer(
             invocation -> {
               final int count = callCount.incrementAndGet();
@@ -324,12 +333,14 @@ public class CheckpointScheduleTest {
     }
 
     // then – marker fires every 5s (3 times), backup fires at 15s (1 time)
-    verify(backupRequestHandler, times(3)).checkpoint(CheckpointType.MARKER);
     verify(backupRequestHandler, times(3))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.MARKER));
-    verify(backupRequestHandler, times(1)).checkpoint(CheckpointType.SCHEDULED_BACKUP);
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.MARKER);
+    verify(backupRequestHandler, times(3))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.MARKER));
     verify(backupRequestHandler, times(1))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.SCHEDULED_BACKUP);
+    verify(backupRequestHandler, times(1))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
   }
 
   @Test
@@ -339,7 +350,7 @@ public class CheckpointScheduleTest {
     checkpointScheduler =
         createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(
                 checkpointState(0L, now.minus(1, ChronoUnit.DAYS).toEpochMilli())));
@@ -351,12 +362,13 @@ public class CheckpointScheduleTest {
     actorScheduler.workUntilDone();
 
     // then
-    verify(backupRequestHandler, times(2)).getCheckpointState();
+    verify(backupRequestHandler, times(2)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
     // Schedule will be executed twice, once instantly as it's overdue and once at the corrected
     // schedule time
-    verify(backupRequestHandler, times(2)).checkpoint(CheckpointType.SCHEDULED_BACKUP);
     verify(backupRequestHandler, times(2))
-        .takeBackup(anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
+        .checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.SCHEDULED_BACKUP);
+    verify(backupRequestHandler, times(2))
+        .takeBackup(any(), anyLong(), argThat(type -> type == CheckpointType.SCHEDULED_BACKUP));
     verifyNoMoreInteractions(backupRequestHandler);
   }
 
@@ -367,7 +379,7 @@ public class CheckpointScheduleTest {
     checkpointScheduler =
         createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(
                 checkpointState(0L, now.minus(1, ChronoUnit.DAYS).toEpochMilli())));
@@ -393,7 +405,7 @@ public class CheckpointScheduleTest {
     checkpointScheduler =
         createScheduler(null, new Schedule.IntervalSchedule(Duration.ofSeconds(5)));
 
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(
                 checkpointState(0L, now.minus(1, ChronoUnit.DAYS).toEpochMilli())));
@@ -418,7 +430,7 @@ public class CheckpointScheduleTest {
     final var lastCheckpoint = now.minus(interval).minus(Duration.ofSeconds(10));
 
     checkpointScheduler = createScheduler(new Schedule.IntervalSchedule(interval), null);
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(checkpointState(lastCheckpoint.toEpochMilli(), 0L)));
 
@@ -427,7 +439,7 @@ public class CheckpointScheduleTest {
               return CompletableFuture.completedFuture(1L);
             })
         .when(backupRequestHandler)
-        .checkpoint(any());
+        .checkpoint(eq(DEFAULT_PHYSICAL_TENANT_ID), any());
 
     // when
     actorScheduler.submitActor(checkpointScheduler);
@@ -435,7 +447,7 @@ public class CheckpointScheduleTest {
 
     // then
     // it should have triggered checkpoint immediately
-    verify(backupRequestHandler).checkpoint(CheckpointType.MARKER);
+    verify(backupRequestHandler).checkpoint(DEFAULT_PHYSICAL_TENANT_ID, CheckpointType.MARKER);
   }
 
   @Test
@@ -446,7 +458,7 @@ public class CheckpointScheduleTest {
         createScheduler(new Schedule.IntervalSchedule(Duration.ofSeconds(60)), null);
 
     // First call fails, second call succeeds
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.failedStage(new RuntimeException("Expected error")))
         .thenReturn(CompletableFuture.completedStage(checkpointState(now.toEpochMilli(), 0L)));
 
@@ -455,14 +467,14 @@ public class CheckpointScheduleTest {
     actorScheduler.workUntilDone(); // Should handle error and schedule backoff
 
     // then
-    verify(backupRequestHandler, times(1)).getCheckpointState();
+    verify(backupRequestHandler, times(1)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
 
     // Move clock past initial backoff (1s)
     actorScheduler.updateClock(Duration.ofSeconds(2));
     actorScheduler.workUntilDone();
 
     // Should have retried
-    verify(backupRequestHandler, times(2)).getCheckpointState();
+    verify(backupRequestHandler, times(2)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Test
@@ -473,7 +485,7 @@ public class CheckpointScheduleTest {
         createScheduler(new Schedule.IntervalSchedule(Duration.ofSeconds(60)), null);
 
     // Provide a state where last checkpoint was long ago
-    when(backupRequestHandler.getCheckpointState())
+    when(backupRequestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(
             CompletableFuture.completedStage(
                 checkpointState(now.minus(Duration.ofHours(1)).toEpochMilli(), 0L)));
@@ -481,21 +493,21 @@ public class CheckpointScheduleTest {
     // First checkpoint call fails
     doAnswer(invocation -> CompletableFuture.failedStage(new RuntimeException("Checkpoint failed")))
         .when(backupRequestHandler)
-        .checkpoint(any());
+        .checkpoint(eq(DEFAULT_PHYSICAL_TENANT_ID), any());
 
     // when
     actorScheduler.submitActor(checkpointScheduler);
     actorScheduler.workUntilDone(); // Should handle checkpoint error and schedule backoff
 
     // then
-    verify(backupRequestHandler, times(1)).checkpoint(any());
+    verify(backupRequestHandler, times(1)).checkpoint(eq(DEFAULT_PHYSICAL_TENANT_ID), any());
 
     // Move clock past initial backoff (1s)
     actorScheduler.updateClock(Duration.ofSeconds(2));
     actorScheduler.workUntilDone();
 
     // Should have retried (starts by acquiring state again)
-    verify(backupRequestHandler, times(2)).getCheckpointState();
+    verify(backupRequestHandler, times(2)).getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   private CheckpointStateResponse checkpointState(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlApi.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlApi.java
@@ -9,10 +9,17 @@ package io.camunda.zeebe.gateway.admin.exporting;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Every operation targets a single physical tenant (partition group). The {@code physicalTenantId}
+ * selects the partition set the operation enumerates and is stamped on every outgoing broker
+ * request so that routing resolves leaders from that group's topology. Callers that do not care
+ * about physical tenants pass {@link
+ * io.camunda.cluster.PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID}.
+ */
 public interface ExportingControlApi {
-  CompletableFuture<Void> pauseExporting();
+  CompletableFuture<Void> pauseExporting(String physicalTenantId);
 
-  CompletableFuture<Void> softPauseExporting();
+  CompletableFuture<Void> softPauseExporting(String physicalTenantId);
 
-  CompletableFuture<Void> resumeExporting();
+  CompletableFuture<Void> resumeExporting(String physicalTenantId);
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -30,38 +30,43 @@ public class ExportingControlService implements ExportingControlApi {
   }
 
   @Override
-  public CompletableFuture<Void> pauseExporting() {
-    LOG.info("Pausing exporting on all partitions.");
-    final var topology = brokerClient.getTopologyManager().getTopology();
-    return broadcastOnTopology(topology, BrokerAdminRequest::pauseExporting);
+  public CompletableFuture<Void> pauseExporting(final String physicalTenantId) {
+    LOG.info("Pausing exporting on all partitions of physical tenant {}.", physicalTenantId);
+    final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
+    return broadcastOnTopology(physicalTenantId, topology, BrokerAdminRequest::pauseExporting);
   }
 
   @Override
-  public CompletableFuture<Void> softPauseExporting() {
-    LOG.info("Soft Pausing exporting on all partitions.");
-    final var topology = brokerClient.getTopologyManager().getTopology();
-    return broadcastOnTopology(topology, BrokerAdminRequest::softPauseExporting);
+  public CompletableFuture<Void> softPauseExporting(final String physicalTenantId) {
+    LOG.info("Soft Pausing exporting on all partitions of physical tenant {}.", physicalTenantId);
+    final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
+    return broadcastOnTopology(physicalTenantId, topology, BrokerAdminRequest::softPauseExporting);
   }
 
   @Override
-  public CompletableFuture<Void> resumeExporting() {
-    LOG.info("Resuming exporting on all partitions.");
-    final var topology = brokerClient.getTopologyManager().getTopology();
-    return broadcastOnTopology(topology, BrokerAdminRequest::resumeExporting);
+  public CompletableFuture<Void> resumeExporting(final String physicalTenantId) {
+    LOG.info("Resuming exporting on all partitions of physical tenant {}.", physicalTenantId);
+    final var topology = brokerClient.getTopologyManager().getTopology(physicalTenantId);
+    return broadcastOnTopology(physicalTenantId, topology, BrokerAdminRequest::resumeExporting);
   }
 
   private CompletableFuture<Void> broadcastOnTopology(
-      final BrokerClusterState topology, final Consumer<BrokerAdminRequest> configureRequest) {
+      final String physicalTenantId,
+      final BrokerClusterState topology,
+      final Consumer<BrokerAdminRequest> configureRequest) {
     validateTopology(topology);
 
     final var requests =
         topology.getPartitions().stream()
-            .map(partition -> broadcastOnPartition(topology, partition, configureRequest))
+            .map(
+                partition ->
+                    broadcastOnPartition(physicalTenantId, topology, partition, configureRequest))
             .toArray(CompletableFuture<?>[]::new);
     return CompletableFuture.allOf(requests);
   }
 
   private CompletableFuture<Void> broadcastOnPartition(
+      final String physicalTenantId,
       final BrokerClusterState topology,
       final Integer partitionId,
       final Consumer<BrokerAdminRequest> configureRequest) {
@@ -84,6 +89,7 @@ public class ExportingControlService implements ExportingControlApi {
             .map(
                 brokerId -> {
                   final var request = new BrokerAdminRequest();
+                  request.setPartitionGroup(physicalTenantId);
                   request.setBrokerId(brokerId);
                   request.setPartitionId(partitionId);
                   configureRequest.accept(request);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/backup/BackupRequestHandlerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin.backup;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.backup.client.api.BackupAlreadyExistException;
@@ -58,7 +59,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.takeBackup(1);
+    final var future = requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -73,7 +74,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.takeBackup(1);
+    final var future = requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -90,7 +91,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.withResponse(new BackupResponse(false, 2), 1);
 
     // when
-    final var future = requestHandler.takeBackup(1);
+    final var future = requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -114,7 +115,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
             });
 
     // when
-    final var future = requestHandler.takeBackup(1);
+    final var future = requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -132,7 +133,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.withResponse(new BackupResponse(false, 1), 1);
 
     // when
-    final var future = requestHandler.takeBackup(1);
+    final var future = requestHandler.takeBackup(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -145,7 +146,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -165,7 +166,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -185,7 +186,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -206,7 +207,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -226,7 +227,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -246,7 +247,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -266,7 +267,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -286,7 +287,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
     stub.registerWith(brokerClient);
 
     // when
-    final var future = requestHandler.getStatus(1);
+    final var future = requestHandler.getStatus(DEFAULT_PHYSICAL_TENANT_ID, 1);
 
     // then
     assertThat(future)
@@ -308,7 +309,8 @@ public class BackupRequestHandlerTest extends GatewayTest {
                         getCompletedBackup(2, request.getPartitionId())))));
 
     // when
-    final var future = requestHandler.listBackups();
+    final var future =
+        requestHandler.listBackups(DEFAULT_PHYSICAL_TENANT_ID, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -336,7 +338,8 @@ public class BackupRequestHandlerTest extends GatewayTest {
                         getInProgressBackup(1, request.getPartitionId())))));
 
     // when
-    final var future = requestHandler.listBackups();
+    final var future =
+        requestHandler.listBackups(DEFAULT_PHYSICAL_TENANT_ID, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -365,7 +368,8 @@ public class BackupRequestHandlerTest extends GatewayTest {
         });
 
     // when
-    final var future = requestHandler.listBackups();
+    final var future =
+        requestHandler.listBackups(DEFAULT_PHYSICAL_TENANT_ID, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -396,7 +400,8 @@ public class BackupRequestHandlerTest extends GatewayTest {
         });
 
     // when
-    final var future = requestHandler.listBackups();
+    final var future =
+        requestHandler.listBackups(DEFAULT_PHYSICAL_TENANT_ID, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -428,7 +433,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         });
 
     // when
-    final var future = requestHandler.getCheckpointState();
+    final var future = requestHandler.getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -462,7 +467,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         });
 
     // when
-    final var future = requestHandler.getBackupRanges();
+    final var future = requestHandler.getBackupRanges(DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -487,7 +492,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
                     .setPartitionId(request.getPartitionId())));
 
     // when
-    final var future = requestHandler.deleteBackup(backupId);
+    final var future = requestHandler.deleteBackup(DEFAULT_PHYSICAL_TENANT_ID, backupId);
 
     // then
     assertThat(future).succeedsWithin(Duration.ofMillis(500));
@@ -510,7 +515,7 @@ public class BackupRequestHandlerTest extends GatewayTest {
         });
 
     // when
-    final var future = requestHandler.deleteBackup(backupId);
+    final var future = requestHandler.deleteBackup(DEFAULT_PHYSICAL_TENANT_ID, backupId);
 
     // then
     assertThat(future)

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.admin.exporting;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.gateway.admin.exporting.ExportingControlServiceTest.RequestMatcher.requestTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -55,7 +56,7 @@ public class ExportingControlServiceTest {
     final var service = new ExportingControlService(client);
 
     // when
-    service.pauseExporting().join();
+    service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID).join();
 
     // then
     for (final var partition : topology.getPartitions()) {
@@ -81,7 +82,7 @@ public class ExportingControlServiceTest {
 
     // then
     assertThatExceptionOfType(IncompleteTopologyException.class)
-        .isThrownBy(service::pauseExporting);
+        .isThrownBy(() -> service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID));
   }
 
   @ParameterizedTest
@@ -92,7 +93,8 @@ public class ExportingControlServiceTest {
     final var service = new ExportingControlService(client);
 
     // then
-    assertThat(service.pauseExporting()).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
+        .succeedsWithin(Duration.ofSeconds(10));
   }
 
   @ParameterizedTest
@@ -107,14 +109,15 @@ public class ExportingControlServiceTest {
         .thenThrow(new RuntimeException("request failed"));
 
     // then
-    assertThatExceptionOfType(Throwable.class).isThrownBy(service::pauseExporting);
+    assertThatExceptionOfType(Throwable.class)
+        .isThrownBy(() -> service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID));
   }
 
   private BrokerClient setupBrokerClient(final BrokerClusterState topology) {
     final var client = mock(BrokerClient.class);
     final var topologyManager = mock(BrokerTopologyManager.class);
 
-    when(topologyManager.getTopology()).thenReturn(topology);
+    when(topologyManager.getTopology(DEFAULT_PHYSICAL_TENANT_ID)).thenReturn(topology);
     when(client.getTopologyManager()).thenReturn(topologyManager);
     when(client.sendRequest(any()))
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(new AdminResponse())));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static java.util.function.Predicate.isEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -421,13 +422,16 @@ class BackupMultiPartitionTest {
 
   private BackupStatus getBackupStatus(final long backupId)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return backupRequestHandler.getStatus(backupId).toCompletableFuture().get(30, TimeUnit.SECONDS);
+    return backupRequestHandler
+        .getStatus(DEFAULT_PHYSICAL_TENANT_ID, backupId)
+        .toCompletableFuture()
+        .get(30, TimeUnit.SECONDS);
   }
 
   private CheckpointStateResponse getCheckpointState()
       throws InterruptedException, ExecutionException, TimeoutException {
     return backupRequestHandler
-        .getCheckpointState()
+        .getCheckpointState(DEFAULT_PHYSICAL_TENANT_ID)
         .toCompletableFuture()
         .get(30, TimeUnit.SECONDS);
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupReplicatedPartitionTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.backup;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.backup.client.api.BackupRequestHandler;
@@ -146,7 +147,10 @@ class BackupReplicatedPartitionTest {
   }
 
   private void backup(final long backupId) {
-    assertThat(backupRequestHandler.takeBackup(backupId).toCompletableFuture())
+    assertThat(
+            backupRequestHandler
+                .takeBackup(DEFAULT_PHYSICAL_TENANT_ID, backupId)
+                .toCompletableFuture())
         .succeedsWithin(Duration.ofSeconds(30));
   }
 
@@ -165,6 +169,9 @@ class BackupReplicatedPartitionTest {
 
   private BackupStatus getBackupStatus(final long backupId)
       throws InterruptedException, ExecutionException, TimeoutException {
-    return backupRequestHandler.getStatus(backupId).toCompletableFuture().get(30, TimeUnit.SECONDS);
+    return backupRequestHandler
+        .getStatus(DEFAULT_PHYSICAL_TENANT_ID, backupId)
+        .toCompletableFuture()
+        .get(30, TimeUnit.SECONDS);
   }
 }


### PR DESCRIPTION
Changes `BackupRequestHandler` and `ExportingControlService` to require a `physicalTenantId` to be passed in.
For now, all callers just provide the default id.

Closes #57008