### PR TITLE
Fix scoped OIDC resource propagation to token requests

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -279,11 +279,9 @@ public class OidcOverrideBeansConfiguration {
 
   @Bean
   public OidcTokenEndpointCustomizer oidcTokenEndpointCustomizer(
-      final OidcProviderConfigurationPort oidcAuthenticationConfigurationRepository,
       final AssertionJwkProvider assertionJwkProvider,
       final ObjectProvider<ObservationRegistry> observationRegistry) {
     return new OidcTokenEndpointCustomizer(
-        oidcAuthenticationConfigurationRepository,
         assertionJwkProvider,
         restClient(observationRegistry.getIfAvailable(() -> ObservationRegistry.NOOP)));
   }

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
@@ -12,6 +12,8 @@ import io.camunda.security.spring.oidc.AssertionJwkProvider;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
@@ -28,6 +30,8 @@ import org.springframework.web.client.RestClient;
 // implements clause stays fully qualified.
 public class OidcTokenEndpointCustomizer
     implements io.camunda.security.spring.oidc.OidcTokenEndpointCustomizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OidcTokenEndpointCustomizer.class);
 
   private final AssertionJwkProvider assertionJwkProvider;
   private final Map<String, JWK> resolvedJwks;
@@ -87,6 +91,14 @@ public class OidcTokenEndpointCustomizer
         final MultiValueMap<String, String> parametersToAdd = new LinkedMultiValueMap<>();
         parametersToAdd.add(OAuth2ParameterNames.RESOURCE, resourceValue);
         return parametersToAdd;
+      }
+      if (resource != null
+          && !(resource instanceof Collection<?>)
+          && !(resource instanceof String)) {
+        LOG.warn(
+            "Ignoring OIDC resource parameter with unsupported type {} for client registration {}",
+            resource.getClass().getName(),
+            request.getClientRegistration().getRegistrationId());
       }
       return null;
     };

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
@@ -83,6 +83,11 @@ public class OidcTokenEndpointCustomizer
             value -> parametersToAdd.add(OAuth2ParameterNames.RESOURCE, value.toString()));
         return parametersToAdd;
       }
+      if (resource instanceof final String resourceValue && !resourceValue.isBlank()) {
+        final MultiValueMap<String, String> parametersToAdd = new LinkedMultiValueMap<>();
+        parametersToAdd.add(OAuth2ParameterNames.RESOURCE, resourceValue);
+        return parametersToAdd;
+      }
       return null;
     };
   }

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcTokenEndpointCustomizer.java
@@ -8,12 +8,10 @@
 package io.camunda.authentication.config;
 
 import com.nimbusds.jose.jwk.JWK;
-import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
 import io.camunda.security.spring.oidc.AssertionJwkProvider;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
@@ -31,17 +29,12 @@ import org.springframework.web.client.RestClient;
 public class OidcTokenEndpointCustomizer
     implements io.camunda.security.spring.oidc.OidcTokenEndpointCustomizer {
 
-  private static final Logger LOG = LoggerFactory.getLogger(OidcTokenEndpointCustomizer.class);
-  private final OidcProviderConfigurationPort oidcAuthenticationConfigurationRepository;
   private final AssertionJwkProvider assertionJwkProvider;
   private final Map<String, JWK> resolvedJwks;
   private final RestClient restClient;
 
   public OidcTokenEndpointCustomizer(
-      final OidcProviderConfigurationPort oidcAuthenticationConfigurationRepository,
-      final AssertionJwkProvider assertionJwkProvider,
-      final RestClient restClient) {
-    this.oidcAuthenticationConfigurationRepository = oidcAuthenticationConfigurationRepository;
+      final AssertionJwkProvider assertionJwkProvider, final RestClient restClient) {
     this.assertionJwkProvider = assertionJwkProvider;
     resolvedJwks = new ConcurrentHashMap<>();
     this.restClient = restClient;
@@ -75,18 +68,19 @@ public class OidcTokenEndpointCustomizer
     return converter;
   }
 
-  private Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>>
+  Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>>
       createResourceParameterConverter() {
     return request -> {
-      final var clientRegistration = request.getClientRegistration();
-      final var clientRegistrationId = clientRegistration.getRegistrationId();
-      final var oidcConfig =
-          oidcAuthenticationConfigurationRepository.getOidcAuthenticationConfigurationById(
-              clientRegistrationId);
-      final var resource = oidcConfig.getResource();
-      if (resource != null && !resource.isEmpty()) {
+      final var resource =
+          request
+              .getAuthorizationExchange()
+              .getAuthorizationRequest()
+              .getAdditionalParameters()
+              .get(OAuth2ParameterNames.RESOURCE);
+      if (resource instanceof final Collection<?> resources && !resources.isEmpty()) {
         final MultiValueMap<String, String> parametersToAdd = new LinkedMultiValueMap<>();
-        parametersToAdd.addAll(OAuth2ParameterNames.RESOURCE, resource);
+        resources.forEach(
+            value -> parametersToAdd.add(OAuth2ParameterNames.RESOURCE, value.toString()));
         return parametersToAdd;
       }
       return null;

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcTokenEndpointCustomizerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcTokenEndpointCustomizerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.spring.oidc.AssertionJwkProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+class OidcTokenEndpointCustomizerTest {
+
+  @Mock private AssertionJwkProvider assertionJwkProvider;
+
+  @Test
+  void shouldCopyResourceFromAuthorizationRequest() {
+    // given
+    final var customizer =
+        new OidcTokenEndpointCustomizer(assertionJwkProvider, RestClient.create());
+    final var request = grantRequest(List.of("resource-a", "resource-b"));
+
+    // when
+    final var parameters = customizer.createResourceParameterConverter().convert(request);
+
+    // then
+    assertThat(parameters)
+        .isNotNull()
+        .containsEntry(OAuth2ParameterNames.RESOURCE, List.of("resource-a", "resource-b"));
+  }
+
+  @Test
+  void shouldNotAddResourceWhenAuthorizationRequestHasNone() {
+    // given
+    final var customizer =
+        new OidcTokenEndpointCustomizer(assertionJwkProvider, RestClient.create());
+    final var request = grantRequest(null);
+
+    // when
+    final var parameters = customizer.createResourceParameterConverter().convert(request);
+
+    // then
+    assertThat(parameters).isNull();
+  }
+
+  private static OAuth2AuthorizationCodeGrantRequest grantRequest(final List<String> resources) {
+    final var registration =
+        ClientRegistration.withRegistrationId("custom")
+            .clientId("client")
+            .clientSecret("secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("https://example.com/callback")
+            .authorizationUri("https://idp.example.com/authorize")
+            .tokenUri("https://idp.example.com/token")
+            .build();
+    final var requestBuilder =
+        OAuth2AuthorizationRequest.authorizationCode()
+            .authorizationUri("https://idp.example.com/authorize")
+            .clientId("client")
+            .redirectUri("https://example.com/callback")
+            .state("state");
+    if (resources != null) {
+      requestBuilder.additionalParameters(Map.of(OAuth2ParameterNames.RESOURCE, resources));
+    }
+    final var authorizationRequest = requestBuilder.build();
+    final var authorizationResponse =
+        OAuth2AuthorizationResponse.success("code")
+            .redirectUri("https://example.com/callback")
+            .state("state")
+            .build();
+    return new OAuth2AuthorizationCodeGrantRequest(
+        registration, new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcTokenEndpointCustomizerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcTokenEndpointCustomizerTest.java
@@ -51,7 +51,7 @@ class OidcTokenEndpointCustomizerTest {
     // given
     final var customizer =
         new OidcTokenEndpointCustomizer(assertionJwkProvider, RestClient.create());
-    final var request = grantRequest("resource-a");
+    final var request = grantRequest("https://test.com");
 
     // when
     final var parameters = customizer.createResourceParameterConverter().convert(request);
@@ -59,7 +59,7 @@ class OidcTokenEndpointCustomizerTest {
     // then
     assertThat(parameters)
         .isNotNull()
-        .containsEntry(OAuth2ParameterNames.RESOURCE, List.of("resource-a"));
+        .containsEntry(OAuth2ParameterNames.RESOURCE, List.of("https://test.com"));
   }
 
   @Test
@@ -68,6 +68,20 @@ class OidcTokenEndpointCustomizerTest {
     final var customizer =
         new OidcTokenEndpointCustomizer(assertionJwkProvider, RestClient.create());
     final var request = grantRequest(null);
+
+    // when
+    final var parameters = customizer.createResourceParameterConverter().convert(request);
+
+    // then
+    assertThat(parameters).isNull();
+  }
+
+  @Test
+  void shouldNotAddResourceWhenItHasUnsupportedType() {
+    // given
+    final var customizer =
+        new OidcTokenEndpointCustomizer(assertionJwkProvider, RestClient.create());
+    final var request = grantRequest(42);
 
     // when
     final var parameters = customizer.createResourceParameterConverter().convert(request);

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcTokenEndpointCustomizerTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcTokenEndpointCustomizerTest.java
@@ -47,6 +47,22 @@ class OidcTokenEndpointCustomizerTest {
   }
 
   @Test
+  void shouldCopySingleResourceFromAuthorizationRequest() {
+    // given
+    final var customizer =
+        new OidcTokenEndpointCustomizer(assertionJwkProvider, RestClient.create());
+    final var request = grantRequest("resource-a");
+
+    // when
+    final var parameters = customizer.createResourceParameterConverter().convert(request);
+
+    // then
+    assertThat(parameters)
+        .isNotNull()
+        .containsEntry(OAuth2ParameterNames.RESOURCE, List.of("resource-a"));
+  }
+
+  @Test
   void shouldNotAddResourceWhenAuthorizationRequestHasNone() {
     // given
     final var customizer =
@@ -60,7 +76,7 @@ class OidcTokenEndpointCustomizerTest {
     assertThat(parameters).isNull();
   }
 
-  private static OAuth2AuthorizationCodeGrantRequest grantRequest(final List<String> resources) {
+  private static OAuth2AuthorizationCodeGrantRequest grantRequest(final Object resources) {
     final var registration =
         ClientRegistration.withRegistrationId("custom")
             .clientId("client")


### PR DESCRIPTION
## Summary

- propagate OAuth 2.0 `resource` from the scoped authorization request to the token request
- remove the incorrect global provider-repository lookup for scoped registrations
- cover token requests with and without `resource`

## Verification

- `./mvnw clean verify -pl authentication -DskipTests=false -Dquickly -T1C` (300 unit tests and 14 integration tests passed)
- live SM physical-tenant login verified with a patched authentication JAR: the token endpoint received `resource` and returned HTTP 200
- `./mvnw install -Dquickly -T1C` is currently blocked in `camunda-gateway-mapping-http` by unrelated `EntityType` compilation mismatches on the base revision

Closes #57763