### PR TITLE
fix: correct ES/OS exporter misconfiguration for Optimize in load tests

### DIFF
--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -76,6 +76,11 @@ else ifeq ($(secondary_storage), opensearch)
 	#
 	# We need to apply specific Optimize related opensearch configs
 	platform_values += -f camunda-platform-values-optimize-opensearch.yaml
+else ifeq ($(secondary_storage), none)
+	# Optimize requires a secondary storage backend (Elasticsearch, OpenSearch,
+	# or a dedicated Elasticsearch cluster); it cannot run at all when secondary
+	# storage is disabled entirely.
+	platform_values += --set optimize.enabled=false
 else
 	# If we are not using OpenSearch as a secondary storage, Optimize will
 	# be configured with the Elasticsearch backend, either:

--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -70,19 +70,20 @@ platform_values += -f camunda-platform-values-$(secondary_storage).yaml
 # Disable Optimize if not enabled
 ifneq ($(enable_optimize),true)
 	platform_values += --set optimize.enabled=false
+else ifeq ($(secondary_storage), opensearch)
+	# When deploying the OpenSearch secondary storage, Optimize is
+	# configured via the camunda-platform-values-opensearch.yaml file.
+	#
+	# We need to apply specific Optimize related opensearch configs
+	platform_values += -f camunda-platform-values-optimize-opensearch.yaml
 else
-	ifeq ($(filter $(secondary_storage),elasticsearch opensearch),)
-		# When deploying the OpenSearch secondary storage, Optimize is
-		# configured via the camunda-platform-values-opensearch.yaml file.
-		#
-		# If we are not using OpenSearch as a secondary storage, Optimize will
-		# be configured with the Elasticsearch backend, either:
-		# * Using the same Elasticsearch cluster as the secondary storage, if
-		#   the secondary storage is also Elasticsearch.
-		# * Or using its dedicated Elasticsearch cluster, different from the
-		#   configured secondary storage.
-		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
-	endif
+	# If we are not using OpenSearch as a secondary storage, Optimize will
+	# be configured with the Elasticsearch backend, either:
+	# * Using the same Elasticsearch cluster as the secondary storage, if
+	#   the secondary storage is also Elasticsearch.
+	# * Or using its dedicated Elasticsearch cluster, different from the
+	#   configured secondary storage.
+	platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
 endif
 
 # Platform values with stable configuration

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -174,6 +174,10 @@ if [[ "$enable_optimize" == "true" ]]; then
   elif [[ "$secondaryStorage" =~ ^(elasticsearch)$ ]]; then
     # Secondary storage is ES: configures Optimize to use Elasticsearch properly.
     cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
+  elif [[ "$secondaryStorage" =~ ^(none)$ ]]; then
+    # Optimize requires a secondary storage backend; it cannot run at all
+    # when secondary storage is disabled entirely.
+    echo "Optimize requires a secondary storage backend; ignoring enable_optimize=true because secondaryStorage=none"
   else
     # Secondary storage is not ES nor OS: Forcefully configures Optimize to
     # use Elasticsearch.

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -168,7 +168,13 @@ if [[ "$enable_optimize" == "true" ]]; then
   # We only request and configure Elasticsearch in this fallback case ; ES or
   # OS should have been configured as part of the secondary storage
   # configuration before, otherwise.
-  if [[ ! "$secondaryStorage" =~ ^(elasticsearch|opensearch)$ ]]; then
+  if [[ "$secondaryStorage" =~ ^(opensearch)$ ]]; then
+    # Secondary storage is OS: configures Optimize to use OpenSearch properly.
+    cp -v "values/camunda-platform-values-optimize-opensearch.yaml" "$TARGET_DIRECTORY/"
+  elif [[ "$secondaryStorage" =~ ^(elasticsearch)$ ]]; then
+    # Secondary storage is ES: configures Optimize to use Elasticsearch properly.
+    cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
+  else
     # Secondary storage is not ES nor OS: Forcefully configures Optimize to
     # use Elasticsearch.
     elasticsearchEnabled=true

--- a/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
@@ -31,29 +31,3 @@ orchestration:
   data:
     secondaryStorage:
       type: elasticsearch
-
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"

--- a/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
@@ -19,32 +19,6 @@ orchestration:
     secondaryStorage:
       type: opensearch
 
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
-
 ###########################################################################
 #######
 #     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #

--- a/load-tests/setup/main/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,7 +1,7 @@
 # Elasticsearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used fr Optimize, but NOT as the Camunda secondary storage.
+# This configures Elasticsearch when it's used for Optimize, but NOT as the Camunda secondary storage.
 # storage.
 #
 # For the Elasticsearch as secondary storage configuration, see the

--- a/load-tests/setup/main/values/camunda-platform-values-optimize-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize-opensearch.yaml
@@ -1,18 +1,18 @@
-# Optimize Elasticsearch values for Camunda Platform Chart.
+# Optimize OpenSearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used for Optimize.
+# This configures OpenSearch when it's used for Optimize.
 #
-# For the Elasticsearch as secondary storage configuration, see the
-# "camunda-platform-values-elasticsearch.yaml" file.
-# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# For the OpenSearch as secondary storage configuration, see the
+# "camunda-platform-values-opensearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-opensearch.yaml" file, make
 # sure to keep the other file in sync (minus the secondary storage-only options).
 
 orchestration:
   data:
     secondary-storage:
-      elasticsearch:
-        url: http://elasticsearch-es-http:9200
+      opensearch:
+        url: http://opensearch:9200
 
   # Secondary storage configuration is not configured here, but in the
   # Elasticsearch/OpenSearch/RDBMS-specific values file.
@@ -20,7 +20,7 @@ orchestration:
     # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
     # otherwise it is vulnerable to node restarts
     # ES/OS exporter configuration is bound to the Optimize usage
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
       value: "1"
 
     ## The values below are duplicated from
@@ -50,10 +50,7 @@ orchestration:
 ##########################################################################
 optimize:
   database:
-    elasticsearch:
+    opensearch:
       enabled: true
       url:
-        # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
-        # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
-        # See load-tests/setup/default/resources/elasticsearch.yaml for the resource definition.
-        host: elasticsearch-es-http
+        host: opensearch

--- a/load-tests/setup/stable-88/Makefile
+++ b/load-tests/setup/stable-88/Makefile
@@ -68,6 +68,11 @@ platform_values += -f camunda-platform-values-$(secondary_storage).yaml
 # Disable Optimize if not enabled
 ifneq ($(enable_optimize),true)
 	platform_values += --set optimize.enabled=false
+else ifeq ($(secondary_storage), none)
+	# Optimize requires a secondary storage backend (Elasticsearch, OpenSearch,
+	# or a dedicated Elasticsearch cluster); it cannot run at all when secondary
+	# storage is disabled entirely.
+	platform_values += --set optimize.enabled=false
 else
 	# Optimize needs Elasticsearch or OpenSearch, so enable Elasticsearch if
 	# we are not already creating a cluster for secondary storage.

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -160,7 +160,11 @@ if [[ "$enable_optimize" == "true" ]]; then
   # We only request and configure Elasticsearch in this fallback case ; ES or
   # OS should have been configured as part of the secondary storage
   # configuration before, otherwise.
-  if [[ ! "$secondaryStorage" =~ ^(elasticsearch|opensearch)$ ]]; then
+  if [[ "$secondaryStorage" =~ ^(none)$ ]]; then
+    # Optimize requires a secondary storage backend; it cannot run at all
+    # when secondary storage is disabled entirely.
+    echo "Optimize requires a secondary storage backend; ignoring enable_optimize=true because secondaryStorage=none"
+  elif [[ ! "$secondaryStorage" =~ ^(elasticsearch|opensearch)$ ]]; then
     # Secondary storage is not ES nor OS: forcefully configures Optimize to
     # use Elasticsearch.
     elasticsearchEnabled=true

--- a/load-tests/setup/stable-89/Makefile
+++ b/load-tests/setup/stable-89/Makefile
@@ -74,12 +74,20 @@ ifneq ($(enable_optimize),true)
 	ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
 		platform_values += --set elasticsearch.enabled=false
 	endif
+else ifeq ($(secondary_storage), opensearch)
+	# When deploying the OpenSearch secondary storage, Optimize is
+	# configured via the camunda-platform-values-opensearch.yaml file.
+	#
+	# We need to apply specific Optimize related opensearch configs
+	platform_values += -f camunda-platform-values-optimize-opensearch.yaml
 else
-	# Optimize needs Elasticsearch or OpenSearch, so enable Elasticsearch if
-	# we are not already creating a cluster for secondary storage.
-	ifeq ($(filter $(secondary_storage),elasticsearch opensearch),)
-		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
-	endif
+	# If we are not using OpenSearch as a secondary storage, Optimize will
+	# be configured with the Elasticsearch backend, either:
+	# * Using the same Elasticsearch cluster as the secondary storage, if
+	#   the secondary storage is also Elasticsearch.
+	# * Or using its dedicated Elasticsearch cluster, different from the
+	#   configured secondary storage.
+	platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
 endif
 
 # Platform values with stable configuration

--- a/load-tests/setup/stable-89/Makefile
+++ b/load-tests/setup/stable-89/Makefile
@@ -80,6 +80,11 @@ else ifeq ($(secondary_storage), opensearch)
 	#
 	# We need to apply specific Optimize related opensearch configs
 	platform_values += -f camunda-platform-values-optimize-opensearch.yaml
+else ifeq ($(secondary_storage), none)
+	# Optimize requires a secondary storage backend (Elasticsearch, OpenSearch,
+	# or a dedicated Elasticsearch cluster); it cannot run at all when secondary
+	# storage is disabled entirely.
+	platform_values += --set optimize.enabled=false
 else
 	# If we are not using OpenSearch as a secondary storage, Optimize will
 	# be configured with the Elasticsearch backend, either:

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -169,12 +169,18 @@ if [[ "$enable_optimize" == "true" ]]; then
   # OS should have been configured as part of the secondary storage
   # configuration before, otherwise.
   case "$secondaryStorage" in
-    elasticsearch|opensearch)
-      # Nothing to do here: Optimize will use the configured OpenSearch/Elasticsearch for secondary storage.
+    opensearch)
+      # Secondary storage is OS: configures Optimize to use OpenSearch properly.
+      cp -v "values/camunda-platform-values-optimize-opensearch.yaml" "$TARGET_DIRECTORY/"
+      ;;
+
+    elasticsearch)
+      # Secondary storage is ES: configures Optimize to use Elasticsearch properly.
+      cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
       ;;
 
     *)
-      # For the other secondary storage (not OpenSearch): this forcefully
+      # For the other secondary storage (not ES nor OS): this forcefully
       # configures Optimize to use Elasticsearch.
       elasticsearchEnabled=true
       echo "Forcefully enabling Elasticsearch for Optimize"

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -179,6 +179,12 @@ if [[ "$enable_optimize" == "true" ]]; then
       cp -v "values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
       ;;
 
+    none)
+      # Optimize requires a secondary storage backend; it cannot run at all
+      # when secondary storage is disabled entirely.
+      echo "Optimize requires a secondary storage backend; ignoring enable_optimize=true because secondaryStorage=none"
+      ;;
+
     *)
       # For the other secondary storage (not ES nor OS): this forcefully
       # configures Optimize to use Elasticsearch.

--- a/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
@@ -31,29 +31,3 @@ orchestration:
   data:
     secondaryStorage:
       type: elasticsearch
-
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
@@ -19,32 +19,6 @@ orchestration:
     secondaryStorage:
       type: opensearch
 
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
-
 ###########################################################################
 #######
 #     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #

--- a/load-tests/setup/stable-89/values/camunda-platform-values-optimize-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-optimize-opensearch.yaml
@@ -1,33 +1,21 @@
-# Elasticsearch values for Camunda Platform Chart.
+# Optimize OpenSearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used for Optimize.
+# This configures OpenSearch when it's used for Optimize.
 #
-# For the Elasticsearch as secondary storage configuration, see the
-# "camunda-platform-values-elasticsearch.yaml" file.
-# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# For the OpenSearch as secondary storage configuration, see the
+# "camunda-platform-values-opensearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-opensearch.yaml" file, make
 # sure to keep the other file in sync (minus the secondary storage-only options).
-
-########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  elasticsearch:
-    enabled: true
-    url:
-      # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
-      # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
-      # See load-tests/setup/charts/load-test-setup/templates/elasticsearch.yaml for the resource definition.
-      host: elasticsearch-es-http
 
 orchestration:
   # Secondary storage configuration is not configured here, but in the
-  # Elasticsearch/OpenSearch/RDBMS-specific values file.
+  # Elasticsearch/OpenSearch-specific values file.
   env:
     # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
     # otherwise it is vulnerable to node restarts
     # ES/OS exporter configuration is bound to the Optimize usage
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
       value: "1"
 
     ## The values below are duplicated from

--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -17,12 +17,22 @@ help:
 	@echo "  update-golden  Regenerate golden files after an intentional change,"
 	@echo "                 then review 'git diff golden/' before committing"
 	@echo "  clean          Remove leftover scaffolded namespace directories"
+	@echo ""
+	@echo "Scope test/update-golden to one setup version with VERSION=, e.g.:"
+	@echo "  make update-golden VERSION=stable-89"
 
 # Each scenario scaffolds a namespace, which clones camunda-platform-helm and
 # runs `helm dependency build`. Cap parallelism so many simultaneous clones / OCI
 # pulls don't exhaust helm's timeouts on high-core machines (the default is
 # GOMAXPROCS). Override with `make test PARALLEL=N`.
 PARALLEL ?= 4
+
+# Optional: scope test/update-golden to one setup version (e.g. VERSION=stable-89).
+# Leave unset to run/update every version listed in golden_test.go.
+VERSION ?=
+ifneq ($(VERSION),)
+run_filter := -run 'TestGoldenFiles/.*$(VERSION).*'
+endif
 
 build:
 	go build ./...
@@ -34,10 +44,10 @@ helm-repos:
 	helm repo update
 
 test: helm-repos
-	go test -v -timeout 50m -parallel $(PARALLEL) ./...
+	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...
 
 update-golden: helm-repos
-	go test -v -timeout 50m -parallel $(PARALLEL) -update-golden ./...
+	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...
 
 clean:
 	rm -rf ../c8-golden-*

--- a/load-tests/setup/test/README.md
+++ b/load-tests/setup/test/README.md
@@ -60,6 +60,13 @@ make update-golden   # regenerate golden files after an intentional change
 make clean           # remove leftover scaffolded namespace directories
 ```
 
+Scope either target to one setup version with `VERSION=`, e.g. when porting a fix to a
+single stable branch's golden files:
+
+```bash
+make update-golden VERSION=stable-89
+```
+
 After `make update-golden`, always review `git diff golden/` before committing.
 Never hand-edit golden `.yaml` files — only `make update-golden` applies the
 correct normalization.
@@ -70,7 +77,7 @@ Versions under test are listed explicitly in `golden_test.go`. Only `main` is
 active; the stable entries are commented out. To enable one:
 
 1. Uncomment its line in the `versions` slice.
-2. `make update-golden` (or scope it: `go test -update-golden -run 'TestGoldenFiles/stable-89' ./...`).
+2. `make update-golden VERSION=stable-89`.
 3. Commit the generated golden files. No other code change is needed.
 
 ## If golden diffs become noisy in PRs

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Xaci6)SevoTalk"
+  identity-admin-client-token: "Gasm6/DeboXiqi"
+  identity-firstuser-password: "PapeBiyfNemm3@"
+  identity-keycloak-admin-password: "YanoPusi0-Kuve"
+  identity-keycloak-postgresql-admin-password: "BaroVabvJogh5]"
+  identity-keycloak-postgresql-user-password: "Kuqo5(KegzGesi"
+  identity-optimize-client-token: "VoliDormKucu9$"
+  identity-optimize-loadtest-client-secret: "Xuzz5_JurmVuyi"
+  identity-postgresql-admin-password: "Kupf6~MejuCand"
+  identity-postgresql-user-password: "MindFoqo8?Tuhq"
+  orchestration-security-authentication-oidc-secret: "XuquBugk7@Xuko"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-b"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 512Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "XuquBugk7@Xuko"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-b"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-main-elasticsearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: 60427a143342fcb35f3979429cfa1a6920eeb0f3a0274a4f40539c0f292f2a17
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-main-elasticsearch-no-optimize
+      namespace: c8-golden-main-elasticsearch-no-optimize
+      version: 15.0.0-alpha1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha1
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-main-elasticsearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-main-elasticsearch-no-optimize:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha1
+        url: http://connectors.c8-golden-main-elasticsearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-main-elasticsearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-main-elasticsearch-no-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: orchestrationIdentity
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-elasticsearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,128 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,216 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,148 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,281 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-main-elasticsearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,211 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -88,8 +88,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    load-tester:
+      monitor-data-availability: false

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,149 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,148 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Gami7~VokeDegc"
+  identity-admin-client-token: "Juht1+VipaZopz"
+  identity-firstuser-password: "FunjGekoTovt6/"
+  identity-keycloak-admin-password: "RotaXabu7^Ruho"
+  identity-keycloak-postgresql-admin-password: "BoreButq3&Feyn"
+  identity-keycloak-postgresql-user-password: "GiveNufoZesv4="
+  identity-optimize-client-token: "VujaBosePumw5("
+  identity-optimize-loadtest-client-secret: "TetdMuheJorp1_"
+  identity-postgresql-admin-password: "BucqJoba4]Jevu"
+  identity-postgresql-user-password: "QekuXeyp7(Tobu"
+  orchestration-security-authentication-oidc-secret: "Seke9'WaxeBesv"

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Seke9'WaxeBesv"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-main-none-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-none-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-main-none-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: 559fe2ccdc9d3ff79b940d7d5d1a6a5db478b5722db4177a7730e01772d9dec4
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-none-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-none-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-none-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,63 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-none-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-main-none-optimize
+      namespace: c8-golden-main-none-optimize
+      version: 15.0.0-alpha1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha1
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-main-none-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-main-none-optimize:82/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-main-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-none-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-main-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-none-optimize:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: orchestrationIdentity
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-main-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-none-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-main-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-none-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,205 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,143 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-none-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,244 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "none"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: false
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-main-none-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters: {}
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,209 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-none-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-none-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "QujuCisx0^Mate"
+  identity-admin-client-token: "MapiHele1,Xalu"
+  identity-firstuser-password: "QonlLeso6(Bibo"
+  identity-keycloak-admin-password: "DigiVuyk9%Ceye"
+  identity-keycloak-postgresql-admin-password: "SewoXimi4%Yesc"
+  identity-keycloak-postgresql-user-password: "Dork5,BoluQefe"
+  identity-optimize-client-token: "MicaXaboFige3="
+  identity-optimize-loadtest-client-secret: "Tode6]TeqgSeco"
+  identity-postgresql-admin-password: "NigeMipb8[Xaso"
+  identity-postgresql-user-password: "Qinp7-MojoXufe"
+  orchestration-security-authentication-oidc-secret: "Sild6/HajhMeqe"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Sild6/HajhMeqe"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://opensearch:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-main-opensearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: 5639c14d338dcfded28cd1b87a9b9e873408ca870b5ca605c57cd5cd63038c16
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-opensearch-no-optimize-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-opensearch-no-optimize-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-opensearch-no-optimize-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-main-opensearch-no-optimize
+      namespace: c8-golden-main-opensearch-no-optimize
+      version: 15.0.0-alpha1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha1
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-main-opensearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-main-opensearch-no-optimize:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha1
+        url: http://connectors.c8-golden-main-opensearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-main-opensearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-main-opensearch-no-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: orchestrationIdentity
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-opensearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,128 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-opensearch-no-optimize-identity-env-vars
+            - configMapRef:
+                name: c8-golden-main-opensearch-no-optimize-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,216 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,148 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-opensearch-no-optimize-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+        awsEnabled: false
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-main-opensearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,211 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-opensearch-no-optimize-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -88,8 +88,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-opensearch-no-optimize-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-opensearch-no-optimize-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Bocz8'BehkTunu"
+  identity-admin-client-token: "Fedl6[KuzoCico"
+  identity-firstuser-password: "LaqhRisaCazk3-"
+  identity-keycloak-admin-password: "Juhf9?MiluZagf"
+  identity-keycloak-postgresql-admin-password: "GadmHajoQakq0?"
+  identity-keycloak-postgresql-user-password: "HuxuXijv2.Wune"
+  identity-optimize-client-token: "HusyMufuZike8-"
+  identity-optimize-loadtest-client-secret: "Zeff8-PelbMala"
+  identity-postgresql-admin-password: "FelaPoho6%Ximo"
+  identity-postgresql-user-password: "XiqfRoza3(Kafi"
+  identity-zeebe-client-token: "CagaQapwFana1?"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://zeebe-gateway:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.17.4
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-b"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 512Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "zeebe"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "identity-zeebe-client-token"
+  clientSecret: "CagaQapwFana1?"
+  zeebeRestAddress: "http://zeebe-gateway:8080"
+  authServer: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://zeebe-gateway:26500"
+  authorizationAudience: "zeebe-api"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-b"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-87-elasticsearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-87-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: 043b8fc77ca2d16a8cd0d45fa3038fdcbc91eaf6b204285f2a46a7338ec97490
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/camunda/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/camunda/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak:80/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/configmap-release.yaml
@@ -1,0 +1,64 @@
+---
+# Source: camunda-platform/templates/camunda/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-87-elasticsearch-no-optimize
+      namespace: c8-golden-stable-87-elasticsearch-no-optimize
+      version: 12.10.0
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.7.19
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-87-elasticsearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-87-elasticsearch-no-optimize:82/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.7.29
+        url: http://localhost:8081
+        readiness: http://operate.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://operate.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.7.20
+        url: http://connectors.c8-golden-stable-87-elasticsearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-stable-87-elasticsearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-87-elasticsearch-no-optimize:8080/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.7.29
+        url: http://localhost:8082
+        readiness: http://tasklist.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://tasklist.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Zeebe Gateway
+        id: zeebeGateway
+        version: 8.7.34
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8088
+        readiness: http://zeebe-gateway.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://zeebe-gateway.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Zeebe
+        id: zeebe
+        version: 8.7.34
+        readiness: http://zeebe.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://zeebe.c8-golden-stable-87-elasticsearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-camunda-license.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-camunda-license.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/camunda/secret-camunda-license.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+type: Opaque
+data:
+  CAMUNDA_LICENSE_KEY: ''

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-connectors.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-connectors.yaml
@@ -1,0 +1,17 @@
+---
+# Source: camunda-platform/templates/camunda/secret-connectors.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-connectors-identity-secret
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+
+    app.kubernetes.io/component: identity
+type: Opaque
+data:
+  identity-connectors-client-token: "Y2FtdW5kYS1jcmVkZW50aWFscw=="

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-operate.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-operate.yaml
@@ -1,0 +1,17 @@
+---
+# Source: camunda-platform/templates/camunda/secret-operate.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-operate-identity-secret
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+
+    app.kubernetes.io/component: identity
+type: Opaque
+data:
+  identity-operate-client-token: "Y2FtdW5kYS1jcmVkZW50aWFscw=="

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-optimize.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-optimize.yaml
@@ -1,0 +1,17 @@
+---
+# Source: camunda-platform/templates/camunda/secret-optimize.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-optimize-identity-secret
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+
+    app.kubernetes.io/component: identity
+type: Opaque
+data:
+  identity-optimize-client-token: "Y2FtdW5kYS1jcmVkZW50aWFscw=="

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-tasklist.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/camunda/secret-tasklist.yaml
@@ -1,0 +1,17 @@
+---
+# Source: camunda-platform/templates/camunda/secret-tasklist.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-tasklist-identity-secret
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+
+    app.kubernetes.io/component: identity
+type: Opaque
+data:
+  identity-tasklist-client-token: "Y2FtdW5kYS1jcmVkZW50aWFscw=="

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yml: |
+    server:
+      port: 8080
+    camunda:
+      client:
+        mode: "selfManaged"
+        zeebe:
+          rest-address: "http://zeebe-gateway:8080"
+          grpc-address: "http://zeebe-gateway:26500"
+      identity:
+        audience: "operate-api"
+        client-id: "connectors"
+    operate:
+      client:
+        base-url: "http://operate:80"
+        auth-url: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
+        profile: "oidc"
+        audience: "operate-api"
+    logging:
+      level:
+        io.camunda.connector: ERROR

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,148 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.7.20
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: OPERATE_CLIENT_CLIENT_ID
+              value: "connectors"
+            - name: OPERATE_CLIENT_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-connectors-identity-secret
+                  key: identity-connectors-client-token
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-connectors-identity-secret
+                  key: identity-connectors-client-token
+            - name: CAMUNDA_CLIENT_AUTH_CLIENT_ID
+              value: "zeebe"
+            - name: CAMUNDA_CLIENT_AUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-zeebe-client-token
+            - name: CAMUNDA_CLIENT_AUTH_TOKENURL
+              value: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
+            - name: CAMUNDA_CLIENT_ZEEBE_AUDIENCE
+              value: "zeebe-api"
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2
+              memory: 2Gi
+            requests:
+              cpu: 1
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yml
+              subPath: application.yml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,291 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    identity:
+      url: "http://localhost:8080"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak:80/auth/realms/camunda-platform"
+
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "operate-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "Identity"
+              description: "Provides full access to Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        operate:
+          applications:
+            - name: Operate
+              id: ${CAMUNDA_OPERATE_CLIENT_ID:${KEYCLOAK_INIT_OPERATE_CLIENT_ID:operate}}
+              type: confidential
+              secret: ${CAMUNDA_OPERATE_SECRET:${KEYCLOAK_INIT_OPERATE_SECRET:}}
+              root-url: "http://localhost:8081"
+              redirect-uris:
+                - "/identity-callback"
+          apis:
+            - name: Operate API
+              audience: "operate-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Operate"
+              description: "Grants full access to Operate"
+              permissions:
+                - audience: "operate-api"
+                  definition: read:*
+                - audience: "operate-api"
+                  definition: write:*
+        optimize:
+          applications:
+            - name: Optimize
+              id: ${CAMUNDA_OPTIMIZE_CLIENT_ID:${KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}}
+              type: confidential
+              secret: ${CAMUNDA_OPTIMIZE_SECRET:${KEYCLOAK_INIT_OPTIMIZE_SECRET:}}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+          apis:
+            - name: Optimize API
+              audience: "optimize-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Optimize"
+              description: "Grants full access to Optimize"
+              permissions:
+                - audience: "optimize-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+        tasklist:
+          applications:
+            - name: Tasklist
+              id: ${CAMUNDA_TASKLIST_CLIENT_ID:${KEYCLOAK_INIT_TASKLIST_CLIENT_ID:tasklist}}
+              type: confidential
+              secret: ${CAMUNDA_TASKLIST_SECRET:${KEYCLOAK_INIT_TASKLIST_SECRET:}}
+              root-url: "http://localhost:8082"
+              redirect-uris:
+                - "/identity-callback"
+          apis:
+            - name: Tasklist API
+              audience: "tasklist-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Tasklist"
+              description: "Grants full access to Tasklist"
+              permissions:
+                - audience: "tasklist-api"
+                  definition: read:*
+                - audience: "tasklist-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8084"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+        zeebe:
+          apis:
+            - name: Zeebe API
+              audience: "zeebe-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Zeebe"
+              description: "Grants full access to the Zeebe API"
+              permissions:
+                - audience: "zeebe-api"
+                  definition: write:*
+    keycloak:
+      clients:
+        - name: Zeebe
+          id: zeebe
+          secret: ${KEYCLOAK_INIT_ZEEBE_SECRET:${ZEEBE_CLIENT_SECRET}}
+          type: M2M
+          permissions:
+            - resource-server-id: "zeebe-api"
+              definition: write:*
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - Identity
+            - Operate
+            - Tasklist
+            - Optimize
+            - Web Modeler
+            - Web Modeler Admin
+            - Console
+            - Zeebe
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8080"
+            redirect-uris:
+              - "/auth/login-callback"
+      # The presets key should be removed when 8.6.0 of the applications are released
+      presets:
+        tasklist:
+          clients:
+            - name: Tasklist
+              id: tasklist
+              type: confidential
+              secret: ${KEYCLOAK_INIT_TASKLIST_SECRET:}
+              root-url: "http://localhost:8082"
+              redirect-uris:
+                - "/identity-callback"
+        operate:
+          clients:
+            - name: Operate
+              id: ${KEYCLOAK_INIT_OPERATE_CLIENT_ID:operate}
+              type: confidential
+              secret: ${KEYCLOAK_INIT_OPERATE_SECRET:}
+              root-url: "http://localhost:8081"
+              redirect-uris:
+                - "/identity-callback"
+        optimize:
+          clients:
+            - name: Optimize
+              id: ${KEYCLOAK_INIT_OPTIMIZE_CLIENT_ID:optimize}
+              type: confidential
+              secret: ${KEYCLOAK_INIT_OPTIMIZE_SECRET:}
+              root-url: "http://localhost:8083"
+              redirect-uris:
+                - "/api/authentication/callback"
+        console:
+          clients:
+            - name: "Console"
+              id: ${KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}
+              type: public
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/"
+    server:
+      port: 8080
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,171 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.7.19
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: KEYCLOAK_INIT_OPERATE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-operate-identity-secret
+                  key: identity-operate-client-token
+            - name: KEYCLOAK_INIT_CONSOLE_ROOT_URL
+              value: "http://localhost:8080"
+            - name: KEYCLOAK_INIT_TASKLIST_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-tasklist-identity-secret
+                  key: identity-tasklist-client-token
+            - name: KEYCLOAK_INIT_OPTIMIZE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-optimize-identity-secret
+                  key: identity-optimize-client-token
+            - name: KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-connectors-identity-secret
+                  key: identity-connectors-client-token
+            - name: KEYCLOAK_INIT_WEBMODELER_ROOT_URL
+              value: "http://localhost:8084"
+            - name: KEYCLOAK_INIT_ZEEBE_NAME
+              value: "Zeebe"
+            - name: KEYCLOAK_INIT_ZEEBE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-zeebe-client-token
+            - name: KEYCLOAK_URL
+              value: "http://keycloak:80/auth"
+            - name: KEYCLOAK_SETUP_USER
+              value: "admin"
+            - name: KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8080
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/configmap.yaml
@@ -1,0 +1,86 @@
+---
+# Source: camunda-platform/templates/operate/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operate-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: operate
+
+data:
+  application.yaml: |
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "identity-auth"
+      security:
+        oauth2:
+          resourceserver:
+            jwt:
+              issuer-uri: "http://keycloak:80/auth/realms/camunda-platform"
+              jwk-set-uri: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
+    camunda:
+      identity:
+        clientId: "operate"
+        audience: "operate-api"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://elasticsearch-es-http:9200"
+
+    # Operate configuration file
+    camunda.operate:
+      identity:
+        redirectRootUrl: "http://localhost:8081"
+
+      # ELS instance to store Operate data
+      elasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-es-http
+        # Transport port
+        port: 9200
+        # Elasticsearch full url
+        url: "http://elasticsearch-es-http:9200"
+      # ELS instance to export Zeebe data to
+      zeebeElasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-es-http
+        # Transport port
+        port: 9200
+        # Index prefix, configured in Zeebe Elasticsearch exporter
+        prefix: zeebe-record
+        # Elasticsearch full url
+        url: "http://elasticsearch-es-http:9200"
+      # Zeebe instance
+      zeebe:
+        # Gateway address
+        gatewayAddress: "zeebe-gateway:26500"
+      archiver:
+        ilmEnabled: true
+        ilmMinAgeForDeleteArchivedIndices: 1d
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.operate: INFO
+    #Spring Boot Actuator endpoints to be exposed
+    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus,loggers,usage-metrics,backups

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/deployment.yaml
@@ -1,0 +1,204 @@
+---
+# Source: camunda-platform/templates/operate/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: operate
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: operate
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: operate
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        - name: migration
+          image: camunda/operate:8.7.29
+          command: ['/bin/sh', '/usr/local/operate/bin/migrate']
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: OPERATE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 1Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/operate/config/application.yaml
+              subPath: application.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: camunda
+              mountPath: /camunda
+      containers:
+        - name: operate
+          image: camunda/operate:8.7.29
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-operate-identity-secret
+                  key: identity-operate-client-token
+            - name: ZEEBE_CLIENT_ID
+              value: "zeebe"
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-zeebe-client-token
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              value: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
+            - name: ZEEBE_TOKEN_AUDIENCE
+              value: "zeebe-api"
+            - name: ZEEBE_CLIENT_CONFIG_PATH
+              value: /tmp/zeebe_auth_cache
+            # the host name of Operate that is used when connecting with the Zeebe cluster
+            # via atomix-cluster (SWIM)
+            - name: ZEEBE_GATEWAY_CLUSTER_HOST
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            # the unique member id (in this case the pod name) that is used as identifier inside the SWIM cluster
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            # the name of the atomix cluster (SWIM) to connect to (must be the same as for the Zeebe cluster)
+            - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
+              value: zeebe
+            # the port the service expects requests/messages from the atomix cluster (must be exposed internally)
+            - name: ZEEBE_GATEWAY_CLUSTER_PORT
+              value: "26502"
+            # the initial contact point to join the SWIM (atomix) cluster
+            - name: ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS
+              value: zeebe:26502
+            - name: OPERATE_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_OPERATE_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 9600
+              name: management
+            - containerPort: 26502
+              name: internal
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: management
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/operate/config/application.yaml
+              subPath: application.yaml
+            - name: tmp
+              mountPath: /tmp
+            - name: camunda
+              mountPath: /camunda
+      volumes:
+        - name: config
+          configMap:
+            name: operate-configuration
+            defaultMode: 484
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+      serviceAccountName: operate
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/operate/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: operate
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8080
+      protocol: TCP
+    - port: 9600
+      name: management
+      targetPort: 9600
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: operate

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/operate/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/operate/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: operate
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/operate-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/operate-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/operate-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: operate
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/tasklist-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/tasklist-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/tasklist-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-tasklist
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: tasklist
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: management
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/zeebe-gateway-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/zeebe-gateway-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/zeebe-gateway-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-zeebe-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/zeebe-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/service-monitor/zeebe-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/zeebe-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-zeebe
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/configmap.yaml
@@ -1,0 +1,92 @@
+---
+# Source: camunda-platform/templates/tasklist/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tasklist-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: tasklist
+
+data:
+  application.yaml: |
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: identity-auth
+      security:
+        oauth2:
+          resourceserver:
+            jwt:
+              issuer-uri: "http://keycloak:80/auth/realms/camunda-platform"
+              jwk-set-uri: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
+    camunda:
+      identity:
+        clientId: "tasklist"
+        audience: "tasklist-api"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://elasticsearch-es-http:9200"
+
+    # Tasklist configuration file
+    camunda.tasklist:
+
+      identity:
+        redirectRootUrl: "http://localhost:8082"
+        userAccessRestrictionsEnabled: true
+
+      # Set Tasklist username and password.
+      # If user with <username> does not exists it will be created.
+      # Default: demo/demo
+      #username:
+      #password:
+      # ELS instance to store Tasklist data
+      elasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-es-http
+        # Transport port
+        port: 9200
+        # Elasticsearch full url
+        url: "http://elasticsearch-es-http:9200"
+      # ELS instance to export Zeebe data to
+      zeebeElasticsearch:
+        # Cluster name
+        clusterName: elasticsearch
+        # Host
+        host: elasticsearch-es-http
+        # Transport port
+        port: 9200
+        # Index prefix, configured in Zeebe Elasticsearch exporter
+        prefix: zeebe-record
+        # Elasticsearch full url
+        url: "http://elasticsearch-es-http:9200"
+      # Zeebe instance
+      zeebe:
+        # Gateway address
+        gatewayAddress: "zeebe-gateway:26500"
+        restAddress: "http://zeebe-gateway:8080"
+      archiver:
+        ilmEnabled: true
+        ilmMinAgeForDeleteArchivedIndices: 30d
+    #Spring Boot Actuator endpoints to be exposed
+    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus,loggers,usage-metrics,backups
+    # Enable or disable metrics
+    #management.metrics.export.prometheus.enabled: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/deployment.yaml
@@ -1,0 +1,176 @@
+---
+# Source: camunda-platform/templates/tasklist/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tasklist
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: tasklist
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: Recreate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: tasklist
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: tasklist
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: tasklist
+          image: camunda/tasklist:8.7.29
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-tasklist-identity-secret
+                  key: identity-tasklist-client-token
+            - name: ZEEBE_CLIENT_ID
+              value: "zeebe"
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-zeebe-client-token
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              value: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
+            - name: ZEEBE_TOKEN_AUDIENCE
+              value: "zeebe-api"
+            - name: HOME
+              value: /parent
+            - name: ZEEBE_CLIENT_CONFIG_PATH
+              value: /tmp/zeebe_auth_cache
+            # the host name of Operate that is used when connecting with the Zeebe cluster
+            # via atomix-cluster (SWIM)
+            - name: ZEEBE_GATEWAY_CLUSTER_HOST
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            # the unique member id (in this case the pod name) that is used as identifier inside the SWIM cluster
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            # the name of the atomix cluster (SWIM) to connect to (must be the same as for the Zeebe cluster)
+            - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
+              value: zeebe
+            # the port the service expects requests/messages from the atomix cluster (must be exposed internally)
+            - name: ZEEBE_GATEWAY_CLUSTER_PORT
+              value: "26502"
+            # the initial contact point to join the SWIM (atomix) cluster
+            - name: ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS
+              value: zeebe:26502
+            - name: TASKLIST_LOG_APPENDER
+              value: Stackdriver
+            - name: CAMUNDA_TASKLIST_ELASTICSEARCH_NUMBER_OF_REPLICAS
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+            requests:
+              cpu: 400m
+              memory: 1Gi
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+            - containerPort: 9600
+              name: management
+            - containerPort: 26502
+              name: internal
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: management
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/tasklist/config/application.yaml
+              subPath: application.yaml
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /camunda
+              name: camunda
+      volumes:
+        - name: config
+          configMap:
+            name: tasklist-configuration
+            defaultMode: 484
+        - name: tmp
+          emptyDir: {}
+        - name: camunda
+          emptyDir: {}
+      serviceAccountName: tasklist
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/tasklist/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: tasklist
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: tasklist
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8080
+      protocol: TCP
+    - port: 9600
+      name: management
+      targetPort: 9600
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: tasklist

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/tasklist/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/tasklist/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tasklist
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: tasklist
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/configmap.yaml
@@ -1,0 +1,63 @@
+---
+# Source: camunda-platform/templates/zeebe-gateway/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-gateway-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+apiVersion: v1
+data:
+  gateway-log4j2.xml: |
+  application.yaml: |
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "identity-auth"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://elasticsearch-es-http:9200"
+
+    server:
+      address: "0.0.0.0"
+      port: "8080"
+    camunda:
+      identity:
+        type: "KEYCLOAK"
+        issuerBackendUrl: "http://keycloak:80/auth/realms/camunda-platform"
+        audience: "zeebe-api"
+        baseUrl: "http://identity:80"
+    zeebe:
+      gateway:
+        enable: true
+        security:
+          authentication:
+            mode: identity
+        monitoring:
+          host: 0.0.0.0
+          port: "9600"
+        cluster:
+          clusterName: zeebe
+          port: "26502"
+        network:
+          host: 0.0.0.0
+          port: "26500"
+  application.yml: |
+    zeebe.gateway.monitoring.enabled: "true"
+    zeebe.gateway.threads.managementThreads: "1"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/deployment.yaml
@@ -1,0 +1,169 @@
+---
+# Source: camunda-platform/templates/zeebe-gateway/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zeebe-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 2
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-gateway
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: zeebe-gateway
+          image: docker.io/camunda/zeebe:8.7.34
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9600
+              name: http
+            - containerPort: 26500
+              name: gateway
+            - containerPort: 26502
+              name: internal
+            - containerPort: 8080
+              name: rest
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: ZEEBE_STANDALONE_GATEWAY
+              value: "true"
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_LEVEL
+              value: "debug"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:+ExitOnOutOfMemoryError"
+            - name: ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS
+              value: zeebe:26502
+            - name: ZEEBE_GATEWAY_CLUSTER_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/zeebe/config/application.yml
+            - name: CAMUNDA_REST_QUERY_ENABLED
+              value: "true"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/zeebe/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/zeebe/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/zeebe/logs
+              name: logs
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 450m
+              memory: 1Gi
+            requests:
+              cpu: 450m
+              memory: 1Gi
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-gateway-configuration
+            defaultMode: 484
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-gateway
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        topology.kubernetes.io/zone: europe-west1-b
+  # yamllint disable
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - zeebe-gateway
+            topologyKey: kubernetes.io/hostname
+  # yamllint enable

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/service.yaml
@@ -1,0 +1,37 @@
+---
+# Source: camunda-platform/templates/zeebe-gateway/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: zeebe-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+spec:
+  type: ClusterIP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-gateway
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: gateway
+    - port: 8080
+      protocol: TCP
+      name: rest

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe-gateway/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/zeebe-gateway/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/configmap.yaml
@@ -1,0 +1,103 @@
+---
+# Source: camunda-platform/templates/zeebe/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  application.yaml: |
+    zeebe:
+      broker:
+        exporters:
+          elasticsearch:
+            className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            args:
+              url: "http://elasticsearch-es-http:9200"
+              index:
+                prefix: "zeebe-record"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+        gateway:
+          enable: true
+          network:
+            port: 26500
+          security:
+            enabled: false
+            authentication:
+              mode: none
+        network:
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+          monitoringApi:
+            port: "9600"
+        cluster:
+          clusterSize: "3"
+          replicationFactor: "3"
+          partitionsCount: "3"
+          clusterName: zeebe
+        threads:
+          cpuThreadCount: "3"
+          ioThreadCount: "3"
+        data:
+          snapshotPeriod: "5m"
+          disk:
+            freeSpace:
+              processing: "2GB"
+              replication: "1GB"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://elasticsearch-es-http:9200"
+
+  startup.sh: |
+    #!/usr/bin/env bash
+    set -eux -o pipefail
+
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 1 + 0]}
+
+    if [ "$(ls -A /exporters/)" ]; then
+      mkdir -p /usr/local/zeebe/exporters/
+      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
+    else
+      echo "No exporters available."
+    fi
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/zeebe/bin/broker
+    fi
+
+  broker-log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    zeebe.broker.data.diskUsageCommandWatermark: "0.8"
+    zeebe.broker.data.diskUsageReplicationWatermark: "0.9"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 4000

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/zeebe/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: "zeebe"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: http
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/zeebe/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/statefulset.yaml
@@ -1,0 +1,219 @@
+---
+# Source: camunda-platform/templates/zeebe/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "zeebe"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "zeebe"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: zeebe
+          image: docker.io/camunda/zeebe:8.7.34
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "zeebe"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
+            - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
+              value:
+                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME):26502,
+            - name: ZEEBE_LOG_LEVEL
+              value: "info"
+            - name: ZEEBE_BROKER_GATEWAY_ENABLE
+              value: "false"
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
+              value: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
+              value: "http://elasticsearch-es-http:9200"
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX
+              value: "zeebe-record"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/zeebe/config/application.yml,optional:/usr/local/zeebe/config/application-override.yml
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 9600
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/zeebe/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/zeebe/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/zeebe/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/zeebe/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/zeebe/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: c8-golden-stable-87-elasticsearch-no-optimize-zeebe
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+# yamllint disable
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - zeebe-broker
+            topologyKey: kubernetes.io/hostname
+# yamllint enable
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Pojl2~TeflDefe"
+  identity-admin-client-token: "Dicw7+HawwDowe"
+  identity-firstuser-password: "KekiRoyuXeyp3-"
+  identity-keycloak-admin-password: "JukeDoye2*Jojc"
+  identity-keycloak-postgresql-admin-password: "PidmLuxo6.Luxa"
+  identity-keycloak-postgresql-user-password: "KuquTotl0(Ciyi"
+  identity-optimize-client-token: "GehqHoqu2=Dupa"
+  identity-optimize-loadtest-client-secret: "Bepo0&DubeTovo"
+  identity-postgresql-admin-password: "PanuZamu4-Benu"
+  identity-postgresql-user-password: "YezpYoleFugq7-"
+  orchestration-security-authentication-oidc-secret: "Naxs3^PaboLonr"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-d"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 512Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Naxs3^PaboLonr"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: c8-golden-stable-88-elasticsearch-no-optimize-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql-hl
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "c8-golden-stable-88-elasticsearch-no-optimize-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-88-elasticsearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: 82b5a7f46713e11b7c37e9bf4b617d779820a23fcdac2c3c5b419b04c4c4304d
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-88-elasticsearch-no-optimize
+      namespace: c8-golden-stable-88-elasticsearch-no-optimize
+      version: 13.12.1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.8.14
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-88-elasticsearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-88-elasticsearch-no-optimize:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.8.15
+        url: http://connectors.c8-golden-stable-88-elasticsearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-stable-88-elasticsearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-88-elasticsearch-no-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.8.29
+        url: http://localhost:8088/operate
+        readiness: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.8.29
+        url: http://localhost:8088/tasklist
+        readiness: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Orchestration Identity
+        id: orchestrationIdentity
+        version: 8.8.29
+        url: http://localhost:8088/identity
+        readiness: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: 8.8.29
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8088
+        readiness: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-elasticsearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,126 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.8.15
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,143 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.8.14
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap-unified.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration-unified
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/camunda/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/camunda/bin/camunda
+    fi
+  application.yaml: |    
+    spring:
+      profiles:
+        active: "broker,identity,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        index:
+          numberOfReplicas: "1"
+        retention:
+          enabled: true
+          minimumAge: "1d"
+          policyName: "camunda-retention-policy"
+          usageMetricsMinimumAge: "730d"
+          usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          elasticsearch:
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              mappingRules: []
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              mappingRules: []
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        persistentSessionsEnabled: true
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          initialContactPoints:
+            - camunda-0.${K8S_SERVICE_NAME}:26502
+            - camunda-1.${K8S_SERVICE_NAME}:26502
+            - camunda-2.${K8S_SERVICE_NAME}:26502
+          clusterName: c8-golden-stable-88-elasticsearch-no-optimize-zeebe
+    
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                url: "http://elasticsearch-es-http:9200"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+                retention:
+                  enabled: true
+                  minimumAge: "1d"
+                  policyName: "camunda-retention-policy"
+                  usageMetricsMinimumAge: "730d"
+                  usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+  log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    zeebe.gateway.monitoring.enabled: "true"
+    zeebe.gateway.threads.managementThreads: "1"
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # We moved the archiver configuration under retention at some point, but still need to support the previous
+    # versions for now, so the configurations for retention are duplicated
+    zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # Disable the importers
+    camunda.tasklist.importerEnabled: "false"
+    camunda.operate.importerEnabled: "false"
+    camunda.operate.elasticsearch.numberOfShards: 3
+    # Schema management has been moved out of exporter - to be bootstrap at start; once
+    camunda.database.retention.enabled: "true"
+    camunda.database.retention.policyName: "camunda-retention-policy"
+    #Metrics:
+    camunda.flags.jfr.metrics: "true"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,40 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.8.29
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration-unified
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    load-tester:
+      monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,149 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,148 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "BameDurg4,Hahu"
+  identity-admin-client-token: "Wuyx4$HedrSika"
+  identity-firstuser-password: "Coww9=ModaTaqz"
+  identity-keycloak-admin-password: "Tiba5=SegrKovo"
+  identity-keycloak-postgresql-admin-password: "HulsVemgGoga0,"
+  identity-keycloak-postgresql-user-password: "LoruDobx2'Jaql"
+  identity-optimize-client-token: "Xexu4%KimaGexe"
+  identity-optimize-loadtest-client-secret: "XaqeQekuWorx5-"
+  identity-postgresql-admin-password: "VolePameKusw5_"
+  identity-postgresql-user-password: "JugeZiviLafi6/"
+  orchestration-security-authentication-oidc-secret: "Jupz3=WokoQizd"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Jupz3=WokoQizd"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-88-none-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: c8-golden-stable-88-none-optimize-postgresql
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: c8-golden-stable-88-none-optimize-postgresql
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: c8-golden-stable-88-none-optimize-postgresql
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: c8-golden-stable-88-none-optimize-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: c8-golden-stable-88-none-optimize-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: c8-golden-stable-88-none-optimize-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: c8-golden-stable-88-none-optimize-postgresql-hl
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: c8-golden-stable-88-none-optimize-postgresql
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: c8-golden-stable-88-none-optimize-postgresql
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "c8-golden-stable-88-none-optimize-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-88-none-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: d4e507cf1cd830548e86cb18184baafc92166be376e9ab5b5703e0c6f62bb23a
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-none-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-none-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,63 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-none-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-88-none-optimize
+      namespace: c8-golden-stable-88-none-optimize
+      version: 13.12.1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.8.14
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-88-none-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-88-none-optimize:82/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.8.29
+        url: http://localhost:8088/operate
+        readiness: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.8.29
+        url: http://localhost:8088/tasklist
+        readiness: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/prometheus
+      - name: Orchestration Identity
+        id: orchestrationIdentity
+        version: 8.8.29
+        url: http://localhost:8088/identity
+        readiness: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: 8.8.29
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8088
+        readiness: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-none-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,197 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+
+      component-presets:
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,138 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.8.14
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-none-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -1,0 +1,241 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap-unified.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration-unified
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/camunda/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/camunda/bin/camunda
+    fi
+  application.yaml: |    
+    spring:
+      profiles:
+        active: "broker,identity,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        index:
+          numberOfReplicas: "1"
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "none"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              mappingRules: []
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              mappingRules: []
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        persistentSessionsEnabled: false
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          initialContactPoints:
+            - camunda-0.${K8S_SERVICE_NAME}:26502
+            - camunda-1.${K8S_SERVICE_NAME}:26502
+            - camunda-2.${K8S_SERVICE_NAME}:26502
+          clusterName: c8-golden-stable-88-none-optimize-zeebe
+    
+        # zeebe.broker.exporters
+        exporters: {}
+    
+  log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,40 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.8.29
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-none-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration-unified
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-88-none-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "QidxKara9_Deso"
+  identity-admin-client-token: "WardCosuCocf6^"
+  identity-firstuser-password: "CaviFajvJopm4@"
+  identity-keycloak-admin-password: "FopzJoya0]Bekp"
+  identity-keycloak-postgresql-admin-password: "TalmQows7*Gawe"
+  identity-keycloak-postgresql-user-password: "LeleXofxWexe7^"
+  identity-optimize-client-token: "SafjFuwaLopu5*"
+  identity-optimize-loadtest-client-secret: "Coye3=KijnSani"
+  identity-postgresql-admin-password: "XobgQivu8-Xozo"
+  identity-postgresql-user-password: "DaxvYihuWipi0'"
+  orchestration-security-authentication-oidc-secret: "Haya7@DusuFitk"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Haya7@DusuFitk"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://opensearch:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: c8-golden-stable-88-opensearch-no-optimize-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: c8-golden-stable-88-opensearch-no-optimize-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: c8-golden-stable-88-opensearch-no-optimize-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-postgresql-hl
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-postgresql
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "c8-golden-stable-88-opensearch-no-optimize-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-88-opensearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-88-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: d3fe871193d0d49271f8378af76ce3dcd15b7088bf9804166b9cdb557a32b072
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-88-opensearch-no-optimize
+      namespace: c8-golden-stable-88-opensearch-no-optimize
+      version: 13.12.1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.8.14
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-88-opensearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-88-opensearch-no-optimize:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.8.15
+        url: http://connectors.c8-golden-stable-88-opensearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-stable-88-opensearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-88-opensearch-no-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.8.29
+        url: http://localhost:8088/operate
+        readiness: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.8.29
+        url: http://localhost:8088/tasklist
+        readiness: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/prometheus
+      - name: Orchestration Identity
+        id: orchestrationIdentity
+        version: 8.8.29
+        url: http://localhost:8088/identity
+        readiness: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: 8.8.29
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8088
+        readiness: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-88-opensearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,126 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.8.15
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-opensearch-no-optimize-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-88-opensearch-no-optimize-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,143 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.8.14
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-opensearch-no-optimize-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -1,0 +1,309 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap-unified.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration-unified
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/camunda/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/camunda/bin/camunda
+    fi
+  application.yaml: |    
+    spring:
+      profiles:
+        active: "broker,identity,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        awsEnabled: false
+        index:
+          numberOfReplicas: "1"
+        retention:
+          enabled: true
+          minimumAge: "1d"
+          policyName: "camunda-retention-policy"
+          usageMetricsMinimumAge: "730d"
+          usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          opensearch:
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              mappingRules: []
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              mappingRules: []
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        persistentSessionsEnabled: true
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          initialContactPoints:
+            - camunda-0.${K8S_SERVICE_NAME}:26502
+            - camunda-1.${K8S_SERVICE_NAME}:26502
+            - camunda-2.${K8S_SERVICE_NAME}:26502
+          clusterName: c8-golden-stable-88-opensearch-no-optimize-zeebe
+    
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                url: "http://opensearch:9200"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+                retention:
+                  enabled: true
+                  minimumAge: "1d"
+                  policyName: "camunda-retention-policy"
+                  usageMetricsMinimumAge: "730d"
+                  usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+  log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    zeebe.gateway.monitoring.enabled: "true"
+    zeebe.gateway.threads.managementThreads: "1"
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # We moved the archiver configuration under retention at some point, but still need to support the previous
+    # versions for now, so the configurations for retention are duplicated
+    zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # Disable the importers
+    camunda.tasklist.importerEnabled: "false"
+    camunda.operate.importerEnabled: "false"
+    camunda.operate.elasticsearch.numberOfShards: 3
+    # Schema management has been moved out of exporter - to be bootstrap at start; once
+    camunda.database.retention.enabled: "true"
+    camunda.database.retention.policyName: "camunda-retention-policy"
+    #Metrics:
+    camunda.flags.jfr.metrics: "true"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,40 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.8.29
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-opensearch-no-optimize-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration-unified
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-88-opensearch-no-optimize-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Yemm1_BoyuQevj"
+  identity-admin-client-token: "PifaZaxe9=Fipe"
+  identity-firstuser-password: "TekiKonm9,Xidz"
+  identity-keycloak-admin-password: "SazbNitv1*Miqa"
+  identity-keycloak-postgresql-admin-password: "QoddFoybYoya1^"
+  identity-keycloak-postgresql-user-password: "YuwmBeqa0)Juky"
+  identity-optimize-client-token: "NepvYuzi6#Wawo"
+  identity-optimize-loadtest-client-secret: "Zira5(ZalsVuqc"
+  identity-postgresql-admin-password: "Yusc3~PumyPici"
+  identity-postgresql-user-password: "NivuLasuMuvo6*"
+  orchestration-security-authentication-oidc-secret: "Joru0%GuwiRigo"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/elasticsearch.yaml
@@ -1,0 +1,80 @@
+---
+# Source: load-test-setup/templates/elasticsearch.yaml
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: elasticsearch
+  labels:
+    camunda.io/created-by: "golden-test"
+    camunda.io/purpose: load-test
+spec:
+  version: 8.18.0
+
+  nodeSets:
+  - config:
+      # Disable mmap for compatibility with containers that lack the required vm.max_map_count sysctl
+      node.store.allow_mmap: "false"
+
+      # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
+      logger.org.elasticsearch.deprecation: "OFF"
+
+      # Authenticate unauthenticated requests as the "anonymous" user with the "superuser" role.
+      # This is not a recommended production configuration, but is OK for the load tests environment.
+      # See https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/file-based#k8s-basic for additional users.
+      xpack.security.authc:
+        # https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/anonymous-access
+        anonymous:
+          username: anonymous
+          roles: superuser
+
+    count: 3
+    name: masters
+
+    podTemplate:
+      metadata:
+        labels:
+          app.kubernetes.io/component: master
+          app.kubernetes.io/name: elasticsearch
+          camunda.io/created-by: "golden-test"
+          camunda.io/purpose: load-test
+
+      spec:
+        containers:
+        - name: elasticsearch
+          env:
+            - name: ES_JAVA_OPTS
+              value: -Xms3g -Xmx3g
+          resources:
+            limits:
+              cpu: "7"
+              memory: 8Gi
+            requests:
+              cpu: "7"
+              memory: 8Gi
+
+        nodeSelector:
+          topology.kubernetes.io/zone: "europe-west1-c"
+          component: benchmark-n2-standard-8
+        tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-8
+
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        storageClassName: benchmark-ssd-zonal-v1
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 512Gi
+
+  http:
+    tls:
+      selfSignedCertificate:
+        # Disable TLS on the HTTP API.
+        # This is not a recommended production configuration, but is OK for the load tests environment.
+        # See https://www.elastic.co/docs/deploy-manage/security/k8s-https-settings#k8s-disable-tls for more details.
+        disabled: true

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "Joru0%GuwiRigo"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-c"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-89-elasticsearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-elasticsearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: fed111b4702ff2bc9a6d3899cee06730af3651ff14e9bc5f502cdd75dba5cf7b
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-89-elasticsearch-no-optimize
+      namespace: c8-golden-stable-89-elasticsearch-no-optimize
+      version: 14.6.0
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.9.5
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-89-elasticsearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-89-elasticsearch-no-optimize:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.9.6
+        url: http://connectors.c8-golden-stable-89-elasticsearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-stable-89-elasticsearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-89-elasticsearch-no-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.9.11
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.9.11
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/prometheus
+      - name: Orchestration Identity
+        id: orchestrationIdentity
+        version: 8.9.11
+        url: http://localhost:8080/identity
+        readiness: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: 8.9.11
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-elasticsearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,127 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.9.6
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,207 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,142 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.9.5
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,289 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-89-elasticsearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.9.11
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -87,8 +87,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/load-test-config.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/load-test-config.yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: load-test-config
+  labels:
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+data:
+  load-test-config.yaml: |
+    # Extra configuration for the load test applications
+    load-tester:
+      monitor-data-availability: false

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,149 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,148 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            # To be able to load a separate/additional configuration
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: "/usr/local/camunda/config/load-test-config.yaml"
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"
+          volumeMounts:
+            - name: load-test-config
+              mountPath: /usr/local/camunda/config/load-test-config.yaml
+              subPath: load-test-config.yaml
+      volumes:
+        - name: load-test-config
+          configMap:
+            name: load-test-config
+            defaultMode: 0754

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Wiko9)ZildLann"
+  identity-admin-client-token: "ToleTojhMupy4~"
+  identity-firstuser-password: "HuleYorhCoxi3="
+  identity-keycloak-admin-password: "Nica2[NawiFevm"
+  identity-keycloak-postgresql-admin-password: "VufeTajd2]Ceke"
+  identity-keycloak-postgresql-user-password: "PofoXeleMasr6^"
+  identity-optimize-client-token: "Piqr2-KitqSife"
+  identity-optimize-loadtest-client-secret: "Xisf5=RawoZaqi"
+  identity-postgresql-admin-password: "FemlVoqo8]Laso"
+  identity-postgresql-user-password: "YehiSujaTaca7&"
+  orchestration-security-authentication-oidc-secret: "GezlZuzu1@Lulp"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "GezlZuzu1@Lulp"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-89-none-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-89-none-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-none-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: a8ec13d812621c068efda6bb770fdb8ca64dfb6f9e7c294081d142c33bb1c317
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-none-optimize-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-none-optimize-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,63 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-none-optimize-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-89-none-optimize
+      namespace: c8-golden-stable-89-none-optimize
+      version: 14.6.0
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.9.5
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-89-none-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-89-none-optimize:82/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.9.11
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.9.11
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/prometheus
+      - name: Orchestration Identity
+        id: orchestrationIdentity
+        version: 8.9.11
+        url: http://localhost:8080/identity
+        readiness: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: 8.9.11
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-none-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,196 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,137 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.9.5
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-none-optimize-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,252 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "none"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: false
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-89-none-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters: {}
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.9.11
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-none-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-89-none-optimize-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/none-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-none-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "MapuCaxjKuji4!"
+  identity-admin-client-token: "Fuxk0:KajeGerd"
+  identity-firstuser-password: "Gayn4)XudiNati"
+  identity-keycloak-admin-password: "Kevb6_RizkGuwi"
+  identity-keycloak-postgresql-admin-password: "DabrJohu7;Dufv"
+  identity-keycloak-postgresql-user-password: "HiyaGogoRizw5&"
+  identity-optimize-client-token: "Raya0?MumeXamt"
+  identity-optimize-loadtest-client-secret: "Danf3#TeceZedb"
+  identity-postgresql-admin-password: "KohaQidcTudu2&"
+  identity-postgresql-user-password: "NicwBeqi1]Nayi"
+  orchestration-security-authentication-oidc-secret: "RirkMoco5-Yemo"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "RirkMoco5-Yemo"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://opensearch:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-b"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "bn_keycloak"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "bitnami_keycloak"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "bn_keycloak" -d "dbname=bitnami_keycloak" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "bitnami_keycloak"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "bn_keycloak"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-stable-89-opensearch-no-optimize.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-stable-89-opensearch-no-optimize"
+  labels:
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: bfb8a2232348aa4c440f3911eef3aca0d9eb5269d6573de01814139da1a2bb48
+      labels:
+        app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-opensearch-no-optimize-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-opensearch-no-optimize-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-89-opensearch-no-optimize-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-stable-89-opensearch-no-optimize
+      namespace: c8-golden-stable-89-opensearch-no-optimize
+      version: 14.6.0
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.9.5
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-stable-89-opensearch-no-optimize:82/actuator/health
+        metrics: http://identity.c8-golden-stable-89-opensearch-no-optimize:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.9.6
+        url: http://connectors.c8-golden-stable-89-opensearch-no-optimize:8080
+        readiness: http://connectors.c8-golden-stable-89-opensearch-no-optimize:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-stable-89-opensearch-no-optimize:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: 8.9.11
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: 8.9.11
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/prometheus
+      - name: Orchestration Identity
+        id: orchestrationIdentity
+        version: 8.9.11
+        url: http://localhost:8080/identity
+        readiness: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: 8.9.11
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-stable-89-opensearch-no-optimize:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,127 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.9.6
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-opensearch-no-optimize-identity-env-vars
+            - configMapRef:
+                name: c8-golden-stable-89-opensearch-no-optimize-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/configmap.yaml
@@ -1,0 +1,207 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/deployment.yaml
@@ -1,0 +1,142 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.9.5
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-opensearch-no-optimize-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: identity
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,302 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        awsEnabled: false
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-89-opensearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,210 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.9.11
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-opensearch-no-optimize-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -87,8 +87,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-89-opensearch-no-optimize-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-stable-89-opensearch-no-optimize-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -60,6 +60,10 @@ var defaultScenarios = []scenario{
 	{Name: "rdbms", Storage: "postgresql", Optimize: false, Stable: false},
 	{Name: "rdbms-optimize", Storage: "postgresql", Optimize: true, Stable: false},
 	{Name: "none", Storage: "none", Optimize: false, Stable: false},
+	// Optimize cannot run without a secondary storage backend, so this covers
+	// that enable_optimize=true is correctly ignored (rather than crashing or
+	// silently misconfiguring the ES/OS exporter) when storage is disabled.
+	{Name: "none-optimize", Storage: "none", Optimize: true, Stable: false},
 	{Name: "elasticsearch-stable", Storage: "elasticsearch", Optimize: true, Stable: true},
 	{Name: "opensearch-stable", Storage: "opensearch", Optimize: true, Stable: true},
 	{Name: "rdbms-stable", Storage: "postgresql", Optimize: false, Stable: true},

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -56,6 +56,7 @@ var defaultScenarios = []scenario{
 	{Name: "elasticsearch", Storage: "elasticsearch", Optimize: true, Stable: false},
 	{Name: "elasticsearch-no-optimize", Storage: "elasticsearch", Optimize: false, Stable: false},
 	{Name: "opensearch", Storage: "opensearch", Optimize: true, Stable: false},
+	{Name: "opensearch-no-optimize", Storage: "opensearch", Optimize: false, Stable: false},
 	{Name: "rdbms", Storage: "postgresql", Optimize: false, Stable: false},
 	{Name: "rdbms-optimize", Storage: "postgresql", Optimize: true, Stable: false},
 	{Name: "none", Storage: "none", Optimize: false, Stable: false},

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -54,6 +54,7 @@ type versionedScenario struct {
 // regenerated when that file changes.
 var defaultScenarios = []scenario{
 	{Name: "elasticsearch", Storage: "elasticsearch", Optimize: true, Stable: false},
+	{Name: "elasticsearch-no-optimize", Storage: "elasticsearch", Optimize: false, Stable: false},
 	{Name: "opensearch", Storage: "opensearch", Optimize: true, Stable: false},
 	{Name: "rdbms", Storage: "postgresql", Optimize: false, Stable: false},
 	{Name: "rdbms-optimize", Storage: "postgresql", Optimize: true, Stable: false},


### PR DESCRIPTION
## Description

Fixes two related bugs in `load-tests/setup` where the ES/OS exporter configuration for Optimize broke cluster startup or silently ignored the `enable_optimize` flag, reported in [Slack](https://camunda.slack.com/archives/C0807665N8G/p1783609223812999).

**1. Dangling exporter with no `className` when Optimize is disabled** (`main`, `stable-89`)

`camunda-platform-values-elasticsearch.yaml`/`-opensearch.yaml` applied the ES/OS exporter replica config unconditionally, regardless of Optimize. With Optimize disabled, this registers a partial `elasticsearch`/`opensearch` exporter entry with no `className`, crashing the broker at startup:

```
java.lang.IllegalArgumentException: Expected to find a 'className' configured for the exporter.
Couldn't find a valid one for the following exporters [elasticsearch]
```

Moved the config into the Optimize-gated values files, and added the missing `camunda-platform-values-optimize-opensearch.yaml` for `stable-89`.

**2. `secondary_storage=none` + `enable_optimize=true` forced a dedicated ES cluster it can't use** (`main`, `stable-89`, `stable-88`)

Optimize cannot run without a secondary storage backend, but this combination still applied `camunda-platform-values-optimize-elasticsearch.yaml`, which either hard-crashed the chart render (`stable-89`/`stable-88`, via a `global.noSecondaryStorage` conflict) or silently left Optimize disabled anyway (`main`, since `camunda-platform-values-none.yaml` already forces `optimize.enabled=false`). Now `secondary_storage=none` disables Optimize outright, matching intent, instead of forcing on a cluster nothing will use.

`stable-87` needed no change for either issue - its chart registers the classic ES exporter unconditionally (independent of Optimize) and doesn't support `secondary_storage=none`.

**Also included:**
- `VERSION=` on the golden test Makefile, so `make test`/`make update-golden` can target a single setup version instead of all of them.
- A new `none-optimize` golden scenario (main/stable-89/stable-88) - this combination existed in the Makefile/script logic but had zero test coverage on any version, which is how bug #2 went unnoticed.

Verified by scaffolding and rendering each affected combination directly (`newLoadTest.sh` + `make template`) before and after the fix, and by tracing the exact crash condition in `SystemContextLoader.validateExporters`.

## Checklist

- [ ] Enable backports when necessary - not applicable: this only touches `load-tests/setup` on `main`. The versioned `stable-8x` subdirectories are testing fixtures that live entirely within `main` (to validate against historical chart versions); the actual `stable/8.x` branches have a different, non-versioned `load-tests/setup` layout, so there is nothing to backport there.
- [ ] C8 Orchestration Cluster E2E Test Suite - not applicable, this PR doesn't touch `qa/c8-orchestration-cluster-e2e-test-suite`.

## Related issues

None tracked - reported and discussed in [Slack](https://camunda.slack.com/archives/C0807665N8G/p1783609223812999).