### PR TITLE
test: scope golden test targets to a single setup version

### DIFF
--- a/load-tests/setup/test/Makefile
+++ b/load-tests/setup/test/Makefile
@@ -17,12 +17,22 @@ help:
 	@echo "  update-golden  Regenerate golden files after an intentional change,"
 	@echo "                 then review 'git diff golden/' before committing"
 	@echo "  clean          Remove leftover scaffolded namespace directories"
+	@echo ""
+	@echo "Scope test/update-golden to one setup version with PATTERN=, e.g.:"
+	@echo "  make update-golden PATTERN=stable-89"
 
 # Each scenario scaffolds a namespace, which clones camunda-platform-helm and
 # runs `helm dependency build`. Cap parallelism so many simultaneous clones / OCI
 # pulls don't exhaust helm's timeouts on high-core machines (the default is
 # GOMAXPROCS). Override with `make test PARALLEL=N`.
 PARALLEL ?= 4
+
+# Optional: scope test/update-golden to one setup version (e.g. PATTERN=stable-89).
+# Leave unset to run/update every version listed in golden_test.go.
+PATTERN ?=
+ifneq ($(PATTERN),)
+run_filter := -run '.*$(PATTERN).*'
+endif
 
 build:
 	go build ./...
@@ -34,10 +44,10 @@ helm-repos:
 	helm repo update
 
 test: helm-repos
-	go test -v -timeout 50m -parallel $(PARALLEL) ./...
+	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) ./...
 
 update-golden: helm-repos
-	go test -v -timeout 50m -parallel $(PARALLEL) -update-golden ./...
+	go test -v -timeout 50m -parallel $(PARALLEL) $(run_filter) -update-golden ./...
 
 clean:
 	rm -rf ../c8-golden-*

--- a/load-tests/setup/test/README.md
+++ b/load-tests/setup/test/README.md
@@ -60,17 +60,24 @@ make update-golden   # regenerate golden files after an intentional change
 make clean           # remove leftover scaffolded namespace directories
 ```
 
+Scope either target to one setup version with `PATTERN=`, e.g. when porting a fix to a
+single stable branch's golden files:
+
+```bash
+make update-golden PATTERN=stable-89
+```
+
 After `make update-golden`, always review `git diff golden/` before committing.
 Never hand-edit golden `.yaml` files — only `make update-golden` applies the
 correct normalization.
 
 ## Adding a stable version
 
-Versions under test are listed explicitly in `golden_test.go`. Only `main` is
-active; the stable entries are commented out. To enable one:
+Versions under test are listed explicitly in the `versions` slice in
+`golden_test.go`. To add a new version:
 
-1. Uncomment its line in the `versions` slice.
-2. `make update-golden` (or scope it: `go test -update-golden -run 'TestGoldenFiles/stable-89' ./...`).
+1. Add its directory name (e.g. `"stable-90"`) to the `versions` slice.
+2. `make update-golden PATTERN=stable-90`.
 3. Commit the generated golden files. No other code change is needed.
 
 ## If golden diffs become noisy in PRs

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -79,10 +79,9 @@ var defaultScenarios = []scenario{
 // versions lists the setup directories under test, each the name of a directory
 // under load-tests/setup/ that contains a newLoadTest.sh.
 //
-// Only "main" is active for now. The stable versions scaffold identically; to
-// enable one, uncomment its line and run:
+// To add a new version, append its directory name here and run:
 //
-//	go test -update-golden -run 'TestGoldenFiles/<version>' ./...
+//	make update-golden PATTERN=<version>
 //
 // to generate its golden files, then commit them. No other code change is needed.
 var versions = []string{


### PR DESCRIPTION
## Description

Split out of [#57769](https://github.com/camunda/camunda/pull/57769) as an independent, reviewable piece.

Porting a fix across the `stable-8x` setup versions in `load-tests/setup` means re-running the golden test suite once per version. Adds `PATTERN=` to the test Makefile so `make test`/`make update-golden` can target one setup version (`main`, `stable-89`, `stable-88`, `stable-87`) instead of always running all of them.

```bash
make update-golden PATTERN=stable-89
```

No behavior change when `PATTERN` is left unset - the full suite still runs exactly as before.

## Checklist

- [ ] Enable backports when necessary - not applicable, test-tooling-only change to `load-tests/setup` on `main`.
- [ ] C8 Orchestration Cluster E2E Test Suite - not applicable.

## Related issues

None tracked.