### PR TITLE
fix: gate ES/OS exporter config on Optimize

### DIFF
--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -128,6 +128,16 @@ platform_values += -f camunda-platform-values-$(secondary_storage).yaml
 # Disable Optimize if not enabled
 ifneq ($(enable_optimize),true)
 	platform_values += --set optimize.enabled=false
+else ifeq ($(secondary_storage),opensearch)
+	# When deploying the OpenSearch secondary storage, Optimize needs the
+	# OpenSearch-specific exporter/client configuration.
+ifneq ($(wildcard camunda-platform-values-optimize-opensearch.yaml),)
+	platform_values += -f camunda-platform-values-optimize-opensearch.yaml
+endif
+else ifeq ($(secondary_storage),elasticsearch)
+	# When deploying the Elasticsearch secondary storage, Optimize needs the
+	# Elasticsearch-specific exporter/client configuration.
+	platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
 else
 	ifeq ($(filter $(secondary_storage),$(optimize_self_sufficient_storages)),)
 		# If we are not using Elasticsearch/OpenSearch as a secondary storage, Optimize will

--- a/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-elasticsearch.yaml
@@ -31,29 +31,3 @@ orchestration:
   data:
     secondaryStorage:
       type: elasticsearch
-
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"

--- a/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
@@ -19,32 +19,6 @@ orchestration:
     secondaryStorage:
       type: opensearch
 
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
-
 ###########################################################################
 #######
 #     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #

--- a/load-tests/setup/main/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -1,8 +1,7 @@
-# Elasticsearch values for Camunda Platform Chart.
+# Optimize Elasticsearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used fr Optimize, but NOT as the Camunda secondary storage.
-# storage.
+# This configures Elasticsearch when it's used for Optimize.
 #
 # For the Elasticsearch as secondary storage configuration, see the
 # "camunda-platform-values-elasticsearch.yaml" file.
@@ -18,6 +17,9 @@ orchestration:
   # Secondary storage configuration is not configured here, but in the
   # Elasticsearch/OpenSearch/RDBMS-specific values file.
   env:
+    # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
+    # otherwise it is vulnerable to node restarts
+    # ES/OS exporter configuration is bound to the Optimize usage
     - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
       value: "1"
 

--- a/load-tests/setup/main/values/camunda-platform-values-optimize-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize-opensearch.yaml
@@ -1,33 +1,26 @@
-# Elasticsearch values for Camunda Platform Chart.
+# Optimize OpenSearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used for Optimize.
+# This configures OpenSearch when it's used for Optimize.
 #
-# For the Elasticsearch as secondary storage configuration, see the
-# "camunda-platform-values-elasticsearch.yaml" file.
-# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# For the OpenSearch as secondary storage configuration, see the
+# "camunda-platform-values-opensearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-opensearch.yaml" file, make
 # sure to keep the other file in sync (minus the secondary storage-only options).
 
-########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  elasticsearch:
-    enabled: true
-    url:
-      # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
-      # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
-      # See load-tests/setup/charts/load-test-setup/templates/elasticsearch.yaml for the resource definition.
-      host: elasticsearch-es-http
-
 orchestration:
+  data:
+    secondary-storage:
+      opensearch:
+        url: http://opensearch:9200
+
   # Secondary storage configuration is not configured here, but in the
   # Elasticsearch/OpenSearch/RDBMS-specific values file.
   env:
     # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
     # otherwise it is vulnerable to node restarts
     # ES/OS exporter configuration is bound to the Optimize usage
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
       value: "1"
 
     ## The values below are duplicated from
@@ -51,3 +44,13 @@ orchestration:
       # application-override.yml is listed second so it has higher priority and can override application.yml.
       # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
       value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
+##########################################################################
+################################################### Optimize configuration
+##########################################################################
+optimize:
+  database:
+    opensearch:
+      enabled: true
+      url:
+        host: opensearch

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -182,6 +182,11 @@ if [[ "$enable_optimize" == "true" ]]; then
     # stable-87's Makefile uses this file when secondary_storage=elasticsearch;
     # for other versions it's harmlessly present (their Makefiles skip it for ES).
     cp -v "$VERSION_DIR/values/camunda-platform-values-optimize-elasticsearch.yaml" "$TARGET_DIRECTORY/"
+  elif [[ "$secondary_storage" == "opensearch" ]]; then
+    optimize_opensearch_config_file="$VERSION_DIR/values/camunda-platform-values-optimize-opensearch.yaml"
+    if [[ -f "$optimize_opensearch_config_file" ]]; then
+      cp -v "$optimize_opensearch_config_file" "$TARGET_DIRECTORY/"
+    fi
   elif [[ "$secondary_storage" != "opensearch" ]]; then
     # Non-ES/non-OS storage: forcefully configure Optimize to use Elasticsearch.
     elasticsearchEnabled=true

--- a/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -25,9 +25,6 @@ orchestration:
   # Secondary storage configuration is not configured here, but in the
   # Elasticsearch/OpenSearch values file.
   env:
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
     ## The values below are duplicated from
     ## camunda-platform-values-defaults.yaml. Keep them in sync.
     # Enable JSON logging for google cloud stackdriver

--- a/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -20,29 +20,3 @@ global:
       # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
       # See load-tests/setup/charts/load-test-setup/templates/elasticsearch.yaml for the resource definition.
       host: elasticsearch-es-http
-
-orchestration:
-  # Secondary storage configuration is not configured here, but in the
-  # Elasticsearch/OpenSearch values file.
-  env:
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-elasticsearch.yaml
@@ -31,29 +31,3 @@ orchestration:
   data:
     secondaryStorage:
       type: elasticsearch
-
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
@@ -19,32 +19,6 @@ orchestration:
     secondaryStorage:
       type: opensearch
 
-  env:
-    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
-      value: "1"
-
-    ## The values below are duplicated from
-    ## camunda-platform-values-defaults.yaml. Keep them in sync.
-    # Enable JSON logging for google cloud stackdriver
-    - name: ZEEBE_LOG_APPENDER
-      value: Stackdriver
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
-      value: zeebe
-    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    - name: ATOMIX_LOG_LEVEL
-      value: INFO
-    - name: ZEEBE_LOG_LEVEL
-      value: DEBUG
-    # To be able to load a separate/additional configuration
-    # See https://github.com/camunda/camunda-platform-helm/issues/2197
-    - name: SPRING_CONFIG_ADDITIONALLOCATION
-      # application-override.yml is listed second so it has higher priority and can override application.yml.
-      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
-      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
-
 ###########################################################################
 #######
 #     # #####  ###### #    #  ####  ######   ##   #####   ####  #    #

--- a/load-tests/setup/stable-89/values/camunda-platform-values-optimize-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-optimize-opensearch.yaml
@@ -1,33 +1,21 @@
-# Elasticsearch values for Camunda Platform Chart.
+# Optimize OpenSearch values for Camunda Platform Chart.
 # https://github.com/camunda/camunda-platform-helm
 #
-# This configures Elasticsearch when it's used for Optimize.
+# This configures OpenSearch when it's used for Optimize.
 #
-# For the Elasticsearch as secondary storage configuration, see the
-# "camunda-platform-values-elasticsearch.yaml" file.
-# If you make changes to this file or the "camunda-platform-values-elasticsearch.yaml" file, make
+# For the OpenSearch as secondary storage configuration, see the
+# "camunda-platform-values-opensearch.yaml" file.
+# If you make changes to this file or the "camunda-platform-values-opensearch.yaml" file, make
 # sure to keep the other file in sync (minus the secondary storage-only options).
-
-########################################################################################
-################################################### Global cluster configuration
-########################################################################################
-global:
-  elasticsearch:
-    enabled: true
-    url:
-      # The Elasticsearch host value is derived from the ECK Elasticsearch custom resource name.
-      # The ECK operator creates a service named "<resource-name>-es-http" for HTTP access.
-      # See load-tests/setup/charts/load-test-setup/templates/elasticsearch.yaml for the resource definition.
-      host: elasticsearch-es-http
 
 orchestration:
   # Secondary storage configuration is not configured here, but in the
-  # Elasticsearch/OpenSearch/RDBMS-specific values file.
+  # Elasticsearch/OpenSearch-specific values file.
   env:
     # We need to configure the Elasticsearch/OpenSearch exporter to use 1 replica for the index,
     # otherwise it is vulnerable to node restarts
     # ES/OS exporter configuration is bound to the Optimize usage
-    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
       value: "1"
 
     ## The values below are duplicated from

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,281 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-main-elasticsearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,209 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+        awsEnabled: false
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-main-opensearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,209 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-main-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-opensearch-no-optimize-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/configmap.yaml
@@ -1,0 +1,103 @@
+---
+# Source: camunda-platform/templates/zeebe/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  application.yaml: |
+    zeebe:
+      broker:
+        exporters:
+          elasticsearch:
+            className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            args:
+              url: "http://elasticsearch-es-http:9200"
+              index:
+                prefix: "zeebe-record"
+              retention:
+                enabled: true
+                minimumAge: "3d"
+                policyName: "zeebe-record-retention-policy"
+        gateway:
+          enable: true
+          network:
+            port: 26500
+          security:
+            enabled: false
+            authentication:
+              mode: none
+        network:
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+          monitoringApi:
+            port: "9600"
+        cluster:
+          clusterSize: "3"
+          replicationFactor: "3"
+          partitionsCount: "3"
+          clusterName: zeebe
+        threads:
+          cpuThreadCount: "3"
+          ioThreadCount: "3"
+        data:
+          snapshotPeriod: "5m"
+          disk:
+            freeSpace:
+              processing: "2GB"
+              replication: "1GB"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://elasticsearch-es-http:9200"
+
+  startup.sh: |
+    #!/usr/bin/env bash
+    set -eux -o pipefail
+
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 1 + 0]}
+
+    if [ "$(ls -A /exporters/)" ]; then
+      mkdir -p /usr/local/zeebe/exporters/
+      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
+    else
+      echo "No exporters available."
+    fi
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/zeebe/bin/broker
+    fi
+
+  broker-log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    zeebe.broker.data.diskUsageCommandWatermark: "0.8"
+    zeebe.broker.data.diskUsageReplicationWatermark: "0.9"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 4000

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/zeebe/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: "zeebe"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: http
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/zeebe/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-no-optimize/platform/templates/zeebe/statefulset.yaml
@@ -1,0 +1,219 @@
+---
+# Source: camunda-platform/templates/zeebe/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: "zeebe"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "zeebe"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: zeebe
+          image: docker.io/camunda/zeebe:8.7.35
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: CAMUNDA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-license
+                  key: CAMUNDA_LICENSE_KEY
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "zeebe"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
+            - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
+              value:
+                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME):26502,
+            - name: ZEEBE_LOG_LEVEL
+              value: "info"
+            - name: ZEEBE_BROKER_GATEWAY_ENABLE
+              value: "false"
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
+              value: "io.camunda.zeebe.exporter.ElasticsearchExporter"
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
+              value: "http://elasticsearch-es-http:9200"
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX
+              value: "zeebe-record"
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/zeebe/config/application.yml,optional:/usr/local/zeebe/config/application-override.yml
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-87-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 9600
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/zeebe/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/zeebe/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/zeebe/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/zeebe/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/zeebe/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: c8-golden-stable-87-elasticsearch-no-optimize-zeebe-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: c8-golden-stable-87-elasticsearch-no-optimize-zeebe
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+# yamllint disable
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - zeebe-broker
+            topologyKey: kubernetes.io/hostname
+# yamllint enable
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap-unified.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration-unified
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/camunda/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/camunda/bin/camunda
+    fi
+  application.yaml: |    
+    spring:
+      profiles:
+        active: "broker,identity,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        index:
+          numberOfReplicas: "1"
+        retention:
+          enabled: true
+          minimumAge: "1d"
+          policyName: "camunda-retention-policy"
+          usageMetricsMinimumAge: "730d"
+          usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          elasticsearch:
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              mappingRules: []
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              mappingRules: []
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        persistentSessionsEnabled: true
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          initialContactPoints:
+            - camunda-0.${K8S_SERVICE_NAME}:26502
+            - camunda-1.${K8S_SERVICE_NAME}:26502
+            - camunda-2.${K8S_SERVICE_NAME}:26502
+          clusterName: c8-golden-stable-88-elasticsearch-no-optimize-zeebe
+    
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                url: "http://elasticsearch-es-http:9200"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+                retention:
+                  enabled: true
+                  minimumAge: "1d"
+                  policyName: "camunda-retention-policy"
+                  usageMetricsMinimumAge: "730d"
+                  usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+  log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    zeebe.gateway.monitoring.enabled: "true"
+    zeebe.gateway.threads.managementThreads: "1"
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # We moved the archiver configuration under retention at some point, but still need to support the previous
+    # versions for now, so the configurations for retention are duplicated
+    zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # Disable the importers
+    camunda.tasklist.importerEnabled: "false"
+    camunda.operate.importerEnabled: "false"
+    camunda.operate.elasticsearch.numberOfShards: 3
+    # Schema management has been moved out of exporter - to be bootstrap at start; once
+    camunda.database.retention.enabled: "true"
+    camunda.database.retention.policyName: "camunda-retention-policy"
+    #Metrics:
+    camunda.flags.jfr.metrics: "true"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,40 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.8.31
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration-unified
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/configmap-unified.yaml
@@ -1,0 +1,309 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap-unified.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration-unified
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "${ZEEBE_RESTORE}" = "true" ]; then
+      exec /usr/local/camunda/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
+    else
+      exec /usr/local/camunda/bin/camunda
+    fi
+  application.yaml: |    
+    spring:
+      profiles:
+        active: "broker,identity,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        awsEnabled: false
+        index:
+          numberOfReplicas: "1"
+        retention:
+          enabled: true
+          minimumAge: "1d"
+          policyName: "camunda-retention-policy"
+          usageMetricsMinimumAge: "730d"
+          usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          opensearch:
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              mappingRules: []
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              mappingRules: []
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        persistentSessionsEnabled: true
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          initialContactPoints:
+            - camunda-0.${K8S_SERVICE_NAME}:26502
+            - camunda-1.${K8S_SERVICE_NAME}:26502
+            - camunda-2.${K8S_SERVICE_NAME}:26502
+          clusterName: c8-golden-stable-88-opensearch-no-optimize-zeebe
+    
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                url: "http://opensearch:9200"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+                retention:
+                  enabled: true
+                  minimumAge: "1d"
+                  policyName: "camunda-retention-policy"
+                  usageMetricsMinimumAge: "730d"
+                  usageMetricsPolicyName: "camunda-usage-metrics-retention-policy"
+    
+  log4j2.xml: |
+  application-override.yml: |
+    # no overrides
+  application.yml: |
+    zeebe.gateway.monitoring.enabled: "true"
+    zeebe.gateway.threads.managementThreads: "1"
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # We moved the archiver configuration under retention at some point, but still need to support the previous
+    # versions for now, so the configurations for retention are duplicated
+    zeebe.broker.exporters.camundaexporter.args.history.retention.enabled: "true"
+    zeebe.broker.exporters.camundaexporter.args.history.retention.policyName: "camunda-retention-policy"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # Disable the importers
+    camunda.tasklist.importerEnabled: "false"
+    camunda.operate.importerEnabled: "false"
+    camunda.operate.elasticsearch.numberOfShards: 3
+    # Schema management has been moved out of exporter - to be bootstrap at start; once
+    camunda.database.retention.enabled: "true"
+    camunda.database.retention.policyName: "camunda-retention-policy"
+    #Metrics:
+    camunda.flags.jfr.metrics: "true"

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,40 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,206 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-88-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.8.31
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-88-opensearch-no-optimize-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration-unified
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,289 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "elasticsearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          elasticsearch:
+            aws-enabled: false
+            url: "http://elasticsearch-es-http:9200"
+            cluster-name: "elasticsearch"
+            username: ""
+            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-89-elasticsearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "elasticsearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.9.12
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-elasticsearch-no-optimize-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-c
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,302 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+      tomcat:
+        max-http-form-post-size: "10MB"
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
+        network:
+          max-message-size: "10MB"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+          max-message-size: "10MB"
+    
+      # Database configuration - Separated syntax.
+      database:
+        awsEnabled: false
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: true
+          type: "opensearch"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          opensearch:
+            aws-enabled: false
+            url: "http://opensearch:9200"
+            cluster-name: "opensearch"
+            username: ""
+            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            index-prefix: ""
+            number-of-replicas: "1"
+            history:
+              policy-name: "camunda-retention-policy"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # OpenSearch
+        opensearch:
+          awsEnabled: false
+        zeebeOpensearch:
+          awsEnabled: false
+          username: ""
+          password: "${VALUES_OPENSEARCH_PASSWORD:}"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
+          maxMessageSize: "10MB"
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-stable-89-opensearch-no-optimize-zeebe
+        # zeebe.broker.exporters
+        exporters:
+          camundaexporter:
+            className: "io.camunda.exporter.CamundaExporter"
+            args:
+              connect:
+                type: "opensearch"
+                awsEnabled: false
+              history:
+                elsRolloverDateFormat: "date"
+                rolloverInterval: "1d"
+                rolloverBatchSize: 100
+                waitPeriodBeforeArchiving: "1h"
+                delayBetweenRuns: 2000
+                maxDelayBetweenRuns: 60000
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    
+    # Camunda Exporter configuration
+    zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+    zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
+    
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/part-of: camunda-platform
+
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-no-optimize/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,208 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: opensearch
+    app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: opensearch
+      app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: opensearch
+        app.kubernetes.io/instance: c8-golden-stable-89-opensearch-no-optimize
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:8.9.12
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-stable-89-opensearch-no-optimize-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 4Gi
+            requests:
+              cpu: 3000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-b
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -33,6 +33,9 @@ var update = flag.Bool("update-golden", false,
 // PhysicalTenants, when true, passes physical_tenants=true to the platform
 // template target. Only supported for rdbms secondary_storage (main version only).
 //
+// PlatformOnly, when true, renders only the platform chart. Use it for
+// scenarios whose assertions are scoped to platform-only templates.
+//
 // PathFilter, when set, restricts golden comparison (and, under
 // -update-golden, what gets committed) to rendered manifest paths with one of
 // these prefixes, relative to each chart's own output tree — e.g.
@@ -51,6 +54,7 @@ type scenario struct {
 	Workload        string // "" = default profile; e.g. "max", "realistic"
 	SetupTarget     string // named make target for template-load-test-setup variants
 	PhysicalTenants bool
+	PlatformOnly    bool
 	PathFilter      []string
 }
 
@@ -72,7 +76,15 @@ type versionedScenario struct {
 // regenerated when that file changes.
 var defaultScenarios = []scenario{
 	{Name: "elasticsearch", Storage: "elasticsearch", Optimize: true, Stable: false},
+	// no-optimize scenarios only exist to catch the ES/OS exporter/Optimize
+	// interaction bug (see PR #57771) — scoped to the orchestration templates
+	// where that config actually appears, not the full rendered tree.
+	// stable-87 uses the pre-orchestration zeebe template path.
+	{Name: "elasticsearch-no-optimize", Storage: "elasticsearch", Optimize: false, Stable: false,
+		PlatformOnly: true, PathFilter: []string{"templates/orchestration", "templates/zeebe"}},
 	{Name: "opensearch", Storage: "opensearch", Optimize: true, Stable: false},
+	{Name: "opensearch-no-optimize", Storage: "opensearch", Optimize: false, Stable: false,
+		PlatformOnly: true, PathFilter: []string{"templates/orchestration", "templates/zeebe"}},
 	{Name: "rdbms", Storage: "postgresql", Optimize: false, Stable: false},
 	{Name: "rdbms-optimize", Storage: "postgresql", Optimize: true, Stable: false},
 	{Name: "none", Storage: "none", Optimize: false, Stable: false},
@@ -188,6 +200,9 @@ func TestGoldenFiles(t *testing.T) {
 			}
 
 			renderAndAssert(t, s.Version, s.Name, "platform", ns, platformTarget, "", s.PathFilter, extraVars...)
+			if s.PlatformOnly {
+				return
+			}
 			renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", "", s.PathFilter, extraVars...)
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes the load-test setup so Elasticsearch/OpenSearch exporter config is only rendered when Optimize is enabled and configured for that backend.

- Moves ES/OS exporter overrides out of the base storage values and into Optimize-specific values.
- Adds the missing OpenSearch Optimize values for the affected setup versions.
- Adds scoped no-Optimize golden scenarios using `PathFilter`.

## Validation

- `go test -v -timeout 50m -parallel 4 ./...` from `load-tests/setup/test`

## Checklist

- [ ] Enable backports when necessary - not applicable; `load-tests/setup` versioned fixtures live on `main`.
- [ ] C8 Orchestration Cluster E2E Test Suite - not applicable.

## Related

Split out of #57769. Follow-up stack: #57772.
