### PR TITLE
Fix scoped OIDC provider claims for interactive login

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -9,7 +9,7 @@ package io.camunda.authentication.config;
 
 import static java.util.stream.Collectors.toMap;
 
-import io.camunda.authentication.pt.PhysicalTenantAuthConfigurations;
+import io.camunda.authentication.pt.PhysicalTenantOidcProviders;
 import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
@@ -37,11 +37,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -206,9 +203,9 @@ public class OidcOverrideBeansConfiguration {
         request,
         buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository),
         buildPreferIdTokenClaimsByRegistrationId(oidcProviderRepository),
-        buildTokenClaimsConvertersByRegistrationId(
-            membershipPort, membershipResolutionContextPropagator, environment),
-        buildIdentityClaimsByRegistrationId(environment));
+        PhysicalTenantOidcProviders.tokenClaimsConvertersByRegistrationId(
+            environment, membershipPort, membershipResolutionContextPropagator),
+        PhysicalTenantOidcProviders.identityClaimsByRegistrationId(environment));
   }
 
   @Bean
@@ -286,50 +283,6 @@ public class OidcOverrideBeansConfiguration {
     return oidcProviderRepository.getOidcAuthenticationConfigurations().entrySet().stream()
         .filter(entry -> entry.getValue().isPreferIdTokenClaims())
         .collect(toMap(Map.Entry::getKey, entry -> Boolean.TRUE));
-  }
-
-  private Map<String, LazyTokenClaimsConverter> buildTokenClaimsConvertersByRegistrationId(
-      final MembershipPort membershipPort,
-      final MembershipResolutionContextPropagator membershipResolutionContextPropagator,
-      final Environment environment) {
-    final Map<String, OidcConfiguration> providersByRegistrationId = new LinkedHashMap<>();
-    PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment).values().stream()
-        .map(authentication -> authentication.getProviders())
-        .filter(providers -> providers != null && providers.getOidc() != null)
-        .forEach(providers -> providersByRegistrationId.putAll(providers.getOidc()));
-    return providersByRegistrationId.entrySet().stream()
-        .collect(
-            toMap(
-                Map.Entry::getKey,
-                entry -> {
-                  final var config = entry.getValue();
-                  return new LazyTokenClaimsConverter(
-                      config.getUsernameClaim(),
-                      config.getClientIdClaim(),
-                      config.isPreferUsernameClaim(),
-                      membershipPort,
-                      membershipResolutionContextPropagator);
-                }));
-  }
-
-  private Map<String, List<String>> buildIdentityClaimsByRegistrationId(
-      final Environment environment) {
-    final Map<String, List<String>> claimsByRegistrationId = new LinkedHashMap<>();
-    PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment).values().stream()
-        .map(authentication -> authentication.getProviders())
-        .filter(providers -> providers != null && providers.getOidc() != null)
-        .forEach(
-            providers ->
-                providers
-                    .getOidc()
-                    .forEach(
-                        (registrationId, config) ->
-                            claimsByRegistrationId.put(
-                                registrationId,
-                                Stream.of(config.getUsernameClaim(), config.getClientIdClaim())
-                                    .filter(Objects::nonNull)
-                                    .toList())));
-    return claimsByRegistrationId;
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.config;
 
 import static java.util.stream.Collectors.toMap;
 
+import io.camunda.authentication.pt.PhysicalTenantAuthConfigurations;
 import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
@@ -22,7 +23,6 @@ import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.security.spring.converter.OidcTokenAuthenticationConverter;
-import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
 import io.camunda.security.spring.handler.OAuth2AuthenticationExceptionHandler;
 import io.camunda.security.spring.oidc.AssertionJwkProvider;
 import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -48,6 +49,7 @@ import org.springframework.boot.ssl.NoSuchSslBundleException;
 import org.springframework.boot.ssl.SslBundles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
@@ -191,14 +193,20 @@ public class OidcOverrideBeansConfiguration {
       final OidcAccessTokenDecoderFactory oidcAccessTokenDecoderFactory,
       final LazyTokenClaimsConverter tokenClaimsConverter,
       final HttpServletRequest request,
-      final OidcProviderConfigurationPort oidcProviderRepository) {
-    return new OidcUserAuthenticationConverter(
+      final OidcProviderConfigurationPort oidcProviderRepository,
+      final MembershipPort membershipPort,
+      final MembershipResolutionContextPropagator membershipResolutionContextPropagator,
+      final Environment environment) {
+    return new ProviderAwareOidcUserAuthenticationConverter(
         authorizedClientRepository,
         oidcAccessTokenDecoderFactory,
         tokenClaimsConverter,
         request,
         buildAdditionalJwkSetUrisByIssuer(oidcProviderRepository),
-        buildPreferIdTokenClaimsByRegistrationId(oidcProviderRepository));
+        buildPreferIdTokenClaimsByRegistrationId(oidcProviderRepository),
+        buildTokenClaimsConvertersByRegistrationId(
+            membershipPort, membershipResolutionContextPropagator, environment),
+        buildIdentityClaimsByRegistrationId(environment));
   }
 
   @Bean
@@ -235,7 +243,8 @@ public class OidcOverrideBeansConfiguration {
                 toMap(Map.Entry::getKey, e -> parseAlgorithm(e.getValue().getIdTokenAlgorithm())));
     decoderFactory.setJwsAlgorithmResolver(
         clientRegistration ->
-            algorithmByRegistrationId.get(clientRegistration.getRegistrationId()));
+            algorithmByRegistrationId.getOrDefault(
+                clientRegistration.getRegistrationId(), SignatureAlgorithm.RS256));
     return decoderFactory;
   }
 
@@ -275,6 +284,51 @@ public class OidcOverrideBeansConfiguration {
     return oidcProviderRepository.getOidcAuthenticationConfigurations().entrySet().stream()
         .filter(entry -> entry.getValue().isPreferIdTokenClaims())
         .collect(toMap(Map.Entry::getKey, entry -> Boolean.TRUE));
+  }
+
+  private Map<String, LazyTokenClaimsConverter> buildTokenClaimsConvertersByRegistrationId(
+      final MembershipPort membershipPort,
+      final MembershipResolutionContextPropagator membershipResolutionContextPropagator,
+      final Environment environment) {
+    final Map<String, OidcConfiguration> providersByRegistrationId = new LinkedHashMap<>();
+    PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment).values().stream()
+        .map(authentication -> authentication.getProviders())
+        .filter(providers -> providers != null && providers.getOidc() != null)
+        .forEach(providers -> providersByRegistrationId.putAll(providers.getOidc()));
+    return providersByRegistrationId.entrySet().stream()
+        .collect(
+            toMap(
+                Map.Entry::getKey,
+                entry -> {
+                  final var config = entry.getValue();
+                  return new LazyTokenClaimsConverter(
+                      config.getUsernameClaim(),
+                      config.getClientIdClaim(),
+                      config.isPreferUsernameClaim(),
+                      membershipPort,
+                      membershipResolutionContextPropagator);
+                }));
+  }
+
+  private Map<String, List<String>> buildIdentityClaimsByRegistrationId(
+      final Environment environment) {
+    final Map<String, List<String>> claimsByRegistrationId = new LinkedHashMap<>();
+    PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment).values().stream()
+        .map(authentication -> authentication.getProviders())
+        .filter(providers -> providers != null && providers.getOidc() != null)
+        .forEach(
+            providers ->
+                providers
+                    .getOidc()
+                    .forEach(
+                        (registrationId, config) ->
+                            claimsByRegistrationId.put(
+                                registrationId,
+                                java.util.stream.Stream.of(
+                                        config.getUsernameClaim(), config.getClientIdClaim())
+                                    .filter(java.util.Objects::nonNull)
+                                    .toList())));
+    return claimsByRegistrationId;
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -37,6 +37,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -205,7 +206,20 @@ public class OidcOverrideBeansConfiguration {
         buildPreferIdTokenClaimsByRegistrationId(oidcProviderRepository),
         PhysicalTenantOidcProviders.tokenClaimsConvertersByRegistrationId(
             environment, membershipPort, membershipResolutionContextPropagator),
-        PhysicalTenantOidcProviders.identityClaimsByRegistrationId(environment));
+        buildIdentityClaimsByRegistrationId(environment));
+  }
+
+  private Map<String, List<String>> buildIdentityClaimsByRegistrationId(
+      final Environment environment) {
+    final Map<String, List<String>> identityClaims =
+        new LinkedHashMap<>(
+            PhysicalTenantOidcProviders.identityClaimsByRegistrationId(environment));
+    // The root default slot is not a named provider, so normalize its URI-valued identity claims
+    // (e.g. iss) under the default registration id too, matching the scoped registrations.
+    identityClaims.put(
+        OidcConfiguration.DEFAULT_REGISTRATION_ID,
+        PhysicalTenantOidcProviders.identityClaims(cslProperties.getAuthentication().getOidc()));
+    return identityClaims;
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -40,6 +40,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -324,9 +326,8 @@ public class OidcOverrideBeansConfiguration {
                         (registrationId, config) ->
                             claimsByRegistrationId.put(
                                 registrationId,
-                                java.util.stream.Stream.of(
-                                        config.getUsernameClaim(), config.getClientIdClaim())
-                                    .filter(java.util.Objects::nonNull)
+                                Stream.of(config.getUsernameClaim(), config.getClientIdClaim())
+                                    .filter(Objects::nonNull)
                                     .toList())));
     return claimsByRegistrationId;
   }

--- a/authentication/src/main/java/io/camunda/authentication/config/ProviderAwareOidcUserAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ProviderAwareOidcUserAuthenticationConverter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
+import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+final class ProviderAwareOidcUserAuthenticationConverter extends OidcUserAuthenticationConverter {
+
+  private final LazyTokenClaimsConverter defaultTokenClaimsConverter;
+  private final Map<String, LazyTokenClaimsConverter> tokenClaimsConvertersByRegistrationId;
+  private final Map<String, List<String>> identityClaimsByRegistrationId;
+
+  ProviderAwareOidcUserAuthenticationConverter(
+      final OAuth2AuthorizedClientRepository authorizedClientRepository,
+      final OidcAccessTokenDecoderFactory accessTokenDecoderFactory,
+      final LazyTokenClaimsConverter defaultTokenClaimsConverter,
+      final HttpServletRequest request,
+      final Map<String, List<String>> additionalJwkSetUrisByIssuer,
+      final Map<String, Boolean> preferIdTokenClaimsByRegistrationId,
+      final Map<String, LazyTokenClaimsConverter> tokenClaimsConvertersByRegistrationId,
+      final Map<String, List<String>> identityClaimsByRegistrationId) {
+    super(
+        authorizedClientRepository,
+        accessTokenDecoderFactory,
+        defaultTokenClaimsConverter,
+        request,
+        additionalJwkSetUrisByIssuer,
+        preferIdTokenClaimsByRegistrationId);
+    this.defaultTokenClaimsConverter = defaultTokenClaimsConverter;
+    this.tokenClaimsConvertersByRegistrationId = Map.copyOf(tokenClaimsConvertersByRegistrationId);
+    this.identityClaimsByRegistrationId = Map.copyOf(identityClaimsByRegistrationId);
+  }
+
+  @Override
+  public CamundaAuthentication convert(final Authentication authentication) {
+    final var oauth2Authentication = (OAuth2AuthenticationToken) authentication;
+    final var registrationId = oauth2Authentication.getAuthorizedClientRegistrationId();
+    final var tokenClaimsConverter =
+        tokenClaimsConvertersByRegistrationId.getOrDefault(
+            registrationId, defaultTokenClaimsConverter);
+    try {
+      final var claims = new HashMap<>(getClaims(oauth2Authentication));
+      identityClaimsByRegistrationId
+          .getOrDefault(registrationId, List.of())
+          .forEach(claim -> normalizeUriClaim(claims, claim));
+      return tokenClaimsConverter.convert(claims);
+    } catch (final IllegalArgumentException e) {
+      throw new OAuth2AuthenticationException(
+          new OAuth2Error("invalid_token", e.getMessage(), null), e);
+    }
+  }
+
+  private static void normalizeUriClaim(final Map<String, Object> claims, final String claimName) {
+    final var value = claims.get(claimName);
+    if (value instanceof URI || value instanceof URL) {
+      claims.put(claimName, value.toString());
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/ProviderAwareOidcUserAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ProviderAwareOidcUserAuthenticationConverter.java
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 
 final class ProviderAwareOidcUserAuthenticationConverter extends OidcUserAuthenticationConverter {
 
@@ -65,7 +66,7 @@ final class ProviderAwareOidcUserAuthenticationConverter extends OidcUserAuthent
       return tokenClaimsConverter.convert(claims);
     } catch (final IllegalArgumentException e) {
       throw new OAuth2AuthenticationException(
-          new OAuth2Error("invalid_token", e.getMessage(), null), e);
+          new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN, e.getMessage(), null), e);
     }
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantOidcProviders.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantOidcProviders.java
@@ -82,14 +82,17 @@ public final class PhysicalTenantOidcProviders {
   public static Map<String, List<String>> identityClaimsByRegistrationId(
       final Environment environment) {
     return providersByRegistrationId(environment).entrySet().stream()
-        .collect(
-            toMap(
-                Map.Entry::getKey,
-                entry ->
-                    Stream.of(
-                            entry.getValue().getUsernameClaim(),
-                            entry.getValue().getClientIdClaim())
-                        .filter(Objects::nonNull)
-                        .toList()));
+        .collect(toMap(Map.Entry::getKey, entry -> identityClaims(entry.getValue())));
+  }
+
+  /**
+   * Returns the configured identity claim names (username and client-id, omitting the unset ones)
+   * for a single provider. These are the claims the provider-aware converter normalizes to strings
+   * before conversion.
+   */
+  public static List<String> identityClaims(final OidcConfiguration config) {
+    return Stream.of(config.getUsernameClaim(), config.getClientIdClaim())
+        .filter(Objects::nonNull)
+        .toList();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantOidcProviders.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantOidcProviders.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import static java.util.stream.Collectors.toMap;
+
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.out.MembershipPort;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.springframework.core.env.Environment;
+
+/**
+ * Derives per-registration OIDC claim wiring for the named providers of every physical tenant.
+ *
+ * <p>Interactive OIDC login selects claim mapping by {@code
+ * OAuth2AuthenticationToken#getAuthorizedClientRegistrationId()}. A physical-tenant scoped provider
+ * (e.g. an Auth0 registration) can configure different identity claims than the root provider, so
+ * the host cannot reuse the single root {@link LazyTokenClaimsConverter}. This factory flattens the
+ * named providers of all physical tenants (see {@link
+ * PhysicalTenantAuthConfigurations#forAllPhysicalTenants(Environment)}) into maps keyed by
+ * registration id that the provider-aware converter looks up at conversion time.
+ */
+public final class PhysicalTenantOidcProviders {
+
+  private PhysicalTenantOidcProviders() {}
+
+  /**
+   * Flattens the named OIDC providers of every physical tenant into a map keyed by registration id.
+   * The unnamed default slot ({@code authentication.oidc.*}) is not a named provider and is
+   * therefore absent, so the root registration keeps the default converter.
+   */
+  public static Map<String, OidcConfiguration> providersByRegistrationId(
+      final Environment environment) {
+    final Map<String, OidcConfiguration> providersByRegistrationId = new LinkedHashMap<>();
+    PhysicalTenantAuthConfigurations.forAllPhysicalTenants(environment).values().stream()
+        .map(AuthenticationConfiguration::getProviders)
+        .filter(providers -> providers != null && providers.getOidc() != null)
+        .forEach(providers -> providersByRegistrationId.putAll(providers.getOidc()));
+    return providersByRegistrationId;
+  }
+
+  /**
+   * Builds a {@link LazyTokenClaimsConverter} per scoped registration from its configured username
+   * and client-id claims.
+   */
+  public static Map<String, LazyTokenClaimsConverter> tokenClaimsConvertersByRegistrationId(
+      final Environment environment,
+      final MembershipPort membershipPort,
+      final MembershipResolutionContextPropagator membershipResolutionContextPropagator) {
+    return providersByRegistrationId(environment).entrySet().stream()
+        .collect(
+            toMap(
+                Map.Entry::getKey,
+                entry -> {
+                  final var config = entry.getValue();
+                  return new LazyTokenClaimsConverter(
+                      config.getUsernameClaim(),
+                      config.getClientIdClaim(),
+                      config.isPreferUsernameClaim(),
+                      membershipPort,
+                      membershipResolutionContextPropagator);
+                }));
+  }
+
+  /**
+   * Collects the configured identity claims (username and client-id) per scoped registration.
+   * Spring can represent a standard claim such as {@code iss} as a URI, so the provider-aware
+   * converter normalizes these claim values to strings before conversion.
+   */
+  public static Map<String, List<String>> identityClaimsByRegistrationId(
+      final Environment environment) {
+    return providersByRegistrationId(environment).entrySet().stream()
+        .collect(
+            toMap(
+                Map.Entry::getKey,
+                entry ->
+                    Stream.of(
+                            entry.getValue().getUsernameClaim(),
+                            entry.getValue().getClientIdClaim())
+                        .filter(Objects::nonNull)
+                        .toList()));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantOidcProviders.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantOidcProviders.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.pt;
 
+import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toMap;
 
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
@@ -14,6 +15,7 @@ import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.out.MembershipPort;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,9 +39,13 @@ public final class PhysicalTenantOidcProviders {
   private PhysicalTenantOidcProviders() {}
 
   /**
-   * Flattens the named OIDC providers of every physical tenant into a map keyed by registration id.
-   * The unnamed default slot ({@code authentication.oidc.*}) is not a named provider and is
-   * therefore absent, so the root registration keeps the default converter.
+   * Flattens the named OIDC providers of every physical tenant into an unmodifiable map keyed by
+   * registration id. The unnamed default slot ({@code authentication.oidc.*}) is not a named
+   * provider and is therefore absent, so the root registration keeps the default converter.
+   *
+   * <p>A registration id can legitimately appear in more than one tenant (a shared cluster provider
+   * is merged into every tenant), so entries are merged last-wins rather than rejected as
+   * duplicates.
    */
   public static Map<String, OidcConfiguration> providersByRegistrationId(
       final Environment environment) {
@@ -48,7 +54,7 @@ public final class PhysicalTenantOidcProviders {
         .map(AuthenticationConfiguration::getProviders)
         .filter(providers -> providers != null && providers.getOidc() != null)
         .forEach(providers -> providersByRegistrationId.putAll(providers.getOidc()));
-    return providersByRegistrationId;
+    return Collections.unmodifiableMap(providersByRegistrationId);
   }
 
   /**
@@ -61,17 +67,19 @@ public final class PhysicalTenantOidcProviders {
       final MembershipResolutionContextPropagator membershipResolutionContextPropagator) {
     return providersByRegistrationId(environment).entrySet().stream()
         .collect(
-            toMap(
-                Map.Entry::getKey,
-                entry -> {
-                  final var config = entry.getValue();
-                  return new LazyTokenClaimsConverter(
-                      config.getUsernameClaim(),
-                      config.getClientIdClaim(),
-                      config.isPreferUsernameClaim(),
-                      membershipPort,
-                      membershipResolutionContextPropagator);
-                }));
+            collectingAndThen(
+                toMap(
+                    Map.Entry::getKey,
+                    entry -> {
+                      final var config = entry.getValue();
+                      return new LazyTokenClaimsConverter(
+                          config.getUsernameClaim(),
+                          config.getClientIdClaim(),
+                          config.isPreferUsernameClaim(),
+                          membershipPort,
+                          membershipResolutionContextPropagator);
+                    }),
+                Collections::unmodifiableMap));
   }
 
   /**
@@ -82,7 +90,10 @@ public final class PhysicalTenantOidcProviders {
   public static Map<String, List<String>> identityClaimsByRegistrationId(
       final Environment environment) {
     return providersByRegistrationId(environment).entrySet().stream()
-        .collect(toMap(Map.Entry::getKey, entry -> identityClaims(entry.getValue())));
+        .collect(
+            collectingAndThen(
+                toMap(Map.Entry::getKey, entry -> identityClaims(entry.getValue())),
+                Collections::unmodifiableMap));
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationConverterWiringTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
+import io.camunda.security.core.port.out.MembershipPort;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+/**
+ * Verifies the {@code oidcUserAuthenticationConverter} bean is wired so interactive login (issue
+ * #57776) selects claim mapping by registration id and normalizes URI-valued identity claims. This
+ * drives the real bean factory method (not the converter in isolation), so reverting the wiring
+ * back to the plain root converter fails these tests.
+ */
+@ExtendWith(MockitoExtension.class)
+class OidcOverrideBeansConfigurationConverterWiringTest {
+
+  private static final String SCOPED_PREFIX =
+      "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.auth0";
+
+  @Mock private OAuth2AuthorizedClientRepository authorizedClientRepository;
+  @Mock private OidcAccessTokenDecoderFactory accessTokenDecoderFactory;
+  @Mock private HttpServletRequest request;
+  @Mock private MembershipPort membershipPort;
+  @Mock private OidcProviderConfigurationPort oidcProviderRepository;
+
+  @Test
+  void shouldSelectScopedConverterAndNormalizeUriClaimForScopedRegistration() {
+    // given — root Keycloak uses preferred_username, scoped Auth0 uses iss (a URI-valued claim)
+    final var converter = converter("preferred_username", "iss");
+    final var authentication = login("auth0", Map.of("iss", URI.create("https://scoped-idp")));
+
+    // when
+    final var result = converter.convert(authentication);
+
+    // then — the scoped iss converter runs and the URI iss is normalized to a string
+    assertThat(result.authenticatedUsername()).isEqualTo("https://scoped-idp");
+  }
+
+  @Test
+  void shouldNormalizeUriClaimForRootRegistrationToo() {
+    // given — the root registration itself uses a URI-valued identity claim
+    final var converter = converter("iss", "sub");
+    final var authentication = login("oidc", Map.of("iss", URI.create("https://root-idp")));
+
+    // when
+    final var result = converter.convert(authentication);
+
+    // then — the root iss is normalized so the default converter can resolve it
+    assertThat(result.authenticatedUsername()).isEqualTo("https://root-idp");
+  }
+
+  private CamundaAuthenticationConverter<Authentication> converter(
+      final String rootUsernameClaim, final String scopedUsernameClaim) {
+    when(oidcProviderRepository.getOidcAuthenticationConfigurations()).thenReturn(Map.of());
+    // authorizedClientRepository returns no client, so the converter falls back to ID-token
+    // (principal) claims, which is the interactive-login path this test exercises.
+
+    final var cslProperties = new CamundaSecurityLibraryProperties();
+    cslProperties.getAuthentication().getOidc().setUsernameClaim(rootUsernameClaim);
+    final var configuration = new OidcOverrideBeansConfiguration(cslProperties);
+
+    final var defaultConverter =
+        new LazyTokenClaimsConverter(
+            rootUsernameClaim,
+            null,
+            false,
+            membershipPort,
+            MembershipResolutionContextPropagator.identity());
+
+    final var environment = new MockEnvironment();
+    environment.setProperty("camunda.security.authentication.method", "oidc");
+    environment.setProperty(SCOPED_PREFIX + ".username-claim", scopedUsernameClaim);
+
+    return configuration.oidcUserAuthenticationConverter(
+        authorizedClientRepository,
+        accessTokenDecoderFactory,
+        defaultConverter,
+        request,
+        oidcProviderRepository,
+        membershipPort,
+        MembershipResolutionContextPropagator.identity(),
+        environment);
+  }
+
+  private static OAuth2AuthenticationToken login(
+      final String registrationId, final Map<String, Object> attributes) {
+    final var principal = mock(OidcUser.class);
+    when(principal.getAttributes()).thenReturn(attributes);
+    return new OAuth2AuthenticationToken(principal, List.of(), registrationId);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationIdTokenDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationIdTokenDecoderTest.java
@@ -104,6 +104,23 @@ class OidcOverrideBeansConfigurationIdTokenDecoderTest {
     assertThat(decoderTwo).isNotNull();
   }
 
+  @Test
+  void shouldDefaultToRs256ForScopedRegistrationMissingFromGlobalRepository() {
+    // given
+    when(oidcProviderConfigurationPort.getOidcAuthenticationConfigurations()).thenReturn(Map.of());
+    final var tokenValidatorFactory =
+        new TokenValidatorFactory(Map.of(), Duration.ofSeconds(60), List.of());
+    final var configuration = new OidcOverrideBeansConfiguration(null);
+    final JwtDecoderFactory<ClientRegistration> decoderFactory =
+        configuration.idTokenDecoderFactory(tokenValidatorFactory, oidcProviderConfigurationPort);
+
+    // when
+    final JwtDecoder decoder = decoderFactory.createDecoder(buildRegistration("scoped"));
+
+    // then
+    assertThat(decoder).isNotNull();
+  }
+
   private static ClientRegistration buildRegistration(final String registrationId) {
     return ClientRegistration.withRegistrationId(registrationId)
         .clientId("client-id")

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationIdTokenDecoderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcOverrideBeansConfigurationIdTokenDecoderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
@@ -113,12 +114,14 @@ class OidcOverrideBeansConfigurationIdTokenDecoderTest {
     final var configuration = new OidcOverrideBeansConfiguration(null);
     final JwtDecoderFactory<ClientRegistration> decoderFactory =
         configuration.idTokenDecoderFactory(tokenValidatorFactory, oidcProviderConfigurationPort);
+    final var scopedRegistration = buildRegistration("scoped");
 
-    // when
-    final JwtDecoder decoder = decoderFactory.createDecoder(buildRegistration("scoped"));
-
-    // then
-    assertThat(decoder).isNotNull();
+    // when / then — without the RS256 default the resolver returns null and
+    // OidcIdTokenDecoderFactory rejects the registration at decoder-build time with
+    // "missing_signature_verifier"; the default must yield a usable decoder instead.
+    assertThatCode(() -> decoderFactory.createDecoder(scopedRegistration))
+        .doesNotThrowAnyException();
+    assertThat(decoderFactory.createDecoder(scopedRegistration)).isNotNull();
   }
 
   private static ClientRegistration buildRegistration(final String registrationId) {

--- a/authentication/src/test/java/io/camunda/authentication/config/ProviderAwareOidcUserAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ProviderAwareOidcUserAuthenticationConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+@SuppressWarnings("unchecked")
+class ProviderAwareOidcUserAuthenticationConverterTest {
+
+  @Test
+  void shouldUseProviderConverterAndNormalizeUriIdentityClaim() {
+    // given
+    final var defaultConverter = mock(LazyTokenClaimsConverter.class);
+    final var providerConverter = mock(LazyTokenClaimsConverter.class);
+    final var authentication = authentication("okta", Map.of("iss", URI.create("https://idp")));
+    when(providerConverter.convert(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(CamundaAuthentication.of(builder -> builder.user("https://idp")));
+    final var converter = converter(defaultConverter, Map.of("okta", providerConverter));
+
+    // when
+    final var result = converter.convert(authentication);
+
+    // then
+    final ArgumentCaptor<Map<String, Object>> claims = ArgumentCaptor.forClass(Map.class);
+    verify(providerConverter).convert(claims.capture());
+    verifyNoInteractions(defaultConverter);
+    assertThat(claims.getValue()).containsEntry("iss", "https://idp");
+    assertThat(result.authenticatedUsername()).isEqualTo("https://idp");
+  }
+
+  @Test
+  void shouldUseDefaultConverterForRootRegistration() {
+    // given
+    final var defaultConverter = mock(LazyTokenClaimsConverter.class);
+    final var providerConverter = mock(LazyTokenClaimsConverter.class);
+    final var authentication = authentication("oidc", Map.of("preferred_username", "demo"));
+    when(defaultConverter.convert(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(CamundaAuthentication.of(builder -> builder.user("demo")));
+    final var converter = converter(defaultConverter, Map.of("okta", providerConverter));
+
+    // when
+    final var result = converter.convert(authentication);
+
+    // then
+    verify(defaultConverter).convert(Map.of("preferred_username", "demo"));
+    verifyNoInteractions(providerConverter);
+    assertThat(result.authenticatedUsername()).isEqualTo("demo");
+  }
+
+  private static ProviderAwareOidcUserAuthenticationConverter converter(
+      final LazyTokenClaimsConverter defaultConverter,
+      final Map<String, LazyTokenClaimsConverter> providerConverters) {
+    return new ProviderAwareOidcUserAuthenticationConverter(
+        mock(OAuth2AuthorizedClientRepository.class),
+        mock(OidcAccessTokenDecoderFactory.class),
+        defaultConverter,
+        mock(HttpServletRequest.class),
+        Map.of(),
+        Map.of("okta", true),
+        providerConverters,
+        Map.of("okta", List.of("iss", "https://camunda.com/claims/client_id")));
+  }
+
+  private static OAuth2AuthenticationToken authentication(
+      final String registrationId, final Map<String, Object> attributes) {
+    final var principal = mock(OidcUser.class);
+    when(principal.getAttributes()).thenReturn(attributes);
+    return new OAuth2AuthenticationToken(principal, List.of(), registrationId);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantOidcProvidersTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantOidcProvidersTest.java
@@ -121,7 +121,7 @@ class PhysicalTenantOidcProvidersTest {
         SCOPED_PREFIX + ".client-id-claim", "https://camunda.com/claims/client_id");
     environment.setProperty(SCOPED_PREFIX + ".prefer-username-claim", "true");
     environment.setProperty(
-        "camunda.physical-tenants.tenanta.security.authentication.providers.assigned", "auth0");
+        "camunda.physical-tenants.tenanta.security.authentication.providers.assigned[0]", "auth0");
     return environment;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantOidcProvidersTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantOidcProvidersTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.core.port.out.MembershipPort;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -18,38 +19,44 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
- * Verifies that the scoped OIDC claim wiring (issue #57776) is derived from the merged
- * physical-tenant configuration: a physical tenant with its own named provider and provider-scoped
- * identity claims yields a converter and an identity-claim list keyed by that registration id,
- * while the root registration keeps the default converter.
+ * Verifies the scoped OIDC claim wiring (issue #57776) for the reported topology: a root Keycloak
+ * provider (the unnamed default slot) configured alongside a physical-tenant scoped Auth0 provider
+ * with its own identity claims.
+ *
+ * <p>The scoped provider must yield a converter and an identity-claim list keyed by its
+ * registration id, using its own claims and not the root claims. The root registration ({@code
+ * oidc}, the default slot) must stay absent from the derived maps so interactive root login keeps
+ * the default converter.
  */
 @ExtendWith(MockitoExtension.class)
 class PhysicalTenantOidcProvidersTest {
 
-  private static final String PREFIX =
+  private static final String ROOT_PREFIX = "camunda.security.authentication.oidc";
+  private static final String SCOPED_PREFIX =
       "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.auth0";
 
   @Mock private MembershipPort membershipPort;
 
   @Test
-  void shouldFlattenNamedPhysicalTenantProvidersByRegistrationId() {
+  void shouldFlattenScopedProviderWithoutRootRegistration() {
     // given
-    final var environment = environmentWithScopedAuth0Provider();
+    final var environment = rootKeycloakWithScopedAuth0();
 
     // when
     final var providers = PhysicalTenantOidcProviders.providersByRegistrationId(environment);
 
     // then
-    assertThat(providers).containsKey("auth0");
+    assertThat(providers).containsOnlyKeys("auth0");
+    // the scoped provider keeps its own claim, not the root "preferred_username"
     assertThat(providers.get("auth0").getUsernameClaim()).isEqualTo("iss");
-    // the unnamed default slot ("oidc") is not a named provider, so the root keeps its converter
+    // the root default slot is not a named provider, so the root keeps the default converter
     assertThat(providers).doesNotContainKey("oidc");
   }
 
   @Test
-  void shouldBuildScopedTokenClaimsConverterPerRegistration() {
+  void shouldBuildScopedTokenClaimsConverterOnlyForScopedRegistration() {
     // given
-    final var environment = environmentWithScopedAuth0Provider();
+    final var environment = rootKeycloakWithScopedAuth0();
 
     // when
     final var converters =
@@ -64,7 +71,7 @@ class PhysicalTenantOidcProvidersTest {
   @Test
   void shouldCollectScopedIdentityClaimsForUriNormalization() {
     // given
-    final var environment = environmentWithScopedAuth0Provider();
+    final var environment = rootKeycloakWithScopedAuth0();
 
     // when
     final var identityClaims =
@@ -72,14 +79,14 @@ class PhysicalTenantOidcProvidersTest {
 
     // then
     assertThat(identityClaims)
-        .containsEntry("auth0", java.util.List.of("iss", "https://camunda.com/claims/client_id"));
+        .containsOnlyKeys("auth0")
+        .containsEntry("auth0", List.of("iss", "https://camunda.com/claims/client_id"));
   }
 
   @Test
-  void shouldReturnEmptyMapsWhenNoPhysicalTenantProvidersConfigured() {
+  void shouldReturnEmptyMapsWhenOnlyRootProviderConfigured() {
     // given
-    final var environment = new MockEnvironment();
-    environment.setProperty("camunda.security.authentication.method", "oidc");
+    final var environment = rootKeycloakOnly();
 
     // when
     final var providers = PhysicalTenantOidcProviders.providersByRegistrationId(environment);
@@ -95,13 +102,26 @@ class PhysicalTenantOidcProvidersTest {
     assertThat(identityClaims).isEmpty();
   }
 
-  private static MockEnvironment environmentWithScopedAuth0Provider() {
+  private static MockEnvironment rootKeycloakOnly() {
     final var environment = new MockEnvironment();
     environment.setProperty("camunda.security.authentication.method", "oidc");
-    // Auth0-like scoped provider: iss as the username claim and a custom client-id claim.
-    environment.setProperty(PREFIX + ".username-claim", "iss");
-    environment.setProperty(PREFIX + ".client-id-claim", "https://camunda.com/claims/client_id");
-    environment.setProperty(PREFIX + ".prefer-username-claim", "true");
+    // Root Keycloak provider in the unnamed default slot.
+    environment.setProperty(ROOT_PREFIX + ".client-id", "keycloak-client");
+    environment.setProperty(ROOT_PREFIX + ".issuer-uri", "http://keycloak.local/realms/camunda");
+    environment.setProperty(ROOT_PREFIX + ".username-claim", "preferred_username");
+    return environment;
+  }
+
+  private static MockEnvironment rootKeycloakWithScopedAuth0() {
+    final var environment = rootKeycloakOnly();
+    // Auth0-like scoped provider assigned to tenant "tenanta": iss as the username claim and a
+    // custom client-id claim, both differing from the root Keycloak claims.
+    environment.setProperty(SCOPED_PREFIX + ".username-claim", "iss");
+    environment.setProperty(
+        SCOPED_PREFIX + ".client-id-claim", "https://camunda.com/claims/client_id");
+    environment.setProperty(SCOPED_PREFIX + ".prefer-username-claim", "true");
+    environment.setProperty(
+        "camunda.physical-tenants.tenanta.security.authentication.providers.assigned", "auth0");
     return environment;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantOidcProvidersTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantOidcProvidersTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.security.core.port.out.MembershipPort;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Verifies that the scoped OIDC claim wiring (issue #57776) is derived from the merged
+ * physical-tenant configuration: a physical tenant with its own named provider and provider-scoped
+ * identity claims yields a converter and an identity-claim list keyed by that registration id,
+ * while the root registration keeps the default converter.
+ */
+@ExtendWith(MockitoExtension.class)
+class PhysicalTenantOidcProvidersTest {
+
+  private static final String PREFIX =
+      "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.auth0";
+
+  @Mock private MembershipPort membershipPort;
+
+  @Test
+  void shouldFlattenNamedPhysicalTenantProvidersByRegistrationId() {
+    // given
+    final var environment = environmentWithScopedAuth0Provider();
+
+    // when
+    final var providers = PhysicalTenantOidcProviders.providersByRegistrationId(environment);
+
+    // then
+    assertThat(providers).containsKey("auth0");
+    assertThat(providers.get("auth0").getUsernameClaim()).isEqualTo("iss");
+    // the unnamed default slot ("oidc") is not a named provider, so the root keeps its converter
+    assertThat(providers).doesNotContainKey("oidc");
+  }
+
+  @Test
+  void shouldBuildScopedTokenClaimsConverterPerRegistration() {
+    // given
+    final var environment = environmentWithScopedAuth0Provider();
+
+    // when
+    final var converters =
+        PhysicalTenantOidcProviders.tokenClaimsConvertersByRegistrationId(
+            environment, membershipPort, MembershipResolutionContextPropagator.identity());
+
+    // then
+    assertThat(converters).containsOnlyKeys("auth0");
+    assertThat(converters.get("auth0")).isNotNull();
+  }
+
+  @Test
+  void shouldCollectScopedIdentityClaimsForUriNormalization() {
+    // given
+    final var environment = environmentWithScopedAuth0Provider();
+
+    // when
+    final var identityClaims =
+        PhysicalTenantOidcProviders.identityClaimsByRegistrationId(environment);
+
+    // then
+    assertThat(identityClaims)
+        .containsEntry("auth0", java.util.List.of("iss", "https://camunda.com/claims/client_id"));
+  }
+
+  @Test
+  void shouldReturnEmptyMapsWhenNoPhysicalTenantProvidersConfigured() {
+    // given
+    final var environment = new MockEnvironment();
+    environment.setProperty("camunda.security.authentication.method", "oidc");
+
+    // when
+    final var providers = PhysicalTenantOidcProviders.providersByRegistrationId(environment);
+    final var converters =
+        PhysicalTenantOidcProviders.tokenClaimsConvertersByRegistrationId(
+            environment, membershipPort, MembershipResolutionContextPropagator.identity());
+    final var identityClaims =
+        PhysicalTenantOidcProviders.identityClaimsByRegistrationId(environment);
+
+    // then
+    assertThat(providers).isEmpty();
+    assertThat(converters).isEmpty();
+    assertThat(identityClaims).isEmpty();
+  }
+
+  private static MockEnvironment environmentWithScopedAuth0Provider() {
+    final var environment = new MockEnvironment();
+    environment.setProperty("camunda.security.authentication.method", "oidc");
+    // Auth0-like scoped provider: iss as the username claim and a custom client-id claim.
+    environment.setProperty(PREFIX + ".username-claim", "iss");
+    environment.setProperty(PREFIX + ".client-id-claim", "https://camunda.com/claims/client_id");
+    environment.setProperty(PREFIX + ".prefer-username-claim", "true");
+    return environment;
+  }
+}


### PR DESCRIPTION
## Summary

- select interactive OIDC claim conversion by OAuth registration ID
- source named providers from merged physical-tenant authentication configuration
- default scoped ID-token verification to RS256 when absent from the global provider repository
- normalize URI-valued identity claims such as `iss` before principal conversion

## Verification

- `./mvnw clean verify -pl authentication -DskipTests=false -Dquickly -T1C` (305 unit tests and 14 integration tests passed)
- live SM physical-tenant login verified with root Keycloak and scoped Auth0 providers

## Dependency

This PR is stacked on #57764 to keep the diff focused. Change the base to `main` after #57764 merges.

Closes #57776