### PR TITLE
fix: clean up deprecated Maven build warnings

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -766,6 +766,26 @@
           <meminitial>128m</meminitial>
           <maxmem>256m</maxmem>
         </configuration>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <!-- See https://logging.apache.org/log4j/2.x/manual/plugins.html#plugin-registry -->
+              <annotationProcessorPaths>
+                <!-- Include `log4j-core` providing `org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor` that generates `Log4j2Plugins.dat`-->
+                <path>
+                  <groupId>org.apache.logging.log4j</groupId>
+                  <artifactId>log4j-core</artifactId>
+                  <version>${version.log4j}</version>
+                </path>
+              </annotationProcessorPaths>
+              <annotationProcessors>
+                <!-- Process sources using `PluginProcessor` to generate `Log4j2Plugins.dat` -->
+                <processor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</processor>
+              </annotationProcessors>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -816,30 +836,6 @@
             <configuration>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>
               <includeScope>runtime</includeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <configuration>
-              <!-- See https://logging.apache.org/log4j/2.x/manual/plugins.html#plugin-registry -->
-              <annotationProcessorPaths>
-                <!-- Include `log4j-core` providing `org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor` that generates `Log4j2Plugins.dat`-->
-                <path>
-                  <groupId>org.apache.logging.log4j</groupId>
-                  <artifactId>log4j-core</artifactId>
-                  <version>${version.log4j}</version>
-                </path>
-              </annotationProcessorPaths>
-              <annotationProcessors>
-                <!-- Process sources using `PluginProcessor` to generate `Log4j2Plugins.dat` -->
-                <processor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</processor>
-              </annotationProcessors>
             </configuration>
           </execution>
         </executions>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -733,12 +733,9 @@
             <printStderrOnFailure>true</printStderrOnFailure>
             <printStderrOnSuccess>false</printStderrOnSuccess>
           </statelessTestsetInfoReporter>
-          <systemProperties>
-            <property>
-              <name>identity.docker.image.version</name>
-              <value>${version.identity}</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+            <identity.docker.image.version>${version.identity}</identity.docker.image.version>
+          </systemPropertyVariables>
           <excludedGroups>rdbms, rdbms-aurora, multi-db-test, compatibility-test, dl-nightly</excludedGroups>
         </configuration>
         <dependencies>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -713,12 +713,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <systemProperties>
-            <property>
-              <name>identity.docker.image.version</name>
-              <value>${version.identity}</value>
-            </property>
-          </systemProperties>
+          <systemPropertyVariables>
+            <identity.docker.image.version>${version.identity}</identity.docker.image.version>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Summary
Found these build warnings while working on something else, opened this PR to clean them up.

- Replace deprecated `systemProperties` with `systemPropertyVariables` in surefire/failsafe config (`zeebe/qa/integration-tests`, `qa/acceptance-tests`)
- Merge duplicate `maven-compiler-plugin` declaration in `optimize/backend/pom.xml`