### PR TITLE
fix: add safety hatch to skip Entra token version check

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/converter/TokenClaimsConverter.java
@@ -35,6 +35,7 @@ public class TokenClaimsConverter {
   private final String usernameClaim;
   private final String clientIdClaim;
   private final boolean preferUsernameClaim;
+  private final boolean entraTokenVersionCheckEnabled;
   private final MembershipService membershipService;
 
   public TokenClaimsConverter(
@@ -45,11 +46,15 @@ public class TokenClaimsConverter {
     clientIdClaim = securityConfiguration.getAuthentication().getOidc().getClientIdClaim();
     preferUsernameClaim =
         securityConfiguration.getAuthentication().getOidc().isPreferUsernameClaim();
+    entraTokenVersionCheckEnabled =
+        securityConfiguration.getAuthentication().getOidc().isEntraTokenVersionCheckEnabled();
     oidcPrincipalLoader = new OidcPrincipalLoader(usernameClaim, clientIdClaim);
   }
 
   public CamundaAuthentication convert(final Map<String, Object> tokenClaims) {
-    validateEntraTokenVersion(tokenClaims);
+    if (entraTokenVersionCheckEnabled) {
+      validateEntraTokenVersion(tokenClaims);
+    }
 
     final var principals = oidcPrincipalLoader.load(tokenClaims);
     final var username = principals.username();
@@ -99,6 +104,10 @@ public class TokenClaimsConverter {
    * surface as {@code iss=sts.windows.net}, {@code ver=1.0}, fail downstream validation, and
    * typically manifest as a silent redirect loop back to Entra. Detecting the mismatch here turns
    * that into a clear, actionable failure for operators.
+   *
+   * <p>Can be disabled via {@code
+   * camunda.security.authentication.oidc.entraTokenVersionCheckEnabled} as a safety hatch, in case
+   * this check incorrectly rejects a previously-working v1 authentication.
    */
   private void validateEntraTokenVersion(final Map<String, Object> tokenClaims) {
     final Object issuer = tokenClaims.get(ISSUER_CLAIM);

--- a/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/TokenClaimsConverterNoDbTest.java
@@ -181,6 +181,36 @@ public class TokenClaimsConverterNoDbTest {
   }
 
   @Test
+  void shouldAcceptEntraV1AccessTokenWhenVersionCheckDisabled() {
+    // given - the safety hatch is disabled, so a v1.0 token must be let through
+    final var oidcConfig = new OidcAuthenticationConfiguration();
+    oidcConfig.setUsernameClaim("preferred_username");
+    oidcConfig.setClientIdClaim("azp");
+    oidcConfig.setEntraTokenVersionCheckEnabled(false);
+    final var authConfig = new AuthenticationConfiguration();
+    authConfig.setOidc(oidcConfig);
+    final var config = new SecurityConfiguration();
+    config.setAuthentication(authConfig);
+
+    final var converter = new TokenClaimsConverter(config, membershipService);
+    final Map<String, Object> claims =
+        Map.of(
+            "preferred_username",
+            "testuser",
+            "iss",
+            "https://sts.windows.net/9188040d-6c67-4c5b-b112-36a304b66dad/",
+            "ver",
+            "1.0");
+
+    // when
+    final var result = converter.convert(claims);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.authenticatedUsername()).isEqualTo("testuser");
+  }
+
+  @Test
   void shouldNotApplyEntraGuardToNonMicrosoftIssuer() {
     // given - a non-Microsoft issuer (e.g. Keycloak) with no ver claim
     final Map<String, Object> claims =

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -58,6 +58,7 @@ public class OidcAuthenticationConfiguration {
   private Duration clockSkew = DEFAULT_CLOCK_SKEW;
   private boolean idpLogoutEnabled = true;
   private boolean userInfoEnabled = true;
+  private boolean entraTokenVersionCheckEnabled = true;
   private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
       new OidcUserInfoAugmentationConfiguration();
   private OidcDiagnosticsConfiguration diagnostics = new OidcDiagnosticsConfiguration();
@@ -289,6 +290,14 @@ public class OidcAuthenticationConfiguration {
     this.userInfoEnabled = userInfoEnabled;
   }
 
+  public boolean isEntraTokenVersionCheckEnabled() {
+    return entraTokenVersionCheckEnabled;
+  }
+
+  public void setEntraTokenVersionCheckEnabled(final boolean entraTokenVersionCheckEnabled) {
+    this.entraTokenVersionCheckEnabled = entraTokenVersionCheckEnabled;
+  }
+
   public OidcUserInfoAugmentationConfiguration getUserInfoAugmentation() {
     return userInfoAugmentation;
   }
@@ -374,6 +383,7 @@ public class OidcAuthenticationConfiguration {
     private Duration clockSkew = DEFAULT_CLOCK_SKEW;
     private boolean idpLogoutEnabled = true;
     private boolean userInfoEnabled = true;
+    private boolean entraTokenVersionCheckEnabled = true;
     private OidcUserInfoAugmentationConfiguration userInfoAugmentation =
         new OidcUserInfoAugmentationConfiguration();
     private OidcDiagnosticsConfiguration diagnostics = new OidcDiagnosticsConfiguration();
@@ -510,6 +520,11 @@ public class OidcAuthenticationConfiguration {
       return this;
     }
 
+    public Builder entraTokenVersionCheckEnabled(final boolean entraTokenVersionCheckEnabled) {
+      this.entraTokenVersionCheckEnabled = entraTokenVersionCheckEnabled;
+      return this;
+    }
+
     public Builder userInfoAugmentation(
         final OidcUserInfoAugmentationConfiguration userInfoAugmentation) {
       this.userInfoAugmentation = userInfoAugmentation;
@@ -549,6 +564,7 @@ public class OidcAuthenticationConfiguration {
       config.setClockSkew(clockSkew);
       config.setIdpLogoutEnabled(idpLogoutEnabled);
       config.setUserInfoEnabled(userInfoEnabled);
+      config.setEntraTokenVersionCheckEnabled(entraTokenVersionCheckEnabled);
       config.setUserInfoAugmentation(userInfoAugmentation);
       config.setDiagnostics(diagnostics);
       return config;


### PR DESCRIPTION
## Summary
- The Entra v1 token rejection can break existing authentications that were previously working with v1.
- Adds `camunda.security.authentication.oidc.entraTokenVersionCheckEnabled` (default `true`) as a safety hatch to skip the check when disabled.

## Test plan
- [x] `TokenClaimsConverterNoDbTest` — added `shouldAcceptEntraV1AccessTokenWhenVersionCheckDisabled`, verified all existing tests still pass
- [x] `TokenClaimsConverterTest` — unaffected, still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)