### PR TITLE
test: skip swagger specs pending bug #57502

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -33,7 +33,8 @@ test.beforeEach(async ({context}) => {
 });
 
 test.describe('Swagger UI Tests', () => {
-  test('Swagger UI is accessible and presents the API list', async ({
+  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
+  test.skip('Swagger UI is accessible and presents the API list', async ({
     swaggerPage,
   }) => {
     await swaggerPage.gotoSwaggerUI();
@@ -47,7 +48,8 @@ test.describe('Swagger UI Tests', () => {
     await expect(swaggerPage.firstApiTag).toBeVisible({timeout: 60_000});
   });
 
-  test('Grouped OpenAPI spec returns valid JSON without external file refs', async ({
+  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
+  test.skip('Grouped OpenAPI spec returns valid JSON without external file refs', async ({
     request,
     swaggerPage,
   }) => {
@@ -85,7 +87,8 @@ test.describe('Swagger UI Tests', () => {
     expect(externalFileRefs).toEqual([]);
   });
 
-  test('CSRF token is filled in and Swagger UI is accessible with CSRF token', async ({
+  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
+  test.skip('CSRF token is filled in and Swagger UI is accessible with CSRF token', async ({
     loginPage,
     operateHomePage,
     page,
@@ -119,7 +122,8 @@ test.describe('Swagger UI Tests', () => {
     expect(curlCommandText).toMatch(/x-csrf-token\s*:\s*(?!null\b)\S+/i);
   });
 
-  test('CSRF token is NOT filled in and Swagger UI is accessible', async ({
+  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
+  test.skip('CSRF token is NOT filled in and Swagger UI is accessible', async ({
     swaggerPage,
   }) => {
     // go to swagger UI


### PR DESCRIPTION
## Description

The four specs in `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts` fail on every `main` nightly run. This is a **confirmed product regression**, not a test defect, tracked by #57502:

- `/v3/api-docs/swagger-config` now advertises the grouped `Orchestration Cluster API` spec at `/physical-tenants/{physicalTenantId}/v3/api-docs/...` with the `{physicalTenantId}` template left unsubstituted, so the URL 404s and Swagger UI shows "Failed to load remote configuration" (no `.opblock-tag` ever renders).
- Introduced by `ec684110804` ("feat: register PT-prefixed sibling for /v3/api-docs"), which added `/v3/api-docs` to `PREFIXABLE_ROOTS` in `PhysicalTenantRequestMappingHandlerMapping`.

The tests are correct and the failure is deterministic (every retry failed), so per the nightly product-bug escalation policy the tests are skipped with a bug-linked annotation until the gateway-rest mapping is fixed. Each skip carries `// Skipped due to bug #57502: <url>` so the tests are re-enabled when the issue is closed.

Scoped to `main` only — the stable branches (8.7–8.10) are not affected by this regression.

Refs #57502

- Nightly run: https://github.com/camunda/camunda/actions/runs/29384586530
- Triage run: https://github.com/camunda/camunda/actions/runs/29390222050