### PR TITLE
test: [DO NOT MERGE] vuln-gate canary — commons-text@1.9 true-positive check

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -32,6 +32,15 @@
   </properties>
 
   <dependencies>
+    <!-- DO NOT MERGE: intentionally vulnerable dependency to exercise the
+         pr-vuln-check gate's true-positive path. commons-text 1.9 carries
+         CVE-2022-42889 (Text4Shell, critical, fixable in 1.10.0). -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.9</version>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>


### PR DESCRIPTION
## DO NOT MERGE

Canary PR to verify the `pr-vuln-check` dependency vulnerability gate still fires on a **genuine newly-introduced vulnerable dependency** (true-positive path) after the base-branch-drift fix.

## What

Adds `org.apache.commons:commons-text:1.9` as a runtime dependency of `clients/java` (a module covered by the Maven dependency-snapshot submission).

- **CVE-2022-42889** (Text4Shell) — GHSA-599f-7c49-w659 — **critical**, **fixable** in 1.10.0.

## Expected

- `Security / Submit Maven Dependency Snapshot` → pass (head SBOM indexed).
- `Security / Dependency Vulnerability Gate` → posts a **🚨 blocking issue(s) found 🚨** advisory comment naming commons-text@1.9 / GHSA-599f-7c49-w659, and `check.py` exits 1. (On `main` the job still has `continue-on-error: true` until #57561 merges, so it will not block *this* PR's merge — we only verify detection.)
- The dep must appear under **blocking**, NOT pre-existing / non-gated — confirming the drift filter does not over-suppress a real PR-introduced vuln.

## Cleanup

Close without merging. No backport labels.