### PR TITLE
fix: route AlwaysGreen owner to test-automation-team when E2E tests fail

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -673,13 +673,17 @@ jobs:
             --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
             2>/dev/null || echo 0)
           if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
-            echo "failure_category=test-infra"    >> "$GITHUB_OUTPUT"
-            echo "owner_team=@camunda/test-automation-team" >> "$GITHUB_OUTPUT"
-            echo "evidence=Playwright E2E tests failed after Helm install." >> "$GITHUB_OUTPUT"
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/test-automation-team"
+              echo "evidence=Playwright E2E tests failed after Helm install."
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "failure_category=test-infra"    >> "$GITHUB_OUTPUT"
-            echo "owner_team=@camunda/distribution" >> "$GITHUB_OUTPUT"
-            echo "evidence=Helm chart Integration Tests failed." >> "$GITHUB_OUTPUT"
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/distribution"
+              echo "evidence=Helm chart Integration Tests failed."
+            } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback
         if: failure()

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -669,9 +669,9 @@ jobs:
           # → test-automation-team owns. If absent, the install/setup failed
           # before tests ever ran → distribution owns.
           E2E_ARTIFACTS=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
             --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
-            2>/dev/null || echo 0)
+            || echo 0)
           if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
             {
               echo "failure_category=test-infra"
@@ -682,7 +682,7 @@ jobs:
             {
               echo "failure_category=test-infra"
               echo "owner_team=@camunda/distribution"
-              echo "evidence=Helm chart Integration Tests failed."
+              echo "evidence=Helm install or setup failed before E2E tests could run."
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -618,8 +618,8 @@ jobs:
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions:
-
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: |
@@ -657,17 +657,41 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           owner: camunda
           repositories: camunda
+      - name: Classify helm failure type
+        id: classify
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # playwright-results-json-* artifacts are uploaded only when the E2E step ran.
+          # If they exist, the Helm install succeeded but the E2E tests failed
+          # → test-automation-team owns. If absent, the install/setup failed
+          # before tests ever ran → distribution owns.
+          E2E_ARTIFACTS=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
+            2>/dev/null || echo 0)
+          if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
+            echo "failure_category=test-infra"    >> "$GITHUB_OUTPUT"
+            echo "owner_team=@camunda/test-automation-team" >> "$GITHUB_OUTPUT"
+            echo "evidence=Playwright E2E tests failed after Helm install." >> "$GITHUB_OUTPUT"
+          else
+            echo "failure_category=test-infra"    >> "$GITHUB_OUTPUT"
+            echo "owner_team=@camunda/distribution" >> "$GITHUB_OUTPUT"
+            echo "evidence=Helm chart Integration Tests failed." >> "$GITHUB_OUTPUT"
+          fi
       - name: Post AlwaysGreen failure feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
         with:
-          failure_category: test-infra
+          failure_category: ${{ steps.classify.outputs.failure_category || 'test-infra' }}
           stage: helm-integration
-          owner_team: "@camunda/distribution"
+          owner_team: ${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status: failure
-          evidence: "Helm chart Integration Tests failed."
+          evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
           # Existing AlwaysGreen alerting channel (#alwaysgreen-reliability), same
           # as alwaysgreen-streak-detector.yml.
@@ -691,7 +715,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ needs.helm-deploy.result }}" == "failure" || "${{ needs.helm-deploy.result }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/distribution"
+            OWNER_TEAM="${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}"
             FAILURE_CATEGORY="helm_install_or_it"
           fi
           jq -n \


### PR DESCRIPTION
## Summary

- The `helm-deploy-status` job in `docker-build-helm-integration.yml` was hardcoding `owner_team: "@camunda/distribution"` regardless of which job actually failed
- When \"Playwright e2e after install\" fails (E2E tests), `@camunda/test-automation-team` should be pinged, not `@camunda/distribution`
- When the Helm install/setup itself fails (before E2E runs), `@camunda/distribution` is the correct owner

## How it works

A new `Classify helm failure type` step uses the GitHub API to check for `playwright-results-json-*` artifacts. These artifacts are uploaded **only** when the E2E tests actually ran. Their presence/absence distinguishes the two failure modes:

| Artifacts present | Failure mode | Owner |
|---|---|---|
| Yes | Playwright E2E tests failed after install | `@camunda/test-automation-team` |
| No | Helm install/setup failed before E2E | `@camunda/distribution` |

The `Post AlwaysGreen failure feedback` step and `Emit AlwaysGreen failure context` step both consume the classify outputs with `@camunda/distribution` as fallback.

Also adds `actions: read` permission (needed for `gh api` artifact listing).

## Test plan

- [ ] Trigger a run where the Playwright E2E step fails → verify AlwaysGreen pings `@camunda/test-automation-team`
- [ ] Trigger a run where the Helm install fails → verify AlwaysGreen pings `@camunda/distribution`
- [ ] Confirm `actions: read` permission is present

🤖 Generated with [Claude Code](https://claude.ai/claude-code)