### PR TITLE
fix: route AlwaysGreen owner to test-automation-team when E2E tests fail (backport stable/8.7)

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -728,6 +728,7 @@ jobs:
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions:
       contents: read
+      actions: read
     steps:
       - run: |
           # shellcheck disable=SC2242
@@ -764,17 +765,45 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           owner: camunda
           repositories: camunda
+      - name: Classify helm failure type
+        id: classify
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # playwright-results-json-* artifacts are uploaded only when the E2E step ran.
+          # If they exist, the Helm install succeeded but the E2E tests failed
+          # → test-automation-team owns. If absent, the install/setup failed
+          # before tests ever ran → distribution owns.
+          E2E_ARTIFACTS=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
+            2>/dev/null || echo 0)
+          if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/test-automation-team"
+              echo "evidence=Playwright E2E tests failed after Helm install."
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/distribution"
+              echo "evidence=Helm chart Integration Tests failed."
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Post AlwaysGreen failure feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
         with:
-          failure_category: test-infra
+          failure_category: ${{ steps.classify.outputs.failure_category || 'test-infra' }}
           stage: helm-integration
-          owner_team: "@camunda/distribution"
+          owner_team: ${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status: failure
-          evidence: "Helm chart Integration Tests failed."
+          evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
           slack_channel: "C0AK0AVKRL0"
           slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
@@ -799,7 +828,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ needs.helm-deploy.result }}" == "failure" || "${{ needs.helm-deploy.result }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/distribution"
+            OWNER_TEAM="${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}"
             FAILURE_CATEGORY="helm_install_or_it"
           fi
           jq -n \

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1,17 +1,17 @@
-# description: This workflow builds the Camunda Docker image, pushes it to Harbor, runs Helm integration and E2E tests, and triggers SaaS E2E smoke tests in the c8-cross-component-e2e-tests repo. This is part of the AlwaysGreen project where every PR is deployed via helm to confirm no breaking changes.
+# description: This workflow builds the Camunda Docker image, pushes it to Harbor, and runs Helm integration tests. This is part of the AlwaysGreen project where every PR is deployed via helm to confirm no breaking changes.
 # type: CI
 # owner: @camunda/distribution
 ---
-name: Docker Build, Helm Deploy & E2E Tests (SaaS + Helm)
+name: Docker Build and Helm Integration Test
 
 on:
   push:
     branches:
-      - stable/8.9
+      - stable/8.7
   workflow_dispatch:
     inputs:
       version:
-        description: 'Docker image version tag (defaults to ...-mq<PR_NUMBER>-run<run_id>-a<attempt> for merge queue, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-mq<PR_NUMBER|SHA>-run<run_id>-a<attempt> for push to stable/8.9 — the mq prefix is required by the Harbor replication filter `**-mq**-run**`)'
+        description: 'Docker image version tag (defaults to ...-mq<PR_NUMBER>-run<run_id>-a<attempt> for merge queue, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-mq<PR_NUMBER|SHA>-run<run_id>-a<attempt> for push to stable/8.7 — the mq prefix is required by the Harbor replication filter `**-mq**-run**`)'
         type: string
         required: false
       helmRepositoryBranchName:
@@ -21,7 +21,7 @@ on:
       helmRepositoryDirName:
         description: 'Helm chart directory name'
         type: string
-        default: 'camunda-platform-8.9'
+        default: 'camunda-platform-8.7'
       scenario:
         description: 'Test scenario'
         type: string
@@ -35,17 +35,13 @@ on:
         type: string
         default: 'agrn'
 
-# Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
-# Exception for main + stable/* branches: complete builds for every commit needed for confidence
-concurrency:
-  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
-  cancel-in-progress: true
-
 env:
   TEST_OWNER: '@camunda/distribution'
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
-  HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda
+  HARBOR_ZEEBE_REPOSITORY: registry.camunda.cloud/team-camunda/zeebe
+  HARBOR_OPERATE_REPOSITORY: registry.camunda.cloud/team-camunda/operate
+  HARBOR_TASKLIST_REPOSITORY: registry.camunda.cloud/team-camunda/tasklist
 
 defaults:
   run:
@@ -59,11 +55,40 @@ jobs:
     timeout-minutes: 1
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
+    outputs:
+      concurrency-group: ${{ steps.concurrency-group.outputs.group }}
+      merge-group-pr-numbers: ${{ steps.concurrency-group.outputs.pr-numbers }}
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
       github.event_name == 'merge_group'
     steps:
+      - name: Compute concurrency group
+        id: concurrency-group
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            REF_SOURCE="${{ github.event.merge_group.head_ref || github.ref }}"
+            # Expected merge queue ref shape includes pr-<number> segments, e.g.
+            # refs/heads/gh-readonly-queue/stable/8.7/pr-123-<suffix>
+            PR_MATCHES=$(grep -oE 'pr-[0-9]+' <<< "${REF_SOURCE}" | paste -sd '-' - || true)
+            if [[ -n "${PR_MATCHES}" ]]; then
+              echo "pr-numbers=${PR_MATCHES//pr-/pr}" >> "$GITHUB_OUTPUT"
+              echo "group=${{ github.workflow }}-${PR_MATCHES}" >> "$GITHUB_OUTPUT"
+            else
+              echo "pr-numbers=" >> "$GITHUB_OUTPUT"
+              echo "::warning::Could not derive stable merge_group PR key from ref '${REF_SOURCE}'; using ref as fallback."
+              echo "group=${{ github.workflow }}-${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            fi
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            # For push to main/stable/*, every commit must run its own build (no cancellation),
+            # so use the SHA in the concurrency group. Other branches keep ref-based grouping.
+            echo "pr-numbers=" >> "$GITHUB_OUTPUT"
+            echo "group=${{ github.workflow }}-push-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr-numbers=" >> "$GITHUB_OUTPUT"
+            echo "group=${{ github.workflow }}-${{ github.ref }}" >> "$GITHUB_OUTPUT"
+          fi
       - run: echo "Workflow conditions met, proceeding with build"
       - name: Emit AlwaysGreen failure context
         if: ${{ always() && (failure() || cancelled()) }}
@@ -232,11 +257,16 @@ jobs:
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
-    needs: preflight
+    # needs both: preflight gates execution; should-run provides the
+    # concurrency-group output the `concurrency:` block below reads.
+    needs: [should-run, preflight]
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: ${{ github.event_name == 'merge_group' }}
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-build-operate-frontend
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -284,14 +314,16 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
-
   build-tasklist-frontend:
     name: Build Tasklist Frontend
-    needs: preflight
+    needs: [should-run, preflight]
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: ${{ github.event_name == 'merge_group' }}
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-build-tasklist-frontend
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -339,14 +371,16 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
-
   build-identity-frontend:
     name: Build Identity Frontend
-    needs: preflight
+    needs: [should-run, preflight]
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: ${{ github.event_name == 'merge_group' }}
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-build-identity-frontend
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -396,13 +430,17 @@ jobs:
           retention-days: 5
 
   # Main build job - waits for all frontends to complete
-  build-and-push:
-    name: Build and Push Docker Image
-    needs: [build-operate-frontend, build-tasklist-frontend, build-identity-frontend]
+  build-and-push-images:
+    name: Build and Push Docker Images
+    # Includes should-run to consume its computed concurrency-group output.
+    needs: [should-run, build-operate-frontend, build-tasklist-frontend, build-identity-frontend]
     permissions: { }
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     continue-on-error: ${{ github.event_name == 'merge_group' }}
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-build-and-push-images
+      cancel-in-progress: true
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.tag }}
     steps:
@@ -422,40 +460,44 @@ jobs:
       - name: Get Maven project version
         id: maven-version
         run: |
-          VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args="\${project.version}" --non-recursive exec:exec)
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout --non-recursive)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set semantic image tag
         id: set-image-tag
+        shell: bash
         run: |
           MAVEN_VERSION="${{ steps.maven-version.outputs.version }}"
           if [[ -n "${{ inputs.version }}" ]]; then
             # Use explicitly provided version
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            # For merge queue: <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
-            PR_NUM=$(sed -nE 's|^refs/heads/gh-readonly-queue/.+/pr-([0-9]+)-.*$|\1|p' <<< "${{ github.ref }}")
-            if [[ -z "${PR_NUM}" ]]; then
-              echo "Failed to resolve a single PR number from merge_group ref: '${{ github.ref }}'" >&2
-              exit 1
+            # For merge queue: prefer <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
+            # but fall back to a SHA-based tag if we cannot derive PR numbers from merge_group payload/ref.
+            PR_NUM="${{ needs.should-run.outputs.merge-group-pr-numbers }}"
+            if [[ -n "${PR_NUM}" ]]; then
+              echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+            else
+              SHA_SHORT="${GITHUB_SHA::7}"
+              echo "::warning::Could not determine PR number from merge_group payload/ref; using merge-group SHA-based tag instead."
+              echo "tag=${MAVEN_VERSION}-mq${SHA_SHORT}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
             fi
-            echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.9.0-SNAPSHOT-dispatch-run12345678-a1)
+            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.7.0-SNAPSHOT-dispatch-run12345678-a1)
             echo "tag=${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
-            # For push to stable/8.9 (typically a backport): synthesize an
+            # For push to stable/8.7 (typically a backport): synthesize an
             # `-mq<N>-run<id>-a<n>` tag from the original PR number carried in
             # the commit subject's "(#NNNN)" suffix so the SRE Harbor
             # replication filter `**-mq**-run**` accepts the image. Without
-            # this prefix, stable backport pushes produced `-stable-8.9-run`
+            # this prefix, stable backport pushes produced `-stable-8.7-run`
             # tags that the replication rule silently dropped.
             # Fall back to a 7-char SHA-based mq tag if the subject doesn't
             # carry a PR number (manual squash, rebase, force-push).
             SUBJECT=$(git log -1 --format=%s)
             PR_NUM=$(sed -nE 's|.*\(#([0-9]+)\).*|\1|p' <<< "${SUBJECT}")
             if [[ -n "${PR_NUM}" ]]; then
-              # e.g. 8.9.0-SNAPSHOT-mq53787-run12345678-a1
+              # e.g. 8.7.0-SNAPSHOT-mq53787-run12345678-a1
               echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
             else
               SHA_SHORT="${GITHUB_SHA::7}"
@@ -488,25 +530,51 @@ jobs:
         with:
           maven-extra-args: -PskipFrontendBuild
 
-      - name: Build and push Docker image to Harbor
-        id: build-docker
+      - name: Build and push Zeebe Docker image to Harbor
+        id: build-zeebe-docker
         uses: ./.github/actions/build-platform-docker
         with:
-          repository: ${{ env.HARBOR_REPOSITORY }}
+          repository: ${{ env.HARBOR_ZEEBE_REPOSITORY }}
           version: ${{ steps.set-image-tag.outputs.tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: linux/amd64
-          dockerfile: camunda.Dockerfile
+          dockerfile: Dockerfile
+          push: true
+
+      - name: Build and push Operate Docker image to Harbor
+        id: build-operate-docker
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: ${{ env.HARBOR_OPERATE_REPOSITORY }}
+          version: ${{ steps.set-image-tag.outputs.tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: linux/amd64
+          dockerfile: operate.Dockerfile
+          push: true
+
+      - name: Build and push Tasklist Docker image to Harbor
+        id: build-tasklist-docker
+        uses: ./.github/actions/build-platform-docker
+        with:
+          repository: ${{ env.HARBOR_TASKLIST_REPOSITORY }}
+          version: ${{ steps.set-image-tag.outputs.tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: linux/amd64
+          dockerfile: tasklist.Dockerfile
           push: true
 
       - name: Output image details
         run: |
           {
-            echo "### Docker Image Built and Pushed"
+            echo "### Docker Images Built and Pushed"
             echo ""
-            echo "**Repository:** ${{ env.HARBOR_REPOSITORY }}"
             echo "**Tag:** ${{ steps.set-image-tag.outputs.tag }}"
-            echo "**Full Image:** ${{ env.HARBOR_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }}"
+            echo ""
+            echo "| Component | Image |"
+            echo "|-----------|-------|"
+            echo "| Zeebe | ${{ env.HARBOR_ZEEBE_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }} |"
+            echo "| Operate | ${{ env.HARBOR_OPERATE_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }} |"
+            echo "| Tasklist | ${{ env.HARBOR_TASKLIST_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }} |"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Observe build status
@@ -547,12 +615,17 @@ jobs:
 
   format-identifier:
     name: Format Identifier
-    # Runs in parallel with frontend builds (no dependency on their outputs)
-    needs: preflight
+    # Runs in parallel with frontend builds (no dependency on their outputs).
+    # Needs both: preflight gates execution; should-run provides the
+    # concurrency-group output.
+    needs: [should-run, preflight]
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-format-identifier
+      cancel-in-progress: true
     outputs:
       identifier: ${{ steps.format.outputs.identifier }}
     steps:
@@ -594,15 +667,18 @@ jobs:
 
   helm-deploy:
     name: Helm chart Integration Tests
-    needs: [build-and-push, format-identifier]
+    needs: [should-run, build-and-push-images, format-identifier]
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-helm-deploy
+      cancel-in-progress: true
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
       identifier: ${{ needs.format-identifier.outputs.identifier }}
       platforms: gke
       camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
-      camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
-      namespace-prefix: monorepo
+      camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.7' }}
+      namespace-prefix: mono-8-7
       test-enabled: true
       e2e-enabled: true
       deployment-ttl: ${{ inputs.deployment-ttl || '' }}
@@ -611,11 +687,28 @@ jobs:
       always-delete-namespace: true
       flows: install
       extra-values: |
-        orchestration:
+        zeebe:
           image:
             registry: registry.camunda.cloud
-            repository: team-camunda/camunda
-            tag: ${{ needs.build-and-push.outputs.image-tag }}
+            repository: team-camunda/zeebe
+            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
+        zeebeGateway:
+          image:
+            registry: registry.camunda.cloud
+            repository: team-camunda/zeebe
+            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
+        operate:
+          image:
+            registry: registry.camunda.cloud
+            repository: team-camunda/operate
+            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
+        tasklist:
+          image:
+            registry: registry.camunda.cloud
+            repository: team-camunda/tasklist
+            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
+        global:
+          image:
             pullSecrets:
               - name: index-docker-io
               - name: registry-camunda-cloud
@@ -624,6 +717,7 @@ jobs:
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
+        secret/data/products/distribution/ci DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET;
 
   helm-deploy-status:
     name: Observe Helm chart Integration Tests status
@@ -639,16 +733,15 @@ jobs:
       - run: |
           # shellcheck disable=SC2242
           exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
-      # Standardised AlwaysGreen feedback → also post a Verdict/Evidence/Next-steps
-      # comment on the PR (resolved from the merge_group head_ref). Best-effort.
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         if: failure()
         with:
           node-version: "20"
       - name: Import Slack token
         id: slack-secrets
         if: failure()
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
+        continue-on-error: true
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -659,6 +752,7 @@ jobs:
       - name: Generate GitHub App Token
         id: app-token
         if: failure()
+        continue-on-error: true
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
           github-app-id-vault-key: GITHUB_APP_ID
@@ -709,10 +803,8 @@ jobs:
           owner_team: ${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status: failure
-          evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
+          evidence: ${{ steps.classify.outputs.evidence || 'Helm install or setup failed before E2E tests could run.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
-          # Existing AlwaysGreen alerting channel (#alwaysgreen-reliability), same
-          # as alwaysgreen-streak-detector.yml.
           slack_channel: "C0AK0AVKRL0"
           slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -759,10 +851,12 @@ jobs:
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
-    needs: [build-and-push, format-identifier]
-    timeout-minutes: 35
-    continue-on-error: ${{ github.event_name == 'merge_group' }}
+    needs: [should-run, build-and-push-images, format-identifier]
+    timeout-minutes: 30
     permissions: { }
+    concurrency:
+      group: ${{ needs.should-run.outputs.concurrency-group }}-trigger-saas-e2e
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -786,12 +880,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
-          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
-          # Use the image tag as the generation name to match filter patterns
-          # e.g., "8.9.0-SNAPSHOT-mq53787-run12345678-a1" matches "**-mq**-run**-a**"
-          GEN_NAME="${IMAGE_TAG}"
-
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -802,13 +891,12 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
-                      "gen_name": "'"${GEN_NAME}"'",
-                      "c8Version": "8.9",
-                      "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
-                      "operateVersion": "8.9-SNAPSHOT",
-                      "tasklistVersion": "8.9-SNAPSHOT",
-                      "connectorsVersion": "8.9-SNAPSHOT",
-                      "optimizeVersion": "8.9-SNAPSHOT"
+                      "c8Version": "8.7",
+                      "zeebeVersion": "${{ needs.build-and-push-images.outputs.image-tag }}",
+                      "operateVersion": "8.7-SNAPSHOT",
+                      "tasklistVersion": "8.7-SNAPSHOT",
+                      "connectorsVersion": "8.7-SNAPSHOT",
+                      "optimizeVersion": "8.7-SNAPSHOT"
                   }
                 }'
 
@@ -1127,4 +1215,5 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
+
 

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -243,7 +243,6 @@ jobs:
       - uses: ./.github/actions/build-frontend
         with:
           directory: ./operate/client
-          package-manager: "npm"
       - name: Upload Operate frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -299,7 +298,6 @@ jobs:
       - uses: ./.github/actions/build-frontend
         with:
           directory: ./tasklist/client
-          package-manager: "npm"
       - name: Upload Tasklist frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -355,7 +353,6 @@ jobs:
       - uses: ./.github/actions/build-frontend
         with:
           directory: ./identity/client
-          package-manager: "npm"
       - name: Upload Identity frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1,17 +1,17 @@
-# description: This workflow builds the Camunda Docker image, pushes it to Harbor, and runs Helm integration tests. This is part of the AlwaysGreen project where every PR is deployed via helm to confirm no breaking changes.
+# description: This workflow builds the Camunda Docker image, pushes it to Harbor, runs Helm integration and E2E tests, and triggers SaaS E2E smoke tests in the c8-cross-component-e2e-tests repo. This is part of the AlwaysGreen project where every PR is deployed via helm to confirm no breaking changes.
 # type: CI
 # owner: @camunda/distribution
 ---
-name: Docker Build and Helm Integration Test
+name: Docker Build, Helm Deploy & E2E Tests (SaaS + Helm)
 
 on:
   push:
     branches:
-      - stable/8.7
+      - stable/8.9
   workflow_dispatch:
     inputs:
       version:
-        description: 'Docker image version tag (defaults to ...-mq<PR_NUMBER>-run<run_id>-a<attempt> for merge queue, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-mq<PR_NUMBER|SHA>-run<run_id>-a<attempt> for push to stable/8.7 — the mq prefix is required by the Harbor replication filter `**-mq**-run**`)'
+        description: 'Docker image version tag (defaults to ...-mq<PR_NUMBER>-run<run_id>-a<attempt> for merge queue, ...-dispatch-run<run_id>-a<attempt> for manual dispatch, or ...-mq<PR_NUMBER|SHA>-run<run_id>-a<attempt> for push to stable/8.9 — the mq prefix is required by the Harbor replication filter `**-mq**-run**`)'
         type: string
         required: false
       helmRepositoryBranchName:
@@ -21,7 +21,7 @@ on:
       helmRepositoryDirName:
         description: 'Helm chart directory name'
         type: string
-        default: 'camunda-platform-8.7'
+        default: 'camunda-platform-8.9'
       scenario:
         description: 'Test scenario'
         type: string
@@ -35,13 +35,17 @@ on:
         type: string
         default: 'agrn'
 
+# Limit workflow to 1 concurrent run per ref (branch) and trigger event (push/schedule/etc): new commit -> old runs are canceled to save costs
+# Exception for main + stable/* branches: complete builds for every commit needed for confidence
+concurrency:
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
+  cancel-in-progress: true
+
 env:
   TEST_OWNER: '@camunda/distribution'
   GHA_BEST_PRACTICES_LINTER: enabled
   HARBOR_REGISTRY: registry.camunda.cloud
-  HARBOR_ZEEBE_REPOSITORY: registry.camunda.cloud/team-camunda/zeebe
-  HARBOR_OPERATE_REPOSITORY: registry.camunda.cloud/team-camunda/operate
-  HARBOR_TASKLIST_REPOSITORY: registry.camunda.cloud/team-camunda/tasklist
+  HARBOR_REPOSITORY: registry.camunda.cloud/team-camunda/camunda
 
 defaults:
   run:
@@ -55,40 +59,11 @@ jobs:
     timeout-minutes: 1
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
-    outputs:
-      concurrency-group: ${{ steps.concurrency-group.outputs.group }}
-      merge-group-pr-numbers: ${{ steps.concurrency-group.outputs.pr-numbers }}
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
       github.event_name == 'merge_group'
     steps:
-      - name: Compute concurrency group
-        id: concurrency-group
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            REF_SOURCE="${{ github.event.merge_group.head_ref || github.ref }}"
-            # Expected merge queue ref shape includes pr-<number> segments, e.g.
-            # refs/heads/gh-readonly-queue/stable/8.7/pr-123-<suffix>
-            PR_MATCHES=$(grep -oE 'pr-[0-9]+' <<< "${REF_SOURCE}" | paste -sd '-' - || true)
-            if [[ -n "${PR_MATCHES}" ]]; then
-              echo "pr-numbers=${PR_MATCHES//pr-/pr}" >> "$GITHUB_OUTPUT"
-              echo "group=${{ github.workflow }}-${PR_MATCHES}" >> "$GITHUB_OUTPUT"
-            else
-              echo "pr-numbers=" >> "$GITHUB_OUTPUT"
-              echo "::warning::Could not derive stable merge_group PR key from ref '${REF_SOURCE}'; using ref as fallback."
-              echo "group=${{ github.workflow }}-${{ github.ref }}" >> "$GITHUB_OUTPUT"
-            fi
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            # For push to main/stable/*, every commit must run its own build (no cancellation),
-            # so use the SHA in the concurrency group. Other branches keep ref-based grouping.
-            echo "pr-numbers=" >> "$GITHUB_OUTPUT"
-            echo "group=${{ github.workflow }}-push-${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr-numbers=" >> "$GITHUB_OUTPUT"
-            echo "group=${{ github.workflow }}-${{ github.ref }}" >> "$GITHUB_OUTPUT"
-          fi
       - run: echo "Workflow conditions met, proceeding with build"
       - name: Emit AlwaysGreen failure context
         if: ${{ always() && (failure() || cancelled()) }}
@@ -257,22 +232,18 @@ jobs:
   # Parallel frontend builds
   build-operate-frontend:
     name: Build Operate Frontend
-    # needs both: preflight gates execution; should-run provides the
-    # concurrency-group output the `concurrency:` block below reads.
-    needs: [should-run, preflight]
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: ${{ github.event_name == 'merge_group' }}
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-build-operate-frontend
-      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/build-frontend
         with:
           directory: ./operate/client
+          package-manager: "npm"
       - name: Upload Operate frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -314,22 +285,21 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
+
   build-tasklist-frontend:
     name: Build Tasklist Frontend
-    needs: [should-run, preflight]
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: ${{ github.event_name == 'merge_group' }}
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-build-tasklist-frontend
-      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/build-frontend
         with:
           directory: ./tasklist/client
+          package-manager: "npm"
       - name: Upload Tasklist frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -371,22 +341,21 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
+
   build-identity-frontend:
     name: Build Identity Frontend
-    needs: [should-run, preflight]
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: ${{ github.event_name == 'merge_group' }}
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-build-identity-frontend
-      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/build-frontend
         with:
           directory: ./identity/client
+          package-manager: "npm"
       - name: Upload Identity frontend artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -430,17 +399,13 @@ jobs:
           retention-days: 5
 
   # Main build job - waits for all frontends to complete
-  build-and-push-images:
-    name: Build and Push Docker Images
-    # Includes should-run to consume its computed concurrency-group output.
-    needs: [should-run, build-operate-frontend, build-tasklist-frontend, build-identity-frontend]
+  build-and-push:
+    name: Build and Push Docker Image
+    needs: [build-operate-frontend, build-tasklist-frontend, build-identity-frontend]
     permissions: { }
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     continue-on-error: ${{ github.event_name == 'merge_group' }}
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-build-and-push-images
-      cancel-in-progress: true
     outputs:
       image-tag: ${{ steps.set-image-tag.outputs.tag }}
     steps:
@@ -460,44 +425,40 @@ jobs:
       - name: Get Maven project version
         id: maven-version
         run: |
-          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout --non-recursive)
+          VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args="\${project.version}" --non-recursive exec:exec)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set semantic image tag
         id: set-image-tag
-        shell: bash
         run: |
           MAVEN_VERSION="${{ steps.maven-version.outputs.version }}"
           if [[ -n "${{ inputs.version }}" ]]; then
             # Use explicitly provided version
             echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            # For merge queue: prefer <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
-            # but fall back to a SHA-based tag if we cannot derive PR numbers from merge_group payload/ref.
-            PR_NUM="${{ needs.should-run.outputs.merge-group-pr-numbers }}"
-            if [[ -n "${PR_NUM}" ]]; then
-              echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
-            else
-              SHA_SHORT="${GITHUB_SHA::7}"
-              echo "::warning::Could not determine PR number from merge_group payload/ref; using merge-group SHA-based tag instead."
-              echo "tag=${MAVEN_VERSION}-mq${SHA_SHORT}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+            # For merge queue: <maven-version>-mq<PR_NUMBER>-run<run_id>-a<run_attempt>
+            PR_NUM=$(sed -nE 's|^refs/heads/gh-readonly-queue/.+/pr-([0-9]+)-.*$|\1|p' <<< "${{ github.ref }}")
+            if [[ -z "${PR_NUM}" ]]; then
+              echo "Failed to resolve a single PR number from merge_group ref: '${{ github.ref }}'" >&2
+              exit 1
             fi
+            echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.7.0-SNAPSHOT-dispatch-run12345678-a1)
+            # For manual dispatch: <maven-version>-dispatch-run<run_id>-a<run_attempt> (e.g., 8.9.0-SNAPSHOT-dispatch-run12345678-a1)
             echo "tag=${MAVEN_VERSION}-dispatch-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
           else
-            # For push to stable/8.7 (typically a backport): synthesize an
+            # For push to stable/8.9 (typically a backport): synthesize an
             # `-mq<N>-run<id>-a<n>` tag from the original PR number carried in
             # the commit subject's "(#NNNN)" suffix so the SRE Harbor
             # replication filter `**-mq**-run**` accepts the image. Without
-            # this prefix, stable backport pushes produced `-stable-8.7-run`
+            # this prefix, stable backport pushes produced `-stable-8.9-run`
             # tags that the replication rule silently dropped.
             # Fall back to a 7-char SHA-based mq tag if the subject doesn't
             # carry a PR number (manual squash, rebase, force-push).
             SUBJECT=$(git log -1 --format=%s)
             PR_NUM=$(sed -nE 's|.*\(#([0-9]+)\).*|\1|p' <<< "${SUBJECT}")
             if [[ -n "${PR_NUM}" ]]; then
-              # e.g. 8.7.0-SNAPSHOT-mq53787-run12345678-a1
+              # e.g. 8.9.0-SNAPSHOT-mq53787-run12345678-a1
               echo "tag=${MAVEN_VERSION}-mq${PR_NUM}-run${{ github.run_id }}-a${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
             else
               SHA_SHORT="${GITHUB_SHA::7}"
@@ -530,51 +491,25 @@ jobs:
         with:
           maven-extra-args: -PskipFrontendBuild
 
-      - name: Build and push Zeebe Docker image to Harbor
-        id: build-zeebe-docker
+      - name: Build and push Docker image to Harbor
+        id: build-docker
         uses: ./.github/actions/build-platform-docker
         with:
-          repository: ${{ env.HARBOR_ZEEBE_REPOSITORY }}
+          repository: ${{ env.HARBOR_REPOSITORY }}
           version: ${{ steps.set-image-tag.outputs.tag }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: linux/amd64
-          dockerfile: Dockerfile
-          push: true
-
-      - name: Build and push Operate Docker image to Harbor
-        id: build-operate-docker
-        uses: ./.github/actions/build-platform-docker
-        with:
-          repository: ${{ env.HARBOR_OPERATE_REPOSITORY }}
-          version: ${{ steps.set-image-tag.outputs.tag }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          platforms: linux/amd64
-          dockerfile: operate.Dockerfile
-          push: true
-
-      - name: Build and push Tasklist Docker image to Harbor
-        id: build-tasklist-docker
-        uses: ./.github/actions/build-platform-docker
-        with:
-          repository: ${{ env.HARBOR_TASKLIST_REPOSITORY }}
-          version: ${{ steps.set-image-tag.outputs.tag }}
-          distball: ${{ steps.build-camunda.outputs.distball }}
-          platforms: linux/amd64
-          dockerfile: tasklist.Dockerfile
+          dockerfile: camunda.Dockerfile
           push: true
 
       - name: Output image details
         run: |
           {
-            echo "### Docker Images Built and Pushed"
+            echo "### Docker Image Built and Pushed"
             echo ""
+            echo "**Repository:** ${{ env.HARBOR_REPOSITORY }}"
             echo "**Tag:** ${{ steps.set-image-tag.outputs.tag }}"
-            echo ""
-            echo "| Component | Image |"
-            echo "|-----------|-------|"
-            echo "| Zeebe | ${{ env.HARBOR_ZEEBE_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }} |"
-            echo "| Operate | ${{ env.HARBOR_OPERATE_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }} |"
-            echo "| Tasklist | ${{ env.HARBOR_TASKLIST_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }} |"
+            echo "**Full Image:** ${{ env.HARBOR_REPOSITORY }}:${{ steps.set-image-tag.outputs.tag }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Observe build status
@@ -615,17 +550,12 @@ jobs:
 
   format-identifier:
     name: Format Identifier
-    # Runs in parallel with frontend builds (no dependency on their outputs).
-    # Needs both: preflight gates execution; should-run provides the
-    # concurrency-group output.
-    needs: [should-run, preflight]
+    # Runs in parallel with frontend builds (no dependency on their outputs)
+    needs: preflight
     permissions: { }
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-format-identifier
-      cancel-in-progress: true
     outputs:
       identifier: ${{ steps.format.outputs.identifier }}
     steps:
@@ -667,18 +597,15 @@ jobs:
 
   helm-deploy:
     name: Helm chart Integration Tests
-    needs: [should-run, build-and-push-images, format-identifier]
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-helm-deploy
-      cancel-in-progress: true
+    needs: [build-and-push, format-identifier]
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
       identifier: ${{ needs.format-identifier.outputs.identifier }}
       platforms: gke
       camunda-helm-git-ref: ${{ inputs.helmRepositoryBranchName || 'main' }}
-      camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.7' }}
-      namespace-prefix: mono-8-7
+      camunda-helm-dir: ${{ inputs.helmRepositoryDirName || 'camunda-platform-8.9' }}
+      namespace-prefix: monorepo
       test-enabled: true
       e2e-enabled: true
       deployment-ttl: ${{ inputs.deployment-ttl || '' }}
@@ -687,28 +614,11 @@ jobs:
       always-delete-namespace: true
       flows: install
       extra-values: |
-        zeebe:
+        orchestration:
           image:
             registry: registry.camunda.cloud
-            repository: team-camunda/zeebe
-            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
-        zeebeGateway:
-          image:
-            registry: registry.camunda.cloud
-            repository: team-camunda/zeebe
-            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
-        operate:
-          image:
-            registry: registry.camunda.cloud
-            repository: team-camunda/operate
-            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
-        tasklist:
-          image:
-            registry: registry.camunda.cloud
-            repository: team-camunda/tasklist
-            tag: ${{ needs.build-and-push-images.outputs.image-tag }}
-        global:
-          image:
+            repository: team-camunda/camunda
+            tag: ${{ needs.build-and-push.outputs.image-tag }}
             pullSecrets:
               - name: index-docker-io
               - name: registry-camunda-cloud
@@ -717,7 +627,6 @@ jobs:
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
-        secret/data/products/distribution/ci DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET;
 
   helm-deploy-status:
     name: Observe Helm chart Integration Tests status
@@ -733,15 +642,16 @@ jobs:
       - run: |
           # shellcheck disable=SC2242
           exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      # Standardised AlwaysGreen feedback → also post a Verdict/Evidence/Next-steps
+      # comment on the PR (resolved from the merge_group head_ref). Best-effort.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: failure()
         with:
           node-version: "20"
       - name: Import Slack token
         id: slack-secrets
         if: failure()
-        continue-on-error: true
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -752,7 +662,6 @@ jobs:
       - name: Generate GitHub App Token
         id: app-token
         if: failure()
-        continue-on-error: true
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
         with:
           github-app-id-vault-key: GITHUB_APP_ID
@@ -777,9 +686,9 @@ jobs:
           # → test-automation-team owns. If absent, the install/setup failed
           # before tests ever ran → distribution owns.
           E2E_ARTIFACTS=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
             --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
-            2>/dev/null || echo 0)
+            || echo 0)
           if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
             {
               echo "failure_category=test-infra"
@@ -790,7 +699,7 @@ jobs:
             {
               echo "failure_category=test-infra"
               echo "owner_team=@camunda/distribution"
-              echo "evidence=Helm chart Integration Tests failed."
+              echo "evidence=Helm install or setup failed before E2E tests could run."
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback
@@ -805,6 +714,8 @@ jobs:
           status: failure
           evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
+          # Existing AlwaysGreen alerting channel (#alwaysgreen-reliability), same
+          # as alwaysgreen-streak-detector.yml.
           slack_channel: "C0AK0AVKRL0"
           slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -851,12 +762,10 @@ jobs:
   trigger-saas-e2e:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
-    needs: [should-run, build-and-push-images, format-identifier]
-    timeout-minutes: 30
+    needs: [build-and-push, format-identifier]
+    timeout-minutes: 35
+    continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }
-    concurrency:
-      group: ${{ needs.should-run.outputs.concurrency-group }}-trigger-saas-e2e
-      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -880,7 +789,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ github.run_attempt }}:${{ github.sha }}
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image-tag }}
         run: |
+          # Use the image tag as the generation name to match filter patterns
+          # e.g., "8.9.0-SNAPSHOT-mq53787-run12345678-a1" matches "**-mq**-run**-a**"
+          GEN_NAME="${IMAGE_TAG}"
+
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
@@ -891,12 +805,13 @@ jobs:
                       "correlation_id": "'"$CORRELATION_ID"'",
                       "source_repo": "${{ github.repository }}",
                       "source_sha": "${{ github.sha }}",
-                      "c8Version": "8.7",
-                      "zeebeVersion": "${{ needs.build-and-push-images.outputs.image-tag }}",
-                      "operateVersion": "8.7-SNAPSHOT",
-                      "tasklistVersion": "8.7-SNAPSHOT",
-                      "connectorsVersion": "8.7-SNAPSHOT",
-                      "optimizeVersion": "8.7-SNAPSHOT"
+                      "gen_name": "'"${GEN_NAME}"'",
+                      "c8Version": "8.9",
+                      "zeebeVersion": "${{ needs.build-and-push.outputs.image-tag }}",
+                      "operateVersion": "8.9-SNAPSHOT",
+                      "tasklistVersion": "8.9-SNAPSHOT",
+                      "connectorsVersion": "8.9-SNAPSHOT",
+                      "optimizeVersion": "8.9-SNAPSHOT"
                   }
                 }'
 
@@ -1215,5 +1130,4 @@ jobs:
           name: alwaysgreen-failure-context-${{ github.job }}
           path: ${{ runner.temp }}/alwaysgreen-context-${{ github.job }}.json
           retention-days: 5
-
 


### PR DESCRIPTION
## Summary

- Adds `actions: read` permission to the `helm-deploy-status` job so it can query the run's artifact list via the GitHub API.
- Inserts a new `Classify helm failure type` step (runs on `failure()`) that checks whether `playwright-results-json-*` artifacts exist for the current run: if they do, the Helm install succeeded and E2E tests failed (owner → `@camunda/test-automation-team`); if not, the Helm install itself failed (owner → `@camunda/distribution`).
- Updates `Post AlwaysGreen failure feedback` to consume `steps.classify.outputs` for `failure_category`, `owner_team`, and `evidence` (falls back to the previous hardcoded values if the classify step was skipped or errored).
- Updates `Emit AlwaysGreen failure context` to use the same classify output for `OWNER_TEAM`.

## Test plan

- [ ] Merge a PR that causes only the Helm install to fail (no E2E artifacts) → confirm `@camunda/distribution` receives the Slack notification.
- [ ] Merge a PR where Helm install passes but E2E tests fail (playwright-results-json artifacts present) → confirm `@camunda/test-automation-team` receives the notification.
- [ ] Happy-path run → confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)