### PR TITLE
fix: route AlwaysGreen owner to test-automation-team when E2E tests fail (backport stable/8.9)

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -686,9 +686,9 @@ jobs:
           # → test-automation-team owns. If absent, the install/setup failed
           # before tests ever ran → distribution owns.
           E2E_ARTIFACTS=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
             --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
-            2>/dev/null || echo 0)
+            || echo 0)
           if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
             {
               echo "failure_category=test-infra"
@@ -699,7 +699,7 @@ jobs:
             {
               echo "failure_category=test-infra"
               echo "owner_team=@camunda/distribution"
-              echo "evidence=Helm chart Integration Tests failed."
+              echo "evidence=Helm install or setup failed before E2E tests could run."
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -636,8 +636,8 @@ jobs:
     timeout-minutes: 5
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions:
-
       contents: read
+      actions: read
     steps:
       - run: |
           # shellcheck disable=SC2242
@@ -674,17 +674,45 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           owner: camunda
           repositories: camunda
+      - name: Classify helm failure type
+        id: classify
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # playwright-results-json-* artifacts are uploaded only when the E2E step ran.
+          # If they exist, the Helm install succeeded but the E2E tests failed
+          # → test-automation-team owns. If absent, the install/setup failed
+          # before tests ever ran → distribution owns.
+          E2E_ARTIFACTS=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
+            2>/dev/null || echo 0)
+          if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/test-automation-team"
+              echo "evidence=Playwright E2E tests failed after Helm install."
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/distribution"
+              echo "evidence=Helm chart Integration Tests failed."
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Post AlwaysGreen failure feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
         with:
-          failure_category: test-infra
+          failure_category: ${{ steps.classify.outputs.failure_category || 'test-infra' }}
           stage: helm-integration
-          owner_team: "@camunda/distribution"
+          owner_team: ${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status: failure
-          evidence: "Helm chart Integration Tests failed."
+          evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
           # Existing AlwaysGreen alerting channel (#alwaysgreen-reliability), same
           # as alwaysgreen-streak-detector.yml.
@@ -711,7 +739,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ needs.helm-deploy.result }}" == "failure" || "${{ needs.helm-deploy.result }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/distribution"
+            OWNER_TEAM="${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}"
             FAILURE_CATEGORY="helm_install_or_it"
           fi
           jq -n \


### PR DESCRIPTION
## Summary

- Adds `actions: read` permission to the `helm-deploy-status` job so it can query the GitHub API for workflow artifacts.
- Inserts a `Classify helm failure type` step that checks whether `playwright-results-json-*` artifacts were uploaded: if yes → E2E tests failed → `@camunda/test-automation-team`; if no → Helm install failed → `@camunda/distribution`.
- Updates `Post AlwaysGreen failure feedback` to use the dynamic classify outputs (with fallback to `@camunda/distribution`).
- Updates `Emit AlwaysGreen failure context` to use the same classify output for `OWNER_TEAM`.

## Test plan

- [ ] Confirm CI passes on the PR branch.
- [ ] Simulate a Helm install failure (no E2E artifacts) → verify `@camunda/distribution` is routed.
- [ ] Simulate an E2E failure (playwright-results-json artifacts present) → verify `@camunda/test-automation-team` is routed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)