### PR TITLE
fix: route AlwaysGreen owner to test-automation-team when E2E tests fail (backport stable/8.8)

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -638,6 +638,7 @@ jobs:
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: |
@@ -675,17 +676,45 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           owner: camunda
           repositories: camunda
+      - name: Classify helm failure type
+        id: classify
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # playwright-results-json-* artifacts are uploaded only when the E2E step ran.
+          # If they exist, the Helm install succeeded but the E2E tests failed
+          # → test-automation-team owns. If absent, the install/setup failed
+          # before tests ever ran → distribution owns.
+          E2E_ARTIFACTS=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
+            2>/dev/null || echo 0)
+          if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/test-automation-team"
+              echo "evidence=Playwright E2E tests failed after Helm install."
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "failure_category=test-infra"
+              echo "owner_team=@camunda/distribution"
+              echo "evidence=Helm chart Integration Tests failed."
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Post AlwaysGreen failure feedback
         if: failure()
         continue-on-error: true
         uses: ./.github/actions/post-failure-feedback
         with:
-          failure_category: test-infra
+          failure_category: ${{ steps.classify.outputs.failure_category || 'test-infra' }}
           stage: helm-integration
-          owner_team: "@camunda/distribution"
+          owner_team: ${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}
           run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           status: failure
-          evidence: "Helm chart Integration Tests failed."
+          evidence: ${{ steps.classify.outputs.evidence || 'Helm chart Integration Tests failed.' }}
           pr: ${{ github.event.merge_group.head_ref || github.event.pull_request.number }}
           slack_channel: "C0AK0AVKRL0"
           slack_bot_token: ${{ steps.slack-secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
@@ -707,7 +736,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ needs.helm-deploy.result }}" == "failure" || "${{ needs.helm-deploy.result }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/distribution"
+            OWNER_TEAM="${{ steps.classify.outputs.owner_team || '@camunda/distribution' }}"
             FAILURE_CATEGORY="helm_install_or_it"
           fi
           jq -n \

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -688,9 +688,9 @@ jobs:
           # → test-automation-team owns. If absent, the install/setup failed
           # before tests ever ran → distribution owns.
           E2E_ARTIFACTS=$(gh api \
-            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
             --jq '[.artifacts[] | select(.name | startswith("playwright-results-json"))] | length' \
-            2>/dev/null || echo 0)
+            || echo 0)
           if [[ "$E2E_ARTIFACTS" -gt 0 ]]; then
             {
               echo "failure_category=test-infra"
@@ -701,7 +701,7 @@ jobs:
             {
               echo "failure_category=test-infra"
               echo "owner_team=@camunda/distribution"
-              echo "evidence=Helm chart Integration Tests failed."
+              echo "evidence=Helm install or setup failed before E2E tests could run."
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post AlwaysGreen failure feedback


### PR DESCRIPTION
## Summary

- Adds a `Classify helm failure type` step in the `helm-deploy-status` job that queries the GitHub Actions artifacts API to detect whether `playwright-results-json-*` artifacts were uploaded during the run.
- If those artifacts exist, the Helm install succeeded but E2E tests failed → routes to `@camunda/test-automation-team`.
- If absent, the Helm install/setup failed before tests could run → routes to `@camunda/distribution` (preserving the existing behavior).
- Adds `actions: read` permission to the `helm-deploy-status` job (required for the artifact API call).
- Threads the `classify` step outputs into both `Post AlwaysGreen failure feedback` and `Emit AlwaysGreen failure context`, with safe fallbacks.

## Test plan

- [ ] Verify workflow file parses cleanly (YAML lint)
- [ ] Trigger a run where Helm install fails (no playwright artifacts) → confirm owner routes to `@camunda/distribution`
- [ ] Trigger a run where E2E tests fail (playwright artifacts present) → confirm owner routes to `@camunda/test-automation-team`

🤖 Generated with [Claude Code](https://claude.com/claude-code)