### PR TITLE
feat: add Operate DateRangeField root component

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
@@ -26,7 +26,6 @@ describe('<DateRangeField />', () => {
 		await screen.getByLabelText('Start Date Range').click();
 		await expect.element(screen.getByTestId('date-range-modal')).toHaveClass(/is-visible/);
 
-		// getByRole doesn't help here since the date range modal portal renders to document.body
 		await screen.getByRole('button', {name: 'Cancel'}).click();
 		await expect.element(screen.getByTestId('date-range-modal')).not.toBeInTheDocument();
 	});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
@@ -8,14 +8,9 @@
 
 import {render, cleanup} from 'vitest-browser-react';
 import {describe, it, expect, vi, afterEach} from 'vitest';
-import {applyDateRange, pickDateTimeRange} from './pickDateTimeRange';
+import {applyDateRange, pickDateTimeRange, retryAssertion} from './pickDateTimeRange';
 import {MockDateRangeField} from './mocks';
 import {getWrapper} from './getWrapper';
-
-// This suite drives a real Carbon Modal + flatpickr instance in the browser; under heavy
-// parallel-test CPU load their internal async sync can take longer than the default poll
-// timeout, so every assertion below gets a longer one.
-const TIMEOUT = {timeout: 10_000};
 
 describe('<DateRangeField />', () => {
 	afterEach(cleanup);
@@ -23,14 +18,14 @@ describe('<DateRangeField />', () => {
 	it('should close modal on cancel click', async () => {
 		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
 
-		await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).not.toBeInTheDocument();
+		await expect.element(screen.getByTestId('date-range-modal')).not.toBeInTheDocument();
 
 		await screen.getByLabelText('Start Date Range').click();
-		await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).toHaveClass(/is-visible/);
+		await expect.element(screen.getByTestId('date-range-modal')).toHaveClass(/is-visible/);
 
 		// getByRole doesn't help here since the date range modal portal renders to document.body
 		await screen.getByRole('button', {name: 'Cancel'}).click();
-		await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).not.toBeInTheDocument();
+		await expect.element(screen.getByTestId('date-range-modal')).not.toBeInTheDocument();
 	});
 
 	it('should pick from and to dates and times', async () => {
@@ -50,7 +45,7 @@ describe('<DateRangeField />', () => {
 		await applyDateRange(screen);
 
 		await expect
-			.element(screen.getByLabelText('Start Date Range'), TIMEOUT)
+			.element(screen.getByLabelText('Start Date Range'))
 			.toHaveValue(`${year}-${month}-${fromDay} ${fromTime} - ${year}-${month}-${toDay} ${toTime}`);
 	});
 
@@ -58,7 +53,7 @@ describe('<DateRangeField />', () => {
 		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
 
 		await screen.getByLabelText('Start Date Range').click();
-		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue('Custom');
+		await expect.element(screen.getByLabelText('Start Date Range')).toHaveValue('Custom');
 
 		const {year, month, fromDay, toDay} = await pickDateTimeRange({
 			screen,
@@ -68,13 +63,13 @@ describe('<DateRangeField />', () => {
 		await applyDateRange(screen);
 
 		const expectedValue = `${year}-${month}-${fromDay} 00:00:00 - ${year}-${month}-${toDay} 23:59:59`;
-		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue(expectedValue);
+		await expect.element(screen.getByLabelText('Start Date Range')).toHaveValue(expectedValue);
 
 		await screen.getByLabelText('Start Date Range').click();
-		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue('Custom');
+		await expect.element(screen.getByLabelText('Start Date Range')).toHaveValue('Custom');
 
 		await screen.getByRole('button', {name: 'Cancel'}).click();
-		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue(expectedValue);
+		await expect.element(screen.getByLabelText('Start Date Range')).toHaveValue(expectedValue);
 	});
 
 	it('should set default values', async () => {
@@ -86,16 +81,20 @@ describe('<DateRangeField />', () => {
 		});
 
 		await expect
-			.element(screen.getByLabelText('Start Date Range'), TIMEOUT)
+			.element(screen.getByLabelText('Start Date Range'))
 			.toHaveValue('2021-02-03 12:34:56 - 2021-02-06 01:02:03');
 
 		await screen.getByLabelText('Start Date Range').click();
 
-		await expect.element(screen.getByLabelText('From date'), TIMEOUT).toHaveValue('2021-02-03');
-		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).toHaveValue('12:34:56');
-		await expect.element(screen.getByLabelText('To date'), TIMEOUT).toHaveValue('2021-02-06');
-		await expect.element(screen.getByTestId('toTime'), TIMEOUT).toHaveValue('01:02:03');
-	});
+		// Carbon's DatePicker syncs its child inputs from the calendar's selected dates
+		// asynchronously on mount; under heavy parallel-test CPU load that can occasionally
+		// take longer than the default poll window, so retry the whole assertion. The test
+		// timeout below is extended to give the retries room (default 15s is too tight).
+		await retryAssertion(() => expect.element(screen.getByLabelText('From date')).toHaveValue('2021-02-03'));
+		await retryAssertion(() => expect.element(screen.getByTestId('fromTime')).toHaveValue('12:34:56'));
+		await retryAssertion(() => expect.element(screen.getByLabelText('To date')).toHaveValue('2021-02-06'));
+		await retryAssertion(() => expect.element(screen.getByTestId('toTime')).toHaveValue('01:02:03'));
+	}, 30_000);
 
 	it('should apply from and to dates', async () => {
 		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
@@ -107,8 +106,8 @@ describe('<DateRangeField />', () => {
 		// calendar's onChange (ported 1:1 from legacy). Under CI/parallel-test CPU pressure
 		// that reset can race a same-tick time fill, so retry the fill until it sticks —
 		// a real user's fill is never fast enough to hit this window.
-		await expect.element(screen.getByLabelText('From date'), TIMEOUT).toHaveValue('2022-01-01');
-		await expect.element(screen.getByLabelText('To date'), TIMEOUT).toHaveValue('2022-12-01');
+		await expect.element(screen.getByLabelText('From date')).toHaveValue('2022-01-01');
+		await expect.element(screen.getByLabelText('To date')).toHaveValue('2022-12-01');
 		await expect
 			.poll(async () => {
 				await screen.getByTestId('fromTime').fill('12:30:00');
@@ -124,7 +123,7 @@ describe('<DateRangeField />', () => {
 		await applyDateRange(screen);
 
 		await expect
-			.element(screen.getByLabelText('Start Date Range'), TIMEOUT)
+			.element(screen.getByLabelText('Start Date Range'))
 			.toHaveValue('2022-01-01 12:30:00 - 2022-12-01 17:15:00');
 	});
 
@@ -140,15 +139,15 @@ describe('<DateRangeField />', () => {
 			toDay: '20',
 		});
 
-		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).not.toBeInvalid();
-		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).not.toBeInTheDocument();
-		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).not.toBeDisabled();
+		await expect.element(screen.getByTestId('fromTime')).not.toBeInvalid();
+		await expect.element(screen.getByText(TIME_ERROR)).not.toBeInTheDocument();
+		await expect.element(screen.getByRole('button', {name: 'Apply'})).not.toBeDisabled();
 
 		await screen.getByTestId('fromTime').fill('12:30:xx');
 
-		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).toBeInvalid();
-		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).toBeVisible();
-		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).toBeDisabled();
+		await expect.element(screen.getByTestId('fromTime')).toBeInvalid();
+		await expect.element(screen.getByText(TIME_ERROR)).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
 	});
 
 	it('should show validation error on invalid time format', async () => {
@@ -167,15 +166,15 @@ describe('<DateRangeField />', () => {
 
 		await screen.getByTestId('fromTime').fill('1111');
 
-		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).not.toBeInvalid();
-		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).not.toBeInTheDocument();
-		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).not.toBeDisabled();
+		await expect.element(screen.getByTestId('fromTime')).not.toBeInvalid();
+		await expect.element(screen.getByText(TIME_ERROR)).not.toBeInTheDocument();
+		await expect.element(screen.getByRole('button', {name: 'Apply'})).not.toBeDisabled();
 
 		vi.runOnlyPendingTimers();
 
-		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).toBeVisible();
-		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).toBeInvalid();
-		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).toBeDisabled();
+		await expect.element(screen.getByText(TIME_ERROR)).toBeVisible();
+		await expect.element(screen.getByTestId('fromTime')).toBeInvalid();
+		await expect.element(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
 
 		vi.clearAllTimers();
 		vi.useRealTimers();

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, cleanup} from 'vitest-browser-react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {applyDateRange, pickDateTimeRange} from './pickDateTimeRange';
+import {MockDateRangeField} from './mocks';
+import {getWrapper} from './getWrapper';
+
+// This suite drives a real Carbon Modal + flatpickr instance in the browser; under heavy
+// parallel-test CPU load their internal async sync can take longer than the default poll
+// timeout, so every assertion below gets a longer one.
+const TIMEOUT = {timeout: 10_000};
+
+describe('<DateRangeField />', () => {
+	afterEach(cleanup);
+
+	it('should close modal on cancel click', async () => {
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+
+		await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).not.toBeInTheDocument();
+
+		await screen.getByLabelText('Start Date Range').click();
+		await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).toHaveClass(/is-visible/);
+
+		// getByRole doesn't help here since the date range modal portal renders to document.body
+		await screen.getByRole('button', {name: 'Cancel'}).click();
+		await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).not.toBeInTheDocument();
+	});
+
+	it('should pick from and to dates and times', async () => {
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+
+		await screen.getByLabelText('Start Date Range').click();
+
+		const fromTime = '11:22:33';
+		const toTime = '08:59:59';
+		const {year, month, fromDay, toDay} = await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+			fromTime,
+			toTime,
+		});
+		await applyDateRange(screen);
+
+		await expect
+			.element(screen.getByLabelText('Start Date Range'), TIMEOUT)
+			.toHaveValue(`${year}-${month}-${fromDay} ${fromTime} - ${year}-${month}-${toDay} ${toTime}`);
+	});
+
+	it('should restore previous date on cancel', async () => {
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+
+		await screen.getByLabelText('Start Date Range').click();
+		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue('Custom');
+
+		const {year, month, fromDay, toDay} = await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+		});
+		await applyDateRange(screen);
+
+		const expectedValue = `${year}-${month}-${fromDay} 00:00:00 - ${year}-${month}-${toDay} 23:59:59`;
+		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue(expectedValue);
+
+		await screen.getByLabelText('Start Date Range').click();
+		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue('Custom');
+
+		await screen.getByRole('button', {name: 'Cancel'}).click();
+		await expect.element(screen.getByLabelText('Start Date Range'), TIMEOUT).toHaveValue(expectedValue);
+	});
+
+	it('should set default values', async () => {
+		const screen = await render(<MockDateRangeField />, {
+			wrapper: getWrapper({
+				startDateFrom: '2021-02-03T12:34:56',
+				startDateTo: '2021-02-06T01:02:03',
+			}),
+		});
+
+		await expect
+			.element(screen.getByLabelText('Start Date Range'), TIMEOUT)
+			.toHaveValue('2021-02-03 12:34:56 - 2021-02-06 01:02:03');
+
+		await screen.getByLabelText('Start Date Range').click();
+
+		await expect.element(screen.getByLabelText('From date'), TIMEOUT).toHaveValue('2021-02-03');
+		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).toHaveValue('12:34:56');
+		await expect.element(screen.getByLabelText('To date'), TIMEOUT).toHaveValue('2021-02-06');
+		await expect.element(screen.getByTestId('toTime'), TIMEOUT).toHaveValue('01:02:03');
+	});
+
+	it('should apply from and to dates', async () => {
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+
+		await screen.getByLabelText('Start Date Range').click();
+		await screen.getByLabelText('From date').fill('2022-01-01');
+		await screen.getByLabelText('To date').fill('2022-12-01');
+		// Typing a date asynchronously resets the time fields to their defaults via the
+		// calendar's onChange (ported 1:1 from legacy). Under CI/parallel-test CPU pressure
+		// that reset can race a same-tick time fill, so retry the fill until it sticks —
+		// a real user's fill is never fast enough to hit this window.
+		await expect.element(screen.getByLabelText('From date'), TIMEOUT).toHaveValue('2022-01-01');
+		await expect.element(screen.getByLabelText('To date'), TIMEOUT).toHaveValue('2022-12-01');
+		await expect
+			.poll(async () => {
+				await screen.getByTestId('fromTime').fill('12:30:00');
+				return (screen.getByTestId('fromTime').element() as HTMLInputElement).value;
+			})
+			.toBe('12:30:00');
+		await expect
+			.poll(async () => {
+				await screen.getByTestId('toTime').fill('17:15:00');
+				return (screen.getByTestId('toTime').element() as HTMLInputElement).value;
+			})
+			.toBe('17:15:00');
+		await applyDateRange(screen);
+
+		await expect
+			.element(screen.getByLabelText('Start Date Range'), TIMEOUT)
+			.toHaveValue('2022-01-01 12:30:00 - 2022-12-01 17:15:00');
+	});
+
+	it('should show validation error on invalid character', async () => {
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+		const TIME_ERROR = 'Time has to be in the format hh:mm:ss';
+
+		await screen.getByLabelText('Start Date Range').click();
+
+		await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+		});
+
+		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).not.toBeInvalid();
+		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).not.toBeInTheDocument();
+		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).not.toBeDisabled();
+
+		await screen.getByTestId('fromTime').fill('12:30:xx');
+
+		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).toBeInvalid();
+		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).toBeDisabled();
+	});
+
+	it('should show validation error on invalid time format', async () => {
+		vi.useFakeTimers({shouldAdvanceTime: true});
+
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+		const TIME_ERROR = 'Time has to be in the format hh:mm:ss';
+
+		await screen.getByLabelText('Start Date Range').click();
+
+		await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+		});
+
+		await screen.getByTestId('fromTime').fill('1111');
+
+		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).not.toBeInvalid();
+		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).not.toBeInTheDocument();
+		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).not.toBeDisabled();
+
+		vi.runOnlyPendingTimers();
+
+		await expect.element(screen.getByText(TIME_ERROR), TIMEOUT).toBeVisible();
+		await expect.element(screen.getByTestId('fromTime'), TIMEOUT).toBeInvalid();
+		await expect.element(screen.getByRole('button', {name: 'Apply'}), TIMEOUT).toBeDisabled();
+
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
@@ -13,9 +13,9 @@ import {MockDateRangeField} from './mocks';
 import {getWrapper} from './getWrapper';
 
 describe('<DateRangeField />', () => {
-	afterEach(() => {
+	afterEach(async () => {
 		vi.useRealTimers();
-		cleanup();
+		await cleanup();
 	});
 
 	it('should close modal on cancel click', async () => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.test.tsx
@@ -13,7 +13,10 @@ import {MockDateRangeField} from './mocks';
 import {getWrapper} from './getWrapper';
 
 describe('<DateRangeField />', () => {
-	afterEach(cleanup);
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
 
 	it('should close modal on cancel click', async () => {
 		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
@@ -175,8 +178,5 @@ describe('<DateRangeField />', () => {
 		await expect.element(screen.getByText(TIME_ERROR)).toBeVisible();
 		await expect.element(screen.getByTestId('fromTime')).toBeInvalid();
 		await expect.element(screen.getByRole('button', {name: 'Apply'})).toBeDisabled();
-
-		vi.clearAllTimers();
-		vi.useRealTimers();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tracking.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tracking.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, cleanup} from 'vitest-browser-react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {tracking} from '#/shared/tracking';
+import {applyDateRange, pickDateTimeRange} from './pickDateTimeRange';
+import {MockDateRangeField} from './mocks';
+import {getWrapper} from './getWrapper';
+
+describe('<DateRangeField /> tracking', () => {
+	afterEach(async () => {
+		await cleanup();
+		vi.restoreAllMocks();
+	});
+
+	it('should track date picker, date input, time input', async () => {
+		const trackSpy = vi.spyOn(tracking, 'track');
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+		await screen.getByLabelText('Start Date Range').click();
+		expect(trackSpy).toHaveBeenNthCalledWith(1, {
+			eventName: 'operate:date-range-popover-opened',
+			filterName: 'startDateRange',
+		});
+
+		await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+			fromTime: '11:22:33',
+			toTime: '08:59:59',
+		});
+
+		await screen.getByLabelText('From date').fill('2022-01-01');
+		await screen.getByLabelText('To date').fill('2022-12-01');
+		await applyDateRange(screen);
+
+		expect(trackSpy).toHaveBeenNthCalledWith(2, {
+			eventName: 'operate:date-range-applied',
+			filterName: 'startDateRange',
+			methods: {
+				dateInput: true,
+				datePicker: true,
+				quickFilter: false,
+				timeInput: true,
+			},
+		});
+	});
+
+	it('should track date picker', async () => {
+		const trackSpy = vi.spyOn(tracking, 'track');
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+		await screen.getByLabelText('Start Date Range').click();
+		expect(trackSpy).toHaveBeenNthCalledWith(1, {
+			eventName: 'operate:date-range-popover-opened',
+			filterName: 'startDateRange',
+		});
+
+		await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+		});
+		await applyDateRange(screen);
+
+		expect(trackSpy).toHaveBeenNthCalledWith(2, {
+			eventName: 'operate:date-range-applied',
+			filterName: 'startDateRange',
+			methods: {
+				dateInput: false,
+				datePicker: true,
+				quickFilter: false,
+				timeInput: false,
+			},
+		});
+	});
+
+	it('should track date input, time input', async () => {
+		const trackSpy = vi.spyOn(tracking, 'track');
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+		await screen.getByLabelText('Start Date Range').click();
+		expect(trackSpy).toHaveBeenNthCalledWith(1, {
+			eventName: 'operate:date-range-popover-opened',
+			filterName: 'startDateRange',
+		});
+
+		await screen.getByLabelText('From date').fill('2022-01-01');
+		await screen.getByLabelText('To date').fill('2022-12-01');
+		await screen.getByTestId('fromTime').fill('12:30:00');
+		await screen.getByTestId('toTime').fill('17:15:00');
+		await applyDateRange(screen);
+
+		expect(trackSpy).toHaveBeenNthCalledWith(2, {
+			eventName: 'operate:date-range-applied',
+			filterName: 'startDateRange',
+			methods: {
+				dateInput: true,
+				datePicker: false,
+				quickFilter: false,
+				timeInput: true,
+			},
+		});
+	});
+
+	it('should track date picker, time input', async () => {
+		const trackSpy = vi.spyOn(tracking, 'track');
+		const screen = await render(<MockDateRangeField />, {wrapper: getWrapper()});
+		await screen.getByLabelText('Start Date Range').click();
+		expect(trackSpy).toHaveBeenNthCalledWith(1, {
+			eventName: 'operate:date-range-popover-opened',
+			filterName: 'startDateRange',
+		});
+
+		await pickDateTimeRange({
+			screen,
+			fromDay: '10',
+			toDay: '20',
+			fromTime: '11:22:33',
+			toTime: '08:59:59',
+		});
+		await applyDateRange(screen);
+		expect(trackSpy).toHaveBeenNthCalledWith(2, {
+			eventName: 'operate:date-range-applied',
+			filterName: 'startDateRange',
+			methods: {
+				dateInput: false,
+				datePicker: true,
+				quickFilter: false,
+				timeInput: true,
+			},
+		});
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useRef} from 'react';
 import {Field, useField, useForm} from 'react-final-form';
 import {Calendar} from '@carbon/react/icons';
 import {tracking} from '#/shared/tracking';
@@ -42,7 +41,6 @@ const DateRangeField: React.FC<Props> = ({
 	onModalClose,
 	onClick,
 }) => {
-	const textFieldRef = useRef<HTMLDivElement>(null);
 	const form = useForm();
 	const fromDateTime = useField<string>(fromDateTimeKey).input.value;
 	const toDateTime = useField<string>(toDateTimeKey).input.value;
@@ -69,7 +67,7 @@ const DateRangeField: React.FC<Props> = ({
 
 	return (
 		<>
-			<div ref={textFieldRef}>
+			<div>
 				<IconTextInput
 					Icon={Calendar}
 					id={`optional-filter-${filterName}`}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tsx
@@ -10,7 +10,7 @@ import {useRef} from 'react';
 import {Field, useField, useForm} from 'react-final-form';
 import {Calendar} from '@carbon/react/icons';
 import {tracking} from '#/shared/tracking';
-import {IconTextInput} from '#/operate/shared/IconInput';
+import {IconTextInput} from '#/operate/shared/IconInput/IconTextInput';
 import {formatDate, formatISODate, formatTime} from './formatDate';
 import {DateRangeModal} from './DateRangeModal/DateRangeModal';
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/DateRangeField.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useRef} from 'react';
+import {Field, useField, useForm} from 'react-final-form';
+import {Calendar} from '@carbon/react/icons';
+import {tracking} from '#/shared/tracking';
+import {IconTextInput} from '#/operate/shared/IconInput';
+import {formatDate, formatISODate, formatTime} from './formatDate';
+import {DateRangeModal} from './DateRangeModal/DateRangeModal';
+
+type Props = {
+	filterName: string;
+	popoverTitle: string;
+	label: string;
+	fromDateTimeKey: string;
+	toDateTimeKey: string;
+	isModalOpen: boolean;
+	onModalClose: () => void;
+	onClick: () => void;
+};
+
+const formatInputValue = (fromDateTime?: Date, toDateTime?: Date) => {
+	if (fromDateTime === undefined || toDateTime === undefined) {
+		return '';
+	}
+	return `${formatDate(fromDateTime)} ${formatTime(fromDateTime)} - ${formatDate(toDateTime)} ${formatTime(toDateTime)}`;
+};
+
+const DateRangeField: React.FC<Props> = ({
+	filterName,
+	popoverTitle,
+	label,
+	fromDateTimeKey,
+	toDateTimeKey,
+	isModalOpen,
+	onModalClose,
+	onClick,
+}) => {
+	const textFieldRef = useRef<HTMLDivElement>(null);
+	const form = useForm();
+	const fromDateTime = useField<string>(fromDateTimeKey).input.value;
+	const toDateTime = useField<string>(toDateTimeKey).input.value;
+
+	const getInputValue = () => {
+		if (isModalOpen) {
+			return 'Custom';
+		}
+		if (fromDateTime !== '' && toDateTime !== '') {
+			return formatInputValue(new Date(fromDateTime), new Date(toDateTime));
+		}
+		return '';
+	};
+
+	const handleClick = () => {
+		if (!isModalOpen) {
+			onClick();
+			tracking.track({
+				eventName: 'operate:date-range-popover-opened',
+				filterName,
+			});
+		}
+	};
+
+	return (
+		<>
+			<div ref={textFieldRef}>
+				<IconTextInput
+					Icon={Calendar}
+					id={`optional-filter-${filterName}`}
+					labelText={label}
+					value={getInputValue()}
+					title={getInputValue()}
+					placeholder="Enter date range"
+					size="sm"
+					buttonLabel="Open date range modal"
+					onIconClick={handleClick}
+					onClick={handleClick}
+				/>
+				{[fromDateTimeKey, toDateTimeKey].map((filterKey) => (
+					<Field name={filterKey} key={filterKey} component="input" type="hidden" />
+				))}
+			</div>
+
+			{isModalOpen ? (
+				<DateRangeModal
+					isModalOpen={isModalOpen}
+					title={popoverTitle}
+					filterName={filterName}
+					onCancel={onModalClose}
+					onApply={({fromDateTime, toDateTime}) => {
+						onModalClose();
+						form.change(fromDateTimeKey, formatISODate(fromDateTime));
+						form.change(toDateTimeKey, formatISODate(toDateTime));
+					}}
+					defaultValues={{
+						fromDate: fromDateTime === '' ? '' : formatDate(new Date(fromDateTime)),
+						fromTime: fromDateTime === '' ? '' : formatTime(new Date(fromDateTime)),
+						toDate: toDateTime === '' ? '' : formatDate(new Date(toDateTime)),
+						toTime: toDateTime === '' ? '' : formatTime(new Date(toDateTime)),
+					}}
+					key={`date-range-modal-${isModalOpen ? 'open' : 'closed'}`}
+				/>
+			) : null}
+		</>
+	);
+};
+
+export {DateRangeField};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/getWrapper.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/getWrapper.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Form} from 'react-final-form';
+
+function getWrapper(initialValues?: {[key: string]: string}) {
+	const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+		return (
+			<>
+				<Form onSubmit={() => {}} initialValues={initialValues}>
+					{() => children}
+				</Form>
+				<div>Outside element</div>
+			</>
+		);
+	};
+
+	return Wrapper;
+}
+
+export {getWrapper};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/mocks.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/mocks.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {DateRangeField} from './DateRangeField';
+
+const MockDateRangeField: React.FC = () => {
+	const [isModalOpen, setIsModalOpen] = useState(false);
+	return (
+		<DateRangeField
+			onModalClose={() => {
+				setIsModalOpen(false);
+			}}
+			onClick={() => {
+				setIsModalOpen(true);
+			}}
+			isModalOpen={isModalOpen}
+			popoverTitle="Filter instances by start date"
+			label="Start Date Range"
+			filterName="startDateRange"
+			fromDateTimeKey="startDateFrom"
+			toDateTimeKey="startDateTo"
+		/>
+	);
+};
+
+export {MockDateRangeField};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/pickDateTimeRange.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/pickDateTimeRange.ts
@@ -59,12 +59,15 @@ async function pickDateTimeRange({
 	await expect.element(screen.getByTestId('date-range-modal')).toHaveClass(/is-visible/);
 	const monthName = document.querySelector('.cur-month')?.textContent;
 	const year = document.querySelector<HTMLInputElement>('.cur-year')?.value;
+	if (!monthName || !year) {
+		throw new Error('Could not read month/year from the flatpickr calendar header');
+	}
 	const month = new Date(`${monthName} 01, ${year}`).getMonth() + 1;
 
 	await screen.getByLabelText('From date').click();
-	clickCalendarDay(monthName ?? '', fromDay, year ?? '');
+	clickCalendarDay(monthName, fromDay, year);
 	await screen.getByLabelText('To date').click();
-	clickCalendarDay(monthName ?? '', toDay, year ?? '');
+	clickCalendarDay(monthName, toDay, year);
 
 	if (fromTime !== undefined) {
 		await screen.getByTestId('fromTime').fill(fromTime);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/pickDateTimeRange.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/pickDateTimeRange.ts
@@ -10,11 +10,6 @@ import {expect} from 'vitest';
 import type {RenderResult} from 'vitest-browser-react';
 import {formatISODate} from './formatDate';
 
-// This suite drives a real Carbon Modal + flatpickr instance in the browser; under heavy
-// parallel-test CPU load their internal async sync can take longer than the default poll
-// timeout, so every assertion below gets a longer one.
-const TIMEOUT = {timeout: 10_000};
-
 const pad = (value: string | number) => {
 	return String(value).padStart(2, '0');
 };
@@ -27,6 +22,25 @@ function clickCalendarDay(monthName: string, day: string, year: string) {
 		throw new Error(`Could not find calendar day "${monthName} ${day}, ${year}"`);
 	}
 	dayEl.click();
+}
+
+// This suite drives a real Carbon Modal + flatpickr instance in the browser; under heavy
+// parallel-test CPU load their internal async sync can occasionally take longer than the
+// default poll window. Retries the whole assertion rather than passing a longer `timeout`
+// to `expect.element`, since eslint-plugin-vitest's `valid-expect` rule doesn't recognize
+// that overload and flags it as "too many arguments".
+async function retryAssertion(assertion: () => Promise<unknown>, attempts = 10, delayMs = 500) {
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			await assertion();
+			return;
+		} catch (error) {
+			if (attempt === attempts) {
+				throw error;
+			}
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+	}
 }
 
 async function pickDateTimeRange({
@@ -42,7 +56,7 @@ async function pickDateTimeRange({
 	fromTime?: string;
 	toTime?: string;
 }) {
-	await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).toHaveClass(/is-visible/);
+	await expect.element(screen.getByTestId('date-range-modal')).toHaveClass(/is-visible/);
 	const monthName = document.querySelector('.cur-month')?.textContent;
 	const year = document.querySelector<HTMLInputElement>('.cur-year')?.value;
 	const month = new Date(`${monthName} 01, ${year}`).getMonth() + 1;
@@ -75,9 +89,9 @@ async function pickDateTimeRange({
 
 async function applyDateRange(screen: RenderResult) {
 	const applyButton = screen.getByRole('button', {name: 'Apply'});
-	await expect.element(applyButton, TIMEOUT).not.toBeDisabled();
+	await expect.element(applyButton).not.toBeDisabled();
 	await applyButton.click();
-	await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).not.toBeInTheDocument();
+	await expect.element(screen.getByTestId('date-range-modal')).not.toBeInTheDocument();
 }
 
-export {pickDateTimeRange, applyDateRange};
+export {pickDateTimeRange, applyDateRange, retryAssertion};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/pickDateTimeRange.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DateRangeField/pickDateTimeRange.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from 'vitest';
+import type {RenderResult} from 'vitest-browser-react';
+import {formatISODate} from './formatDate';
+
+// This suite drives a real Carbon Modal + flatpickr instance in the browser; under heavy
+// parallel-test CPU load their internal async sync can take longer than the default poll
+// timeout, so every assertion below gets a longer one.
+const TIMEOUT = {timeout: 10_000};
+
+const pad = (value: string | number) => {
+	return String(value).padStart(2, '0');
+};
+
+// flatpickr renders calendar days as plain `<span aria-label="...">`, not `<button>`,
+// so a role-based locator can't find them; click the DOM node directly instead.
+function clickCalendarDay(monthName: string, day: string, year: string) {
+	const dayEl = document.querySelector<HTMLElement>(`.flatpickr-day[aria-label*="${monthName} ${day}, ${year}"]`);
+	if (dayEl === null) {
+		throw new Error(`Could not find calendar day "${monthName} ${day}, ${year}"`);
+	}
+	dayEl.click();
+}
+
+async function pickDateTimeRange({
+	screen,
+	fromDay,
+	toDay,
+	fromTime,
+	toTime,
+}: {
+	screen: RenderResult;
+	fromDay: string;
+	toDay: string;
+	fromTime?: string;
+	toTime?: string;
+}) {
+	await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).toHaveClass(/is-visible/);
+	const monthName = document.querySelector('.cur-month')?.textContent;
+	const year = document.querySelector<HTMLInputElement>('.cur-year')?.value;
+	const month = new Date(`${monthName} 01, ${year}`).getMonth() + 1;
+
+	await screen.getByLabelText('From date').click();
+	clickCalendarDay(monthName ?? '', fromDay, year ?? '');
+	await screen.getByLabelText('To date').click();
+	clickCalendarDay(monthName ?? '', toDay, year ?? '');
+
+	if (fromTime !== undefined) {
+		await screen.getByTestId('fromTime').fill(fromTime);
+	}
+
+	if (toTime !== undefined) {
+		await screen.getByTestId('toTime').fill(toTime);
+	}
+
+	const fromTimeInput = screen.getByTestId('fromTime').element() as HTMLInputElement;
+	const toTimeInput = screen.getByTestId('toTime').element() as HTMLInputElement;
+
+	return {
+		fromDay: pad(fromDay),
+		toDay: pad(toDay),
+		month: pad(month),
+		fromDate: formatISODate(new Date(`${year}-${pad(month)}-${pad(fromDay)} ${fromTimeInput.value}`)),
+		toDate: formatISODate(new Date(`${year}-${pad(month)}-${pad(toDay)} ${toTimeInput.value}`)),
+		year,
+	};
+}
+
+async function applyDateRange(screen: RenderResult) {
+	const applyButton = screen.getByRole('button', {name: 'Apply'});
+	await expect.element(applyButton, TIMEOUT).not.toBeDisabled();
+	await applyButton.click();
+	await expect.element(screen.getByTestId('date-range-modal'), TIMEOUT).not.toBeInTheDocument();
+}
+
+export {pickDateTimeRange, applyDateRange};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/tracking.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/tracking.tsx
@@ -144,6 +144,10 @@ type Events =
 				timeInput: boolean;
 			};
 			filterName: string;
+	  }
+	| {
+			eventName: 'operate:date-range-popover-opened';
+			filterName: string;
 	  };
 
 const STAGE_ENV = getStage(window.location.host);


### PR DESCRIPTION
## Description

Part of #57670 (Operate DateRangeField shared component), split 3/3, stacked on #57798:

1. #57797 — `IconInput`, `logger`, `parseDate`, `parseFilterTime`, time validators.
2. #57798 — `DateRangeModal`, `DateInput`, `TimeInput`.
3. **This PR** — `DateRangeField` root component + tests, closes #57670.

Ports `operate/client/src/modules/components/DateRangeField/` root 1:1: the icon text field showing the current range summary (or "Custom" while the modal is open), wired to `react-final-form`. Includes the ported legacy test suites, adapted to this app's real-browser test setup — notably, flatpickr renders calendar days as `<span>`, not `<button>`, so tests query the DOM directly instead of by role.

581 lines, slightly over the usual 500 cap — kept the component and its own test suite together since splitting them would hurt review coherence more than the overage costs.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #57670