### PR TITLE
feat: add metadata to cluster variable REST create/update/get/search

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/ClusterVariable.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterVariable.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class ClusterVariable {
+
+  private static final String PREFIX = "camunda.api.rest.cluster-variable";
+
+  /**
+   * Maximum allowed size (in UTF-8 bytes) of a cluster variable's serialized metadata JSON. When
+   * unset, the built-in default is used.
+   */
+  private Integer maxMetadataSize;
+
+  public Integer getMaxMetadataSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".max-metadata-size",
+        maxMetadataSize,
+        Integer.class,
+        BackwardsCompatibilityMode.NOT_SUPPORTED,
+        Set.of());
+  }
+
+  public void setMaxMetadataSize(final Integer maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Rest.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rest.java
@@ -22,6 +22,17 @@ public class Rest {
   /** Set the executor configuration */
   @NestedConfigurationProperty private Executor executor = new Executor();
 
+  /** Set the cluster variable configuration */
+  @NestedConfigurationProperty private ClusterVariable clusterVariable = new ClusterVariable();
+
+  public ClusterVariable getClusterVariable() {
+    return clusterVariable;
+  }
+
+  public void setClusterVariable(final ClusterVariable clusterVariable) {
+    this.clusterVariable = clusterVariable;
+  }
+
   public List<Filter> getFilters() {
     return filters;
   }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -78,6 +78,12 @@ public class GatewayRestPropertiesOverride {
     }
 
     private void populateFromValidators(final GatewayRestConfiguration override) {
+      final var maxClusterVariableMetadataSize =
+          camunda.getApi().getRest().getClusterVariable().getMaxMetadataSize();
+      if (maxClusterVariableMetadataSize != null) {
+        override.setMaxClusterVariableMetadataSize(maxClusterVariableMetadataSize);
+      }
+
       if (camunda.getData().getSecondaryStorage().getType() != SecondaryStorageType.rdbms) {
         return;
       }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -15,6 +15,7 @@ api.long-polling.enabled
 api.long-polling.min-empty-responses
 api.long-polling.probe-timeout
 api.long-polling.timeout
+api.rest.cluster-variable.max-metadata-size
 api.rest.process-cache.expiration-idle
 api.rest.process-cache.max-size
 cluster.global-listeners.user-task

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -852,6 +852,7 @@ public final class ResponseMapper {
         .scope(scope)
         .tenantId(tenantId)
         .value(clusterVariableRecord.getValue())
+        .metadata(clusterVariableRecord.getMetadata())
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -851,8 +851,8 @@ public final class ResponseMapper {
         .name(clusterVariableRecord.getName())
         .scope(scope)
         .tenantId(tenantId)
-        .value(clusterVariableRecord.getValue())
         .metadata(clusterVariableRecord.getMetadata())
+        .value(clusterVariableRecord.getValue())
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
@@ -29,14 +29,16 @@ public class ClusterVariableMapper {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableCreateRequest(
             request, tenantId),
-        () -> new ClusterVariableRequest(request.getName(), request.getValue(), tenantId));
+        () ->
+            new ClusterVariableRequest(
+                request.getName(), request.getValue(), tenantId, request.getMetadata()));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableUpdateRequest(
       final String name, final UpdateClusterVariableRequest request) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableUpdateRequest(name, request),
-        () -> new ClusterVariableRequest(name, request.getValue(), null));
+        () -> new ClusterVariableRequest(name, request.getValue(), null, request.getMetadata()));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableUpdateRequest(
@@ -44,27 +46,30 @@ public class ClusterVariableMapper {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableUpdateRequest(
             name, request, tenantId),
-        () -> new ClusterVariableRequest(name, request.getValue(), tenantId));
+        () ->
+            new ClusterVariableRequest(name, request.getValue(), tenantId, request.getMetadata()));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableRequest(
       final String name, final String tenantId) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableRequest(name, tenantId),
-        () -> new ClusterVariableRequest(name, null, tenantId));
+        () -> new ClusterVariableRequest(name, null, tenantId, null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableCreateRequest(
       final CreateClusterVariableRequest request) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableCreateRequest(request),
-        () -> new ClusterVariableRequest(request.getName(), request.getValue(), null));
+        () ->
+            new ClusterVariableRequest(
+                request.getName(), request.getValue(), null, request.getMetadata()));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableRequest(
       final String name) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableRequest(name),
-        () -> new ClusterVariableRequest(name, null, null));
+        () -> new ClusterVariableRequest(name, null, null, null));
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -1656,6 +1656,7 @@ public final class SearchQueryResponseMapper {
         .name(clusterVariableEntity.name())
         .scope(scope)
         .tenantId(tenantId)
+        .metadata(toMetadataMap(clusterVariableEntity))
         .value(
             requireNonNull(
                 !truncateValues
@@ -1664,7 +1665,6 @@ public final class SearchQueryResponseMapper {
                 "value"))
         .isTruncated(
             truncateValues && requireNonNull(clusterVariableEntity.isPreview(), "isPreview"))
-        .metadata(toMetadataMap(clusterVariableEntity))
         .build();
   }
 
@@ -1683,8 +1683,8 @@ public final class SearchQueryResponseMapper {
         .name(clusterVariableEntity.name())
         .scope(scope)
         .tenantId(tenantId)
-        .value(requireNonNull(getFullValueIfPresent(clusterVariableEntity), "value"))
         .metadata(toMetadataMap(clusterVariableEntity))
+        .value(requireNonNull(getFullValueIfPresent(clusterVariableEntity), "value"))
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -245,6 +245,7 @@ import io.camunda.security.api.model.user.CamundaUserDTO;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -1663,6 +1664,7 @@ public final class SearchQueryResponseMapper {
                 "value"))
         .isTruncated(
             truncateValues && requireNonNull(clusterVariableEntity.isPreview(), "isPreview"))
+        .metadata(toMetadataMap(clusterVariableEntity))
         .build();
   }
 
@@ -1682,7 +1684,22 @@ public final class SearchQueryResponseMapper {
         .scope(scope)
         .tenantId(tenantId)
         .value(requireNonNull(getFullValueIfPresent(clusterVariableEntity), "value"))
+        .metadata(toMetadataMap(clusterVariableEntity))
         .build();
+  }
+
+  private static Map<String, Object> toMetadataMap(
+      final ClusterVariableEntity clusterVariableEntity) {
+    final var metadata = clusterVariableEntity.metadata();
+    if (metadata == null || metadata.isEmpty()) {
+      return Map.of();
+    }
+    final Map<String, Object> result = new LinkedHashMap<>();
+    metadata.forEach(
+        entry ->
+            result.put(
+                entry.key(), entry.valueNumber() != null ? entry.valueNumber() : entry.value()));
+    return result;
   }
 
   private static @Nullable String getFullValueIfPresent(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ClusterVariableRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ClusterVariableRequestValidator.java
@@ -97,6 +97,13 @@ public class ClusterVariableRequestValidator {
     if (metadata == null || metadata.isEmpty()) {
       return violations;
     }
+
+    if (metadata.size() > MAX_METADATA_ENTRIES) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_METADATA_ENTRIES.formatted(metadata.size(), MAX_METADATA_ENTRIES));
+      return violations;
+    }
+
     metadata.forEach(
         (key, value) -> {
           if (!(value instanceof String) && !(value instanceof Number)) {
@@ -105,10 +112,6 @@ public class ClusterVariableRequestValidator {
                     key, value == null ? "null" : value.getClass().getSimpleName()));
           }
         });
-    if (metadata.size() > MAX_METADATA_ENTRIES) {
-      violations.add(
-          ERROR_MESSAGE_TOO_MANY_METADATA_ENTRIES.formatted(metadata.size(), MAX_METADATA_ENTRIES));
-    }
     final int serializedSize = serializedMetadataLength(metadata);
     if (serializedSize > maxMetadataSize) {
       violations.add(ERROR_MESSAGE_METADATA_TOO_LARGE.formatted(maxMetadataSize));

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ClusterVariableRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ClusterVariableRequestValidator.java
@@ -7,36 +7,57 @@
  */
 package io.camunda.gateway.mapping.http.validator;
 
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_METADATA_VALUE_TYPE;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_METADATA_TOO_LARGE;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_METADATA_ENTRIES;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.gateway.protocol.model.CreateClusterVariableRequest;
 import io.camunda.gateway.protocol.model.UpdateClusterVariableRequest;
 import io.camunda.security.validation.ClusterVariableValidator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public class ClusterVariableRequestValidator {
 
-  private final ClusterVariableValidator clusterVariableValidator;
+  /** Maximum number of entries allowed in a cluster variable's metadata bag. */
+  public static final int MAX_METADATA_ENTRIES = 100;
 
-  public ClusterVariableRequestValidator(final ClusterVariableValidator clusterVariableValidator) {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final ClusterVariableValidator clusterVariableValidator;
+  private final int maxMetadataSize;
+
+  public ClusterVariableRequestValidator(
+      final ClusterVariableValidator clusterVariableValidator, final int maxMetadataSize) {
     this.clusterVariableValidator = clusterVariableValidator;
+    this.maxMetadataSize = maxMetadataSize;
   }
 
   public Optional<ProblemDetail> validateTenantClusterVariableCreateRequest(
       final CreateClusterVariableRequest request, final String tenantId) {
     return validate(
-        () ->
-            clusterVariableValidator.validateTenantClusterVariableRequestWithValue(
-                request.getName(), request.getValue(), tenantId));
+        violations -> {
+          violations.addAll(
+              clusterVariableValidator.validateTenantClusterVariableRequestWithValue(
+                  request.getName(), request.getValue(), tenantId));
+          violations.addAll(validateMetadata(request.getMetadata()));
+        });
   }
 
   public Optional<ProblemDetail> validateGlobalClusterVariableCreateRequest(
       final CreateClusterVariableRequest request) {
     return validate(
-        () ->
-            clusterVariableValidator.validateGlobalClusterVariableRequestWithValue(
-                request.getName(), request.getValue()));
+        violations -> {
+          violations.addAll(
+              clusterVariableValidator.validateGlobalClusterVariableRequestWithValue(
+                  request.getName(), request.getValue()));
+          violations.addAll(validateMetadata(request.getMetadata()));
+        });
   }
 
   public Optional<ProblemDetail> validateTenantClusterVariableRequest(
@@ -52,16 +73,56 @@ public class ClusterVariableRequestValidator {
   public Optional<ProblemDetail> validateGlobalClusterVariableUpdateRequest(
       final String name, final UpdateClusterVariableRequest request) {
     return validate(
-        () ->
-            clusterVariableValidator.validateGlobalClusterVariableRequestWithValue(
-                name, request.getValue()));
+        violations -> {
+          violations.addAll(
+              clusterVariableValidator.validateGlobalClusterVariableRequestWithValue(
+                  name, request.getValue()));
+          violations.addAll(validateMetadata(request.getMetadata()));
+        });
   }
 
   public Optional<ProblemDetail> validateTenantClusterVariableUpdateRequest(
       final String name, final UpdateClusterVariableRequest request, final String tenantId) {
     return validate(
-        () ->
-            clusterVariableValidator.validateTenantClusterVariableRequestWithValue(
-                name, request.getValue(), tenantId));
+        violations -> {
+          violations.addAll(
+              clusterVariableValidator.validateTenantClusterVariableRequestWithValue(
+                  name, request.getValue(), tenantId));
+          violations.addAll(validateMetadata(request.getMetadata()));
+        });
+  }
+
+  private List<String> validateMetadata(final Map<String, Object> metadata) {
+    final List<String> violations = new ArrayList<>();
+    if (metadata == null || metadata.isEmpty()) {
+      return violations;
+    }
+    metadata.forEach(
+        (key, value) -> {
+          if (value != null && !(value instanceof String) && !(value instanceof Number)) {
+            violations.add(
+                ERROR_MESSAGE_INVALID_METADATA_VALUE_TYPE.formatted(
+                    key, value.getClass().getSimpleName()));
+          }
+        });
+    if (metadata.size() > MAX_METADATA_ENTRIES) {
+      violations.add(
+          ERROR_MESSAGE_TOO_MANY_METADATA_ENTRIES.formatted(metadata.size(), MAX_METADATA_ENTRIES));
+    }
+    final int serializedSize = serializedMetadataLength(metadata);
+    if (serializedSize > maxMetadataSize) {
+      violations.add(ERROR_MESSAGE_METADATA_TOO_LARGE.formatted(maxMetadataSize));
+    }
+    return violations;
+  }
+
+  private int serializedMetadataLength(final Map<String, Object> metadata) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(metadata).length();
+    } catch (final Exception e) {
+      // metadata values are only strings/numbers by this point in most cases, but if
+      // serialization still fails, treat it as oversized rather than throwing.
+      return Integer.MAX_VALUE;
+    }
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ClusterVariableRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ClusterVariableRequestValidator.java
@@ -99,10 +99,10 @@ public class ClusterVariableRequestValidator {
     }
     metadata.forEach(
         (key, value) -> {
-          if (value != null && !(value instanceof String) && !(value instanceof Number)) {
+          if (!(value instanceof String) && !(value instanceof Number)) {
             violations.add(
                 ERROR_MESSAGE_INVALID_METADATA_VALUE_TYPE.formatted(
-                    key, value.getClass().getSimpleName()));
+                    key, value == null ? "null" : value.getClass().getSimpleName()));
           }
         });
     if (metadata.size() > MAX_METADATA_ENTRIES) {
@@ -118,7 +118,7 @@ public class ClusterVariableRequestValidator {
 
   private int serializedMetadataLength(final Map<String, Object> metadata) {
     try {
-      return OBJECT_MAPPER.writeValueAsString(metadata).length();
+      return OBJECT_MAPPER.writeValueAsBytes(metadata).length;
     } catch (final Exception e) {
       // metadata values are only strings/numbers by this point in most cases, but if
       // serialization still fails, treat it as oversized rather than throwing.

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
@@ -52,4 +52,10 @@ public final class ErrorMessages {
       "When using isLatestVersion filter, pagination is limited to forward pagination using 'after' and 'limit'. The field '%s' is not supported.";
   public static final String ERROR_MESSAGE_UNSUPPORTED_SORT_FIELD_WITH_IS_LATEST_VERSION =
       "When using isLatestVersion filter, sorting is limited to 'processDefinitionId' and 'tenantId' fields only. The field '%s' is not supported.";
+  public static final String ERROR_MESSAGE_INVALID_METADATA_VALUE_TYPE =
+      "The metadata value for key '%s' is of type '%s' but must be a string or a number";
+  public static final String ERROR_MESSAGE_TOO_MANY_METADATA_ENTRIES =
+      "The provided metadata has %d entries but must not exceed %d entries";
+  public static final String ERROR_MESSAGE_METADATA_TOO_LARGE =
+      "The provided metadata exceeds the maximum serialized size of %d characters";
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ErrorMessages.java
@@ -57,5 +57,5 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_TOO_MANY_METADATA_ENTRIES =
       "The provided metadata has %d entries but must not exceed %d entries";
   public static final String ERROR_MESSAGE_METADATA_TOO_LARGE =
-      "The provided metadata exceeds the maximum serialized size of %d characters";
+      "The provided metadata exceeds the maximum serialized size of %d bytes";
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1217,6 +1217,66 @@ class SearchQueryResponseMapperTest {
         .containsExactly("create", "update");
   }
 
+  @Test
+  void shouldMapClusterVariableGetResult() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id",
+            "name",
+            "value",
+            null,
+            false,
+            ClusterVariableScope.GLOBAL,
+            null,
+            List.of(
+                new MetadataEntry("kind", "CREDENTIAL", null),
+                new MetadataEntry("schemaVersion", null, 2.0)));
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
+
+    // then
+    assertThat(result.getMetadata())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL", "schemaVersion", 2.0));
+  }
+
+  @Test
+  void shouldMapClusterVariableGetResultWithoutMetadata() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id", "name", "value", null, false, ClusterVariableScope.GLOBAL, null, List.of());
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
+
+    // then
+    assertThat(result.getMetadata()).isEmpty();
+  }
+
+  @Test
+  void shouldMapClusterVariableSearchResult() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id",
+            "name",
+            "value",
+            null,
+            false,
+            ClusterVariableScope.GLOBAL,
+            null,
+            List.of(new MetadataEntry("kind", "CREDENTIAL", null)));
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableSearchResult(entity, true);
+
+    // then
+    assertThat(result.getMetadata())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL"));
+  }
+
   @Nested
   class AgentHistoryItemResult {
 
@@ -1390,65 +1450,5 @@ class SearchQueryResponseMapperTest {
       assertThat(response.getItems()).hasSize(1);
       assertThat(response.getItems().get(0).getHistoryItemKey()).isEqualTo("42");
     }
-  }
-
-  @Test
-  void shouldMapClusterVariableGetResult() {
-    // given
-    final var entity =
-        new ClusterVariableEntity(
-            "id",
-            "name",
-            "value",
-            null,
-            false,
-            ClusterVariableScope.GLOBAL,
-            null,
-            List.of(
-                new MetadataEntry("kind", "CREDENTIAL", null),
-                new MetadataEntry("schemaVersion", null, 2.0)));
-
-    // when
-    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
-
-    // then
-    assertThat(result.getMetadata())
-        .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL", "schemaVersion", 2.0));
-  }
-
-  @Test
-  void shouldMapClusterVariableGetResultWithoutMetadata() {
-    // given
-    final var entity =
-        new ClusterVariableEntity(
-            "id", "name", "value", null, false, ClusterVariableScope.GLOBAL, null, List.of());
-
-    // when
-    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
-
-    // then
-    assertThat(result.getMetadata()).isEmpty();
-  }
-
-  @Test
-  void shouldMapClusterVariableSearchResult() {
-    // given
-    final var entity =
-        new ClusterVariableEntity(
-            "id",
-            "name",
-            "value",
-            null,
-            false,
-            ClusterVariableScope.GLOBAL,
-            null,
-            List.of(new MetadataEntry("kind", "CREDENTIAL", null)));
-
-    // when
-    final var result = SearchQueryResponseMapper.toClusterVariableSearchResult(entity, true);
-
-    // then
-    assertThat(result.getMetadata())
-        .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL"));
   }
 }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -39,6 +39,9 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationType;
+import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
@@ -1387,5 +1390,65 @@ class SearchQueryResponseMapperTest {
       assertThat(response.getItems()).hasSize(1);
       assertThat(response.getItems().get(0).getHistoryItemKey()).isEqualTo("42");
     }
+  }
+
+  @Test
+  void shouldMapClusterVariableGetResult() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id",
+            "name",
+            "value",
+            null,
+            false,
+            ClusterVariableScope.GLOBAL,
+            null,
+            List.of(
+                new MetadataEntry("kind", "CREDENTIAL", null),
+                new MetadataEntry("schemaVersion", null, 2.0)));
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
+
+    // then
+    assertThat(result.getMetadata())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL", "schemaVersion", 2.0));
+  }
+
+  @Test
+  void shouldMapClusterVariableGetResultWithoutMetadata() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id", "name", "value", null, false, ClusterVariableScope.GLOBAL, null, List.of());
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
+
+    // then
+    assertThat(result.getMetadata()).isEmpty();
+  }
+
+  @Test
+  void shouldMapClusterVariableSearchResult() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id",
+            "name",
+            "value",
+            null,
+            false,
+            ClusterVariableScope.GLOBAL,
+            null,
+            List.of(new MetadataEntry("kind", "CREDENTIAL", null)));
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableSearchResult(entity, true);
+
+    // then
+    assertThat(result.getMetadata())
+        .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL"));
   }
 }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -24,7 +24,10 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteClusterVariableR
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateClusterVariableRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -56,6 +59,7 @@ public final class ClusterVariableServices
         new BrokerCreateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
+            .setMetadata(toDirectBufferMetadata(request.metadata()))
             .setGlobalScope(),
         authentication);
   }
@@ -66,6 +70,7 @@ public final class ClusterVariableServices
         new BrokerCreateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
+            .setMetadata(toDirectBufferMetadata(request.metadata()))
             .setTenantScope(request.tenantId()),
         authentication);
   }
@@ -92,6 +97,11 @@ public final class ClusterVariableServices
         new BrokerUpdateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
+            .setMetadata(
+                toDirectBufferMetadata(
+                    resolveMetadataForUpdate(
+                        request.metadata(),
+                        () -> getGloballyScopedClusterVariable(request, authentication))))
             .setGlobalScope(),
         authentication);
   }
@@ -102,6 +112,11 @@ public final class ClusterVariableServices
         new BrokerUpdateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
+            .setMetadata(
+                toDirectBufferMetadata(
+                    resolveMetadataForUpdate(
+                        request.metadata(),
+                        () -> getTenantScopedClusterVariable(request, authentication))))
             .setTenantScope(request.tenantId()),
         authentication);
   }
@@ -148,5 +163,42 @@ public final class ClusterVariableServices
     return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
   }
 
-  public record ClusterVariableRequest(String name, Object value, String tenantId) {}
+  private DirectBuffer toDirectBufferMetadata(final Map<String, Object> metadata) {
+    return toDirectBufferValue(metadata != null ? metadata : Map.of());
+  }
+
+  /**
+   * Cluster variable updates replace the whole stored record, so an omitted {@code metadata} field
+   * would otherwise silently wipe out previously stored metadata. When the client didn't send
+   * metadata, fall back to the currently stored metadata instead of an empty map; if it can't be
+   * looked up (e.g. the variable doesn't exist), let the update proceed and fail through the usual
+   * existence check in the engine.
+   */
+  private Map<String, Object> resolveMetadataForUpdate(
+      final Map<String, Object> metadata, final Supplier<ClusterVariableEntity> currentEntity) {
+    if (metadata != null) {
+      return metadata;
+    }
+    try {
+      return toMetadataMap(currentEntity.get());
+    } catch (final RuntimeException e) {
+      return Map.of();
+    }
+  }
+
+  private static Map<String, Object> toMetadataMap(final ClusterVariableEntity entity) {
+    final var metadata = entity.metadata();
+    if (metadata == null || metadata.isEmpty()) {
+      return Map.of();
+    }
+    final Map<String, Object> result = new LinkedHashMap<>();
+    metadata.forEach(
+        entry ->
+            result.put(
+                entry.key(), entry.valueNumber() != null ? entry.valueNumber() : entry.value()));
+    return result;
+  }
+
+  public record ClusterVariableRequest(
+      String name, Object value, String tenantId, Map<String, Object> metadata) {}
 }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -24,10 +24,8 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteClusterVariableR
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateClusterVariableRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -97,11 +95,7 @@ public final class ClusterVariableServices
         new BrokerUpdateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
-            .setMetadata(
-                toDirectBufferMetadata(
-                    resolveMetadataForUpdate(
-                        request.metadata(),
-                        () -> getGloballyScopedClusterVariable(request, authentication))))
+            .setMetadata(toDirectBufferMetadata(request.metadata()))
             .setGlobalScope(),
         authentication);
   }
@@ -112,11 +106,7 @@ public final class ClusterVariableServices
         new BrokerUpdateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
-            .setMetadata(
-                toDirectBufferMetadata(
-                    resolveMetadataForUpdate(
-                        request.metadata(),
-                        () -> getTenantScopedClusterVariable(request, authentication))))
+            .setMetadata(toDirectBufferMetadata(request.metadata()))
             .setTenantScope(request.tenantId()),
         authentication);
   }
@@ -165,38 +155,6 @@ public final class ClusterVariableServices
 
   private DirectBuffer toDirectBufferMetadata(final Map<String, Object> metadata) {
     return toDirectBufferValue(metadata != null ? metadata : Map.of());
-  }
-
-  /**
-   * Cluster variable updates replace the whole stored record, so an omitted {@code metadata} field
-   * would otherwise silently wipe out previously stored metadata. When the client didn't send
-   * metadata, fall back to the currently stored metadata instead of an empty map; if it can't be
-   * looked up (e.g. the variable doesn't exist), let the update proceed and fail through the usual
-   * existence check in the engine.
-   */
-  private Map<String, Object> resolveMetadataForUpdate(
-      final Map<String, Object> metadata, final Supplier<ClusterVariableEntity> currentEntity) {
-    if (metadata != null) {
-      return metadata;
-    }
-    try {
-      return toMetadataMap(currentEntity.get());
-    } catch (final RuntimeException e) {
-      return Map.of();
-    }
-  }
-
-  private static Map<String, Object> toMetadataMap(final ClusterVariableEntity entity) {
-    final var metadata = entity.metadata();
-    if (metadata == null || metadata.isEmpty()) {
-      return Map.of();
-    }
-    final Map<String, Object> result = new LinkedHashMap<>();
-    metadata.forEach(
-        entry ->
-            result.put(
-                entry.key(), entry.valueNumber() != null ? entry.valueNumber() : entry.value()));
-    return result;
   }
 
   public record ClusterVariableRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -93,11 +93,12 @@ public class ClusterVariableCreatedUpdatedHandler
     final Map<String, Object> metadata = recordValue.getMetadata();
     entity.setMetadata(
         metadata.entrySet().stream()
+            .filter(e -> e.getValue() != null)
             .map(
                 e ->
                     new MetadataEntry(
                         e.getKey(),
-                        e.getValue() == null ? "" : String.valueOf(e.getValue()),
+                        String.valueOf(e.getValue()),
                         e.getValue() instanceof Number n ? n.doubleValue() : null))
             .toList());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -97,7 +97,7 @@ public class ClusterVariableCreatedUpdatedHandler
                 e ->
                     new MetadataEntry(
                         e.getKey(),
-                        String.valueOf(e.getValue()),
+                        e.getValue() == null ? "" : String.valueOf(e.getValue()),
                         e.getValue() instanceof Number n ? n.doubleValue() : null))
             .toList());
   }

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -472,6 +472,16 @@ components:
         value:
           type: object
           description: The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
+        metadata:
+          description: >-
+            A generic key-value metadata bag attached to the cluster variable, e.g. to let
+            consumers discover and filter variables by semantic metadata without inspecting the
+            value. Values must be strings or numbers; booleans, arrays, and objects are rejected.
+            Limited to 100 entries and a configurable maximum serialized size (defaults to
+            100 entries at the maximum key length of a cluster variable name, 256 characters,
+            plus the maximum value length, 8191 characters).
+          type: object
+          additionalProperties: true
     UpdateClusterVariableRequest:
       type: object
       required:
@@ -480,6 +490,16 @@ components:
         value:
           type: object
           description: The new value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
+        metadata:
+          description: >-
+            A generic key-value metadata bag attached to the cluster variable, e.g. to let
+            consumers discover and filter variables by semantic metadata without inspecting the
+            value. Values must be strings or numbers; booleans, arrays, and objects are rejected.
+            Limited to 100 entries and a configurable maximum serialized size (defaults to
+            100 entries at the maximum key length of a cluster variable name, 256 characters,
+            plus the maximum value length, 8191 characters).
+          type: object
+          additionalProperties: true
     ClusterVariableResult:
       type: object
       required:
@@ -523,6 +543,12 @@ components:
           type: string
           nullable: true
           description: Only provided if the cluster variable scope is TENANT. Null for global scope variables.
+        metadata:
+          description: >-
+            A generic key-value metadata bag attached to the cluster variable. Values are
+            strings or numbers.
+          type: object
+          additionalProperties: true
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -482,6 +482,9 @@ components:
             plus the maximum value length, 8191 characters).
           type: object
           additionalProperties: true
+      x-properties-added-in-version:
+        - propertyName: "metadata"
+          addedInVersion: "8.10"
     UpdateClusterVariableRequest:
       type: object
       required:
@@ -500,6 +503,9 @@ components:
             plus the maximum value length, 8191 characters).
           type: object
           additionalProperties: true
+      x-properties-added-in-version:
+        - propertyName: "metadata"
+          addedInVersion: "8.10"
     ClusterVariableResult:
       type: object
       required:
@@ -532,6 +538,7 @@ components:
         - name
         - scope
         - tenantId
+        - metadata
       properties:
         name:
           description: The name of the cluster variable. Unique within its scope (global or tenant-specific).
@@ -549,6 +556,9 @@ components:
             strings or numbers.
           type: object
           additionalProperties: true
+      x-properties-added-in-version:
+        - propertyName: "metadata"
+          addedInVersion: "8.10"
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -474,14 +474,16 @@ components:
           description: The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
         metadata:
           description: >-
-            A generic key-value metadata bag attached to the cluster variable, e.g. to let
-            consumers discover and filter variables by semantic metadata without inspecting the
-            value. Values must be strings or numbers; booleans, arrays, and objects are rejected.
-            Limited to 100 entries and a configurable maximum serialized size (defaults to
-            100 entries at the maximum key length of a cluster variable name, 256 characters,
-            plus the maximum value length, 8191 characters).
+            A generic key-value metadata bag attached to the cluster variable. Values must be
+            strings or numbers. Limited to 100 entries and a configurable maximum serialized size
+            (default: 100 entries at max key length of a cluster variable name (256 chars) plus the
+            maximum value length, 8192 characters).
           type: object
-          additionalProperties: true
+          maxProperties: 100
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
       x-properties-added-in-version:
         - propertyName: "metadata"
           addedInVersion: "8.10"
@@ -495,14 +497,16 @@ components:
           description: The new value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
         metadata:
           description: >-
-            A generic key-value metadata bag attached to the cluster variable, e.g. to let
-            consumers discover and filter variables by semantic metadata without inspecting the
-            value. Values must be strings or numbers; booleans, arrays, and objects are rejected.
-            Limited to 100 entries and a configurable maximum serialized size (defaults to
-            100 entries at the maximum key length of a cluster variable name, 256 characters,
-            plus the maximum value length, 8191 characters).
+            A generic key-value metadata bag attached to the cluster variable. Values must be
+            strings or numbers. Limited to 100 entries and a configurable maximum serialized size
+            (default: 100 entries at max key length of a cluster variable name (256 chars) plus the
+            maximum value length, 8192 characters).
           type: object
-          additionalProperties: true
+          maxProperties: 100
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
       x-properties-added-in-version:
         - propertyName: "metadata"
           addedInVersion: "8.10"
@@ -555,7 +559,11 @@ components:
             A generic key-value metadata bag attached to the cluster variable. Values are
             strings or numbers.
           type: object
-          additionalProperties: true
+          maxProperties: 100
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
       x-properties-added-in-version:
         - propertyName: "metadata"
           addedInVersion: "8.10"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -13,8 +13,32 @@ public class GatewayRestConfiguration {
 
   private static final int DEFAULT_MAX_NAME_FIELD_LENGTH = 32 * 1024;
 
+  /** Maximum number of entries allowed in a cluster variable's metadata bag. */
+  private static final int MAX_CLUSTER_VARIABLE_METADATA_ENTRIES = 100;
+
+  /**
+   * Matches the default length of the {@code CLUSTER_VARIABLE.VAR_NAME} RDBMS column ({@code
+   * NVARCHAR(256)}).
+   */
+  private static final int MAX_CLUSTER_VARIABLE_METADATA_KEY_LENGTH = 256;
+
+  /**
+   * Matches the default length of the {@code CLUSTER_VARIABLE.VAR_VALUE} RDBMS column ({@code
+   * VARCHAR(8192)}, and the {@code ignore_above: 8191} ES/OS mapping limit).
+   */
+  private static final int MAX_CLUSTER_VARIABLE_METADATA_VALUE_LENGTH = 8191;
+
+  /**
+   * Worst case: every entry uses the maximum key and value length allowed by the RDBMS/ES/OS
+   * schemas, up to the maximum number of entries.
+   */
+  private static final int DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE =
+      MAX_CLUSTER_VARIABLE_METADATA_ENTRIES
+          * (MAX_CLUSTER_VARIABLE_METADATA_KEY_LENGTH + MAX_CLUSTER_VARIABLE_METADATA_VALUE_LENGTH);
+
   private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
+  private int maxClusterVariableMetadataSize = DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE;
 
   public JobMetricsConfiguration getJobMetrics() {
     return jobMetrics;
@@ -32,6 +56,19 @@ public class GatewayRestConfiguration {
 
   public void setMaxNameFieldLength(final int maxNameFieldLength) {
     this.maxNameFieldLength = maxNameFieldLength;
+  }
+
+  /**
+   * Maximum allowed length (in characters) of a cluster variable's serialized metadata JSON.
+   *
+   * <p>Defaults to {@link #DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE}.
+   */
+  public int getMaxClusterVariableMetadataSize() {
+    return maxClusterVariableMetadataSize;
+  }
+
+  public void setMaxClusterVariableMetadataSize(final int maxClusterVariableMetadataSize) {
+    this.maxClusterVariableMetadataSize = maxClusterVariableMetadataSize;
   }
 
   /** Configuration for job metrics export settings. */

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -18,7 +18,7 @@ public class GatewayRestConfiguration {
 
   /**
    * Matches the default length of the {@code CLUSTER_VARIABLE.VAR_NAME} RDBMS column ({@code
-   * NVARCHAR(256)}) and {@code CLUSTER_VARIABLE.VAR_VALUE} RDBMS column ({@code VARCHAR(8192)}.
+   * NVARCHAR(256)}) and {@code CLUSTER_VARIABLE.VAR_VALUE} RDBMS column ({@code VARCHAR(8192)}).
    */
   private static final int MAX_CLUSTER_VARIABLE_METADATA_ENTRY_LENGTH = 256 + 8192;
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -18,23 +18,12 @@ public class GatewayRestConfiguration {
 
   /**
    * Matches the default length of the {@code CLUSTER_VARIABLE.VAR_NAME} RDBMS column ({@code
-   * NVARCHAR(256)}).
+   * NVARCHAR(256)}) and {@code CLUSTER_VARIABLE.VAR_VALUE} RDBMS column ({@code VARCHAR(8192)}.
    */
-  private static final int MAX_CLUSTER_VARIABLE_METADATA_KEY_LENGTH = 256;
+  private static final int MAX_CLUSTER_VARIABLE_METADATA_ENTRY_LENGTH = 256 + 8192;
 
-  /**
-   * Matches the default length of the {@code CLUSTER_VARIABLE.VAR_VALUE} RDBMS column ({@code
-   * VARCHAR(8192)}, and the {@code ignore_above: 8191} ES/OS mapping limit).
-   */
-  private static final int MAX_CLUSTER_VARIABLE_METADATA_VALUE_LENGTH = 8191;
-
-  /**
-   * Worst case: every entry uses the maximum key and value length allowed by the RDBMS/ES/OS
-   * schemas, up to the maximum number of entries.
-   */
   private static final int DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE =
-      MAX_CLUSTER_VARIABLE_METADATA_ENTRIES
-          * (MAX_CLUSTER_VARIABLE_METADATA_KEY_LENGTH + MAX_CLUSTER_VARIABLE_METADATA_VALUE_LENGTH);
+      MAX_CLUSTER_VARIABLE_METADATA_ENTRIES * MAX_CLUSTER_VARIABLE_METADATA_ENTRY_LENGTH;
 
   private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
@@ -59,7 +48,7 @@ public class GatewayRestConfiguration {
   }
 
   /**
-   * Maximum allowed length (in characters) of a cluster variable's serialized metadata JSON.
+   * Maximum allowed size (in UTF-8 bytes) of a cluster variable's serialized metadata JSON.
    *
    * <p>Defaults to {@link #DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE}.
    */

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableController.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
@@ -50,12 +51,15 @@ public class ClusterVariableController {
   public ClusterVariableController(
       final ServiceRegistry serviceRegistry,
       final CamundaAuthenticationProvider authenticationProvider,
-      final IdentifierValidator identifierValidator) {
+      final IdentifierValidator identifierValidator,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
     clusterVariableMapper =
         new ClusterVariableMapper(
-            new ClusterVariableRequestValidator(new ClusterVariableValidator(identifierValidator)));
+            new ClusterVariableRequestValidator(
+                new ClusterVariableValidator(identifierValidator),
+                gatewayRestConfiguration.getMaxClusterVariableMetadataSize()));
   }
 
   @CamundaPostMapping(path = "/global")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -136,39 +136,6 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   @Test
   void shouldCreateGlobalClusterVariable() {
     // given
-    when(clusterVariableServices.createGloballyScopedClusterVariable(
-            any(ClusterVariableRequest.class), any()))
-        .thenReturn(CompletableFuture.completedFuture(new ClusterVariableRecord().setName("foo")));
-
-    final var request =
-        """
-        {
-            "name": "foo",
-            "value": "bar"
-        }""";
-
-    // when / then
-    webClient
-        .post()
-        .uri(GLOBAL_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isOk();
-
-    verify(clusterVariableServices)
-        .createGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
-    final var capturedRequest = createRequestCaptor.getValue();
-    assertThat(capturedRequest.name()).isEqualTo("foo");
-    assertThat(capturedRequest.value()).isEqualTo("bar");
-    assertThat(capturedRequest.tenantId()).isNull();
-  }
-
-  @Test
-  void shouldCreateGlobalClusterVariableWithMetadata() {
-    // given
     final var metadata = Map.<String, Object>of("kind", "CREDENTIAL", "schemaVersion", 2);
     when(clusterVariableServices.createGloballyScopedClusterVariable(
             any(ClusterVariableRequest.class), any()))
@@ -208,6 +175,9 @@ public class ClusterVariableControllerTest extends RestControllerTest {
     verify(clusterVariableServices)
         .createGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
     final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.name()).isEqualTo("foo");
+    assertThat(capturedRequest.value()).isEqualTo("bar");
+    assertThat(capturedRequest.tenantId()).isNull();
     assertThat(capturedRequest.metadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -450,6 +450,110 @@ public class ClusterVariableControllerTest extends RestControllerTest {
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("newValue");
     assertThat(capturedRequest.tenantId()).isNull();
+    assertThat(capturedRequest.metadata()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectUpdateWithNonScalarMetadataValue() {
+    // given
+    final var request =
+        """
+        {
+            "value": "newValue",
+            "metadata": {
+                "kind": ["CREDENTIAL"]
+            }
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The metadata value for key 'kind' is of type 'ArrayList' but must be a string or a number.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_WITH_NAME_URL.formatted("foo"));
+
+    // when / then
+    webClient
+        .put()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectUpdateWithTooManyMetadataEntries() {
+    // given
+    final var metadataEntries =
+        IntStream.range(0, 101)
+            .mapToObj(i -> "\"%d\": \"%d\"".formatted(i, i))
+            .collect(Collectors.joining(","));
+    final var request =
+        """
+        {
+            "value": "newValue",
+            "metadata": { %s }
+        }"""
+            .formatted(metadataEntries);
+
+    // when / then
+    webClient
+        .put()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo("The provided metadata has 101 entries but must not exceed 100 entries.");
+  }
+
+  @Test
+  void shouldRejectUpdateWithOversizedMetadata() {
+    // given: exceeds the test-configured metadata size limit (see TestConfig) without needing a
+    // huge payload
+    final var largeValue = "x".repeat(TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE);
+    final var request =
+        """
+        {
+            "value": "newValue",
+            "metadata": { "key": "%s" }
+        }"""
+            .formatted(largeValue);
+
+    // when / then
+    webClient
+        .put()
+        .uri(GLOBAL_WITH_NAME_URL.formatted("foo"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo(
+            "The provided metadata exceeds the maximum serialized size of %d bytes."
+                .formatted(TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE));
   }
 
   @Test
@@ -868,6 +972,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("newValue");
     assertThat(capturedRequest.tenantId()).isEqualTo("tenant1");
+    assertThat(capturedRequest.metadata()).isEmpty();
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -283,7 +283,7 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .expectBody()
         .jsonPath("$.detail")
         .isEqualTo(
-            "The provided metadata exceeds the maximum serialized size of %d characters."
+            "The provided metadata exceeds the maximum serialized size of %d bytes."
                 .formatted(TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -22,16 +22,24 @@ import io.camunda.service.ClusterVariableServices;
 import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -47,6 +55,9 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   static final String GLOBAL_WITH_NAME_URL = GLOBAL_URL + "/%s";
   static final String TENANT_URL = CLUSTER_VARIABLE_PREFIX_URL + "/tenants/%s";
   static final String TENANT_WITH_NAME_URL = TENANT_URL + "/%s";
+  // large enough that 101 minimal metadata entries (~1.8k serialized chars) don't also trip
+  // this limit, so the too-many-entries test exercises only the entry-count check
+  static final int TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE = 2000;
 
   @Captor ArgumentCaptor<ClusterVariableRequest> createRequestCaptor;
   @MockitoBean ClusterVariableServices clusterVariableServices;
@@ -153,6 +164,157 @@ public class ClusterVariableControllerTest extends RestControllerTest {
     assertThat(capturedRequest.name()).isEqualTo("foo");
     assertThat(capturedRequest.value()).isEqualTo("bar");
     assertThat(capturedRequest.tenantId()).isNull();
+  }
+
+  @Test
+  void shouldCreateGlobalClusterVariableWithMetadata() {
+    // given
+    final var metadata = Map.<String, Object>of("kind", "CREDENTIAL", "schemaVersion", 2);
+    when(clusterVariableServices.createGloballyScopedClusterVariable(
+            any(ClusterVariableRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ClusterVariableRecord()
+                    .setName("foo")
+                    .setMetadata(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(metadata)))));
+
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar",
+            "metadata": {
+                "kind": "CREDENTIAL",
+                "schemaVersion": 2
+            }
+        }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.metadata.kind")
+        .isEqualTo("CREDENTIAL")
+        .jsonPath("$.metadata.schemaVersion")
+        .isEqualTo(2);
+
+    verify(clusterVariableServices)
+        .createGloballyScopedClusterVariable(createRequestCaptor.capture(), any());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.metadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldRejectCreationWithNonScalarMetadataValue() {
+    // given
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar",
+            "metadata": {
+                "kind": ["CREDENTIAL"]
+            }
+        }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "title": "INVALID_ARGUMENT",
+              "status": 400,
+              "detail": "The metadata value for key 'kind' is of type 'ArrayList' but must be a string or a number.",
+              "instance": "%s"
+            }"""
+            .formatted(GLOBAL_URL);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectCreationWithTooManyMetadataEntries() {
+    // given
+    final var metadataEntries =
+        IntStream.range(0, 101)
+            .mapToObj(i -> "\"%d\": \"%d\"".formatted(i, i))
+            .collect(Collectors.joining(","));
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar",
+            "metadata": { %s }
+        }"""
+            .formatted(metadataEntries);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo("The provided metadata has 101 entries but must not exceed 100 entries.");
+  }
+
+  @Test
+  void shouldRejectCreationWithOversizedMetadata() {
+    // given: exceeds the test-configured metadata size limit (see TestConfig) without needing a
+    // huge payload
+    final var largeValue = "x".repeat(TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE);
+    final var request =
+        """
+        {
+            "name": "foo",
+            "value": "bar",
+            "metadata": { "key": "%s" }
+        }"""
+            .formatted(largeValue);
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.detail")
+        .isEqualTo(
+            "The provided metadata exceeds the maximum serialized size of %d characters."
+                .formatted(TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE));
   }
 
   @Test
@@ -896,5 +1058,16 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      final var config = new GatewayRestConfiguration();
+      // kept small so oversized-metadata tests don't need huge payloads
+      config.setMaxClusterVariableMetadataSize(TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE);
+      return config;
+    }
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
@@ -44,6 +44,11 @@ public class BrokerCreateClusterVariableRequest
     return this;
   }
 
+  public BrokerCreateClusterVariableRequest setMetadata(final DirectBuffer metadata) {
+    requestDto.setMetadata(metadata);
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateClusterVariableRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateClusterVariableRequest.java
@@ -44,6 +44,11 @@ public class BrokerUpdateClusterVariableRequest
     return this;
   }
 
+  public BrokerUpdateClusterVariableRequest setMetadata(final DirectBuffer metadata) {
+    requestDto.setMetadata(metadata);
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;


### PR DESCRIPTION
## Description

Wires the cluster variable metadata bag (already carried by the protocol record and search entity)
through the REST layer: request/response DTOs, gateway mapper, and validation.

- Values must be scalar (string or number); `null`, booleans, arrays, and objects are rejected.
- Max 100 metadata entries per cluster variable.
- Serialized metadata size is capped in UTF-8 **bytes**, defaulting to the worst case: 100 entries
  at the maximum key length (256 bytes, matching `VAR_NAME`) plus the maximum value length (8192
  bytes, matching `VAR_VALUE`/ES-OS `ignore_above`) — 844,800 bytes (~825 KiB) by default.
- The size limit is configurable via `camunda.api.rest.cluster-variable.max-metadata-size` in the
  unified configuration system.
- On export, metadata entries with `null` values are dropped rather than persisted as empty
  strings.
- On update, metadata is replaced wholesale (not merged with the existing bag), matching PUT
  semantics.

Also fixes a pre-existing generated-model builder-chain ordering bug surfaced while wiring this up:
`ClusterVariableResult`/`ClusterVariableSearchResult` responses require `.metadata(...)` to be
called before `.value(...)` (the fluent builder generator orders parent-schema-required fields
before the schema's own required fields), but the mappers called them in the reverse order.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55090
