### PR TITLE
test: cover statistics filtering by variable with multiple values

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -516,6 +516,46 @@ public class ProcessDefinitionStatisticsTest {
   }
 
   @Test
+  void shouldGetStatisticsAndFilterByVariableWithMultipleValues() {
+    // given
+    final var processDefinitionKey = deployActiveBPMN();
+    // three instances, each carrying a distinct value for the same variable name
+    TestHelper.startScopedProcessInstance(
+        camundaClient, processDefinitionKey, testScopeId, Map.of("orderId", "1"));
+    TestHelper.startScopedProcessInstance(
+        camundaClient, processDefinitionKey, testScopeId, Map.of("orderId", "2"));
+    TestHelper.startScopedProcessInstance(
+        camundaClient, processDefinitionKey, testScopeId, Map.of("orderId", "3"));
+    waitForProcessInstances(
+        camundaClient, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE), 3);
+    waitForActiveScopedUserTasks(camundaClient, testScopeId, 3);
+
+    Awaitility.await("should return element statistics for both matching instances")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when filtering a single variable name by multiple values (e.g. orderId in [1, 2])
+                assertThat(
+                        camundaClient
+                            .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
+                            .filter(
+                                f ->
+                                    f.variables(
+                                        List.of(
+                                            vf ->
+                                                vf.name("orderId")
+                                                    .value(v -> v.in("\"1\"", "\"2\"")))))
+                            .send()
+                            .join())
+                    // then the counts must include every matching value, not only the first
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L),
+                        new ProcessElementStatisticsImpl("UserTask", 2L, 0L, 0L, 0L)));
+  }
+
+  @Test
   void shouldGetDistinctStatisticsForMultiInstanceActivity() {
     // given
     final var processModel =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessDefinitionStatisticsTest.java
@@ -519,7 +519,6 @@ public class ProcessDefinitionStatisticsTest {
   void shouldGetStatisticsAndFilterByVariableWithMultipleValues() {
     // given
     final var processDefinitionKey = deployActiveBPMN();
-    // three instances, each carrying a distinct value for the same variable name
     TestHelper.startScopedProcessInstance(
         camundaClient, processDefinitionKey, testScopeId, Map.of("orderId", "1"));
     TestHelper.startScopedProcessInstance(
@@ -535,7 +534,7 @@ public class ProcessDefinitionStatisticsTest {
         .ignoreExceptions()
         .untilAsserted(
             () ->
-                // when filtering a single variable name by multiple values (e.g. orderId in [1, 2])
+                // when
                 assertThat(
                         camundaClient
                             .newProcessDefinitionElementStatisticsRequest(processDefinitionKey)
@@ -548,7 +547,7 @@ public class ProcessDefinitionStatisticsTest {
                                                     .value(v -> v.in("\"1\"", "\"2\"")))))
                             .send()
                             .join())
-                    // then the counts must include every matching value, not only the first
+                    // then
                     .hasSize(2)
                     .containsExactlyInAnyOrder(
                         new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 2L),


### PR DESCRIPTION
## Description

Adds backend acceptance-test coverage for the process-definition element-instance
statistics endpoint (`POST /v2/process-definitions/{key}/statistics/element-instances`)
when filtering by a single variable name with multiple values (e.g. `orderId in ["1", "2"]`).

This data path was previously untested — existing `.variables(...)` usage in
`ProcessDefinitionStatisticsTest` only scopes test data, it never asserts variable-filter
correctness. It's also the exact backend path the frontend fix for #57383 depends on.

## Checklist
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes) or [for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)).

## Related issues

closes #57818
