### PR TITLE
docs: fix stale AHSP reference in agent instance OpenAPI spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -637,7 +637,7 @@ components:
       properties:
         elementInstanceKey:
           description: |
-            The key of the AHSP or AI Agent Task element instance.
+            The key of the AI Agent Sub-process or AI Agent Task element instance.
             The engine uses this key to infer processInstanceKey, elementId,
             processDefinitionKey, and tenantId.
           allOf:


### PR DESCRIPTION
## Description

One-line fix: `elementInstanceKey`'s description on `AgentInstanceHistoryItem` still said "AHSP" (the old shorthand for the ad-hoc-subprocess implementation). Sibling `elementInstanceKey` descriptions elsewhere in this same spec file already say "AI Agent Task or ad-hoc sub-process" - this aligns the one remaining stale spot to the canonical L3 template name **AI Agent Sub-process**, per the agent terminology model in [camunda/product-development#31](https://github.com/camunda/product-development/pull/31).

This spec is synced weekly into `camunda-docs` (`.github/workflows/sync-rest-api-docs.yaml`), where the same text was already patched by hand in [camunda/camunda-docs#9388](https://github.com/camunda/camunda-docs/pull/9388) as a stopgap - fixing it here at the actual source so the next scheduled sync doesn't overwrite that fix and revert to "AHSP".

## When should this change go live?

No urgency - can be released at any time.