### PR TITLE
test: add consolidated auth tests and refactor data generators

### DIFF
--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -55,6 +55,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-core</artifactId>
     </dependency>
 

--- a/operate/data-generator/pom.xml
+++ b/operate/data-generator/pom.xml
@@ -58,15 +58,15 @@
       <artifactId>camunda-security-library-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-service</artifactId>
+    </dependency>
+
     <!-- SPRING -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
     </dependency>
 
     <dependency>
@@ -98,6 +98,45 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/operate/data-generator/src/main/java/io/camunda/operate/DataGeneratorModuleConfiguration.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/DataGeneratorModuleConfiguration.java
@@ -33,6 +33,14 @@ public class DataGeneratorModuleConfiguration {
     LOGGER.info("Starting module: data generator");
   }
 
+  /**
+   * Kept for the job-worker paths in {@code AbstractDataGenerator} (progressSimpleTask,
+   * completeTask, failTask, message/signal publishing) that still activate/complete jobs through
+   * the gRPC client. This bean carries no credentials, so it must never be used for the
+   * deploy/create-process-instance/cancel write path under {@code consolidated-auth} — those go
+   * through {@code ServiceRegistry} with an anonymous {@code CamundaAuthentication} instead (see
+   * {@code AbstractDataGenerator}).
+   */
   @Bean
   @ConditionalOnMissingBean
   public CamundaClient camundaClient() {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -20,6 +20,7 @@ import io.camunda.operate.data.usertest.UserTestDataGenerator;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.core.auth.SecurityContext;
@@ -58,13 +59,6 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataGenerator.class);
 
-  /**
-   * Substrings of the transient ES/OS errors seen while the Operate schema is still being created
-   * by the async schema initializer.
-   */
-  private static final List<String> SCHEMA_NOT_READY_MARKERS =
-      List.of("index_not_found_exception", "no_shard_available_action_exception");
-
   private static final ObjectMapper VARIABLES_MAPPER = new ObjectMapper();
 
   @Autowired
@@ -84,8 +78,9 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   @Autowired(required = false)
   private SearchClientsProxy searchClientsProxy;
 
-  @Autowired(required = false)
-  private PhysicalTenantIds physicalTenantIds;
+  @Autowired PhysicalTenantIds physicalTenantIds;
+
+  @Autowired SchemaManagerContainer schemaManagerContainer;
 
   @PostConstruct
   private void startDataGenerator() {
@@ -124,17 +119,18 @@ public abstract class AbstractDataGenerator implements DataGenerator {
         () -> {
           Boolean zeebeDataCreated = null;
           while (zeebeDataCreated == null && !shutdown) {
+            if (!isSchemaReady()) {
+              LOGGER.debug("Operate schema is not ready yet, will retry.");
+              sleepFor(2000);
+              continue;
+            }
             try {
               zeebeDataCreated = createZeebeData(manuallyCalled);
             } catch (final Exception ex) {
-              if (isSchemaNotReady(ex)) {
-                LOGGER.debug("Operate schema is not ready yet, will retry: {}", ex.getMessage());
-              } else {
-                LOGGER.error(
-                    String.format(
-                        "Error occurred when creating demo data: %s. Retrying...", ex.getMessage()),
-                    ex);
-              }
+              LOGGER.error(
+                  String.format(
+                      "Error occurred when creating demo data: %s. Retrying...", ex.getMessage()),
+                  ex);
               sleepFor(2000);
             }
           }
@@ -222,14 +218,8 @@ public abstract class AbstractDataGenerator implements DataGenerator {
     return DEFAULT_TENANT_ID;
   }
 
-  boolean isSchemaNotReady(final Throwable ex) {
-    for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
-      final String message = cause.getMessage();
-      if (message != null && SCHEMA_NOT_READY_MARKERS.stream().anyMatch(message::contains)) {
-        return true;
-      }
-    }
-    return false;
+  boolean isSchemaReady() {
+    return knownPhysicalTenants().stream().allMatch(schemaManagerContainer::isInitialized);
   }
 
   protected Long deployProcess(
@@ -288,9 +278,7 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   }
 
   private Set<String> knownPhysicalTenants() {
-    return physicalTenantIds == null
-        ? Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
-        : physicalTenantIds.known();
+    return physicalTenantIds.known();
   }
 
   private byte[] readClasspathResource(final String classpathResource) throws IOException {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -72,15 +72,15 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   @Autowired CamundaAuthenticationProvider authenticationProvider;
 
+  @Autowired PhysicalTenantIds physicalTenantIds;
+
+  @Autowired SchemaManagerContainer schemaManagerContainer;
+
   @Autowired private CamundaSecurityLibraryProperties cslProperties;
   private boolean shutdown = false;
 
   @Autowired(required = false)
   private SearchClientsProxy searchClientsProxy;
-
-  @Autowired PhysicalTenantIds physicalTenantIds;
-
-  @Autowired SchemaManagerContainer schemaManagerContainer;
 
   @PostConstruct
   private void startDataGenerator() {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -84,6 +84,9 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   @Autowired(required = false)
   private SearchClientsProxy searchClientsProxy;
 
+  @Autowired(required = false)
+  private PhysicalTenantIds physicalTenantIds;
+
   @PostConstruct
   private void startDataGenerator() {
     startGeneratingData();
@@ -265,16 +268,29 @@ public abstract class AbstractDataGenerator implements DataGenerator {
       for (final String classpathResource : classpathResources) {
         resources.put(classpathResource, readClasspathResource(classpathResource));
       }
-      return executeCamundaServiceAnonymously(
-          authentication ->
-              serviceRegistry
-                  .resourceServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
-                  .deployResources(
-                      new DeployResourcesRequest(resources, tenantId), authentication));
+      DeploymentRecord deploymentRecord = null;
+      // Deploy to every known physical tenant so demo processes are visible regardless of which
+      // physical tenant a client (e.g. in physical-tenant test/deployment scenarios) queries.
+      for (final String physicalTenantId : knownPhysicalTenants()) {
+        deploymentRecord =
+            executeCamundaServiceAnonymously(
+                authentication ->
+                    serviceRegistry
+                        .resourceServices(physicalTenantId)
+                        .deployResources(
+                            new DeployResourcesRequest(resources, tenantId), authentication));
+      }
+      return deploymentRecord;
     } catch (final IOException e) {
       throw new OperateRuntimeException(
           "Cannot deploy resource from classpath. " + e.getMessage(), e);
     }
+  }
+
+  private Set<String> knownPhysicalTenants() {
+    return physicalTenantIds == null
+        ? Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        : physicalTenantIds.known();
   }
 
   private byte[] readClasspathResource(final String classpathResource) throws IOException {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -10,21 +10,43 @@ package io.camunda.operate.data;
 import static io.camunda.operate.util.ThreadUtil.sleepFor;
 import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.worker.JobWorker;
+import io.camunda.client.impl.command.StreamUtil;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.operate.data.usertest.UserTestDataGenerator;
+import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.core.auth.SecurityContext;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
+import io.camunda.service.ResourceServices.DeployResourcesRequest;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,12 +58,26 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataGenerator.class);
 
+  /**
+   * Substrings of the transient ES/OS errors seen while the Operate schema is still being created
+   * by the async schema initializer.
+   */
+  private static final List<String> SCHEMA_NOT_READY_MARKERS =
+      List.of("index_not_found_exception", "no_shard_available_action_exception");
+
+  private static final ObjectMapper VARIABLES_MAPPER = new ObjectMapper();
+
   @Autowired
   @Qualifier("camundaClient")
   protected CamundaClient client;
 
   protected boolean manuallyCalled = false;
   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);
+
+  @Autowired ServiceRegistry serviceRegistry;
+
+  @Autowired CamundaAuthenticationProvider authenticationProvider;
+
   @Autowired private CamundaSecurityLibraryProperties cslProperties;
   private boolean shutdown = false;
 
@@ -88,10 +124,14 @@ public abstract class AbstractDataGenerator implements DataGenerator {
             try {
               zeebeDataCreated = createZeebeData(manuallyCalled);
             } catch (final Exception ex) {
-              LOGGER.error(
-                  String.format(
-                      "Error occurred when creating demo data: %s. Retrying...", ex.getMessage()),
-                  ex);
+              if (isSchemaNotReady(ex)) {
+                LOGGER.debug("Operate schema is not ready yet, will retry: {}", ex.getMessage());
+              } else {
+                LOGGER.error(
+                    String.format(
+                        "Error occurred when creating demo data: %s. Retrying...", ex.getMessage()),
+                    ex);
+              }
               sleepFor(2000);
             }
           }
@@ -177,5 +217,166 @@ public abstract class AbstractDataGenerator implements DataGenerator {
       return tenantId;
     }
     return DEFAULT_TENANT_ID;
+  }
+
+  boolean isSchemaNotReady(final Throwable ex) {
+    for (Throwable cause = ex; cause != null; cause = cause.getCause()) {
+      final String message = cause.getMessage();
+      if (message != null && SCHEMA_NOT_READY_MARKERS.stream().anyMatch(message::contains)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected Long deployProcess(
+      final boolean ignoreException, final String tenantId, final String... classpathResources) {
+    try {
+      if (classpathResources.length == 0) {
+        return null;
+      }
+      final DeploymentRecord deploymentRecord =
+          deployResourcesAnonymously(tenantId, classpathResources);
+      LOGGER.debug("Deployment of resource [{}] was performed", (Object[]) classpathResources);
+      final List<ProcessMetadataValue> processes = deploymentRecord.getProcessesMetadata();
+      return processes.get(processes.size() - 1).getProcessDefinitionKey();
+    } catch (final Exception e) {
+      if (ignoreException) {
+        LOGGER.warn("Deployment failed: " + e.getMessage());
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  protected void deployDecision(final String tenantId, final String... classpathResources) {
+    if (classpathResources.length == 0) {
+      return;
+    }
+    deployResourcesAnonymously(tenantId, classpathResources);
+    LOGGER.debug("Deployment of resource [{}] was performed", (Object[]) classpathResources);
+  }
+
+  private DeploymentRecord deployResourcesAnonymously(
+      final String tenantId, final String... classpathResources) {
+    try {
+      final Map<String, byte[]> resources = new LinkedHashMap<>();
+      for (final String classpathResource : classpathResources) {
+        resources.put(classpathResource, readClasspathResource(classpathResource));
+      }
+      return executeCamundaServiceAnonymously(
+          authentication ->
+              serviceRegistry
+                  .resourceServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                  .deployResources(
+                      new DeployResourcesRequest(resources, tenantId), authentication));
+    } catch (final IOException e) {
+      throw new OperateRuntimeException(
+          "Cannot deploy resource from classpath. " + e.getMessage(), e);
+    }
+  }
+
+  private byte[] readClasspathResource(final String classpathResource) throws IOException {
+    try (final InputStream resourceStream =
+        getClass().getClassLoader().getResourceAsStream(classpathResource)) {
+      if (resourceStream == null) {
+        throw new FileNotFoundException(classpathResource);
+      }
+      return StreamUtil.readInputStream(resourceStream);
+    }
+  }
+
+  protected long startProcessInstance(
+      final boolean ignoreException,
+      final String tenantId,
+      final String bpmnProcessId,
+      final String payload) {
+    try {
+      final Map<String, Object> variables = parseVariables(payload);
+      ProcessInstanceCreationRecord record;
+      try {
+        record = createProcessInstanceAnonymously(bpmnProcessId, tenantId, variables);
+      } catch (final Exception ex) {
+        // retry once
+        sleepFor(300L);
+        record = createProcessInstanceAnonymously(bpmnProcessId, tenantId, variables);
+      }
+      LOGGER.debug("Process instance created for process [{}]", bpmnProcessId);
+      return record.getProcessInstanceKey();
+    } catch (final Exception e) {
+      if (ignoreException) {
+        LOGGER.warn("Instance creation failed: " + e.getMessage());
+        return 0L;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  private ProcessInstanceCreationRecord createProcessInstanceAnonymously(
+      final String bpmnProcessId, final String tenantId, final Map<String, Object> variables) {
+    return executeCamundaServiceAnonymously(
+        authentication ->
+            serviceRegistry
+                .processInstanceServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .createProcessInstance(
+                    new ProcessInstanceCreateRequest(
+                        -1L,
+                        bpmnProcessId,
+                        -1,
+                        variables,
+                        tenantId,
+                        null,
+                        null,
+                        null,
+                        List.of(),
+                        List.of(),
+                        null,
+                        Set.of(),
+                        null),
+                    authentication));
+  }
+
+  private Map<String, Object> parseVariables(final String payload) {
+    if (payload == null || payload.isEmpty()) {
+      return Map.of();
+    }
+    try {
+      return VARIABLES_MAPPER.readValue(payload, new TypeReference<Map<String, Object>>() {});
+    } catch (final IOException e) {
+      throw new OperateRuntimeException("Cannot parse process instance variables payload", e);
+    }
+  }
+
+  protected void cancelProcessInstance(
+      final boolean ignoreException, final long processInstanceKey) {
+    try {
+      executeCamundaServiceAnonymously(
+          authentication ->
+              serviceRegistry
+                  .processInstanceServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                  .cancelProcessInstance(
+                      new ProcessInstanceCancelRequest(processInstanceKey, null), authentication));
+    } catch (final Exception e) {
+      if (!ignoreException) {
+        throw e;
+      } else {
+        LOGGER.warn("Cancellation failed: " + e.getMessage());
+      }
+    }
+  }
+
+  protected void resolveIncidentForProcessInstance(final long processInstanceKey) {
+    executeCamundaServiceAnonymously(
+        authentication ->
+            serviceRegistry
+                .processInstanceServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .resolveProcessInstanceIncidents(processInstanceKey, authentication));
+  }
+
+  private <T> T executeCamundaServiceAnonymously(
+      final Function<CamundaAuthentication, CompletableFuture<T>> method) {
+    return method.apply(authenticationProvider.getAnonymousCamundaAuthentication()).join();
   }
 }

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -74,7 +74,8 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   @Autowired PhysicalTenantIds physicalTenantIds;
 
-  @Autowired SchemaManagerContainer schemaManagerContainer;
+  @Autowired(required = false)
+  SchemaManagerContainer schemaManagerContainer;
 
   @Autowired private CamundaSecurityLibraryProperties cslProperties;
   private boolean shutdown = false;
@@ -219,6 +220,11 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   }
 
   boolean isSchemaReady() {
+    if (schemaManagerContainer == null) {
+      // No async schema-init phase to wait for (e.g. RDBMS storage, which uses synchronous
+      // Liquibase migrations instead of the ES/OS schema initializer).
+      return true;
+    }
     return knownPhysicalTenants().stream().allMatch(schemaManagerContainer::isInitialized);
   }
 

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
@@ -13,9 +13,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.operate.data.usertest.UserTestDataGenerator;
-import io.camunda.operate.exceptions.OperateRuntimeException;
-import io.camunda.operate.testhelpers.StatefulRestTemplate;
-import io.camunda.operate.util.ZeebeTestUtil;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -23,42 +20,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.BiFunction;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 @Component("dataGenerator")
 @Profile("dev-data")
 public class DevelopDataGenerator extends UserTestDataGenerator {
 
-  // TODO OPE-938 make this configurable
-  private static final String OPERATE_HOST = "localhost";
-  private static final int OPERATE_PORT = 8080;
-  private static final String OPERATE_USER = "demo";
-  private static final String OPERATE_PASSWORD = "demo";
   private static final String TENANT_A = "tenantA";
 
   private final List<Long> processInstanceKeys = new ArrayList<>();
-
-  @Autowired private BiFunction<String, Integer, StatefulRestTemplate> statefulRestTemplateFactory;
-  private StatefulRestTemplate restTemplate;
-
-  @Override
-  protected void startGeneratingData() {
-    restTemplate = statefulRestTemplateFactory.apply(OPERATE_HOST, OPERATE_PORT);
-    super.startGeneratingData();
-  }
 
   @Override
   public void createSpecialDataV1() {
     int orderId = ThreadLocalRandom.current().current().nextInt(10);
     long instanceKey =
-        ZeebeTestUtil.startProcessInstance(
+        startProcessInstance(
             true,
-            client,
             getTenant(TENANT_A),
             "interruptingBoundaryEvent",
             "{\"orderId\": \"" + orderId + "\"\n}");
@@ -67,9 +45,8 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
 
     orderId = ThreadLocalRandom.current().current().nextInt(10);
     instanceKey =
-        ZeebeTestUtil.startProcessInstance(
+        startProcessInstance(
             true,
-            client,
             getTenant(TENANT_A),
             "interruptingBoundaryEvent",
             "{\"orderId\": \"" + orderId + "\"\n}");
@@ -79,9 +56,8 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
 
     orderId = ThreadLocalRandom.current().current().nextInt(10);
     instanceKey =
-        ZeebeTestUtil.startProcessInstance(
+        startProcessInstance(
             true,
-            client,
             getTenant(TENANT_A),
             "nonInterruptingBoundaryEvent",
             "{\"orderId\": \"" + orderId + "\"\n}");
@@ -90,9 +66,8 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
 
     orderId = ThreadLocalRandom.current().current().nextInt(10);
     instanceKey =
-        ZeebeTestUtil.startProcessInstance(
+        startProcessInstance(
             true,
-            client,
             getTenant(TENANT_A),
             "nonInterruptingBoundaryEvent",
             "{\"orderId\": \"" + orderId + "\"\n}");
@@ -102,9 +77,8 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
 
     orderId = ThreadLocalRandom.current().current().nextInt(10);
     instanceKey =
-        ZeebeTestUtil.startProcessInstance(
+        startProcessInstance(
             true,
-            client,
             getTenant(TENANT_A),
             "nonInterruptingBoundaryEvent",
             "{\"orderId\": \"" + orderId + "\"\n}");
@@ -113,13 +87,11 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     completeTask(instanceKey, "task1", null);
 
     final long rootCauseDecisionInstance =
-        ZeebeTestUtil.startProcessInstance(
-            true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null);
+        startProcessInstance(true, getTenant(TENANT_A), "Process_rootCauseDecision", null);
     doNotTouchProcessInstanceKeys.add(rootCauseDecisionInstance);
 
     final long messageSubscriptionInstance =
-        ZeebeTestUtil.startProcessInstance(
-            true, client, getTenant(TENANT_A), "Process_MessageSubscriptions", null);
+        startProcessInstance(true, getTenant(TENANT_A), "Process_MessageSubscriptions", null);
     doNotTouchProcessInstanceKeys.add(messageSubscriptionInstance);
   }
 
@@ -195,28 +167,14 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
       final int no = ThreadLocalRandom.current().nextInt(operationsCount);
       final Long processInstanceKey = processInstanceKeys.get(no);
       final OperationType type = getType(i);
-      final ResponseEntity<String> response = createOperationViaV2(processInstanceKey, type);
-      if (!response.getStatusCode().is2xxSuccessful()) {
-        throw new OperateRuntimeException(
-            String.format("Unable to create operations. REST response: %s", response));
+      switch (type) {
+        case CANCEL_PROCESS_INSTANCE -> cancelProcessInstance(false, processInstanceKey);
+        case RESOLVE_INCIDENT -> resolveIncidentForProcessInstance(processInstanceKey);
+        default ->
+            throw new IllegalArgumentException(
+                "Unsupported operation type for dev data generation: " + type);
       }
     }
-  }
-
-  private ResponseEntity<String> createOperationViaV2(
-      final Long processInstanceKey, final OperationType type) {
-    final String operationPath =
-        switch (type) {
-          case CANCEL_PROCESS_INSTANCE -> "/v2/process-instances/%d/cancellation";
-          case RESOLVE_INCIDENT -> "/v2/process-instances/%d/incident-resolution";
-          default ->
-              throw new OperateRuntimeException(
-                  "Unsupported operation type for dev data generation: " + type);
-        };
-    final RequestEntity<Void> requestEntity =
-        RequestEntity.post(restTemplate.getURL(operationPath.formatted(processInstanceKey)))
-            .build();
-    return restTemplate.exchange(requestEntity, String.class);
   }
 
   @Override
@@ -266,77 +224,62 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     super.deployVersion1();
 
     // deploy processes v.1
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/complexProcess_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/complexProcess_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/eventBasedGatewayProcess_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/eventBasedGatewayProcess_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/subProcess.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/subProcess.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/interruptingBoundaryEvent_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/interruptingBoundaryEvent_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/nonInterruptingBoundaryEvent_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/nonInterruptingBoundaryEvent_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/timerProcess_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/timerProcess_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/callActivityProcess.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/callActivityProcess.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/eventSubProcess_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/eventSubProcess_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/bigProcess.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/bigProcess.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/errorProcess.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/errorProcess.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/error-end-event.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/error-end-event.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/terminateEndEvent.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/terminateEndEvent.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/undefined-task.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/undefined-task.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/dataStore.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/dataStore.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/linkEvents.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/linkEvents.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/escalationEvents_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/escalationEvents_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/signalEvent.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/signalEvent.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/collapsedSubProcess.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/collapsedSubProcess.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/compensationEvents.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/compensationEvents.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/executionListeners.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/executionListeners.bpmn");
 
-    ZeebeTestUtil.deployDecision(
-        client, getTenant(TENANT_A), "develop/dmn-with-decisions-chain.dmn");
+    deployDecision(getTenant(TENANT_A), "develop/dmn-with-decisions-chain.dmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/process-with-root-cause-decision.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/process-with-root-cause-decision.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/process-with-message-subscriptions.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/process-with-message-subscriptions.bpmn");
 
     // Deploy call activity chain for incident propagation testing
     // Note: level-3 is intentionally NOT deployed to create incident chain
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/level-1.bpmn");
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/level-2.bpmn");
-    ZeebeTestUtil.deployDecision(client, getTenant(TENANT_A), "develop/decisions-chain-a.dmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/level-1.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/level-2.bpmn");
+    deployDecision(getTenant(TENANT_A), "develop/decisions-chain-a.dmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/incidents-process.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/incidents-process.bpmn");
 
     // reverted in Zeebe https://github.com/camunda/camunda/issues/13640
-    // ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A),
+    // deployProcess(true, getTenant(TENANT_A),
     // "develop/inclusiveGateway.bpmn");
   }
 
@@ -359,90 +302,65 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
         // call activity process
         // these instances will have incident on call activity
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "call-activity-process",
                 "{\"var\": " + ThreadLocalRandom.current().nextInt(10) + "}"));
 
         // eventSubprocess
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "eventSubprocessProcess",
                 "{\"clientId\": \"" + ThreadLocalRandom.current().nextInt(10) + "\"}"));
 
         // errorProcess
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true,
-                client,
-                getTenant(TENANT_A),
-                "errorProcess",
-                "{\"errorCode\": \"boundary\"}"));
+            startProcessInstance(
+                true, getTenant(TENANT_A), "errorProcess", "{\"errorCode\": \"boundary\"}"));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true,
-                client,
-                getTenant(TENANT_A),
-                "errorProcess",
-                "{\"errorCode\": \"subProcess\"}"));
+            startProcessInstance(
+                true, getTenant(TENANT_A), "errorProcess", "{\"errorCode\": \"subProcess\"}"));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "errorProcess", "{\"errorCode\": \"unknown\"}"));
+            startProcessInstance(
+                true, getTenant(TENANT_A), "errorProcess", "{\"errorCode\": \"unknown\"}"));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "error-end-process", null));
+            startProcessInstance(true, getTenant(TENANT_A), "error-end-process", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "terminateEndEvent", null));
+            startProcessInstance(true, getTenant(TENANT_A), "terminateEndEvent", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "collapsedSubProcess", null));
+            startProcessInstance(true, getTenant(TENANT_A), "collapsedSubProcess", null));
 
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "dataStoreProcess", null));
+            startProcessInstance(true, getTenant(TENANT_A), "dataStoreProcess", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "linkEventProcess", null));
+            startProcessInstance(true, getTenant(TENANT_A), "linkEventProcess", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "escalationEvents", null));
+            startProcessInstance(true, getTenant(TENANT_A), "escalationEvents", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "undefined-task-process", null));
+            startProcessInstance(true, getTenant(TENANT_A), "undefined-task-process", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "compensationEvents", null));
+            startProcessInstance(true, getTenant(TENANT_A), "compensationEvents", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "executionListeners", null));
+            startProcessInstance(true, getTenant(TENANT_A), "executionListeners", null));
 
         // Root cause decision process
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "Process_rootCauseDecision", null));
+            startProcessInstance(true, getTenant(TENANT_A), "Process_rootCauseDecision", null));
 
         // Call activity chain (level-1 → level-2 → level-3 [not deployed] = incident chain)
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "call-level-1-process", null));
+            startProcessInstance(true, getTenant(TENANT_A), "call-level-1-process", null));
 
         // Incidents / root cause test process
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true,
-                client,
-                getTenant(TENANT_A),
-                "incidents-process",
-                "{\"testItems\": [1, 2, 3]}"));
+            startProcessInstance(
+                true, getTenant(TENANT_A), "incidents-process", "{\"testItems\": [1, 2, 3]}"));
 
         // reverted in Zeebe https://github.com/camunda/camunda/issues/13640
-        //        processInstanceKeys.add(ZeebeTestUtil.startProcessInstance(true, client,
+        //        processInstanceKeys.add(startProcessInstance(true,
         // getTenant(TENANT_A), "inclusiveGatewayProcess",
         //            "{\"saladOrdered\": "+ ThreadLocalRandom.current().nextBoolean()+ ",
         // \"pastaOrdered\": "+ ThreadLocalRandom.current().nextBoolean()+ "}"));
@@ -450,35 +368,29 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
 
       if (version == 2) {
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "interruptingBoundaryEvent", null));
+            startProcessInstance(true, getTenant(TENANT_A), "interruptingBoundaryEvent", null));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "nonInterruptingBoundaryEvent", null));
+            startProcessInstance(true, getTenant(TENANT_A), "nonInterruptingBoundaryEvent", null));
         // call activity process
         // these instances must be fine
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "call-activity-process",
                 "{\"var\": " + ThreadLocalRandom.current().nextInt(10) + "}"));
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "escalationEvents", null));
+            startProcessInstance(true, getTenant(TENANT_A), "escalationEvents", null));
       }
       if (version < 2) {
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
-                true, client, getTenant(TENANT_A), "prWithSubprocess", null));
+            startProcessInstance(true, getTenant(TENANT_A), "prWithSubprocess", null));
       }
 
       if (version < 3) {
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "complexProcess",
                 "{\"clientId\": \"" + ThreadLocalRandom.current().nextInt(10) + "\"}"));
@@ -486,18 +398,16 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
 
       if (version == 3) {
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "complexProcess",
                 "{\"goUp\": " + ThreadLocalRandom.current().nextInt(5) + "}"));
         // call activity process
         // these instances will call second version of called process
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "call-activity-process",
                 "{\"orders\": ["
@@ -508,9 +418,8 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
       }
       if (version == 4) {
         processInstanceKeys.add(
-            ZeebeTestUtil.startProcessInstance(
+            startProcessInstance(
                 true,
-                client,
                 getTenant(TENANT_A),
                 "processAnnualLeave",
                 "{\"leave_type\":\"fto\", \"days\":"
@@ -520,8 +429,7 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
     }
     if (version == 1) {
       processInstanceKeys.add(
-          ZeebeTestUtil.startProcessInstance(
-              true, client, getTenant(TENANT_A), "timerProcess", null));
+          startProcessInstance(true, getTenant(TENANT_A), "timerProcess", null));
     }
   }
 
@@ -529,42 +437,34 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
   protected void deployVersion2() {
     super.deployVersion2();
     //    deploy processes v.2
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/timerProcess_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/timerProcess_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/complexProcess_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/complexProcess_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/eventBasedGatewayProcess_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/eventBasedGatewayProcess_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/interruptingBoundaryEvent_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/interruptingBoundaryEvent_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/nonInterruptingBoundaryEvent_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/nonInterruptingBoundaryEvent_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_A), "develop/calledProcess.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/calledProcess.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/escalationEvents_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/escalationEvents_v_2.bpmn");
   }
 
   @Override
   protected void deployVersion3() {
     super.deployVersion3();
     // deploy processes v.3
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/complexProcess_v_3.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/complexProcess_v_3.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/calledProcess_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/calledProcess_v_2.bpmn");
   }
 
   @Override
   protected void deployVersion4() {
     super.deployVersion4();
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_A), "develop/user-task-annual-leave.bpmn");
+    deployProcess(true, getTenant(TENANT_A), "develop/user-task-annual-leave.bpmn");
   }
 
   private OperationType getType(final int i) {
@@ -742,7 +642,7 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
       arrayNode.add(j);
     }
     final String jsonString = object.toString();
-    ZeebeTestUtil.startProcessInstance(true, client, getTenant(TENANT_A), "bigProcess", jsonString);
+    startProcessInstance(true, getTenant(TENANT_A), "bigProcess", jsonString);
   }
 
   public void setClient(final CamundaClient client) {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/usertest/UserTestDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/usertest/UserTestDataGenerator.java
@@ -20,7 +20,6 @@ import io.camunda.client.api.worker.JobWorker;
 import io.camunda.operate.data.AbstractDataGenerator;
 import io.camunda.operate.data.util.NameGenerator;
 import io.camunda.operate.util.PayloadUtil;
-import io.camunda.operate.util.ZeebeTestUtil;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
@@ -94,20 +93,17 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
   private void createInputOutputMappingInstances() {
     LOGGER.debug("Create input/output mapping process instances");
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "develop/always-completing-process.bpmn");
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "develop/input-output-mappings-process.bpmn");
-    ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "Process_b1711b2e-ec8e-4dad-908c-8c12e028f32f", null);
+    deployProcess(true, getTenant(TENANT_B), "develop/always-completing-process.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "develop/input-output-mappings-process.bpmn");
+    startProcessInstance(
+        true, getTenant(TENANT_B), "Process_b1711b2e-ec8e-4dad-908c-8c12e028f32f", null);
   }
 
   private void createAndStartProcessWithLargeVariableValue() {
     LOGGER.debug("Deploy and start process with large variable value >32kb");
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_B), "usertest/single-task.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/single-task.bpmn");
     final String jsonString = payloadUtil.readStringFromClasspath("/usertest/large-payload.json");
-    ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "bigVarProcess", jsonString);
+    startProcessInstance(true, getTenant(TENANT_B), "bigVarProcess", jsonString);
   }
 
   private void createAndStartProcessWithLotOfVariables() {
@@ -122,8 +118,7 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
       }
     }
     vars.append("}");
-    ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "bigVarProcess", vars.toString());
+    startProcessInstance(true, getTenant(TENANT_B), "bigVarProcess", vars.toString());
   }
 
   public void createSpecialDataV1() {
@@ -137,7 +132,7 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
     final long instanceKey3 = startLoanProcess();
     completeTask(instanceKey3, "reviewLoanRequest", null);
     completeTask(instanceKey3, "checkSchufa", null);
-    ZeebeTestUtil.cancelProcessInstance(true, client, instanceKey3);
+    cancelProcessInstance(true, instanceKey3);
     doNotTouchProcessInstanceKeys.add(instanceKey3);
 
     final long instanceKey4 = startLoanProcess();
@@ -155,7 +150,7 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
     final long instanceKey6 = startOrderProcess();
     completeTask(instanceKey6, "checkPayment", "{\"paid\":false}");
-    ZeebeTestUtil.cancelProcessInstance(true, client, instanceKey6);
+    cancelProcessInstance(true, instanceKey6);
     doNotTouchProcessInstanceKeys.add(instanceKey6);
 
     final long instanceKey7 = startOrderProcess();
@@ -177,7 +172,7 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
     final long instanceKey10 = startFlightRegistrationProcess();
     completeTask(instanceKey10, "registerPassenger", null);
     completeTask(instanceKey10, "registerCabinBag", "{\"luggage\":true}");
-    ZeebeTestUtil.cancelProcessInstance(true, client, instanceKey10);
+    cancelProcessInstance(true, instanceKey10);
     doNotTouchProcessInstanceKeys.add(instanceKey10);
 
     final long instanceKey11 = startFlightRegistrationProcess();
@@ -239,7 +234,7 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
     final long instanceKey6 = startOrderProcess();
     completeTask(instanceKey6, "checkPayment", "{\"paid\":false}");
-    ZeebeTestUtil.cancelProcessInstance(true, client, instanceKey6);
+    cancelProcessInstance(true, instanceKey6);
     doNotTouchProcessInstanceKeys.add(instanceKey6);
 
     doNotTouchProcessInstanceKeys.add(startFlightRegistrationProcess());
@@ -256,7 +251,7 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
     final long instanceKey10 = startFlightRegistrationProcess();
     completeTask(instanceKey10, "registerPassenger", null);
     completeTask(instanceKey10, "registerCabinBag", "{\"luggage\":true}");
-    ZeebeTestUtil.cancelProcessInstance(true, client, instanceKey10);
+    cancelProcessInstance(true, instanceKey10);
     doNotTouchProcessInstanceKeys.add(instanceKey10);
 
     final long instanceKey11 = startFlightRegistrationProcess();
@@ -670,11 +665,9 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
   protected void createProcessWithoutInstances() {
     final Long processDefinitionKeyVersion1 =
-        ZeebeTestUtil.deployProcess(
-            true, client, getTenant(TENANT_B), "usertest/withoutInstancesProcess_v_1.bpmn");
+        deployProcess(true, getTenant(TENANT_B), "usertest/withoutInstancesProcess_v_1.bpmn");
     final Long processDefinitionKeyVersion2 =
-        ZeebeTestUtil.deployProcess(
-            true, client, getTenant(TENANT_B), "usertest/withoutInstancesProcess_v_2.bpmn");
+        deployProcess(true, getTenant(TENANT_B), "usertest/withoutInstancesProcess_v_2.bpmn");
     LOGGER.info(
         "Created process 'withoutInstancesProcess' version 1: {} and version 2: {}",
         processDefinitionKeyVersion1,
@@ -683,20 +676,16 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
   protected void createProcessWithInstancesThatHasOnlyIncidents(
       final int forVersion1, final int forVersion2) {
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/onlyIncidentsProcess_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/onlyIncidentsProcess_v_1.bpmn");
     for (int i = 0; i < forVersion1; i++) {
       final Long processInstanceKey =
-          ZeebeTestUtil.startProcessInstance(
-              true, client, getTenant(TENANT_B), "onlyIncidentsProcess", null);
+          startProcessInstance(true, getTenant(TENANT_B), "onlyIncidentsProcess", null);
       failTask(processInstanceKey, "alwaysFails", "No memory left.");
     }
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/onlyIncidentsProcess_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/onlyIncidentsProcess_v_2.bpmn");
     for (int i = 0; i < forVersion2; i++) {
       final Long processInstanceKey =
-          ZeebeTestUtil.startProcessInstance(
-              true, client, getTenant(TENANT_B), "onlyIncidentsProcess", null);
+          startProcessInstance(true, getTenant(TENANT_B), "onlyIncidentsProcess", null);
       failTask(processInstanceKey, "alwaysFails", "No space left on device.");
       failTask(processInstanceKey, "alwaysFails2", "No space left on device.");
     }
@@ -708,18 +697,14 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
   protected void createProcessWithInstancesWithoutIncidents(
       final int forVersion1, final int forVersion2) {
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/withoutIncidentsProcess_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/withoutIncidentsProcess_v_1.bpmn");
     for (int i = 0; i < forVersion1; i++) {
-      ZeebeTestUtil.startProcessInstance(
-          true, client, getTenant(TENANT_B), "withoutIncidentsProcess", null);
+      startProcessInstance(true, getTenant(TENANT_B), "withoutIncidentsProcess", null);
     }
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/withoutIncidentsProcess_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/withoutIncidentsProcess_v_2.bpmn");
     for (int i = 0; i < forVersion2; i++) {
       final Long processInstanceKey =
-          ZeebeTestUtil.startProcessInstance(
-              true, client, getTenant(TENANT_B), "withoutIncidentsProcess", null);
+          startProcessInstance(true, getTenant(TENANT_B), "withoutIncidentsProcess", null);
       completeTask(processInstanceKey, "neverFails", null);
     }
     LOGGER.info(
@@ -730,30 +715,23 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
 
   protected void deployVersion1() {
     // deploy processes v.1
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(DEFAULT_TENANT_ID), "usertest/orderProcess_v_1.bpmn");
+    deployProcess(true, getTenant(DEFAULT_TENANT_ID), "usertest/orderProcess_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(DEFAULT_TENANT_ID), "usertest/loanProcess_v_1.bpmn");
+    deployProcess(true, getTenant(DEFAULT_TENANT_ID), "usertest/loanProcess_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(DEFAULT_TENANT_ID), "usertest/registerPassenger_v_1.bpmn");
+    deployProcess(true, getTenant(DEFAULT_TENANT_ID), "usertest/registerPassenger_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/multiInstance_v_1.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/multiInstance_v_1.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_B), "usertest/manual-task.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/manual-task.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/intermediate-message-throw-event.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/intermediate-message-throw-event.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/intermediate-none-event.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/intermediate-none-event.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/message-end-event.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/message-end-event.bpmn");
 
-    ZeebeTestUtil.deployProcess(true, client, getTenant(TENANT_B), "usertest/invoice.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/invoice.bpmn");
   }
 
   protected void startProcessInstances(final int version) {
@@ -776,9 +754,8 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
   }
 
   private long startFlightRegistrationProcess() {
-    return ZeebeTestUtil.startProcessInstance(
+    return startProcessInstance(
         true,
-        client,
         getTenant(DEFAULT_TENANT_ID),
         "flightRegistration",
         "{\n"
@@ -801,9 +778,8 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
   private long startOrderProcess() {
     final float price1 = Math.round(ThreadLocalRandom.current().nextFloat() * 100000) / 100;
     final float price2 = Math.round(ThreadLocalRandom.current().nextFloat() * 10000) / 100;
-    return ZeebeTestUtil.startProcessInstance(
+    return startProcessInstance(
         true,
-        client,
         DEFAULT_TENANT_ID,
         "orderProcess",
         "{\n"
@@ -838,9 +814,8 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
   }
 
   private long startLoanProcess() {
-    return ZeebeTestUtil.startProcessInstance(
+    return startProcessInstance(
         true,
-        client,
         getTenant(DEFAULT_TENANT_ID),
         "loanProcess",
         "{\"requestId\": \"RDG123000001\",\n"
@@ -874,9 +849,8 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
     final String[] invoiceCategories =
         new String[] {"Misc", "Travel Expenses", "Software License Costs"};
     if (ThreadLocalRandom.current().nextInt(3) > 0) {
-      return ZeebeTestUtil.startProcessInstance(
+      return startProcessInstance(
           true,
-          client,
           getTenant(TENANT_B),
           "invoice",
           "{\"amount\": "
@@ -887,54 +861,46 @@ public class UserTestDataGenerator extends AbstractDataGenerator {
               + "\"\n"
               + "}");
     } else {
-      return ZeebeTestUtil.startProcessInstance(true, client, getTenant(TENANT_B), "invoice", null);
+      return startProcessInstance(true, getTenant(TENANT_B), "invoice", null);
     }
   }
 
   private long startManualProcess() {
-    return ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "manual-task-process", null);
+    return startProcessInstance(true, getTenant(TENANT_B), "manual-task-process", null);
   }
 
   private Long startIntermediateNoneEventProcess() {
-    return ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "intermediate-none-event-process", null);
+    return startProcessInstance(true, getTenant(TENANT_B), "intermediate-none-event-process", null);
   }
 
   private Long startIntermediateMessageThrowEventProcess() {
-    return ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "intermediate-message-throw-event-process", null);
+    return startProcessInstance(
+        true, getTenant(TENANT_B), "intermediate-message-throw-event-process", null);
   }
 
   private Long startMessageEndEventProcess() {
-    return ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "message-end-event-process", null);
+    return startProcessInstance(true, getTenant(TENANT_B), "message-end-event-process", null);
   }
 
   private long startMultiInstanceProcess() {
-    return ZeebeTestUtil.startProcessInstance(
-        true, client, getTenant(TENANT_B), "multiInstanceProcess", "{\"items\": [1, 2, 3]}");
+    return startProcessInstance(
+        true, getTenant(TENANT_B), "multiInstanceProcess", "{\"items\": [1, 2, 3]}");
   }
 
   protected void deployVersion2() {
     // deploy processes v.2
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(DEFAULT_TENANT_ID), "usertest/orderProcess_v_2.bpmn");
+    deployProcess(true, getTenant(DEFAULT_TENANT_ID), "usertest/orderProcess_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(DEFAULT_TENANT_ID), "usertest/registerPassenger_v_2.bpmn");
+    deployProcess(true, getTenant(DEFAULT_TENANT_ID), "usertest/registerPassenger_v_2.bpmn");
 
-    ZeebeTestUtil.deployProcess(
-        true, client, getTenant(TENANT_B), "usertest/multiInstance_v_2.bpmn");
+    deployProcess(true, getTenant(TENANT_B), "usertest/multiInstance_v_2.bpmn");
 
-    ZeebeTestUtil.deployDecision(
-        client, getTenant(TENANT_B), "usertest/invoiceBusinessDecisions_v_1.dmn");
+    deployDecision(getTenant(TENANT_B), "usertest/invoiceBusinessDecisions_v_1.dmn");
   }
 
   protected void deployVersion3() {
 
-    ZeebeTestUtil.deployDecision(
-        client, getTenant(TENANT_B), "usertest/invoiceBusinessDecisions_v_2.dmn");
+    deployDecision(getTenant(TENANT_B), "usertest/invoiceBusinessDecisions_v_2.dmn");
   }
 
   protected void deployVersion4() {}

--- a/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
+++ b/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
@@ -19,7 +19,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.service.ProcessInstanceServices;
@@ -33,6 +35,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +49,8 @@ class AbstractDataGeneratorTest {
   private final ResourceServices resourceServices = mock(ResourceServices.class);
   private final ProcessInstanceServices processInstanceServices =
       mock(ProcessInstanceServices.class);
+  private final PhysicalTenantIds physicalTenantIds = mock(PhysicalTenantIds.class);
+  private final SchemaManagerContainer schemaManagerContainer = mock(SchemaManagerContainer.class);
 
   private final CamundaAuthentication anonymousAuthentication = CamundaAuthentication.anonymous();
 
@@ -57,11 +62,15 @@ class AbstractDataGeneratorTest {
     generator.serviceRegistry = serviceRegistry;
     generator.authenticationProvider = authenticationProvider;
     generator.client = client;
+    generator.physicalTenantIds = physicalTenantIds;
+    generator.schemaManagerContainer = schemaManagerContainer;
 
     when(authenticationProvider.getAnonymousCamundaAuthentication())
         .thenReturn(anonymousAuthentication);
     when(serviceRegistry.resourceServices(anyString())).thenReturn(resourceServices);
     when(serviceRegistry.processInstanceServices(anyString())).thenReturn(processInstanceServices);
+    when(physicalTenantIds.known())
+        .thenReturn(Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
   }
 
   @Test
@@ -201,18 +210,19 @@ class AbstractDataGeneratorTest {
   }
 
   @Test
-  void shouldIdentifySchemaNotReadyMarkersForLogDemotion() {
+  void shouldReportSchemaReadyOnlyWhenAllKnownPhysicalTenantsAreInitialized() {
     // given
-    final Exception schemaNotReady = new RuntimeException("index_not_found_exception");
-    final Exception wrappedSchemaNotReady =
-        new RuntimeException(
-            "wrapper", new RuntimeException("no_shard_available_action_exception"));
-    final Exception unrelated = new RuntimeException("401 unauthorized");
+    when(physicalTenantIds.known()).thenReturn(Set.of("tenant1", "tenant2"));
+    when(schemaManagerContainer.isInitialized(anyString())).thenReturn(true);
 
     // when / then
-    assertThat(generator.isSchemaNotReady(schemaNotReady)).isTrue();
-    assertThat(generator.isSchemaNotReady(wrappedSchemaNotReady)).isTrue();
-    assertThat(generator.isSchemaNotReady(unrelated)).isFalse();
+    assertThat(generator.isSchemaReady()).isTrue();
+
+    // given
+    when(schemaManagerContainer.isInitialized("tenant2")).thenReturn(false);
+
+    // when / then
+    assertThat(generator.isSchemaReady()).isFalse();
   }
 
   private static final class TestDataGenerator extends AbstractDataGenerator {

--- a/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
+++ b/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
@@ -225,6 +225,15 @@ class AbstractDataGeneratorTest {
     assertThat(generator.isSchemaReady()).isFalse();
   }
 
+  @Test
+  void shouldReportSchemaReadyWhenSchemaManagerContainerIsAbsent() {
+    // given: RDBMS storage, which has no async schema-init phase and never registers the bean
+    generator.schemaManagerContainer = null;
+
+    // when / then
+    assertThat(generator.isSchemaReady()).isTrue();
+  }
+
   private static final class TestDataGenerator extends AbstractDataGenerator {
 
     @Override

--- a/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
+++ b/operate/data-generator/src/test/java/io/camunda/operate/data/AbstractDataGeneratorTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
+import io.camunda.service.ResourceServices;
+import io.camunda.service.ResourceServices.DeployResourcesRequest;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AbstractDataGeneratorTest {
+
+  private final ServiceRegistry serviceRegistry = mock(ServiceRegistry.class);
+  private final CamundaAuthenticationProvider authenticationProvider =
+      mock(CamundaAuthenticationProvider.class);
+  private final CamundaClient client = mock(CamundaClient.class);
+  private final ResourceServices resourceServices = mock(ResourceServices.class);
+  private final ProcessInstanceServices processInstanceServices =
+      mock(ProcessInstanceServices.class);
+
+  private final CamundaAuthentication anonymousAuthentication = CamundaAuthentication.anonymous();
+
+  private TestDataGenerator generator;
+
+  @BeforeEach
+  void setUp() {
+    generator = new TestDataGenerator();
+    generator.serviceRegistry = serviceRegistry;
+    generator.authenticationProvider = authenticationProvider;
+    generator.client = client;
+
+    when(authenticationProvider.getAnonymousCamundaAuthentication())
+        .thenReturn(anonymousAuthentication);
+    when(serviceRegistry.resourceServices(anyString())).thenReturn(resourceServices);
+    when(serviceRegistry.processInstanceServices(anyString())).thenReturn(processInstanceServices);
+  }
+
+  @Test
+  void shouldDeployProcessAnonymouslyWithoutTouchingCredentialFreeClient() {
+    // given
+    final ProcessMetadataValue metadata = mock(ProcessMetadataValue.class);
+    when(metadata.getProcessDefinitionKey()).thenReturn(123L);
+    final DeploymentRecord deploymentRecord = mock(DeploymentRecord.class);
+    when(deploymentRecord.getProcessesMetadata()).thenReturn(List.of(metadata));
+    when(resourceServices.deployResources(
+            any(DeployResourcesRequest.class), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.completedFuture(deploymentRecord));
+
+    // when
+    final Long processDefinitionKey =
+        generator.deployProcess(false, "tenant1", "usertest/single-task.bpmn");
+
+    // then
+    assertThat(processDefinitionKey).isEqualTo(123L);
+    verify(resourceServices)
+        .deployResources(any(DeployResourcesRequest.class), eq(anonymousAuthentication));
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldStartProcessInstanceAnonymouslyWithoutTouchingCredentialFreeClient() {
+    // given
+    final ProcessInstanceCreationRecord record = mock(ProcessInstanceCreationRecord.class);
+    when(record.getProcessInstanceKey()).thenReturn(456L);
+    when(processInstanceServices.createProcessInstance(
+            any(ProcessInstanceCreateRequest.class), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when
+    final long processInstanceKey =
+        generator.startProcessInstance(false, "tenant1", "orderProcess", null);
+
+    // then
+    assertThat(processInstanceKey).isEqualTo(456L);
+    verify(processInstanceServices)
+        .createProcessInstance(
+            any(ProcessInstanceCreateRequest.class), eq(anonymousAuthentication));
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldCancelProcessInstanceAnonymouslyWithoutTouchingCredentialFreeClient() {
+    // given
+    when(processInstanceServices.cancelProcessInstance(
+            any(ProcessInstanceCancelRequest.class), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    generator.cancelProcessInstance(false, 789L);
+
+    // then
+    verify(processInstanceServices)
+        .cancelProcessInstance(
+            any(ProcessInstanceCancelRequest.class), eq(anonymousAuthentication));
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldSwallowDeployFailureWhenIgnoreExceptionIsTrue() {
+    // given
+    when(resourceServices.deployResources(
+            any(DeployResourcesRequest.class), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("401")));
+
+    // when
+    final Long processDefinitionKey = generator.deployProcess(true, "tenant1", "missing.bpmn");
+
+    // then
+    assertThat(processDefinitionKey).isNull();
+  }
+
+  @Test
+  void shouldRetryOnceThenReturnKeyWhenFirstStartProcessInstanceAttemptFails() {
+    // given
+    final ProcessInstanceCreationRecord record = mock(ProcessInstanceCreationRecord.class);
+    when(record.getProcessInstanceKey()).thenReturn(456L);
+    when(processInstanceServices.createProcessInstance(
+            any(ProcessInstanceCreateRequest.class), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("401")))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when
+    final long processInstanceKey =
+        generator.startProcessInstance(false, "tenant1", "orderProcess", null);
+
+    // then
+    assertThat(processInstanceKey).isEqualTo(456L);
+    verify(processInstanceServices, times(2))
+        .createProcessInstance(
+            any(ProcessInstanceCreateRequest.class), eq(anonymousAuthentication));
+  }
+
+  @Test
+  void shouldReturnZeroWhenBothStartProcessInstanceAttemptsFailAndIgnoreExceptionIsTrue() {
+    // given
+    when(processInstanceServices.createProcessInstance(
+            any(ProcessInstanceCreateRequest.class), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("401")));
+
+    // when
+    final long processInstanceKey =
+        generator.startProcessInstance(true, "tenant1", "orderProcess", null);
+
+    // then
+    assertThat(processInstanceKey).isZero();
+  }
+
+  @Test
+  void shouldResolveIncidentForProcessInstanceAnonymouslyWithoutTouchingCredentialFreeClient() {
+    // given
+    final BatchOperationCreationRecord record = mock(BatchOperationCreationRecord.class);
+    when(processInstanceServices.resolveProcessInstanceIncidents(
+            eq(789L), eq(anonymousAuthentication)))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when
+    generator.resolveIncidentForProcessInstance(789L);
+
+    // then
+    verify(processInstanceServices)
+        .resolveProcessInstanceIncidents(eq(789L), eq(anonymousAuthentication));
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldThrowWhenVariablesPayloadIsInvalidJson() {
+    // when / then
+    assertThatThrownBy(
+            () -> generator.startProcessInstance(false, "tenant1", "orderProcess", "{invalid"))
+        .isInstanceOf(OperateRuntimeException.class);
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldIdentifySchemaNotReadyMarkersForLogDemotion() {
+    // given
+    final Exception schemaNotReady = new RuntimeException("index_not_found_exception");
+    final Exception wrappedSchemaNotReady =
+        new RuntimeException(
+            "wrapper", new RuntimeException("no_shard_available_action_exception"));
+    final Exception unrelated = new RuntimeException("401 unauthorized");
+
+    // when / then
+    assertThat(generator.isSchemaNotReady(schemaNotReady)).isTrue();
+    assertThat(generator.isSchemaNotReady(wrappedSchemaNotReady)).isTrue();
+    assertThat(generator.isSchemaNotReady(unrelated)).isFalse();
+  }
+
+  private static final class TestDataGenerator extends AbstractDataGenerator {
+
+    @Override
+    public boolean createZeebeData(final boolean manuallyCalled) {
+      return true;
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/DevDataGeneratorConsolidatedAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/DevDataGeneratorConsolidatedAuthIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it;
+
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class DevDataGeneratorConsolidatedAuthIT {
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication CAMUNDA_APPLICATION =
+      new TestCamundaApplication()
+          .withAdditionalProfile("dev-data")
+          .withAdditionalProfile("consolidated-auth")
+          .withUnauthenticatedAccess();
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldSeedDemoProcessDefinitionsWithoutAuthenticationFailure() {
+    waitForProcessesToBeDeployed(camundaClient, 1);
+  }
+}


### PR DESCRIPTION
## Description

This PR refactors the data generator infrastructure for the Operate module, consolidating common logic and improving test coverage. The changes introduce a base test class for data generators and add consolidated authentication tests to ensure data is properly generated across different authentication scenarios.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56954
