### PR TITLE
feat: port remaining Phase 2 applier-layer operations

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
@@ -8,8 +8,11 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.MemberJoinApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.MemberLeaveApplier;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
 
 public final class GlobalConfigurationChangeAppliersImpl
     implements GlobalConfigurationChangeAppliers {
@@ -26,6 +29,12 @@ public final class GlobalConfigurationChangeAppliersImpl
     return switch (operation) {
       case final MemberJoinOperation op ->
           new MemberJoinApplier(op.memberId(), clusterMembershipChangeExecutor);
+      case final MemberLeaveOperation op ->
+          new MemberLeaveApplier(op.memberId(), clusterMembershipChangeExecutor);
+      case final MemberRemoveOperation op ->
+          // Reuse MemberLeaveApplier, only difference is that the member applying the operation is
+          // not the member that is leaving
+          new MemberLeaveApplier(op.memberToRemove(), clusterMembershipChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
@@ -9,11 +9,13 @@ package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.MemberJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.MemberLeaveApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PostScalingApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PreScalingApplier;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 
 public final class GlobalConfigurationChangeAppliersImpl
@@ -42,6 +44,8 @@ public final class GlobalConfigurationChangeAppliersImpl
           new MemberLeaveApplier(op.memberToRemove(), clusterMembershipChangeExecutor);
       case final PreScalingOperation op ->
           new PreScalingApplier(op.memberId(), op.clusterMembers(), clusterChangeExecutor);
+      case final PostScalingOperation op ->
+          new PostScalingApplier(op.memberId(), op.clusterMembers(), clusterChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
@@ -11,12 +11,14 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.MemberJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.MemberLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PostScalingApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PreScalingApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.UpdatePartitionDistributorConfigApplier;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 
 public final class GlobalConfigurationChangeAppliersImpl
     implements GlobalConfigurationChangeAppliers {
@@ -46,9 +48,8 @@ public final class GlobalConfigurationChangeAppliersImpl
           new PreScalingApplier(op.memberId(), op.clusterMembers(), clusterChangeExecutor);
       case final PostScalingOperation op ->
           new PostScalingApplier(op.memberId(), op.clusterMembers(), clusterChangeExecutor);
-      default ->
-          throw new UnsupportedOperationException(
-              "No new-model applier implemented yet for %s".formatted(operation));
+      case final UpdatePartitionDistributorConfigOperation op ->
+          new UpdatePartitionDistributorConfigApplier(op);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
@@ -9,19 +9,24 @@ package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.MemberJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.MemberLeaveApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PreScalingApplier;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 
 public final class GlobalConfigurationChangeAppliersImpl
     implements GlobalConfigurationChangeAppliers {
 
   private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor;
+  private final ClusterChangeExecutor clusterChangeExecutor;
 
   public GlobalConfigurationChangeAppliersImpl(
-      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor) {
+      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor,
+      final ClusterChangeExecutor clusterChangeExecutor) {
     this.clusterMembershipChangeExecutor = clusterMembershipChangeExecutor;
+    this.clusterChangeExecutor = clusterChangeExecutor;
   }
 
   @Override
@@ -35,6 +40,8 @@ public final class GlobalConfigurationChangeAppliersImpl
           // Reuse MemberLeaveApplier, only difference is that the member applying the operation is
           // not the member that is leaving
           new MemberLeaveApplier(op.memberToRemove(), clusterMembershipChangeExecutor);
+      case final PreScalingOperation op ->
+          new PreScalingApplier(op.memberId(), op.clusterMembers(), clusterChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 
@@ -36,6 +38,8 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
               op.partitionId(),
               op.minimumAllowedReplicas(),
               partitionChangeExecutor);
+      case final PartitionBootstrapOperation op ->
+          new PartitionBootstrapApplier(op, partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRedistributionCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRelocationCompletionApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.DeleteHistoryApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDeleteExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.StartPartitionScaleUpApp
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateIncarnationNumberApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateRoutingStateApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
@@ -41,12 +43,15 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
 
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
+  private final ClusterChangeExecutor clusterChangeExecutor;
 
   public PartitionGroupConfigurationChangeAppliersImpl(
       final PartitionChangeExecutor partitionChangeExecutor,
-      final PartitionScalingChangeExecutor partitionScalingChangeExecutor) {
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
+      final ClusterChangeExecutor clusterChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
     this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
+    this.clusterChangeExecutor = clusterChangeExecutor;
   }
 
   @Override
@@ -99,6 +104,7 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final UpdateRoutingState op ->
           new UpdateRoutingStateApplier(op, partitionScalingChangeExecutor);
       case final UpdateIncarnationNumberOperation ignored -> new UpdateIncarnationNumberApplier();
+      case final DeleteHistoryOperation ignored -> new DeleteHistoryApplier(clusterChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitModeChangeApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRedistributionCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRelocationCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.DeleteHistoryApplier;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.StartPartitionScaleUpApp
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateIncarnationNumberApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateRoutingStateApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
@@ -116,9 +118,8 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
             case RECOVERING -> new EnterRecoveryApplier(op.memberId(), modeChangeExecutor);
             case PROCESSING -> new ExitRecoveryApplier(op.memberId(), modeChangeExecutor);
           };
-      default ->
-          throw new UnsupportedOperationException(
-              "No new-model applier implemented yet for %s".formatted(operation));
+      case final AwaitModeChangeOperation op ->
+          new AwaitModeChangeApplier(op.mode(), modeChangeExecutor);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.StartPartitionScaleUpApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateRoutingStateApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
     implements PartitionGroupConfigurationChangeAppliers {
@@ -92,6 +94,8 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
             case final AwaitRelocationCompletion relocation ->
                 new AwaitRelocationCompletionApplier(partitionScalingChangeExecutor, relocation);
           };
+      case final UpdateRoutingState op ->
+          new UpdateRoutingStateApplier(op, partitionScalingChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionEnableExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionForceReconfigureApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
@@ -15,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
@@ -59,6 +61,9 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
               op.exporterId(),
               op.initializeFrom(),
               partitionChangeExecutor);
+      case final PartitionDisableExporterOperation op ->
+          new PartitionDisableExporterApplier(
+              op.memberId(), op.partitionId(), op.exporterId(), partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRedistributionCompl
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRelocationCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.DeleteHistoryApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.EnterRecoveryApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.ExitRecoveryApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDeleteExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
@@ -113,9 +114,7 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final ModeChangeOperation op ->
           switch (op.mode()) {
             case RECOVERING -> new EnterRecoveryApplier(op.memberId(), modeChangeExecutor);
-            default ->
-                throw new UnsupportedOperationException(
-                    "No new-model applier implemented yet for %s".formatted(operation));
+            case PROCESSING -> new ExitRecoveryApplier(op.memberId(), modeChangeExecutor);
           };
       default ->
           throw new UnsupportedOperationException(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRedistributionCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDeleteExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
@@ -82,6 +84,9 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
                     final var desiredPartitionCount) ->
                 new StartPartitionScaleUpApplier(
                     partitionScalingChangeExecutor, desiredPartitionCount);
+            case final AwaitRedistributionCompletion awaitRedistributionCompletion ->
+                new AwaitRedistributionCompletionApplier(
+                    partitionScalingChangeExecutor, awaitRedistributionCompletion);
             default ->
                 throw new UnsupportedOperationException(
                     "No new-model applier implemented yet for %s".formatted(op));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.dynamic.config.changes;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
     implements PartitionGroupConfigurationChangeAppliers {
@@ -40,6 +42,9 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
               partitionChangeExecutor);
       case final PartitionBootstrapOperation op ->
           new PartitionBootstrapApplier(op, partitionChangeExecutor);
+      case final PartitionReconfigurePriorityOperation op ->
+          new PartitionReconfigurePriorityApplier(
+              op.memberId(), op.partitionId(), op.priority(), partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.StartPartitionScaleUpApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateIncarnationNumberApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateRoutingStateApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
@@ -96,6 +98,7 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
           };
       case final UpdateRoutingState op ->
           new UpdateRoutingStateApplier(op, partitionScalingChangeExecutor);
+      case final UpdateIncarnationNumberOperation ignored -> new UpdateIncarnationNumberApplier();
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRedistributionCompletionApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRelocationCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDeleteExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
@@ -87,9 +89,8 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
             case final AwaitRedistributionCompletion awaitRedistributionCompletion ->
                 new AwaitRedistributionCompletionApplier(
                     partitionScalingChangeExecutor, awaitRedistributionCompletion);
-            default ->
-                throw new UnsupportedOperationException(
-                    "No new-model applier implemented yet for %s".formatted(op));
+            case final AwaitRelocationCompletion relocation ->
+                new AwaitRelocationCompletionApplier(partitionScalingChangeExecutor, relocation);
           };
       default ->
           throw new UnsupportedOperationException(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
     implements PartitionGroupConfigurationChangeAppliers {
@@ -22,7 +24,13 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
   @Override
   public PartitionGroupConfigurationChangeApplier getApplier(
       final PartitionGroupOperation operation) {
-    throw new UnsupportedOperationException(
-        "No new-model applier implemented yet for %s".formatted(operation));
+    return switch (operation) {
+      case final PartitionJoinOperation op ->
+          new PartitionJoinApplier(
+              op.memberId(), op.partitionId(), op.priority(), partitionChangeExecutor);
+      default ->
+          throw new UnsupportedOperationException(
+              "No new-model applier implemented yet for %s".formatted(operation));
+    };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionForceReconfigur
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.StartPartitionScaleUpApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
@@ -24,15 +25,20 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionCh
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
     implements PartitionGroupConfigurationChangeAppliers {
 
   private final PartitionChangeExecutor partitionChangeExecutor;
+  private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
 
   public PartitionGroupConfigurationChangeAppliersImpl(
-      final PartitionChangeExecutor partitionChangeExecutor) {
+      final PartitionChangeExecutor partitionChangeExecutor,
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
+    this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
   }
 
   @Override
@@ -69,6 +75,17 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final PartitionDeleteExporterOperation op ->
           new PartitionDeleteExporterApplier(
               op.memberId(), op.partitionId(), op.exporterId(), partitionChangeExecutor);
+      case final ScaleUpOperation op ->
+          switch (op) {
+            case StartPartitionScaleUp(
+                    final var ignoredMemberId,
+                    final var desiredPartitionCount) ->
+                new StartPartitionScaleUpApplier(
+                    partitionScalingChangeExecutor, desiredPartitionCount);
+            default ->
+                throw new UnsupportedOperationException(
+                    "No new-model applier implemented yet for %s".formatted(op));
+          };
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDeleteExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionEnableExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionForceReconfigureApplier;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -63,6 +65,9 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
               partitionChangeExecutor);
       case final PartitionDisableExporterOperation op ->
           new PartitionDisableExporterApplier(
+              op.memberId(), op.partitionId(), op.exporterId(), partitionChangeExecutor);
+      case final PartitionDeleteExporterOperation op ->
+          new PartitionDeleteExporterApplier(
               op.memberId(), op.partitionId(), op.exporterId(), partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -8,12 +8,14 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionEnableExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionForceReconfigureApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -50,6 +52,13 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final PartitionForceReconfigureOperation op ->
           new PartitionForceReconfigureApplier(
               op.memberId(), op.partitionId(), op.members(), partitionChangeExecutor);
+      case final PartitionEnableExporterOperation op ->
+          new PartitionEnableExporterApplier(
+              op.memberId(),
+              op.partitionId(),
+              op.exporterId(),
+              op.initializeFrom(),
+              partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -8,11 +8,13 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionForceReconfigureApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionReconfigurePriorityApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
@@ -45,6 +47,9 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final PartitionReconfigurePriorityOperation op ->
           new PartitionReconfigurePriorityApplier(
               op.memberId(), op.partitionId(), op.priority(), partitionChangeExecutor);
+      case final PartitionForceReconfigureOperation op ->
+          new PartitionForceReconfigureApplier(
+              op.memberId(), op.partitionId(), op.members(), partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionJoinApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionLeaveApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 
 public final class PartitionGroupConfigurationChangeAppliersImpl
     implements PartitionGroupConfigurationChangeAppliers {
@@ -28,6 +30,12 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
       case final PartitionJoinOperation op ->
           new PartitionJoinApplier(
               op.memberId(), op.partitionId(), op.priority(), partitionChangeExecutor);
+      case final PartitionLeaveOperation op ->
+          new PartitionLeaveApplier(
+              op.memberId(),
+              op.partitionId(),
+              op.minimumAllowedReplicas(),
+              partitionChangeExecutor);
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.changes;
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRedistributionCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.AwaitRelocationCompletionApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.DeleteHistoryApplier;
+import io.camunda.zeebe.dynamic.config.changes.appliers.EnterRecoveryApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionBootstrapApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDeleteExporterApplier;
 import io.camunda.zeebe.dynamic.config.changes.appliers.PartitionDisableExporterApplier;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateIncarnationNumberA
 import io.camunda.zeebe.dynamic.config.changes.appliers.UpdateRoutingStateApplier;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
@@ -44,14 +46,17 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
   private final ClusterChangeExecutor clusterChangeExecutor;
+  private final ModeChangeExecutor modeChangeExecutor;
 
   public PartitionGroupConfigurationChangeAppliersImpl(
       final PartitionChangeExecutor partitionChangeExecutor,
       final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
-      final ClusterChangeExecutor clusterChangeExecutor) {
+      final ClusterChangeExecutor clusterChangeExecutor,
+      final ModeChangeExecutor modeChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
     this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
     this.clusterChangeExecutor = clusterChangeExecutor;
+    this.modeChangeExecutor = modeChangeExecutor;
   }
 
   @Override
@@ -105,6 +110,13 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
           new UpdateRoutingStateApplier(op, partitionScalingChangeExecutor);
       case final UpdateIncarnationNumberOperation ignored -> new UpdateIncarnationNumberApplier();
       case final DeleteHistoryOperation ignored -> new DeleteHistoryApplier(clusterChangeExecutor);
+      case final ModeChangeOperation op ->
+          switch (op.mode()) {
+            case RECOVERING -> new EnterRecoveryApplier(op.memberId(), modeChangeExecutor);
+            default ->
+                throw new UnsupportedOperationException(
+                    "No new-model applier implemented yet for %s".formatted(operation));
+          };
       default ->
           throw new UnsupportedOperationException(
               "No new-model applier implemented yet for %s".formatted(operation));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplier.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.AwaitModeChangeOperation}, operating on a
+ * single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
+ * AwaitModeChangeApplier} in {@code changes/}, which this does not replace or modify. Waits for a
+ * member's partition manager to finish starting in the target {@link Mode}; changes no
+ * configuration state, it only gates the change plan until the local transition has settled.
+ */
+public final class AwaitModeChangeApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final Mode mode;
+  private final ModeChangeExecutor modeChangeExecutor;
+
+  public AwaitModeChangeApplier(final Mode mode, final ModeChangeExecutor modeChangeExecutor) {
+    this.mode = Objects.requireNonNull(mode);
+    this.modeChangeExecutor = Objects.requireNonNull(modeChangeExecutor);
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+    modeChangeExecutor
+        .awaitModeApplied(mode)
+        .onComplete(
+            (ignored, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else {
+                result.complete(UnaryOperator.identity());
+              }
+            });
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRedistributionCompletionApplier.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion}, operating on a single
+ * named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy {@code
+ * AwaitRedistributionCompletionApplier} in {@code changes/}, which this does not replace or modify.
+ */
+public final class AwaitRedistributionCompletionApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final PartitionScalingChangeExecutor executor;
+  private final AwaitRedistributionCompletion operation;
+
+  public AwaitRedistributionCompletionApplier(
+      final PartitionScalingChangeExecutor executor,
+      final AwaitRedistributionCompletion operation) {
+    this.executor = Objects.requireNonNull(executor);
+    this.operation = Objects.requireNonNull(operation);
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+
+    if (operation.partitionsToRedistribute().isEmpty()) {
+      return Either.left(
+          new IllegalArgumentException("Cannot activate partitions: empty list provided"));
+    }
+    if (currentPartitionGroupConfiguration.routingState().isEmpty()) {
+      return Either.left(
+          new IllegalStateException(
+              "Routing state is not initialized yet, cannot include partitions in request handling."));
+    }
+
+    if (currentPartitionGroupConfiguration.routingState().get().requestHandling()
+        instanceof AllPartitions) {
+      return Either.left(
+          new IllegalStateException(
+              "All partitions are active, cannot include partitions in request handling."));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+    executor
+        .awaitRedistributionCompletion(
+            operation.desiredPartitionCount(), operation.partitionsToRedistribute(), null)
+        .onComplete(
+            (ignored, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else {
+                result.complete(this::updateRequestHandling);
+              }
+            });
+    return result;
+  }
+
+  private PartitionGroupConfiguration updateRequestHandling(
+      final PartitionGroupConfiguration group) {
+    final var routingState =
+        group
+            .routingState()
+            .map(state -> state.withRequestHandling(this::updateRequestHandling))
+            .orElseThrow(() -> new IllegalStateException("Missing routingState"));
+    return group.setRoutingState(routingState);
+  }
+
+  private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {
+    return switch (requestHandling) {
+      case final ActivePartitions activePartitions ->
+          activePartitions.activatePartitions(operation.partitionsToRedistribute());
+      case final AllPartitions ignored ->
+          throw new IllegalStateException("Cannot be AllPartitions");
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRelocationCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRelocationCompletionApplier.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion},
+ * operating on a single named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy
+ * {@code AwaitRelocationCompletionApplier} in {@code changes/}, which this does not replace or
+ * modify.
+ */
+public final class AwaitRelocationCompletionApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final PartitionScalingChangeExecutor executor;
+  private final AwaitRelocationCompletion operation;
+
+  public AwaitRelocationCompletionApplier(
+      final PartitionScalingChangeExecutor executor, final AwaitRelocationCompletion operation) {
+    this.executor = Objects.requireNonNull(executor);
+    this.operation = Objects.requireNonNull(operation);
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+
+    if (operation.partitionsToRelocate().isEmpty()) {
+      return Either.left(
+          new IllegalArgumentException("Cannot activate partitions: empty list provided"));
+    }
+    if (currentPartitionGroupConfiguration.routingState().isEmpty()) {
+      return Either.left(
+          new IllegalStateException(
+              "Routing state is not initialized yet, cannot include partitions in request handling."));
+    }
+
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    return CompletableActorFuture.completed(UnaryOperator.identity());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplier.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.DeleteHistoryOperation}, operating on a
+ * single named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy {@code
+ * DeleteHistoryApplier} in {@code changes/}, which this does not replace or modify.
+ *
+ * <p>Ported against the current, unsplit {@link ClusterChangeExecutor} (same as the legacy applier)
+ * — the split into a per-group history-deletion executor is Phase 3 scope, tracked separately.
+ */
+public final class DeleteHistoryApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final ClusterChangeExecutor clusterChangeExecutor;
+
+  public DeleteHistoryApplier(final ClusterChangeExecutor clusterChangeExecutor) {
+    this.clusterChangeExecutor = clusterChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    final var partitionCount = partitionCount(currentPartitionGroupConfiguration);
+    if (partitionCount > 0) {
+      return Either.left(
+          new IllegalStateException(
+              "Cannot delete history as %d partitions still exist.".formatted(partitionCount)));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+    clusterChangeExecutor
+        .deleteHistory()
+        .onComplete(
+            (ignore, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else {
+                result.complete(UnaryOperator.identity());
+              }
+            });
+
+    return result;
+  }
+
+  private int partitionCount(final PartitionGroupConfiguration group) {
+    return (int)
+        group.members().values().stream()
+            .flatMap(m -> m.partitions().keySet().stream())
+            .distinct()
+            .count();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/EnterRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/EnterRecoveryApplier.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.ModeChangeOperation} targeting {@link
+ * Mode#RECOVERING}, operating on a single named {@link PartitionGroupConfiguration}. Mirrors the
+ * legacy {@code EnterRecoveryApplier} in {@code changes/}, which this does not replace or modify.
+ *
+ * <p>The legacy applier reads recovery mode off the same flat {@code MemberState.State} that also
+ * tracks cluster lifecycle (JOINING/ACTIVE/LEAVING/LEFT/RECOVERING). In the new model, cluster
+ * lifecycle lives in {@link GlobalConfiguration} and per-group recovery mode lives in {@code
+ * BrokerPartitionState.mode()} — this applier checks both.
+ */
+public final class EnterRecoveryApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final ModeChangeExecutor modeChangeExecutor;
+
+  public EnterRecoveryApplier(
+      final MemberId memberId, final ModeChangeExecutor modeChangeExecutor) {
+    this.memberId = memberId;
+    this.modeChangeExecutor = modeChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    final boolean localMemberIsActiveInCluster =
+        currentGlobalConfiguration.hasMember(memberId)
+            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+    if (!localMemberIsActiveInCluster) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to enter recovery for member %s, but the member is not an active member of the cluster"
+                  .formatted(memberId)));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(memberId);
+    if (localBroker == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to enter recovery for member %s, but the member is not part of this partition group"
+                  .formatted(memberId)));
+    }
+
+    // Already RECOVERING: this can happen if the node restarted while applying this operation.
+    // To ensure that the configuration change can make progress, we do not treat this as an
+    // error.
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
+        new CompletableActorFuture<>();
+    modeChangeExecutor
+        .enterRecovery()
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(memberId, broker -> broker.setMode(Mode.RECOVERING)));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplier.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.ModeChangeOperation} targeting {@link
+ * Mode#PROCESSING}, operating on a single named {@link PartitionGroupConfiguration}. Mirrors the
+ * legacy {@code ExitRecoveryApplier} in {@code changes/}, which this does not replace or modify.
+ * See {@link EnterRecoveryApplier} for the cluster-lifecycle vs. per-group-mode split rationale.
+ */
+public final class ExitRecoveryApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final ModeChangeExecutor modeChangeExecutor;
+
+  public ExitRecoveryApplier(final MemberId memberId, final ModeChangeExecutor modeChangeExecutor) {
+    this.memberId = memberId;
+    this.modeChangeExecutor = modeChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    final boolean localMemberIsActiveInCluster =
+        currentGlobalConfiguration.hasMember(memberId)
+            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+    if (!localMemberIsActiveInCluster) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to exit recovery for member %s, but the member is not an active member of the cluster"
+                  .formatted(memberId)));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(memberId);
+    if (localBroker == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to exit recovery for member %s, but the member is not part of this partition group"
+                  .formatted(memberId)));
+    }
+
+    // Already PROCESSING: this can happen if the node restarted while applying this operation.
+    // To ensure that the configuration change can make progress, we do not treat this as an
+    // error.
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
+        new CompletableActorFuture<>();
+    modeChangeExecutor
+        .exitRecovery()
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(memberId, broker -> broker.setMode(Mode.PROCESSING)));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
@@ -46,10 +46,19 @@ public final class MemberLeaveApplier implements GlobalConfigurationChangeApplie
   @Override
   public Either<Exception, UnaryOperator<GlobalConfiguration>> init(
       final CurrentClusterConfiguration currentClusterConfiguration) {
-    if (!currentClusterConfiguration.globalConfiguration().hasMember(memberId)) {
+    final GlobalConfiguration globalConfiguration =
+        currentClusterConfiguration.globalConfiguration();
+    if (!globalConfiguration.hasMember(memberId)) {
       return Either.left(
           new IllegalStateException(
               "Expected to remove member %s, but the member is not part of the cluster"
+                  .formatted(memberId)));
+    }
+
+    if (globalConfiguration.getMember(memberId).state() == State.LEFT) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to remove member %s, but the member is already in state LEFT"
                   .formatted(memberId)));
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.TreeMap;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code GlobalChangeOperation.MemberLeaveOperation} and {@code
+ * MemberRemoveOperation}, operating on {@link GlobalConfiguration}. Mirrors the legacy {@code
+ * MemberLeaveApplier} in {@code changes/}, which this does not replace or modify; also reused for
+ * both operations, since the only difference between them is which member applies the operation.
+ *
+ * <p>The legacy applier additionally rejects the operation if the member still has partitions
+ * assigned, since the flat {@code ClusterConfiguration} carries both broker lifecycle and partition
+ * assignment together. In the new model that assignment is split out per group into {@code
+ * PartitionGroupConfiguration}, so this check needs every group, not just one — {@link #init}
+ * therefore receives the whole {@link CurrentClusterConfiguration} rather than a single group.
+ */
+public final class MemberLeaveApplier implements GlobalConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor;
+
+  public MemberLeaveApplier(
+      final MemberId memberId,
+      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor) {
+    this.memberId = memberId;
+    this.clusterMembershipChangeExecutor = clusterMembershipChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<GlobalConfiguration>> init(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    if (!currentClusterConfiguration.globalConfiguration().hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to remove member %s, but the member is not part of the cluster"
+                  .formatted(memberId)));
+    }
+
+    final var partitionsByGroup = new TreeMap<String, Object>();
+    currentClusterConfiguration
+        .partitionGroups()
+        .forEach(
+            (groupId, group) -> {
+              final var broker = group.getMember(memberId);
+              if (broker != null && !broker.partitions().isEmpty()) {
+                partitionsByGroup.put(groupId, broker.partitions());
+              }
+            });
+    if (!partitionsByGroup.isEmpty()) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to remove member %s, but the member still has partitions assigned. Partitions by group: %s"
+                  .formatted(memberId, partitionsByGroup)));
+    }
+
+    return Either.right(
+        config -> config.updateMember(memberId, broker -> broker.setState(State.LEAVING)));
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<GlobalConfiguration>> apply() {
+    final var future = new CompletableActorFuture<UnaryOperator<GlobalConfiguration>>();
+    clusterMembershipChangeExecutor
+        .removeBroker(memberId)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                future.complete(
+                    config -> config.updateMember(memberId, broker -> broker.setState(State.LEFT)));
+              } else {
+                future.completeExceptionally(error);
+              }
+            });
+
+    return future;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionBootstrapApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionBootstrapApplier.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation}, operating on a
+ * single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
+ * PartitionBootstrapApplier} in {@code changes/}, which this does not replace or modify.
+ *
+ * <p>Partition existence and id-contiguity are evaluated against this group only, since each
+ * partition group has its own partition numbering (unlike the legacy flat model where they were
+ * evaluated across the whole cluster). Like {@link PartitionJoinApplier}, this applier must branch
+ * between {@link PartitionGroupConfiguration#addMember} and {@link
+ * PartitionGroupConfiguration#updateMember}, since bootstrapping can be the local broker's first
+ * partition in this group.
+ */
+public final class PartitionBootstrapApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final int priority;
+  private final MemberId memberId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+  private final Optional<DynamicPartitionConfig> config;
+  private final boolean initializeFromSnapshot;
+  private DynamicPartitionConfig partitionConfig;
+
+  public PartitionBootstrapApplier(
+      final PartitionBootstrapOperation operation,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    partitionId = operation.partitionId();
+    priority = operation.priority();
+    memberId = operation.memberId();
+    config = operation.config();
+    initializeFromSnapshot = operation.initializeFromSnapshot();
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+
+    if (partitionId > Protocol.MAXIMUM_PARTITIONS) {
+      return Either.left(
+          new IllegalArgumentException(
+              "Failed to bootstrap partition '%s'. Partition ID is greater than the maximum allowed partition ID '%s'"
+                  .formatted(partitionId, Protocol.MAXIMUM_PARTITIONS)));
+    }
+
+    final boolean localMemberIsActiveInCluster =
+        currentGlobalConfiguration.hasMember(memberId)
+            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+    if (!localMemberIsActiveInCluster) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to bootstrap partition, but the member '%s' is not active"
+                  .formatted(memberId)));
+    }
+
+    if (isPartitionAlreadyBootstrapping(currentPartitionGroupConfiguration)) {
+      partitionConfig = initPartitionConfig(currentPartitionGroupConfiguration);
+      return Either.right(UnaryOperator.identity());
+    }
+
+    if (partitionExists(currentPartitionGroupConfiguration)) {
+      return Either.left(
+          new IllegalStateException(
+              "Failed to bootstrap partition '%s'. Partition already exists in the group"
+                  .formatted(partitionId)));
+    }
+
+    if (!isPartitionIdContiguous(currentPartitionGroupConfiguration, partitionId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Failed to bootstrap partition '%s'. Partition ID is not contiguous"
+                  .formatted(partitionId)));
+    }
+
+    partitionConfig = initPartitionConfig(currentPartitionGroupConfiguration);
+    final var bootstrappingState = PartitionState.bootstrapping(priority, partitionConfig);
+
+    return Either.right(
+        group ->
+            group.hasMember(memberId)
+                ? group.updateMember(
+                    memberId, broker -> broker.addPartition(partitionId, bootstrappingState))
+                : group.addMember(
+                    memberId,
+                    BrokerPartitionState.initialize(Map.of(partitionId, bootstrappingState))));
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
+        new CompletableActorFuture<>();
+    partitionChangeExecutor
+        .bootstrap(partitionId, priority, partitionConfig, initializeFromSnapshot)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(
+                            memberId,
+                            broker ->
+                                broker.updatePartition(partitionId, PartitionState::toActive)));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+
+  private DynamicPartitionConfig initPartitionConfig(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    return config.orElse(
+        getFirstMemberFirstPartitionConfig(currentPartitionGroupConfiguration)
+            .orElse(DynamicPartitionConfig.init()));
+  }
+
+  private Optional<DynamicPartitionConfig> getFirstMemberFirstPartitionConfig(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    return currentPartitionGroupConfiguration.members().values().stream()
+        .flatMap(m -> m.partitions().entrySet().stream().filter(p -> p.getKey() == 1))
+        .findFirst()
+        .map(Entry::getValue)
+        .map(PartitionState::config);
+  }
+
+  // For now, we only allow adding new partitions with continuous IDs within this group. In
+  // theory it should not matter, but there might be legacy code that assumes this, such as
+  // message routing.
+  private boolean isPartitionIdContiguous(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration, final int partitionId) {
+    final var lastPartitionId =
+        currentPartitionGroupConfiguration.members().values().stream()
+            .flatMap(m -> m.partitions().keySet().stream())
+            .max(Integer::compareTo)
+            .orElse(0);
+    return partitionId == lastPartitionId + 1;
+  }
+
+  private boolean isPartitionAlreadyBootstrapping(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    final var member = currentPartitionGroupConfiguration.getMember(memberId);
+    return member != null
+        && member.hasPartition(partitionId)
+        && member.getPartition(partitionId).state() == PartitionState.State.BOOTSTRAPPING;
+  }
+
+  private boolean partitionExists(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    return currentPartitionGroupConfiguration.members().values().stream()
+        .anyMatch(broker -> broker.hasPartition(partitionId));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDeleteExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDeleteExporterApplier.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.dynamic.config.state.ExporterState.State.CONFIG_NOT_FOUND;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation}, operating on
+ * a single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
+ * PartitionDeleteExporterApplier} in {@code changes/}, which this does not replace or modify.
+ */
+public final class PartitionDeleteExporterApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final String exporterId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionDeleteExporterApplier(
+      final MemberId memberId,
+      final int partitionId,
+      final String exporterId,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.exporterId = exporterId;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    if (!currentGlobalConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to delete exporter, but the member '%s' does not exist in the cluster"
+                  .formatted(memberId)));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(memberId);
+    final var localPartition = localBroker == null ? null : localBroker.getPartition(partitionId);
+    if (localPartition == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to delete exporter, but the member '%s' does not have the partition '%s'"
+                  .formatted(memberId, partitionId)));
+    }
+
+    final var exporters = localPartition.config().exporting().exporters();
+    final var exporterState = exporters.get(exporterId);
+    if (exporterState == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to delete exporter, but the partition '%s' does not have the exporter '%s'"
+                  .formatted(partitionId, exporterId)));
+    }
+
+    if (exporterState.state() != CONFIG_NOT_FOUND) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to delete exporter, but partition '%s' with exporter '%s' is in state '%s' instead of '%s'."
+                  .formatted(partitionId, exporterId, exporterState.state(), CONFIG_NOT_FOUND)));
+    }
+
+    // No need to change the state
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    return partitionChangeExecutor
+        .deleteExporter(partitionId, exporterId)
+        .thenApply(
+            nothing ->
+                (UnaryOperator<PartitionGroupConfiguration>)
+                    group ->
+                        group.updateMember(
+                            memberId,
+                            broker ->
+                                broker.updatePartition(
+                                    partitionId,
+                                    partition -> partition.updateConfig(this::deleteExporter))));
+  }
+
+  private DynamicPartitionConfig deleteExporter(final DynamicPartitionConfig config) {
+    return config.updateExporting(exporting -> exporting.deleteExporter(exporterId));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDisableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDisableExporterApplier.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation}, operating on
+ * a single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
+ * PartitionDisableExporterApplier} in {@code changes/}, which this does not replace or modify.
+ */
+public final class PartitionDisableExporterApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final String exporterId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionDisableExporterApplier(
+      final MemberId memberId,
+      final int partitionId,
+      final String exporterId,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.exporterId = exporterId;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    if (!currentGlobalConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to disable exporter, but the member '%s' does not exist in the cluster"
+                  .formatted(memberId)));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(memberId);
+    final var localPartition = localBroker == null ? null : localBroker.getPartition(partitionId);
+    if (localPartition == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to disable exporter, but the member '%s' does not have the partition '%s'"
+                  .formatted(memberId, partitionId)));
+    }
+
+    final var partitionHasExporter =
+        localPartition.config().exporting().exporters().containsKey(exporterId);
+    if (!partitionHasExporter) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to disable exporter, but the partition '%s' does not have the exporter '%s'"
+                  .formatted(partitionId, exporterId)));
+    }
+
+    // No need to change the state
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+
+    partitionChangeExecutor
+        .disableExporter(partitionId, exporterId)
+        .onComplete(
+            (nothing, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(
+                            memberId,
+                            broker ->
+                                broker.updatePartition(
+                                    partitionId,
+                                    partition -> partition.updateConfig(this::disableExporter))));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+
+  private DynamicPartitionConfig disableExporter(final DynamicPartitionConfig config) {
+    return config.updateExporting(exporting -> exporting.disableExporter(exporterId));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplier.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation}, operating on
+ * a single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
+ * PartitionEnableExporterApplier} in {@code changes/}, which this does not replace or modify.
+ */
+public final class PartitionEnableExporterApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final String exporterId;
+  private final Optional<String> initializeFrom;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  private long metadataVersionToUpdate;
+
+  public PartitionEnableExporterApplier(
+      final MemberId memberId,
+      final int partitionId,
+      final String exporterId,
+      final Optional<String> initializeFrom,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.exporterId = exporterId;
+    this.initializeFrom = initializeFrom;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    if (!currentGlobalConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to enable exporter, but the member '%s' does not exist in the cluster"
+                  .formatted(memberId)));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(memberId);
+    final var localPartition = localBroker == null ? null : localBroker.getPartition(partitionId);
+    if (localPartition == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to enable exporter, but the member '%s' does not have the partition '%s'"
+                  .formatted(memberId, partitionId)));
+    }
+
+    final var exportersInPartition = localPartition.config().exporting().exporters();
+
+    if (initializeFrom.isPresent()) {
+      final String otherExporterId = initializeFrom.orElseThrow();
+      final var partitionHasOtherExporter = exportersInPartition.containsKey(otherExporterId);
+      if (!partitionHasOtherExporter) {
+        return Either.left(
+            new IllegalStateException(
+                "Expected to enable exporter and initialize from exporter '%s', but the partition '%s' does not have exporter '%s'"
+                    .formatted(otherExporterId, partitionId, otherExporterId)));
+      } else {
+        final var otherExporter = exportersInPartition.get(otherExporterId);
+        if (otherExporter.state() == State.DISABLED) {
+          return Either.left(
+              new IllegalStateException(
+                  "Expected to enable exporter and initialize from exporter '%s', but the exporter '%s' is disabled"
+                      .formatted(otherExporterId, otherExporterId)));
+        }
+      }
+    }
+
+    final var partitionHasExporter = exportersInPartition.containsKey(exporterId);
+
+    if (partitionHasExporter && exportersInPartition.get(exporterId).state() == State.ENABLED) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to enable exporter, but the exporter '%s' is already enabled"
+                  .formatted(exporterId)));
+    }
+
+    if (partitionHasExporter) {
+      // Increment by one when re-enabling the exporter so that the ExporterDirector can verify
+      // whether the runtime state has the latest state. This is useful when the operation is
+      // retried or if there was restart without a snapshot after a sequence of disable, enable
+      // operations.
+      metadataVersionToUpdate = exportersInPartition.get(exporterId).metadataVersion() + 1;
+    } else {
+      metadataVersionToUpdate = 1;
+    }
+
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+
+    partitionChangeExecutor
+        .enableExporter(
+            partitionId, exporterId, metadataVersionToUpdate, initializeFrom.orElse(null))
+        .onComplete(
+            (nothing, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(
+                            memberId,
+                            broker ->
+                                broker.updatePartition(
+                                    partitionId,
+                                    partition -> partition.updateConfig(this::enableExporter))));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+
+  private DynamicPartitionConfig enableExporter(final DynamicPartitionConfig config) {
+    return config.updateExporting(
+        c ->
+            initializeFrom
+                .map(
+                    otherExporterId ->
+                        c.enableExporter(exporterId, otherExporterId, metadataVersionToUpdate))
+                .orElse(c.enableExporter(exporterId, metadataVersionToUpdate)));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionForceReconfigureApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionForceReconfigureApplier.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Collection;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation}, operating
+ * on a single named {@link PartitionGroupConfiguration} as a whole (not member-scoped). Mirrors the
+ * legacy {@code PartitionForceReconfigureApplier} in {@code changes/}, which this does not replace
+ * or modify. Force-reconfigures a partition to include only the given members in the replication
+ * group.
+ */
+public final class PartitionForceReconfigureApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final Collection<MemberId> members;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionForceReconfigureApplier(
+      final MemberId memberId,
+      final int partitionId,
+      final Collection<MemberId> members,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.members = members;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+
+    if (members.isEmpty()) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to reconfigure partition '%d' via member '%s', but the new configuration is empty"
+                  .formatted(partitionId, memberId)));
+    }
+
+    if (!members.contains(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to reconfigure partition '%d' via member '%s', but the member is not part of the new configuration '%s'"
+                  .formatted(partitionId, memberId, members)));
+    }
+
+    for (final MemberId member : members) {
+      final boolean memberIsActive =
+          currentGlobalConfiguration.hasMember(member)
+              && currentGlobalConfiguration.getMember(member).state() == BrokerState.State.ACTIVE;
+      if (!memberIsActive) {
+        return Either.left(
+            new IllegalStateException(
+                "Expected to reconfigure partition '%d' with members '%s', but member '%s' is not active."
+                    .formatted(partitionId, members, member)));
+      }
+
+      final var memberState = currentPartitionGroupConfiguration.getMember(member);
+      if (memberState == null || !memberState.hasPartition(partitionId)) {
+        return Either.left(
+            new IllegalStateException(
+                "Expected to reconfigure partition '%d' with members '%s', but member '%s' does not have the partition."
+                    .formatted(partitionId, members, member)));
+      }
+    }
+    // No need to change the state yet
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var future = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+    partitionChangeExecutor
+        .forceReconfigure(partitionId, members)
+        .onComplete(
+            (ignore, error) -> {
+              if (error != null) {
+                future.completeExceptionally(error);
+              } else {
+                future.complete(this::removePartitionFromNonMembers);
+              }
+            });
+
+    return future;
+  }
+
+  private PartitionGroupConfiguration removePartitionFromNonMembers(
+      final PartitionGroupConfiguration group) {
+    // remove this partition from the state of non-members
+    var updatedGroup = group;
+    for (final var member : group.members().keySet()) {
+      if (!members.contains(member) && group.getMember(member).hasPartition(partitionId)) {
+        updatedGroup =
+            updatedGroup.updateMember(member, broker -> broker.removePartition(partitionId));
+      }
+    }
+    return updatedGroup;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionJoinApplier.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation}, operating on a single
+ * named {@link PartitionGroupConfiguration} instead of the legacy {@code ClusterConfiguration}.
+ * Mirrors the legacy {@code PartitionJoinApplier} in {@code changes/}, which this does not replace
+ * or modify.
+ *
+ * <p>Unlike the legacy model — where every cluster member is always visible in the one flat member
+ * map, so joining a partition is always an update to an existing {@code MemberState} — a broker may
+ * not yet be a member of this particular partition group at all (e.g. its first partition
+ * assignment in this group). This applier must therefore branch between {@link
+ * PartitionGroupConfiguration#addMember} (broker not yet in this group) and {@link
+ * PartitionGroupConfiguration#updateMember} (broker already has other partitions in this group).
+ * This distinction does not exist in the legacy applier.
+ */
+public final class PartitionJoinApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final int partitionId;
+  private final int priority;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  private Map<MemberId, Integer> partitionMembersWithPriority;
+  private DynamicPartitionConfig partitionConfig;
+
+  public PartitionJoinApplier(
+      final MemberId memberId,
+      final int partitionId,
+      final int priority,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.memberId = memberId;
+    this.partitionId = partitionId;
+    this.priority = priority;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+
+    final boolean localMemberIsActiveInCluster =
+        currentGlobalConfiguration.hasMember(memberId)
+            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+    if (!localMemberIsActiveInCluster) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to join partition %d, but the local member is not an active member of the cluster"
+                  .formatted(partitionId)));
+    }
+
+    final boolean groupHasActiveMemberForPartition =
+        currentPartitionGroupConfiguration.members().values().stream()
+            .map(broker -> broker.getPartition(partitionId))
+            .filter(Objects::nonNull)
+            .anyMatch(partitionState -> partitionState.state() == PartitionState.State.ACTIVE);
+    if (!groupHasActiveMemberForPartition) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to join partition %d, but partition has no active members in the group"
+                  .formatted(partitionId)));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(memberId);
+    final var existingPartition =
+        localBroker == null ? null : localBroker.getPartition(partitionId);
+    if (existingPartition != null && existingPartition.state() != PartitionState.State.JOINING) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to join partition %d, but the local member already has the partition at state %s"
+                  .formatted(partitionId, existingPartition.state())));
+    }
+
+    // Collect the priority of each member, including the local member. This is needed to generate
+    // PartitionMetadata when joining the partition.
+    partitionMembersWithPriority = collectPriorityByMember(currentPartitionGroupConfiguration);
+
+    if (existingPartition != null) {
+      // Already JOINING: this can happen if the node restarted while applying the join operation.
+      // To ensure that the configuration change can make progress, we do not treat this as an
+      // error.
+      partitionConfig = existingPartition.config();
+      return Either.right(UnaryOperator.identity());
+    }
+
+    partitionConfig = findPartitionConfig(currentPartitionGroupConfiguration);
+    final var joiningState = PartitionState.joining(priority, partitionConfig);
+    return Either.right(
+        group ->
+            group.hasMember(memberId)
+                ? group.updateMember(
+                    memberId, broker -> broker.addPartition(partitionId, joiningState))
+                : group.addMember(
+                    memberId, BrokerPartitionState.initialize(Map.of(partitionId, joiningState))));
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
+        new CompletableActorFuture<>();
+
+    partitionChangeExecutor
+        .join(partitionId, partitionMembersWithPriority, partitionConfig)
+        .onComplete(
+            (ignored, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(
+                            memberId,
+                            broker ->
+                                broker.updatePartition(partitionId, PartitionState::toActive)));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+    return result;
+  }
+
+  private DynamicPartitionConfig findPartitionConfig(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    // Find configuration from any other member that has the same partition. We can assume that
+    // configuration is not being changed at the same time as scaling operations.
+    return currentPartitionGroupConfiguration.members().values().stream()
+        .map(broker -> broker.getPartition(partitionId))
+        .filter(Objects::nonNull)
+        .findAny()
+        .orElseThrow() // We are certain that there is another member with the same partition.
+        .config();
+  }
+
+  private Map<MemberId, Integer> collectPriorityByMember(
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    final var priorityMap = new HashMap<MemberId, Integer>();
+    currentPartitionGroupConfiguration
+        .members()
+        .forEach(
+            (memberId, broker) -> {
+              final var partitionState = broker.getPartition(partitionId);
+              if (partitionState != null) {
+                priorityMap.put(memberId, partitionState.priority());
+              }
+            });
+    priorityMap.put(this.memberId, priority);
+    return priorityMap;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionLeaveApplier.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation}, operating on a single
+ * named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code PartitionLeaveApplier} in
+ * {@code changes/}, which this does not replace or modify. A partition leave operation is executed
+ * when a member wants to stop replicating a partition; this is allowed only when the member is
+ * already replicating the partition.
+ */
+public final class PartitionLeaveApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final MemberId localMemberId;
+  private final int minimumAllowedReplicas;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionLeaveApplier(
+      final MemberId localMemberId,
+      final int partitionId,
+      final int minimumAllowedReplicas,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.localMemberId = localMemberId;
+    this.partitionId = partitionId;
+    this.minimumAllowedReplicas = minimumAllowedReplicas;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+
+    if (!currentGlobalConfiguration.hasMember(localMemberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to leave partition, but the local member does not exist in the cluster"));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(localMemberId);
+    final var localPartition = localBroker == null ? null : localBroker.getPartition(partitionId);
+    if (localPartition == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to leave partition, but the local member does not have the partition %d"
+                  .formatted(partitionId)));
+    }
+
+    if (localPartition.state() == PartitionState.State.LEAVING) {
+      // If partition state is already set to leaving, then we don't need to set it again. This can
+      // happen if the node was restarted while applying the leave operation. To ensure that the
+      // configuration change can make progress, we do not treat this as an error.
+      return Either.right(UnaryOperator.identity());
+    }
+
+    final var partitionReplicaCount =
+        currentPartitionGroupConfiguration.members().values().stream()
+            .filter(broker -> broker.hasPartition(partitionId))
+            .count();
+    if (partitionReplicaCount <= minimumAllowedReplicas) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to leave partition, but the partition %d has %d replicas but minimum allowed replicas is %d"
+                  .formatted(partitionId, partitionReplicaCount, minimumAllowedReplicas)));
+    }
+
+    return Either.right(
+        group ->
+            group.updateMember(
+                localMemberId,
+                broker -> broker.updatePartition(partitionId, PartitionState::toLeaving)));
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
+        new CompletableActorFuture<>();
+
+    partitionChangeExecutor
+        .leave(partitionId)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(
+                            localMemberId, broker -> broker.removePartition(partitionId)));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionReconfigurePriorityApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionReconfigurePriorityApplier.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code
+ * PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation},
+ * operating on a single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
+ * PartitionReconfigurePriorityApplier} in {@code changes/}, which this does not replace or modify.
+ */
+public final class PartitionReconfigurePriorityApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final int partitionId;
+  private final int newPriority;
+  private final MemberId localMemberId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionReconfigurePriorityApplier(
+      final MemberId localMemberId,
+      final int partitionId,
+      final int newPriority,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.localMemberId = localMemberId;
+    this.partitionId = partitionId;
+    this.newPriority = newPriority;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    final boolean localMemberIsActiveInCluster =
+        currentGlobalConfiguration.hasMember(localMemberId)
+            && currentGlobalConfiguration.getMember(localMemberId).state()
+                == BrokerState.State.ACTIVE;
+    if (!localMemberIsActiveInCluster) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to change priority of a partition, but the local member is not active"));
+    }
+
+    final var localBroker = currentPartitionGroupConfiguration.getMember(localMemberId);
+    final var localPartition = localBroker == null ? null : localBroker.getPartition(partitionId);
+    if (localPartition == null) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to change priority of partition %d, but the local member does not have the partition"
+                  .formatted(partitionId)));
+    }
+    if (localPartition.state() != PartitionState.State.ACTIVE) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to change priority of partition %d, but the local member has partition in state %s"
+                  .formatted(partitionId, localPartition.state())));
+    }
+
+    // Nothing to change in the state
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
+        new CompletableActorFuture<>();
+
+    partitionChangeExecutor
+        .reconfigurePriority(partitionId, newPriority)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    group ->
+                        group.updateMember(
+                            localMemberId,
+                            broker ->
+                                broker.updatePartition(
+                                    partitionId,
+                                    partitionState ->
+                                        new PartitionState(
+                                            partitionState.state(),
+                                            newPriority,
+                                            partitionState.config()))));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PostScalingApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PostScalingApplier.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code GlobalChangeOperation.PostScalingOperation}, operating on {@link
+ * GlobalConfiguration}. Mirrors the legacy {@code PostScalingApplier} in {@code changes/}, which
+ * this does not replace or modify. Finalizes a member after scaling by invoking the post-scaling
+ * callback on the {@link ClusterChangeExecutor}.
+ */
+public final class PostScalingApplier implements GlobalConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final Set<MemberId> clusterMembers;
+  private final ClusterChangeExecutor clusterChangeExecutor;
+
+  public PostScalingApplier(
+      final MemberId memberId,
+      final Set<MemberId> clusterMembers,
+      final ClusterChangeExecutor clusterChangeExecutor) {
+    this.memberId = memberId;
+    this.clusterMembers = clusterMembers;
+    this.clusterChangeExecutor = clusterChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<GlobalConfiguration>> init(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    final var currentGlobalConfiguration = currentClusterConfiguration.globalConfiguration();
+    if (!currentGlobalConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Cannot apply post-scaling operation: member "
+                  + memberId
+                  + " is not part of the current cluster configuration."));
+    }
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<GlobalConfiguration>> apply() {
+    // Post-scaling is called after all scaling operations complete.
+    // We always notify the nodeIdProvider of the final cluster size
+    // regardless of whether it was scale-up or scale-down.
+    return clusterChangeExecutor
+        .postScaling(clusterMembers)
+        .thenApply(ignore -> UnaryOperator.identity());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PreScalingApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PreScalingApplier.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code GlobalChangeOperation.PreScalingOperation}, operating on {@link
+ * GlobalConfiguration}. Mirrors the legacy {@code PreScalingApplier} in {@code changes/}, which
+ * this does not replace or modify. Prepares a member for scaling by invoking the pre-scaling
+ * callback on the {@link ClusterChangeExecutor}.
+ */
+public final class PreScalingApplier implements GlobalConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final Set<MemberId> clusterMembers;
+  private final ClusterChangeExecutor clusterChangeExecutor;
+  private int currentClusterSize;
+
+  public PreScalingApplier(
+      final MemberId memberId,
+      final Set<MemberId> clusterMembers,
+      final ClusterChangeExecutor clusterChangeExecutor) {
+    this.memberId = memberId;
+    this.clusterMembers = clusterMembers;
+    this.clusterChangeExecutor = clusterChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<GlobalConfiguration>> init(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    final var currentGlobalConfiguration = currentClusterConfiguration.globalConfiguration();
+    if (!currentGlobalConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Cannot apply pre-scaling operation: member "
+                  + memberId
+                  + " is not part of the current cluster configuration."));
+    }
+    currentClusterSize = currentClusterConfiguration.clusterSize();
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<GlobalConfiguration>> apply() {
+    return clusterChangeExecutor
+        .preScaling(currentClusterSize, clusterMembers)
+        .thenApply(ignore -> UnaryOperator.identity());
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/StartPartitionScaleUpApplier.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.Either.Left;
+import io.camunda.zeebe.util.Either.Right;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.ScaleUpOperation.StartPartitionScaleUp},
+ * operating on a single named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy
+ * {@code StartPartitionScaleUpApplier} in {@code changes/}, which this does not replace or modify.
+ * Starts the process of scaling up partitions within this group.
+ */
+public final class StartPartitionScaleUpApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
+  private final int desiredPartitionCount;
+
+  public StartPartitionScaleUpApplier(
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
+      final int desiredPartitionCount) {
+    this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
+    this.desiredPartitionCount = desiredPartitionCount;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    if (desiredPartitionCount < Protocol.START_PARTITION_ID) {
+      return new Left<>(
+          new IllegalArgumentException(
+              "Desired partition count must be greater than %d"
+                  .formatted(Protocol.START_PARTITION_ID)));
+    }
+
+    if (desiredPartitionCount > Protocol.MAXIMUM_PARTITIONS) {
+      return new Left<>(
+          new IllegalArgumentException(
+              "Desired partition count must not exceed %d".formatted(Protocol.MAXIMUM_PARTITIONS)));
+    }
+
+    if (desiredPartitionCount <= partitionCount(currentPartitionGroupConfiguration)) {
+      return new Left<>(
+          new IllegalStateException(
+              "Desired partition count (%d) must be greater than current partition count(%d)"
+                  .formatted(
+                      desiredPartitionCount, partitionCount(currentPartitionGroupConfiguration))));
+    }
+
+    if (currentPartitionGroupConfiguration.routingState().isEmpty()) {
+      return new Left<>(
+          new IllegalStateException(
+              "Routing state is not initialized yet, scaling up is not possible."));
+    }
+    final var routing = currentPartitionGroupConfiguration.routingState().get();
+    final var requestHandling = routing.requestHandling();
+
+    return switch (requestHandling) {
+      case AllPartitions(final var currentPartitionCount) -> {
+        if (desiredPartitionCount <= currentPartitionCount) {
+          yield new Left<>(
+              new IllegalStateException(
+                  "Already routing to %d partitions, can't scale down to %d"
+                      .formatted(currentPartitionCount, desiredPartitionCount)));
+        } else {
+          yield new Right<>(UnaryOperator.identity());
+        }
+      }
+      default ->
+          new Left<>(
+              new IllegalStateException(
+                  "Cannot start scaling up because request handling strategy is not stable: %s"
+                      .formatted(requestHandling)));
+    };
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>>();
+
+    partitionScalingChangeExecutor
+        .initiateScaleUp(desiredPartitionCount)
+        .onComplete(
+            (ignoredResult, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else {
+                result.complete(
+                    group -> {
+                      final var updatedRoutingState =
+                          group.routingState().map(this::updateRoutingState);
+                      return updatedRoutingState.map(group::setRoutingState).orElse(group);
+                    });
+              }
+            });
+
+    return result;
+  }
+
+  private int partitionCount(final PartitionGroupConfiguration group) {
+    return (int)
+        group.members().values().stream()
+            .flatMap(m -> m.partitions().keySet().stream())
+            .distinct()
+            .count();
+  }
+
+  private RoutingState updateRoutingState(final RoutingState routingState) {
+    return new RoutingState(
+        routingState.version() + 1,
+        updateRequestHandling(routingState.requestHandling()),
+        routingState.messageCorrelation());
+  }
+
+  private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {
+    return switch (requestHandling) {
+      case AllPartitions(final var currentPartitionCount) -> {
+        final var newPartitions =
+            IntStream.rangeClosed(currentPartitionCount + 1, desiredPartitionCount)
+                .boxed()
+                .collect(Collectors.toSet());
+        yield new ActivePartitions(currentPartitionCount, Set.of(), newPartitions);
+      }
+      case final ActivePartitions activePartitions ->
+          throw new IllegalStateException(
+              "Unexpected request handling state: %s".formatted(activePartitions));
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplier.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.UpdateIncarnationNumberOperation}, operating
+ * on a single named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy {@code
+ * UpdateIncarnationNumberApplier} in {@code changes/}, which this does not replace or modify.
+ * Increments the group's incarnation number by 1.
+ */
+public final class UpdateIncarnationNumberApplier
+    implements PartitionGroupConfigurationChangeApplier {
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    return CompletableActorFuture.completed(
+        group ->
+            new PartitionGroupConfiguration(
+                group.version(),
+                group.incarnationNumber() + 1,
+                group.members(),
+                group.routingState(),
+                group.pendingChanges(),
+                group.lastChange()));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdatePartitionDistributorConfigApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdatePartitionDistributorConfigApplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * New-model applier for {@code GlobalChangeOperation.UpdatePartitionDistributorConfigOperation},
+ * operating on {@link GlobalConfiguration}. Mirrors the legacy {@code
+ * UpdatePartitionDistributorConfigApplier} in {@code changes/}, which this does not replace or
+ * modify.
+ */
+@NullMarked
+public final class UpdatePartitionDistributorConfigApplier
+    implements GlobalConfigurationChangeApplier {
+
+  private final UpdatePartitionDistributorConfigOperation operation;
+
+  public UpdatePartitionDistributorConfigApplier(
+      final UpdatePartitionDistributorConfigOperation operation) {
+    this.operation = operation;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<GlobalConfiguration>> init(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<GlobalConfiguration>> apply() {
+    return CompletableActorFuture.completed(
+        config -> config.setPartitionDistributorConfig(operation.config()));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateRoutingStateApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateRoutingStateApplier.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code PartitionGroupOperation.UpdateRoutingState}, operating on a single
+ * named {@link PartitionGroupConfiguration} as a whole. Mirrors the legacy {@code
+ * UpdateRoutingStateApplier} in {@code changes/}, which this does not replace or modify.
+ */
+public final class UpdateRoutingStateApplier implements PartitionGroupConfigurationChangeApplier {
+
+  private final UpdateRoutingState updateRoutingState;
+  private final PartitionScalingChangeExecutor executor;
+
+  public UpdateRoutingStateApplier(
+      final UpdateRoutingState updateRoutingState, final PartitionScalingChangeExecutor executor) {
+    this.updateRoutingState = updateRoutingState;
+    this.executor = executor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      final GlobalConfiguration currentGlobalConfiguration,
+      final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
+    final var routingState =
+        updateRoutingState.routingState().isPresent()
+            ? CompletableActorFuture.completed(updateRoutingState.routingState().get())
+            : executor.getRoutingState();
+
+    return routingState.thenApply(
+        state -> {
+          if (state == null) {
+            return UnaryOperator.identity();
+          } else {
+            return (UnaryOperator<PartitionGroupConfiguration>)
+                group -> {
+                  final var previousVersion =
+                      group.routingState().map(RoutingState::version).orElse(0L);
+                  return group.setRoutingState(state.withVersion(previousVersion + 1));
+                };
+          }
+        });
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -256,6 +256,20 @@ public record CurrentClusterConfiguration(
   }
 
   /**
+   * Returns the number of members in the cluster that are not {@link BrokerState.State#LEFT} or
+   * {@link BrokerState.State#UNINITIALIZED}.
+   */
+  public int clusterSize() {
+    return (int)
+        globalConfiguration.members().entrySet().stream()
+            .filter(
+                entry ->
+                    entry.getValue().state() != BrokerState.State.LEFT
+                        && entry.getValue().state() != BrokerState.State.UNINITIALIZED)
+            .count();
+  }
+
+  /**
    * Activates the plan's current phase by copying its operations into the affected sub-config(s): a
    * {@link GlobalPhase} starts a configuration change on {@link GlobalConfiguration} only; a {@link
    * PartitionGroupParallelPhase} starts one on each named partition group only.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplierTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class AwaitModeChangeApplierTest {
+
+  private final ModeChangeExecutor modeChangeExecutor = mock(ModeChangeExecutor.class);
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+  private final PartitionGroupConfiguration group =
+      new PartitionGroupConfiguration(
+          1, 0, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
+
+  @Test
+  void shouldAlwaysAcceptOnInit() {
+    // when
+    final var result =
+        new AwaitModeChangeApplier(Mode.RECOVERING, modeChangeExecutor)
+            .init(globalConfiguration, group);
+
+    // then
+    assertThat(result).isRight();
+  }
+
+  @Test
+  void shouldExecuteAwaitModeAppliedAsNoop() {
+    // given
+    final var applier = new AwaitModeChangeApplier(Mode.PROCESSING, modeChangeExecutor);
+    when(modeChangeExecutor.awaitModeApplied(Mode.PROCESSING))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(modeChangeExecutor, times(1)).awaitModeApplied(Mode.PROCESSING);
+    Assertions.assertThat(resultingGroup).isEqualTo(group);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRedistributionCompletionApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRedistributionCompletionApplierTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSortedSet;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class AwaitRedistributionCompletionApplierTest {
+
+  private final PartitionScalingChangeExecutor executor =
+      mock(PartitionScalingChangeExecutor.class);
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+
+  private static PartitionGroupConfiguration groupWith(final Optional<RoutingState> routing) {
+    return new PartitionGroupConfiguration(
+        1, 0, Map.of(), routing, Optional.empty(), Optional.empty());
+  }
+
+  private AwaitRedistributionCompletion operationFor(final Set<Integer> partitionsToRedistribute) {
+    final SortedSet<Integer> sorted = ImmutableSortedSet.copyOf(partitionsToRedistribute);
+    return new AwaitRedistributionCompletion(MemberId.from("1"), 3, sorted);
+  }
+
+  @Test
+  void shouldRejectIfPartitionsToRedistributeIsEmpty() {
+    // when
+    final var result =
+        new AwaitRedistributionCompletionApplier(executor, operationFor(Set.of()))
+            .init(globalConfiguration, groupWith(Optional.empty()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft()).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectIfRoutingStateIsNotInitialized() {
+    // when
+    final var result =
+        new AwaitRedistributionCompletionApplier(executor, operationFor(Set.of(2, 3)))
+            .init(globalConfiguration, groupWith(Optional.empty()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Routing state is not initialized");
+  }
+
+  @Test
+  void shouldRejectIfAllPartitionsAreAlreadyActive() {
+    // given
+    final var group =
+        groupWith(Optional.of(new RoutingState(1, new AllPartitions(3), new HashMod(3))));
+
+    // when
+    final var result =
+        new AwaitRedistributionCompletionApplier(executor, operationFor(Set.of(2, 3)))
+            .init(globalConfiguration, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("All partitions are active");
+  }
+
+  @Test
+  void shouldActivatePartitionsOnCompletion() {
+    // given
+    final var group =
+        groupWith(
+            Optional.of(
+                new RoutingState(
+                    1, new ActivePartitions(1, Set.of(), Set.of(2, 3)), new HashMod(1))));
+    final var operation = operationFor(Set.of(2, 3));
+    final var applier = new AwaitRedistributionCompletionApplier(executor, operation);
+    when(executor.awaitRedistributionCompletion(eq(3), eq(Set.of(2, 3)), isNull()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfiguration, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(executor, times(1)).awaitRedistributionCompletion(eq(3), eq(Set.of(2, 3)), any());
+    final var requestHandling = resultingGroup.routingState().orElseThrow().requestHandling();
+    Assertions.assertThat(requestHandling).isEqualTo(new AllPartitions(3));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRelocationCompletionApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitRelocationCompletionApplierTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableSortedSet;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class AwaitRelocationCompletionApplierTest {
+
+  private final PartitionScalingChangeExecutor executor =
+      mock(PartitionScalingChangeExecutor.class);
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+
+  private static PartitionGroupConfiguration groupWith(final Optional<RoutingState> routing) {
+    return new PartitionGroupConfiguration(
+        1, 0, Map.of(), routing, Optional.empty(), Optional.empty());
+  }
+
+  private AwaitRelocationCompletion operationFor(final Set<Integer> partitionsToRelocate) {
+    return new AwaitRelocationCompletion(
+        MemberId.from("1"), 3, ImmutableSortedSet.copyOf(partitionsToRelocate));
+  }
+
+  @Test
+  void shouldRejectIfPartitionsToRelocateIsEmpty() {
+    // when
+    final var result =
+        new AwaitRelocationCompletionApplier(executor, operationFor(Set.of()))
+            .init(globalConfiguration, groupWith(Optional.empty()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft()).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectIfRoutingStateIsNotInitialized() {
+    // when
+    final var result =
+        new AwaitRelocationCompletionApplier(executor, operationFor(Set.of(2, 3)))
+            .init(globalConfiguration, groupWith(Optional.empty()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Routing state is not initialized");
+  }
+
+  @Test
+  void shouldAcceptAndApplyAsNoop() {
+    // given
+    final var group =
+        groupWith(Optional.of(new RoutingState(1, new AllPartitions(3), new HashMod(3))));
+    final var applier = new AwaitRelocationCompletionApplier(executor, operationFor(Set.of(2, 3)));
+
+    // when
+    final var initResult = applier.init(globalConfiguration, group);
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    assertThat(initResult).isRight();
+    Assertions.assertThat(resultingGroup).isEqualTo(group);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/DeleteHistoryApplierTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class DeleteHistoryApplierTest {
+
+  private final ClusterChangeExecutor clusterChangeExecutor = mock(ClusterChangeExecutor.class);
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfPartitionsStillExistInGroup() {
+    // given
+    final var group =
+        groupWithMembers(
+            Map.of(
+                MemberId.from("1"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new DeleteHistoryApplier(clusterChangeExecutor).init(globalConfiguration, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("partitions still exist");
+  }
+
+  @Test
+  void shouldExecuteDeleteHistoryCallback() {
+    // given
+    final var group = groupWithMembers(Map.of());
+    final var applier = new DeleteHistoryApplier(clusterChangeExecutor);
+    when(clusterChangeExecutor.deleteHistory()).thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfiguration, group);
+    assertThat(initResult).isRight();
+    applier.apply().join();
+
+    // then
+    verify(clusterChangeExecutor, times(1)).deleteHistory();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/EnterRecoveryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/EnterRecoveryApplierTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class EnterRecoveryApplierTest {
+
+  private final ModeChangeExecutor modeChangeExecutor = mock(ModeChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+
+  private final GlobalConfiguration globalConfigurationWithLocalMemberActive =
+      globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberIsNotActiveInCluster() {
+    // given
+    final var group =
+        groupWithMembers(
+            Map.of(
+                memberId, new BrokerPartitionState(1, Instant.EPOCH, Map.of(), Mode.PROCESSING)));
+
+    // when
+    final var result =
+        new EnterRecoveryApplier(memberId, modeChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not an active member of the cluster");
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberIsNotPartOfGroup() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new EnterRecoveryApplier(memberId, modeChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not part of this partition group");
+  }
+
+  @Test
+  void shouldExecuteEnterRecoveryCallbackAndSetModeRecovering() {
+    // given
+    final var group =
+        groupWithMembers(
+            Map.of(
+                memberId, new BrokerPartitionState(1, Instant.EPOCH, Map.of(), Mode.PROCESSING)));
+    final var applier = new EnterRecoveryApplier(memberId, modeChangeExecutor);
+    when(modeChangeExecutor.enterRecovery()).thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfigurationWithLocalMemberActive, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(modeChangeExecutor, times(1)).enterRecovery();
+    Assertions.assertThat(resultingGroup.getMember(memberId).mode()).isEqualTo(Mode.RECOVERING);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplierTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class ExitRecoveryApplierTest {
+
+  private final ModeChangeExecutor modeChangeExecutor = mock(ModeChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+
+  private final GlobalConfiguration globalConfigurationWithLocalMemberActive =
+      globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberIsNotActiveInCluster() {
+    // given
+    final var group =
+        groupWithMembers(
+            Map.of(
+                memberId, new BrokerPartitionState(1, Instant.EPOCH, Map.of(), Mode.RECOVERING)));
+
+    // when
+    final var result =
+        new ExitRecoveryApplier(memberId, modeChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not an active member of the cluster");
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberIsNotPartOfGroup() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new ExitRecoveryApplier(memberId, modeChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not part of this partition group");
+  }
+
+  @Test
+  void shouldExecuteExitRecoveryCallbackAndSetModeProcessing() {
+    // given
+    final var group =
+        groupWithMembers(
+            Map.of(
+                memberId, new BrokerPartitionState(1, Instant.EPOCH, Map.of(), Mode.RECOVERING)));
+    final var applier = new ExitRecoveryApplier(memberId, modeChangeExecutor);
+    when(modeChangeExecutor.exitRecovery()).thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfigurationWithLocalMemberActive, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(modeChangeExecutor, times(1)).exitRecovery();
+    Assertions.assertThat(resultingGroup.getMember(memberId).mode()).isEqualTo(Mode.PROCESSING);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplierTest.java
@@ -81,6 +81,24 @@ final class MemberLeaveApplierTest {
   }
 
   @Test
+  void shouldRejectLeaveIfMemberIsAlreadyLeft() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(
+            Map.of(memberId, BrokerState.initializeAsActive().setState(State.LEFT)));
+    final var applier = new MemberLeaveApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig, Map.of()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already in state LEFT");
+  }
+
+  @Test
   void shouldRejectLeaveIfMemberStillHasPartitions() {
     // given
     final var initialConfig =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplierTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class MemberLeaveApplierTest {
+
+  private final MemberId memberId = MemberId.from("1");
+  private final NoopClusterMembershipChangeExecutor clusterMembershipChangeExecutor =
+      new NoopClusterMembershipChangeExecutor();
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static CurrentClusterConfiguration currentClusterConfigurationWith(
+      final GlobalConfiguration globalConfiguration,
+      final Map<String, PartitionGroupConfiguration> partitionGroups) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        partitionGroups,
+        PhasedChangeState.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectLeaveIfMemberIsNotPartOfCluster() {
+    // given
+    final var initialConfig = globalConfigurationWith(Map.of());
+    final var applier = new MemberLeaveApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig, Map.of()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not part of the cluster");
+  }
+
+  @Test
+  void shouldRejectLeaveIfMemberStillHasPartitions() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+    final var groupWithPartitions =
+        groupWithMembers(
+            Map.of(
+                memberId,
+                brokerWith(Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init())))));
+    final var applier = new MemberLeaveApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result =
+        applier.init(
+            currentClusterConfigurationWith(initialConfig, Map.of("default", groupWithPartitions)));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("still has partitions assigned");
+  }
+
+  @Test
+  void shouldRejectLeaveIfMemberHasPartitionsInAnyGroupNotJustTheFirst() {
+    // given — the member has no partitions in "groupA", but does in "groupB"; the check must not
+    // stop at the first group it happens to see
+    final var initialConfig =
+        globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+    final var groupWithoutPartitions = groupWithMembers(Map.of());
+    final var groupWithPartitions =
+        groupWithMembers(
+            Map.of(
+                memberId,
+                brokerWith(Map.of(3, PartitionState.active(1, DynamicPartitionConfig.init())))));
+    final var applier = new MemberLeaveApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result =
+        applier.init(
+            currentClusterConfigurationWith(
+                initialConfig,
+                Map.of("groupA", groupWithoutPartitions, "groupB", groupWithPartitions)));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("still has partitions assigned")
+        .hasMessageContaining("groupB");
+  }
+
+  @Test
+  void shouldMarkMemberAsLeaving() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+    final var applier = new MemberLeaveApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig, Map.of()));
+
+    // then
+    assertThat(result).isRight();
+    final var updatedConfig = result.get().apply(initialConfig);
+    Assertions.assertThat(updatedConfig.getMember(memberId).state()).isEqualTo(State.LEAVING);
+  }
+
+  @Test
+  void shouldExecuteLeaveCallback() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+    final var applier = new MemberLeaveApplier(memberId, clusterMembershipChangeExecutor);
+    final var configWithLeaving =
+        applier
+            .init(currentClusterConfigurationWith(initialConfig, Map.of()))
+            .get()
+            .apply(initialConfig);
+
+    // when
+    final var resultingConfig = applier.apply().join().apply(configWithLeaving);
+
+    // then
+    Assertions.assertThat(resultingConfig.getMember(memberId).state()).isEqualTo(State.LEFT);
+  }
+
+  @Test
+  void shouldReturnExceptionWhenRemoveBrokerFailed() {
+    // given
+    final var failingExecutor =
+        new io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor() {
+          @Override
+          public io.camunda.zeebe.scheduler.future.ActorFuture<Void> addBroker(
+              final MemberId memberId) {
+            return io.camunda.zeebe.scheduler.future.CompletableActorFuture.completed(null);
+          }
+
+          @Override
+          public io.camunda.zeebe.scheduler.future.ActorFuture<Void> removeBroker(
+              final MemberId memberId) {
+            return io.camunda.zeebe.scheduler.future.CompletableActorFuture.completedExceptionally(
+                new RuntimeException("Expected"));
+          }
+        };
+    final var applier = new MemberLeaveApplier(memberId, failingExecutor);
+
+    // when
+    final var leaveFuture = applier.apply();
+
+    // then
+    Assertions.assertThat(leaveFuture)
+        .failsWithin(java.time.Duration.ofMillis(100))
+        .withThrowableOfType(java.util.concurrent.ExecutionException.class)
+        .withCauseInstanceOf(RuntimeException.class)
+        .withMessageContaining("Expected");
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionBootstrapApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionBootstrapApplierTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionBootstrapApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  private final GlobalConfiguration globalConfigurationWithLocalMemberActive =
+      globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  private PartitionBootstrapApplier applierFor(final int partitionId) {
+    return new PartitionBootstrapApplier(
+        new PartitionBootstrapOperation(memberId, partitionId, 1, false), partitionChangeExecutor);
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberIsNotActive() {
+    // given
+    final var initialGroup = groupWithMembers(Map.of());
+
+    // when
+    final var result = applierFor(1).init(globalConfigurationWith(Map.of()), initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not active");
+  }
+
+  @Test
+  void shouldRejectIfPartitionAlreadyExistsInGroup() {
+    // given
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result = applierFor(1).init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already exists in the group");
+  }
+
+  @Test
+  void shouldRejectIfPartitionIdIsNotContiguous() {
+    // given — no existing partitions in the group, so only partition 1 is a valid next id
+    final var initialGroup = groupWithMembers(Map.of());
+
+    // when
+    final var result = applierFor(2).init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not contiguous");
+  }
+
+  @Test
+  void shouldNotFailOnInitIfAlreadyBootstrapping() {
+    // given — restart-safe retry
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                memberId, brokerWith(Map.of(1, PartitionState.bootstrapping(1, partitionConfig)))));
+
+    // when
+    final var result = applierFor(1).init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isRight();
+  }
+
+  @Test
+  void shouldAddNewMemberBootstrappingFirstPartition() {
+    // given — the local member is new to this group entirely
+    final var initialGroup = groupWithMembers(Map.of());
+
+    // when
+    final var updater =
+        applierFor(1).init(globalConfigurationWithLocalMemberActive, initialGroup).get();
+    final var resultingGroup = updater.apply(initialGroup);
+
+    // then
+    final var localPartition = resultingGroup.getMember(memberId).getPartition(1);
+    Assertions.assertThat(localPartition.state()).isEqualTo(State.BOOTSTRAPPING);
+  }
+
+  @Test
+  void shouldAddPartitionToExistingMemberOfTheGroup() {
+    // given — the local member already replicates partition 1 in this group
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var updater =
+        applierFor(2).init(globalConfigurationWithLocalMemberActive, initialGroup).get();
+    final var resultingGroup = updater.apply(initialGroup);
+
+    // then
+    final var localBroker = resultingGroup.getMember(memberId);
+    Assertions.assertThat(localBroker.getPartition(1).state()).isEqualTo(State.ACTIVE);
+    Assertions.assertThat(localBroker.getPartition(2).state()).isEqualTo(State.BOOTSTRAPPING);
+  }
+
+  @Test
+  void shouldExecuteBootstrapCallback() {
+    // given
+    final var initialGroup = groupWithMembers(Map.of());
+    final var applier = applierFor(1);
+    final var groupWithBootstrapping =
+        applier
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get()
+            .apply(initialGroup);
+    when(partitionChangeExecutor.bootstrap(anyInt(), anyInt(), any(), anyBoolean()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(groupWithBootstrapping);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).bootstrap(1, 1, partitionConfig, false);
+    Assertions.assertThat(resultingGroup.getMember(memberId).getPartition(1).state())
+        .isEqualTo(State.ACTIVE);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDeleteExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDeleteExporterApplierTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+final class PartitionDeleteExporterApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      Mockito.mock(PartitionChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+
+  private final GlobalConfiguration globalConfigurationWithMember =
+      globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfMemberDoesNotExist() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new PartitionDeleteExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not exist in the cluster");
+  }
+
+  @Test
+  void shouldRejectIfPartitionDoesNotHaveExporter() {
+    // given
+    final var config = DynamicPartitionConfig.init();
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var result =
+        new PartitionDeleteExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the exporter");
+  }
+
+  @Test
+  void shouldRejectIfExporterIsNotInConfigNotFoundState() {
+    // given — exporter is still ENABLED, not CONFIG_NOT_FOUND
+    final var config =
+        DynamicPartitionConfig.init().updateExporting(c -> c.addExporters(Set.of("exporterA")));
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var result =
+        new PartitionDeleteExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("instead of");
+  }
+
+  @Test
+  void shouldExecuteDeleteExporterCallback() {
+    // given
+    final var config =
+        DynamicPartitionConfig.init()
+            .updateExporting(c -> c.addExporters(Set.of("exporterA")))
+            .updateExporting(c -> c.withConfigNotFoundFor(Set.of("exporterA")));
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+    final var applier =
+        new PartitionDeleteExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor);
+    Mockito.when(partitionChangeExecutor.deleteExporter(1, "exporterA"))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfigurationWithMember, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    Mockito.verify(partitionChangeExecutor, Mockito.times(1)).deleteExporter(1, "exporterA");
+    Assertions.assertThat(
+            resultingGroup
+                .getMember(memberId)
+                .getPartition(1)
+                .config()
+                .exporting()
+                .exporters()
+                .containsKey("exporterA"))
+        .isFalse();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDisableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDisableExporterApplierTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionDisableExporterApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+
+  private final GlobalConfiguration globalConfigurationWithMember =
+      globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfMemberDoesNotExist() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new PartitionDisableExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not exist in the cluster");
+  }
+
+  @Test
+  void shouldRejectIfPartitionDoesNotHaveExporter() {
+    // given
+    final var config = DynamicPartitionConfig.init();
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var result =
+        new PartitionDisableExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the exporter");
+  }
+
+  @Test
+  void shouldExecuteDisableExporterCallback() {
+    // given
+    final var config =
+        DynamicPartitionConfig.init().updateExporting(c -> c.addExporters(Set.of("exporterA")));
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+    final var applier =
+        new PartitionDisableExporterApplier(memberId, 1, "exporterA", partitionChangeExecutor);
+    when(partitionChangeExecutor.disableExporter(anyInt(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfigurationWithMember, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).disableExporter(1, "exporterA");
+    final var exporterState =
+        resultingGroup
+            .getMember(memberId)
+            .getPartition(1)
+            .config()
+            .exporting()
+            .exporters()
+            .get("exporterA");
+    Assertions.assertThat(exporterState.state()).isEqualTo(State.DISABLED);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplierTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionEnableExporterApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+
+  private final GlobalConfiguration globalConfigurationWithMember =
+      globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfMemberDoesNotExist() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new PartitionEnableExporterApplier(
+                memberId, 1, "exporterA", Optional.empty(), partitionChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not exist in the cluster");
+  }
+
+  @Test
+  void shouldRejectIfMemberDoesNotHavePartition() {
+    // given
+    final var group = groupWithMembers(Map.of(memberId, brokerWith(Map.of())));
+
+    // when
+    final var result =
+        new PartitionEnableExporterApplier(
+                memberId, 1, "exporterA", Optional.empty(), partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition");
+  }
+
+  @Test
+  void shouldRejectIfExporterAlreadyEnabled() {
+    // given
+    final var config =
+        DynamicPartitionConfig.init().updateExporting(c -> c.addExporters(Set.of("exporterA")));
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var result =
+        new PartitionEnableExporterApplier(
+                memberId, 1, "exporterA", Optional.empty(), partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already enabled");
+  }
+
+  @Test
+  void shouldRejectIfInitializeFromExporterIsDisabled() {
+    // given
+    final var config =
+        DynamicPartitionConfig.init()
+            .updateExporting(c -> c.addExporters(Set.of("exporterA")))
+            .updateExporting(c -> c.disableExporter("exporterA"));
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var result =
+        new PartitionEnableExporterApplier(
+                memberId, 1, "exporterB", Optional.of("exporterA"), partitionChangeExecutor)
+            .init(globalConfigurationWithMember, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is disabled");
+  }
+
+  @Test
+  void shouldExecuteEnableExporterCallbackForNewExporter() {
+    // given
+    final var config = DynamicPartitionConfig.init();
+    final var group =
+        groupWithMembers(Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, config)))));
+    final var applier =
+        new PartitionEnableExporterApplier(
+            memberId, 1, "exporterA", Optional.empty(), partitionChangeExecutor);
+    when(partitionChangeExecutor.enableExporter(anyInt(), any(), anyLong(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfigurationWithMember, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).enableExporter(1, "exporterA", 1, null);
+    final var exporters =
+        resultingGroup.getMember(memberId).getPartition(1).config().exporting().exporters();
+    Assertions.assertThat(exporters.get("exporterA").metadataVersion()).isEqualTo(1);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionForceReconfigureApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionForceReconfigureApplierTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionForceReconfigureApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId member1 = MemberId.from("1");
+  private final MemberId member2 = MemberId.from("2");
+  private final MemberId member3 = MemberId.from("3");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfNewMembersIsEmpty() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(member1, 1, List.of(), partitionChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the new configuration is empty");
+  }
+
+  @Test
+  void shouldRejectIfApplyingMemberNotInNewConfiguration() {
+    // given
+    final var group = groupWithMembers(Map.of());
+
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(member1, 1, List.of(member2), partitionChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not part of the new configuration");
+  }
+
+  @Test
+  void shouldRejectIfAMemberIsNotActive() {
+    // given
+    final var group =
+        groupWithMembers(
+            Map.of(
+                member1,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig))),
+                member2,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+    final var globalConfig =
+        globalConfigurationWith(Map.of(member1, BrokerState.initializeAsActive()));
+
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(
+                member1, 1, List.of(member1, member2), partitionChangeExecutor)
+            .init(globalConfig, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not active");
+  }
+
+  @Test
+  void shouldRejectIfAMemberDoesNotHaveThePartition() {
+    // given
+    final var group = groupWithMembers(Map.of(member1, brokerWith(Map.of())));
+    final var globalConfig =
+        globalConfigurationWith(
+            Map.of(
+                member1, BrokerState.initializeAsActive(),
+                member2, BrokerState.initializeAsActive()));
+
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(
+                member1, 1, List.of(member1, member2), partitionChangeExecutor)
+            .init(globalConfig, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition");
+  }
+
+  @Test
+  void shouldExecuteForceReconfigureAndRemovePartitionFromNonMembers() {
+    // given — member3 currently has the partition but is not in the new configuration
+    final var group =
+        groupWithMembers(
+            Map.of(
+                member1,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig))),
+                member2,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig))),
+                member3,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+    final var globalConfig =
+        globalConfigurationWith(
+            Map.of(
+                member1, BrokerState.initializeAsActive(),
+                member2, BrokerState.initializeAsActive()));
+    final var applier =
+        new PartitionForceReconfigureApplier(
+            member1, 1, List.of(member1, member2), partitionChangeExecutor);
+    when(partitionChangeExecutor.forceReconfigure(anyInt(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfig, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).forceReconfigure(1, List.of(member1, member2));
+    Assertions.assertThat(resultingGroup.getMember(member3).hasPartition(1)).isFalse();
+    Assertions.assertThat(resultingGroup.getMember(member1).hasPartition(1)).isTrue();
+    Assertions.assertThat(resultingGroup.getMember(member2).hasPartition(1)).isTrue();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionJoinApplierTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionJoinApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId localMemberId = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  // Cluster-wide view with the local member ACTIVE — the precondition most tests exercise.
+  private final GlobalConfiguration globalConfigurationWithLocalMemberActive =
+      globalConfigurationWith(Map.of(localMemberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectJoinIfLocalMemberIsNotPartOfCluster() {
+    // given — the local member is absent from GlobalConfiguration entirely
+    final var globalConfigurationWithoutLocalMember = globalConfigurationWith(Map.of());
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithoutLocalMember, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the local member is not an active member of the cluster");
+  }
+
+  @Test
+  void shouldRejectJoinIfLocalMemberIsNotActiveInCluster() {
+    // given — the local member is part of the cluster, but not ACTIVE (e.g. still JOINING)
+    final var globalConfigurationWithJoiningMember =
+        globalConfigurationWith(
+            Map.of(localMemberId, BrokerState.uninitialized().setState(BrokerState.State.JOINING)));
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithJoiningMember, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the local member is not an active member of the cluster");
+  }
+
+  @Test
+  void shouldRejectJoinIfPartitionIsAlreadyJoined() {
+    // given — the local member is a member of the group and already hosts the partition, ACTIVE
+    final var groupWithPartitionJoined =
+        groupWithMembers(
+            Map.of(
+                localMemberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, groupWithPartitionJoined);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the local member already has the partition");
+  }
+
+  @Test
+  void shouldRejectJoinIfPartitionDoesNotHaveActiveMembersInGroup() {
+    // given — the local member is in the group, but no one hosts the partition yet
+    final var groupWithoutActiveMembers =
+        groupWithMembers(Map.of(localMemberId, brokerWith(Map.of())));
+
+    // when
+    final var result =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, groupWithoutActiveMembers);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("partition has no active members in the group");
+  }
+
+  @Test
+  void shouldInitializeStateToJoiningWhenMemberIsNewToTheGroup() {
+    // given — the local member is not yet a member of this group at all; member "2" hosts the
+    // partition already
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var updater =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get();
+    final var resultingGroup = updater.apply(initialGroup);
+
+    // then — the local member is added to the group with the partition in JOINING state
+    Assertions.assertThat(resultingGroup.hasMember(localMemberId)).isTrue();
+    final var localPartition = resultingGroup.getMember(localMemberId).getPartition(1);
+    Assertions.assertThat(localPartition.state()).isEqualTo(State.JOINING);
+    Assertions.assertThat(localPartition.priority()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldInitializeStateToJoiningWhenMemberAlreadyHasOtherPartitionsInTheGroup() {
+    // given — the local member already replicates a different partition in this group
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId,
+                brokerWith(Map.of(2, PartitionState.active(1, partitionConfig))),
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var updater =
+        new PartitionJoinApplier(localMemberId, 1, 3, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get();
+    final var resultingGroup = updater.apply(initialGroup);
+
+    // then — the new partition is added alongside the existing one
+    final var localBroker = resultingGroup.getMember(localMemberId);
+    Assertions.assertThat(localBroker.getPartition(2).state()).isEqualTo(State.ACTIVE);
+    Assertions.assertThat(localBroker.getPartition(1).state()).isEqualTo(State.JOINING);
+    Assertions.assertThat(localBroker.getPartition(1).priority()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldNotFailOnInitIfPartitionIsAlreadyJoiningLocally() {
+    // given — the local member already has the partition in JOINING state (restart-safe retry)
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId,
+                brokerWith(Map.of(1, PartitionState.joining(1, partitionConfig))),
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isRight();
+    Assertions.assertThat(
+            result.get().apply(initialGroup).getMember(localMemberId).getPartition(1).state())
+        .isEqualTo(State.JOINING);
+  }
+
+  @Test
+  void shouldExecuteJoinCallback() {
+    // given
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+    final var applier = new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor);
+    final var groupWithJoining =
+        applier
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get()
+            .apply(initialGroup);
+    when(partitionChangeExecutor.join(anyInt(), any(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(groupWithJoining);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).join(anyInt(), any(), any());
+    Assertions.assertThat(resultingGroup.getMember(localMemberId).getPartition(1).state())
+        .isEqualTo(State.ACTIVE);
+  }
+
+  @Test
+  void shouldReturnExceptionWhenJoinFailed() {
+    // given
+    when(partitionChangeExecutor.join(anyInt(), any(), any()))
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(new RuntimeException("Expected")));
+
+    // when
+    final var joinFuture =
+        new PartitionJoinApplier(localMemberId, 1, 1, partitionChangeExecutor).apply();
+
+    // then
+    Assertions.assertThat(joinFuture)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(RuntimeException.class)
+        .withMessageContaining("Expected");
+  }
+
+  @Test
+  void shouldInitializeConfigFromOtherMembers() {
+    // given
+    final var config = new DynamicPartitionConfig(ExportingConfig.init());
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(MemberId.from("2"), brokerWith(Map.of(1, PartitionState.active(1, config)))));
+
+    // when
+    final var updater =
+        new PartitionJoinApplier(localMemberId, 1, 2, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get();
+    final var resultingGroup = updater.apply(initialGroup);
+
+    // then
+    final var localPartition = resultingGroup.getMember(localMemberId).getPartition(1);
+    Assertions.assertThat(localPartition.priority()).isEqualTo(2);
+    Assertions.assertThat(localPartition.state()).isEqualTo(State.JOINING);
+    Assertions.assertThat(localPartition.config()).isEqualTo(config);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionLeaveApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionLeaveApplierTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionLeaveApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId localMemberId = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  private final GlobalConfiguration globalConfigurationWithLocalMemberActive =
+      globalConfigurationWith(Map.of(localMemberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectLeaveIfLocalMemberIsNotInCluster() {
+    // given
+    final var globalConfigurationWithoutLocalMember = globalConfigurationWith(Map.of());
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionLeaveApplier(localMemberId, 1, 0, partitionChangeExecutor)
+            .init(globalConfigurationWithoutLocalMember, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the local member does not exist in the cluster");
+  }
+
+  @Test
+  void shouldRejectLeaveIfLocalMemberDoesNotHavePartition() {
+    // given
+    final var initialGroup = groupWithMembers(Map.of(localMemberId, brokerWith(Map.of())));
+
+    // when
+    final var result =
+        new PartitionLeaveApplier(localMemberId, 1, 0, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the local member does not have the partition");
+  }
+
+  @Test
+  void shouldRejectLeaveIfReplicaCountAtMinimum() {
+    // given — only one replica of the partition, minimum allowed is 1
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionLeaveApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("minimum allowed replicas");
+  }
+
+  @Test
+  void shouldNotFailOnInitIfPartitionIsAlreadyLeaving() {
+    // given — restart-safe retry
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig).toLeaving()))));
+
+    // when
+    final var result =
+        new PartitionLeaveApplier(localMemberId, 1, 0, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isRight();
+  }
+
+  @Test
+  void shouldMarkPartitionAsLeaving() {
+    // given — two replicas, minimum allowed is 1, so leaving is allowed
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig))),
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var updater =
+        new PartitionLeaveApplier(localMemberId, 1, 1, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get();
+    final var resultingGroup = updater.apply(initialGroup);
+
+    // then
+    Assertions.assertThat(resultingGroup.getMember(localMemberId).getPartition(1).state())
+        .isEqualTo(State.LEAVING);
+  }
+
+  @Test
+  void shouldExecuteLeaveCallbackAndRemovePartition() {
+    // given
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId,
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig))),
+                MemberId.from("2"),
+                brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+    final var applier = new PartitionLeaveApplier(localMemberId, 1, 1, partitionChangeExecutor);
+    final var groupWithLeaving =
+        applier
+            .init(globalConfigurationWithLocalMemberActive, initialGroup)
+            .get()
+            .apply(initialGroup);
+    when(partitionChangeExecutor.leave(anyInt()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(groupWithLeaving);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).leave(1);
+    Assertions.assertThat(resultingGroup.getMember(localMemberId).hasPartition(1)).isFalse();
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionReconfigurePriorityApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionReconfigurePriorityApplierTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionReconfigurePriorityApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId localMemberId = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  private final GlobalConfiguration globalConfigurationWithLocalMemberActive =
+      globalConfigurationWith(Map.of(localMemberId, BrokerState.initializeAsActive()));
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static PartitionGroupConfiguration groupWithMembers(
+      final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberIsNotActiveInCluster() {
+    // given
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionReconfigurePriorityApplier(localMemberId, 1, 3, partitionChangeExecutor)
+            .init(globalConfigurationWith(Map.of()), initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the local member is not active");
+  }
+
+  @Test
+  void shouldRejectIfLocalMemberDoesNotHavePartition() {
+    // given
+    final var initialGroup = groupWithMembers(Map.of(localMemberId, brokerWith(Map.of())));
+
+    // when
+    final var result =
+        new PartitionReconfigurePriorityApplier(localMemberId, 1, 3, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition");
+  }
+
+  @Test
+  void shouldRejectIfPartitionIsNotActive() {
+    // given
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId, brokerWith(Map.of(1, PartitionState.joining(1, partitionConfig)))));
+
+    // when
+    final var result =
+        new PartitionReconfigurePriorityApplier(localMemberId, 1, 3, partitionChangeExecutor)
+            .init(globalConfigurationWithLocalMemberActive, initialGroup);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("has partition in state");
+  }
+
+  @Test
+  void shouldExecuteReconfigurePriorityCallbackAndUpdatePriority() {
+    // given
+    final var initialGroup =
+        groupWithMembers(
+            Map.of(
+                localMemberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))));
+    final var applier =
+        new PartitionReconfigurePriorityApplier(localMemberId, 1, 5, partitionChangeExecutor);
+    applier.init(globalConfigurationWithLocalMemberActive, initialGroup);
+    when(partitionChangeExecutor.reconfigurePriority(anyInt(), anyInt()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(initialGroup);
+
+    // then
+    verify(partitionChangeExecutor, times(1)).reconfigurePriority(1, 5);
+    final var localPartition = resultingGroup.getMember(localMemberId).getPartition(1);
+    Assertions.assertThat(localPartition.priority()).isEqualTo(5);
+    Assertions.assertThat(localPartition.state()).isEqualTo(PartitionState.State.ACTIVE);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PostScalingApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PostScalingApplierTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PostScalingApplierTest {
+
+  private final MemberId memberId = MemberId.from("1");
+  private final Set<MemberId> clusterMembers = Set.of(memberId, MemberId.from("2"));
+  private final ClusterChangeExecutor clusterChangeExecutor = mock(ClusterChangeExecutor.class);
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static CurrentClusterConfiguration currentClusterConfigurationWith(
+      final GlobalConfiguration globalConfiguration) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        Map.of(),
+        PhasedChangeState.empty());
+  }
+
+  @Test
+  void shouldRejectIfMemberIsNotPartOfCluster() {
+    // given
+    final var initialConfig = globalConfigurationWith(Map.of());
+    final var applier = new PostScalingApplier(memberId, clusterMembers, clusterChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not part of the current cluster configuration");
+  }
+
+  @Test
+  void shouldExecutePostScaling() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+    final var applier = new PostScalingApplier(memberId, clusterMembers, clusterChangeExecutor);
+    when(clusterChangeExecutor.postScaling(any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(currentClusterConfigurationWith(initialConfig));
+    assertThat(initResult).isRight();
+    applier.apply().join();
+
+    // then
+    verify(clusterChangeExecutor, times(1)).postScaling(clusterMembers);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PreScalingApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/PreScalingApplierTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PreScalingApplierTest {
+
+  private final MemberId memberId = MemberId.from("1");
+  private final Set<MemberId> clusterMembers = Set.of(memberId, MemberId.from("2"));
+  private final ClusterChangeExecutor clusterChangeExecutor = mock(ClusterChangeExecutor.class);
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static CurrentClusterConfiguration currentClusterConfigurationWith(
+      final GlobalConfiguration globalConfiguration) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        Map.of(),
+        PhasedChangeState.empty());
+  }
+
+  @Test
+  void shouldRejectIfMemberIsNotPartOfCluster() {
+    // given
+    final var initialConfig = globalConfigurationWith(Map.of());
+    final var applier = new PreScalingApplier(memberId, clusterMembers, clusterChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is not part of the current cluster configuration");
+  }
+
+  @Test
+  void shouldExecutePreScalingWithCurrentClusterSize() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(
+            Map.of(
+                memberId,
+                BrokerState.initializeAsActive(),
+                MemberId.from("2"),
+                BrokerState.initializeAsActive()));
+    final var applier = new PreScalingApplier(memberId, clusterMembers, clusterChangeExecutor);
+    when(clusterChangeExecutor.preScaling(anyInt(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(currentClusterConfigurationWith(initialConfig));
+    assertThat(initResult).isRight();
+    applier.apply().join();
+
+    // then
+    verify(clusterChangeExecutor, times(1)).preScaling(2, clusterMembers);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/StartPartitionScaleUpApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/StartPartitionScaleUpApplierTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class StartPartitionScaleUpApplierTest {
+
+  private final PartitionScalingChangeExecutor executor =
+      mock(PartitionScalingChangeExecutor.class);
+  private final MemberId memberId = MemberId.from("1");
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+
+  private static PartitionGroupConfiguration groupWith(
+      final Map<MemberId, BrokerPartitionState> members, final Optional<RoutingState> routing) {
+    return new PartitionGroupConfiguration(
+        1, 0, members, routing, Optional.empty(), Optional.empty());
+  }
+
+  private static BrokerPartitionState brokerWith(final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  @Test
+  void shouldRejectIfDesiredPartitionCountBelowMinimum() {
+    // when
+    final var result =
+        new StartPartitionScaleUpApplier(executor, 0)
+            .init(globalConfiguration, groupWith(Map.of(), Optional.empty()));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft()).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectIfDesiredPartitionCountNotGreaterThanCurrent() {
+    // given — the group already has partition 1
+    final var group =
+        groupWith(
+            Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.of(new RoutingState(1, new AllPartitions(1), new HashMod(1))));
+
+    // when
+    final var result =
+        new StartPartitionScaleUpApplier(executor, 1).init(globalConfiguration, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("must be greater than current partition count");
+  }
+
+  @Test
+  void shouldRejectIfRoutingStateIsNotInitialized() {
+    // given
+    final var group = groupWith(Map.of(), Optional.empty());
+
+    // when
+    final var result =
+        new StartPartitionScaleUpApplier(executor, 2).init(globalConfiguration, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Routing state is not initialized");
+  }
+
+  @Test
+  void shouldRejectIfRequestHandlingIsNotStable() {
+    // given — already mid-scale-up (ActivePartitions, not AllPartitions)
+    final var group =
+        groupWith(
+            Map.of(),
+            Optional.of(
+                new RoutingState(1, new ActivePartitions(1, Set.of(), Set.of(2)), new HashMod(1))));
+
+    // when
+    final var result =
+        new StartPartitionScaleUpApplier(executor, 3).init(globalConfiguration, group);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("not stable");
+  }
+
+  @Test
+  void shouldExecuteScaleUpAndUpdateRoutingState() {
+    // given
+    final var group =
+        groupWith(
+            Map.of(memberId, brokerWith(Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.of(new RoutingState(1, new AllPartitions(1), new HashMod(1))));
+    final var applier = new StartPartitionScaleUpApplier(executor, 3);
+    when(executor.initiateScaleUp(3)).thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var initResult = applier.init(globalConfiguration, group);
+    assertThat(initResult).isRight();
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    verify(executor, times(1)).initiateScaleUp(3);
+    final var newRoutingState = resultingGroup.routingState().orElseThrow();
+    Assertions.assertThat(newRoutingState.version()).isEqualTo(2);
+    Assertions.assertThat(newRoutingState.requestHandling())
+        .isEqualTo(new ActivePartitions(1, Set.of(), Set.of(2, 3)));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateIncarnationNumberApplierTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class UpdateIncarnationNumberApplierTest {
+
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+
+  @Test
+  void shouldIncrementIncarnationNumber() {
+    // given
+    final var group =
+        new PartitionGroupConfiguration(
+            1, 5, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
+    final var applier = new UpdateIncarnationNumberApplier();
+
+    // when
+    final var initResult = applier.init(globalConfiguration, group);
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    assertThat(initResult).isRight();
+    Assertions.assertThat(resultingGroup.incarnationNumber()).isEqualTo(6);
+    Assertions.assertThat(resultingGroup.version()).isEqualTo(1);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdatePartitionDistributorConfigApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdatePartitionDistributorConfigApplierTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class UpdatePartitionDistributorConfigApplierTest {
+
+  private final GlobalConfiguration initialConfig =
+      new GlobalConfiguration(
+          GlobalConfiguration.INITIAL_VERSION,
+          Optional.empty(),
+          Map.of(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty());
+  private final CurrentClusterConfiguration currentClusterConfiguration =
+      new CurrentClusterConfiguration(
+          CurrentClusterConfiguration.INITIAL_VERSION,
+          initialConfig,
+          Map.of(),
+          PhasedChangeState.empty());
+
+  @Test
+  void shouldUpdatePartitionDistributorConfig() {
+    // given
+    final var newConfig = new RoundRobinConfig();
+    final var operation =
+        new UpdatePartitionDistributorConfigOperation(MemberId.from("1"), newConfig);
+    final var applier = new UpdatePartitionDistributorConfigApplier(operation);
+
+    // when
+    final var initResult = applier.init(currentClusterConfiguration);
+    assertThat(initResult).isRight();
+    final var updatedConfig = applier.apply().join().apply(initialConfig);
+
+    // then
+    Assertions.assertThat(updatedConfig.partitionDistributorConfig()).contains(newConfig);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateRoutingStateApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateRoutingStateApplierTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class UpdateRoutingStateApplierTest {
+
+  private final PartitionScalingChangeExecutor executor =
+      mock(PartitionScalingChangeExecutor.class);
+  private final GlobalConfiguration globalConfiguration = GlobalConfiguration.init();
+
+  private static PartitionGroupConfiguration groupWith(final Optional<RoutingState> routing) {
+    return new PartitionGroupConfiguration(
+        1, 0, Map.of(), routing, Optional.empty(), Optional.empty());
+  }
+
+  @Test
+  void shouldUseProvidedRoutingStateAndBumpVersion() {
+    // given
+    final var group =
+        groupWith(Optional.of(new RoutingState(1, new AllPartitions(1), new HashMod(1))));
+    final var newState = new RoutingState(5, new AllPartitions(2), new HashMod(2));
+    final var operation = new UpdateRoutingState(MemberId.from("1"), Optional.of(newState));
+    final var applier = new UpdateRoutingStateApplier(operation, executor);
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    Assertions.assertThat(resultingGroup.routingState().orElseThrow().version()).isEqualTo(2);
+    Assertions.assertThat(resultingGroup.routingState().orElseThrow().requestHandling())
+        .isEqualTo(new AllPartitions(2));
+  }
+
+  @Test
+  void shouldFetchRoutingStateFromExecutorWhenNotProvided() {
+    // given
+    final var group = groupWith(Optional.empty());
+    final var fetchedState = new RoutingState(9, new AllPartitions(3), new HashMod(3));
+    when(executor.getRoutingState()).thenReturn(CompletableActorFuture.completed(fetchedState));
+    final var operation = new UpdateRoutingState(MemberId.from("1"), Optional.empty());
+    final var applier = new UpdateRoutingStateApplier(operation, executor);
+
+    // when
+    final var initResult = applier.init(globalConfiguration, group);
+    final var resultingGroup = applier.apply().join().apply(group);
+
+    // then
+    assertThat(initResult).isRight();
+    Assertions.assertThat(resultingGroup.routingState().orElseThrow().version()).isEqualTo(1);
+    Assertions.assertThat(resultingGroup.routingState().orElseThrow().requestHandling())
+        .isEqualTo(new AllPartitions(3));
+  }
+}


### PR DESCRIPTION
## Summary
- Completes the Phase 2 applier-layer work for #56018, following on from #57731 (foundation + `MemberJoinApplier`).
- Ports all remaining operations to the new-model applier layer, one operation per commit: `MemberLeaveApplier`, `PreScalingApplier`, `PostScalingApplier`, `UpdatePartitionDistributorConfigApplier`, `PartitionJoinApplier`, `PartitionLeaveApplier`, `PartitionBootstrapApplier`, `PartitionReconfigurePriorityApplier`, `PartitionForceReconfigureApplier`, `PartitionEnableExporterApplier`, `PartitionDisableExporterApplier`, `PartitionDeleteExporterApplier`, `StartPartitionScaleUpApplier`, `AwaitRedistributionCompletionApplier`, `AwaitRelocationCompletionApplier`, `UpdateRoutingStateApplier`, `UpdateIncarnationNumberApplier`, `DeleteHistoryApplier`, `EnterRecoveryApplier`, `ExitRecoveryApplier`, `AwaitModeChangeApplier`.
- No existing production behavior changes: legacy appliers and gossip remain untouched; new appliers are unit-tested only, not yet wired into production.
- With this PR, the new applier layer's sealed-switch dispatch tables (`GlobalConfigurationChangeAppliersImpl`, `PartitionGroupConfigurationChangeAppliersImpl`) become exhaustive — no more `default -> throw UnsupportedOperationException` placeholders.

closes #57717