### PR TITLE
build: reduce parallelism in AWS OS ITs

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -30,6 +30,12 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
 
+# Prevent concurrent runs of this workflow from stacking additional load on the
+# shared AWS OpenSearch clusters used by the integration-tests matrix below.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   TEST_OWNER: '@camunda/core-features'
 
@@ -91,6 +97,12 @@ jobs:
       TEST_OWNER: ${{ matrix.owner }}
     strategy:
       fail-fast: false
+      # Cap concurrent matrix jobs: all groups for a given os_version share one
+      # AWS OpenSearch cluster, and running all 5 at once overloads it (cluster
+      # event queue timeouts, search_phase_execution_exception, and jobs hanging
+      # until the job timeout). This is a nightly/manual job, so trading some
+      # wall-clock time for reliability is an acceptable tradeoff.
+      max-parallel: 2
       matrix:
         os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
         group:

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -91,7 +91,7 @@ jobs:
     permissions:
       contents: read
       actions: write
-    timeout-minutes: 180
+    timeout-minutes: 360
     runs-on: ${{ matrix.runs-on }}
     env:
       TEST_OWNER: ${{ matrix.owner }}

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -102,7 +102,7 @@ jobs:
       # event queue timeouts, search_phase_execution_exception, and jobs hanging
       # until the job timeout). This is a nightly/manual job, so trading some
       # wall-clock time for reliability is an acceptable tradeoff.
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
         group:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

he AWS OS integration test matrix runs multiple groups against a shared
OpenSearch cluster per os_version. Running all 5 groups concurrently was
overloading the cluster, causing event queue timeouts, 
search_phase_execution_exception errors, and jobs hanging until timeout.

Last run:
https://github.com/camunda/camunda/actions/runs/29411933569

With this PR, 2 additional jobs got green for the first time in a very long while:
<img width="321" height="337" alt="image" src="https://github.com/user-attachments/assets/09b62c89-2675-46b1-bd41-2b534bd53b19" />

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
