### PR TITLE
Cluster admin suppor in OIDC

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverter.java
@@ -10,10 +10,12 @@ package io.camunda.authentication.clusteradmin;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.model.CamundaAuthentication;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 /**
- * Converts a cluster-admin {@link Authentication} into a {@link CamundaAuthentication} with only
- * the configured username.
+ * Converts a cluster-admin {@link Authentication} into a membership-free {@link
+ * CamundaAuthentication} carrying only the principal name — a client id for OIDC bearer principals
+ * ({@link JwtAuthenticationToken}, client_credentials has no username) or a username for Basic.
  *
  * <p>Registered ahead of CSL's DB-backed converter so cluster-admin principals do not pick up DB
  * memberships on name collision. It only claims authentications marked with {@link
@@ -35,7 +37,13 @@ public final class ClusterAdminAuthenticationConverter
 
   @Override
   public CamundaAuthentication convert(final Authentication authentication) {
-    // Username only; groups/roles/tenants deliberately left empty (no MembershipPort lookup).
-    return CamundaAuthentication.of(builder -> builder.user(authentication.getName()));
+    // Build the principal from its name alone — no group/role/tenant lookup (that isolation is the
+    // whole point of this converter). The builder takes either a user or a client id, not both:
+    // a bearer token is an OIDC client (client_credentials, no username), so it becomes a client
+    // id; a Basic login is a user.
+    final String name = authentication.getName();
+    return authentication instanceof JwtAuthenticationToken
+        ? CamundaAuthentication.of(builder -> builder.clientId(name))
+        : CamundaAuthentication.of(builder -> builder.user(name));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminClaim.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminClaim.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+/**
+ * A generic OIDC access-token claim matcher for cluster-admin authorization: a client is granted
+ * cluster-admin access when the token's claim {@code name} matches {@code value}.
+ *
+ * <p>Intentionally duplicated from {@code io.camunda.configuration.ClusterAdminClaim} — {@code
+ * authentication} cannot depend on {@code configuration} (see {@code ClusterAdminUser} for the same
+ * constraint), so this module binds {@code camunda.security.cluster-admin.oidc.claims}
+ * independently. Keep the two in sync.
+ *
+ * @param name the claim name (a JSONPath into the token claims)
+ * @param value the value the claim must equal (scalar) or contain (list)
+ */
+public record ClusterAdminClaim(String name, String value) {}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminConverterConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminConverterConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Registers {@link ClusterAdminAuthenticationConverter} method-agnostically, so it is present for
+ * whichever cluster-admin chain is active — the Basic chain ({@link
+ * ClusterAdminSecurityConfiguration}, {@code @ConditionalOnAuthenticationMethod(BASIC)}) or the
+ * OIDC chain ({@link ClusterAdminOidcSecurityConfiguration},
+ * {@code @ConditionalOnAuthenticationMethod(OIDC)}).
+ *
+ * <p>Registers this converter for OIDC too.
+ *
+ * <p>Without it, a matched cluster-admin bearer token could fall through to CSL's DB-backed
+ * membership converter and inherit memberships from a colliding DB principal.
+ *
+ * <p>This converter only handles principals with {@link
+ * ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY}, so it is inactive when the
+ * cluster-admin chain is disabled.
+ */
+@Configuration
+public class ClusterAdminConverterConfiguration {
+
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  public CamundaAuthenticationConverter<Authentication> clusterAdminAuthenticationConverter() {
+    return new ClusterAdminAuthenticationConverter();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import io.camunda.security.core.auth.MappingRuleMatcher;
+import io.camunda.security.core.auth.MappingRuleMatcher.MappingRule;
+import io.camunda.security.core.oidc.OidcGroupsExtractor;
+import io.camunda.security.core.oidc.OidcPrincipalLoader;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Grants {@link ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY} to a validated bearer
+ * token when it matches a configured cluster-admin OIDC claim: client id, group, or name/value.
+ *
+ * <p>The resulting {@link JwtAuthenticationToken} is named after the resolved client id, or the
+ * token subject if unavailable, so {@code ClusterAdminAuthenticationConverter} creates a
+ * client-based principal.
+ */
+public final class ClusterAdminJwtAuthenticationConverter
+    implements Converter<Jwt, AbstractAuthenticationToken> {
+
+  private static final Collection<GrantedAuthority> CLUSTER_ADMIN_AUTHORITIES =
+      List.of(
+          new SimpleGrantedAuthority(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY));
+
+  private final Set<String> clients;
+  private final Set<String> groups;
+  private final List<MappingRule> claimRules;
+  private final OidcPrincipalLoader principalLoader;
+  private final OidcGroupsExtractor groupsExtractor;
+
+  public ClusterAdminJwtAuthenticationConverter(
+      final ClusterAdminOidcProperties properties,
+      final String clientIdClaim,
+      final String groupsClaim) {
+    clients = Set.copyOf(properties.clients());
+    groups = Set.copyOf(properties.groups());
+    claimRules =
+        properties.claims().stream()
+            .map(claim -> (MappingRule) new ClaimRule(claim.name(), claim.value()))
+            .toList();
+    principalLoader = new OidcPrincipalLoader(null, clientIdClaim);
+    groupsExtractor = new OidcGroupsExtractor(groupsClaim);
+  }
+
+  @Override
+  public AbstractAuthenticationToken convert(final Jwt jwt) {
+    final Map<String, Object> claims = jwt.getClaims();
+    final String clientId = principalLoader.load(claims).clientId();
+    final boolean isClusterAdmin =
+        matchesClient(clientId) || matchesGroup(claims) || matchesClaim(claims);
+
+    final String name = clientId != null ? clientId : jwt.getSubject();
+    final Collection<GrantedAuthority> authorities =
+        isClusterAdmin ? CLUSTER_ADMIN_AUTHORITIES : List.of();
+    return new JwtAuthenticationToken(jwt, authorities, name);
+  }
+
+  private boolean matchesClient(final String clientId) {
+    return clientId != null && clients.contains(clientId);
+  }
+
+  private boolean matchesGroup(final Map<String, Object> claims) {
+    if (groups.isEmpty()) {
+      return false;
+    }
+    final List<String> tokenGroups = groupsExtractor.extract(claims);
+    return tokenGroups != null && tokenGroups.stream().anyMatch(groups::contains);
+  }
+
+  private boolean matchesClaim(final Map<String, Object> claims) {
+    return !claimRules.isEmpty()
+        && MappingRuleMatcher.matchingRules(claimRules.stream(), claims).findAny().isPresent();
+  }
+
+  /**
+   * Adapts a configured {@link ClusterAdminClaim} to CSL's {@link MappingRule} matcher contract.
+   */
+  private record ClaimRule(String claimName, String claimValue) implements MappingRule {
+    @Override
+    public String mappingRuleId() {
+      return claimName;
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcProperties.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcProperties.java
@@ -8,6 +8,8 @@
 package io.camunda.authentication.clusteradmin;
 
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
@@ -18,6 +20,8 @@ import org.springframework.core.env.Environment;
  * full cluster-admin access.
  */
 public final class ClusterAdminOidcProperties {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterAdminOidcProperties.class);
 
   private static final String PREFIX = "camunda.security.cluster-admin.oidc";
   private static final String CLIENTS_PROPERTY = PREFIX + ".clients";
@@ -55,6 +59,21 @@ public final class ClusterAdminOidcProperties {
     final List<ClusterAdminClaim> claims =
         binder.bind(CLAIMS_PROPERTY, Bindable.listOf(ClusterAdminClaim.class)).orElse(List.of());
     validate(clients, groups, claims, clientIdClaim, groupsClaim);
+    // Empty config is legitimate (a deployment may run OIDC without cluster-admin yet), but the
+    // chain is always active under OIDC and denies every token with no matchers — WARN so the
+    // resulting lockout is visible rather than silently shipping an unreachable cluster-admin API.
+    if (clients.isEmpty() && groups.isEmpty() && claims.isEmpty()) {
+      LOG.warn(
+          "No cluster-admin OIDC matchers configured ({}.*): every bearer token will be denied on "
+              + "/cluster/v2/**. Configure at least one client, group, or claim to grant "
+              + "cluster-admin access.",
+          PREFIX);
+    } else {
+      LOG.info(
+          "Loaded {} cluster-admin OIDC matcher(s) from {}.*",
+          clients.size() + groups.size() + claims.size(),
+          PREFIX);
+    }
     return new ClusterAdminOidcProperties(clients, groups, claims);
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcProperties.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcProperties.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import java.util.List;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Binds and validates the cluster-admin OIDC authorization config from {@code
+ * camunda.security.cluster-admin.oidc.*}: the client ids, groups, and generic claims that grant
+ * full cluster-admin access.
+ */
+public final class ClusterAdminOidcProperties {
+
+  private static final String PREFIX = "camunda.security.cluster-admin.oidc";
+  private static final String CLIENTS_PROPERTY = PREFIX + ".clients";
+  private static final String GROUPS_PROPERTY = PREFIX + ".groups";
+  private static final String CLAIMS_PROPERTY = PREFIX + ".claims";
+
+  private final List<String> clients;
+  private final List<String> groups;
+  private final List<ClusterAdminClaim> claims;
+
+  private ClusterAdminOidcProperties(
+      final List<String> clients, final List<String> groups, final List<ClusterAdminClaim> claims) {
+    this.clients = clients;
+    this.groups = groups;
+    this.claims = claims;
+  }
+
+  /**
+   * Binds the cluster-admin OIDC config and validates it against the provider's claim names.
+   *
+   * @param environment the Spring {@link Environment} to bind from
+   * @param clientIdClaim the provider's configured {@code client-id-claim} (may be {@code null})
+   * @param groupsClaim the provider's configured {@code groups-claim} (may be {@code null})
+   * @return the validated config
+   * @throws IllegalStateException on a blank client/group, a claim with a blank name/value, or a
+   *     client/group matcher whose required provider claim name is not configured
+   */
+  public static ClusterAdminOidcProperties loadAndValidate(
+      final Environment environment, final String clientIdClaim, final String groupsClaim) {
+    final Binder binder = Binder.get(environment);
+    final List<String> clients =
+        binder.bind(CLIENTS_PROPERTY, Bindable.listOf(String.class)).orElse(List.of());
+    final List<String> groups =
+        binder.bind(GROUPS_PROPERTY, Bindable.listOf(String.class)).orElse(List.of());
+    final List<ClusterAdminClaim> claims =
+        binder.bind(CLAIMS_PROPERTY, Bindable.listOf(ClusterAdminClaim.class)).orElse(List.of());
+    validate(clients, groups, claims, clientIdClaim, groupsClaim);
+    return new ClusterAdminOidcProperties(clients, groups, claims);
+  }
+
+  public List<String> clients() {
+    return clients;
+  }
+
+  public List<String> groups() {
+    return groups;
+  }
+
+  public List<ClusterAdminClaim> claims() {
+    return claims;
+  }
+
+  private static void validate(
+      final List<String> clients,
+      final List<String> groups,
+      final List<ClusterAdminClaim> claims,
+      final String clientIdClaim,
+      final String groupsClaim) {
+    rejectBlankEntry(clients, CLIENTS_PROPERTY, "client id");
+    rejectBlankEntry(groups, GROUPS_PROPERTY, "group");
+    validateClaims(claims);
+    if (!clients.isEmpty() && isBlank(clientIdClaim)) {
+      throw new IllegalStateException(
+          "%s is configured but the OIDC provider has no 'client-id-claim'; client-id matching can never fire"
+              .formatted(CLIENTS_PROPERTY));
+    }
+    if (!groups.isEmpty() && isBlank(groupsClaim)) {
+      throw new IllegalStateException(
+          "%s is configured but the OIDC provider has no 'groups-claim'; group matching can never fire"
+              .formatted(GROUPS_PROPERTY));
+    }
+  }
+
+  private static void rejectBlankEntry(
+      final List<String> values, final String property, final String label) {
+    for (final String value : values) {
+      if (isBlank(value)) {
+        throw new IllegalStateException("%s contains a blank %s".formatted(property, label));
+      }
+    }
+  }
+
+  private static void validateClaims(final List<ClusterAdminClaim> claims) {
+    for (final ClusterAdminClaim claim : claims) {
+      if (isBlank(claim.name())) {
+        throw new IllegalStateException(
+            "%s contains an entry with a blank or missing 'name'".formatted(CLAIMS_PROPERTY));
+      }
+      if (isBlank(claim.value())) {
+        throw new IllegalStateException(
+            "%s entry '%s' has a blank or missing 'value'"
+                .formatted(CLAIMS_PROPERTY, claim.name()));
+      }
+    }
+  }
+
+  private static boolean isBlank(final String value) {
+    return value == null || value.isBlank();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  * deployment runs OIDC ({@code @ConditionalOnAuthenticationMethod(OIDC)}). Bearer tokens are
  * validated against the deployment's default OIDC provider (the shared {@link JwtDecoder}); a token
  * is granted access only if it matches a configured cluster-admin client id, group, or claim (see
- * {@link ClusterAdminJwtAuthenticationConverter}). See camunda/camunda#57708.
+ * {@link ClusterAdminJwtAuthenticationConverter}).
  *
  * <p>This chain and the Basic chain ({@link ClusterAdminSecurityConfiguration}) are mutually
  * exclusive by deployment method — only one is instantiated.
@@ -65,12 +65,24 @@ public class ClusterAdminOidcSecurityConfiguration {
     final ClusterAdminOidcProperties oidcProperties =
         ClusterAdminOidcProperties.loadAndValidate(
             environment, oidc.getClientIdClaim(), oidc.getGroupsClaim());
-    LOG.info(
-        "Loaded {} cluster-admin OIDC matcher(s) for {}",
+    final int matcherCount =
         oidcProperties.clients().size()
             + oidcProperties.groups().size()
-            + oidcProperties.claims().size(),
-        CLUSTER_ADMIN_API_PATTERN);
+            + oidcProperties.claims().size();
+    if (matcherCount == 0) {
+      // The chain is always active under OIDC; with no matchers it denies every token, so make the
+      // resulting lockout visible rather than silently shipping an unreachable cluster-admin API.
+      LOG.warn(
+          "No cluster-admin OIDC matchers configured (camunda.security.cluster-admin.oidc.*): every "
+              + "bearer token will be denied on {}. Configure at least one client, group, or claim "
+              + "to grant cluster-admin access.",
+          CLUSTER_ADMIN_API_PATTERN);
+    } else {
+      LOG.info(
+          "Loaded {} cluster-admin OIDC matcher(s) for {}",
+          matcherCount,
+          CLUSTER_ADMIN_API_PATTERN);
+    }
 
     final var jwtAuthenticationConverter =
         new ClusterAdminJwtAuthenticationConverter(

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -15,8 +15,6 @@ import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.security.spring.handler.AuthFailureHandler;
 import io.camunda.security.spring.security.SecurityFilterChainSupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -49,9 +47,6 @@ public class ClusterAdminOidcSecurityConfiguration {
 
   private static final String CLUSTER_ADMIN_API_PATTERN = "/cluster/v2/**";
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ClusterAdminOidcSecurityConfiguration.class);
-
   @Bean
   @Order(ORDER_WEBAPP_API)
   public SecurityFilterChain clusterAdminOidcSecurityFilterChain(
@@ -65,24 +60,6 @@ public class ClusterAdminOidcSecurityConfiguration {
     final ClusterAdminOidcProperties oidcProperties =
         ClusterAdminOidcProperties.loadAndValidate(
             environment, oidc.getClientIdClaim(), oidc.getGroupsClaim());
-    final int matcherCount =
-        oidcProperties.clients().size()
-            + oidcProperties.groups().size()
-            + oidcProperties.claims().size();
-    if (matcherCount == 0) {
-      // The chain is always active under OIDC; with no matchers it denies every token, so make the
-      // resulting lockout visible rather than silently shipping an unreachable cluster-admin API.
-      LOG.warn(
-          "No cluster-admin OIDC matchers configured (camunda.security.cluster-admin.oidc.*): every "
-              + "bearer token will be denied on {}. Configure at least one client, group, or claim "
-              + "to grant cluster-admin access.",
-          CLUSTER_ADMIN_API_PATTERN);
-    } else {
-      LOG.info(
-          "Loaded {} cluster-admin OIDC matcher(s) for {}",
-          matcherCount,
-          CLUSTER_ADMIN_API_PATTERN);
-    }
 
     final var jwtAuthenticationConverter =
         new ClusterAdminJwtAuthenticationConverter(

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -77,6 +77,7 @@ public class ClusterAdminOidcSecurityConfiguration {
                         jwt ->
                             jwt.decoder(jwtDecoder)
                                 .jwtAuthenticationConverter(jwtAuthenticationConverter))
+                    .authenticationEntryPoint(authFailureHandler)
                     .accessDeniedHandler(authFailureHandler))
         .cors(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 
 /**
@@ -37,6 +38,10 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  *
  * <p>This chain and the Basic chain ({@link ClusterAdminSecurityConfiguration}) are mutually
  * exclusive by deployment method — only one is instantiated.
+ *
+ * <p><strong>Statelessness:</strong> the chain binds a request-scoped, session-free {@link
+ * RequestAttributeSecurityContextRepository} explicitly and never creates a session, so an existing
+ * webapp OIDC session cookie cannot authenticate {@code /cluster/v2/**} without a bearer token.
  */
 @Configuration
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
@@ -87,9 +92,13 @@ public class ClusterAdminOidcSecurityConfiguration {
         .cors(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .anonymous(AbstractHttpConfigurer::disable)
-        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+        // Request-scoped, session-free context repository bound explicitly so a webapp OIDC session
+        // cookie can't authenticate this bearer chain. Explicit is required: STATELESS installs one
+        // only if none was set already (SessionManagementConfigurer's `if (repo == null)` guard).
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .securityContext(
+            sc -> sc.securityContextRepository(new RequestAttributeSecurityContextRepository()))
         .requestCache(cache -> cache.requestCache(new NullRequestCache()))
-        // Stateless bearer chain: no session, no CSRF surface, so disable it explicitly.
         .csrf(AbstractHttpConfigurer::disable);
 
     SecurityFilterChainSupport.setupSecureHeaders(http, properties.getHttpHeaders());

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_WEBAPP_API;
+
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
+import io.camunda.security.spring.handler.AuthFailureHandler;
+import io.camunda.security.spring.security.SecurityFilterChainSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.savedrequest.NullRequestCache;
+
+/**
+ * OIDC security chain for the cluster-admin API under {@code /cluster/v2/**}, active only when the
+ * deployment runs OIDC ({@code @ConditionalOnAuthenticationMethod(OIDC)}). Bearer tokens are
+ * validated against the deployment's default OIDC provider (the shared {@link JwtDecoder}); a token
+ * is granted access only if it matches a configured cluster-admin client id, group, or claim (see
+ * {@link ClusterAdminJwtAuthenticationConverter}). See camunda/camunda#57708.
+ *
+ * <p>This chain and the Basic chain ({@link ClusterAdminSecurityConfiguration}) are mutually
+ * exclusive by deployment method — only one is instantiated.
+ */
+@Configuration
+@ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
+public class ClusterAdminOidcSecurityConfiguration {
+
+  private static final String CLUSTER_ADMIN_API_PATTERN = "/cluster/v2/**";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ClusterAdminOidcSecurityConfiguration.class);
+
+  @Bean
+  @Order(ORDER_WEBAPP_API)
+  public SecurityFilterChain clusterAdminOidcSecurityFilterChain(
+      final HttpSecurity http,
+      final Environment environment,
+      final JwtDecoder jwtDecoder,
+      final AuthFailureHandler authFailureHandler,
+      final CamundaSecurityLibraryProperties properties)
+      throws Exception {
+    final OidcConfiguration oidc = properties.getAuthentication().getOidc();
+    final ClusterAdminOidcProperties oidcProperties =
+        ClusterAdminOidcProperties.loadAndValidate(
+            environment, oidc.getClientIdClaim(), oidc.getGroupsClaim());
+    LOG.info(
+        "Loaded {} cluster-admin OIDC matcher(s) for {}",
+        oidcProperties.clients().size()
+            + oidcProperties.groups().size()
+            + oidcProperties.claims().size(),
+        CLUSTER_ADMIN_API_PATTERN);
+
+    final var jwtAuthenticationConverter =
+        new ClusterAdminJwtAuthenticationConverter(
+            oidcProperties, oidc.getClientIdClaim(), oidc.getGroupsClaim());
+
+    http.securityMatcher(CLUSTER_ADMIN_API_PATTERN)
+        .authorizeHttpRequests(
+            auth ->
+                auth.anyRequest()
+                    .hasAuthority(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))
+        .oauth2ResourceServer(
+            oauth2 ->
+                oauth2
+                    .jwt(
+                        jwt ->
+                            jwt.decoder(jwtDecoder)
+                                .jwtAuthenticationConverter(jwtAuthenticationConverter))
+                    .accessDeniedHandler(authFailureHandler))
+        .cors(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .anonymous(AbstractHttpConfigurer::disable)
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+        .requestCache(cache -> cache.requestCache(new NullRequestCache()))
+        // Stateless bearer chain: no session, no CSRF surface, so disable it explicitly.
+        .csrf(AbstractHttpConfigurer::disable);
+
+    SecurityFilterChainSupport.setupSecureHeaders(http, properties.getHttpHeaders());
+
+    return http.build();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.clusteradmin;
 
 import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_WEBAPP_API;
 
-import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
@@ -19,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -29,7 +27,6 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -56,12 +53,11 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  * NullSecurityContextRepository} explicitly and never creates a session, so an existing webapp
  * session cookie can never authenticate {@code /cluster/v2/**}.
  *
- * <p><strong>#57708 (OIDC):</strong> {@code cluster-admin.basic} and {@code cluster-admin.oidc} are
- * independent sibling config trees, so either mechanism can authenticate this chain based on the
- * {@code Authorization} header scheme. For #57708, OIDC should be added to the same chain through a
- * parallel {@code .oauth2ResourceServer(...)} block gated by {@code cluster-admin.oidc} presence,
- * not through a second same-path chain, since Spring only dispatches to one matching chain per
- * request.
+ * <p><strong>OIDC:</strong> handled by separate {@link ClusterAdminOidcSecurityConfiguration},
+ * gated by {@code @ConditionalOnAuthenticationMethod(OIDC)}.
+ *
+ * <p>The Basic and OIDC chains are mutually exclusive by deployment method, so both can target
+ * {@code /cluster/v2/**} without conflict.
  */
 @Configuration
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
@@ -144,20 +140,5 @@ public class ClusterAdminSecurityConfiguration {
     final var authenticationProvider = new DaoAuthenticationProvider(userDetailsManager);
     authenticationProvider.setPasswordEncoder(passwordEncoder);
     return new ProviderManager(authenticationProvider);
-  }
-
-  /**
-   * Converter that prevents cluster-admin principals from going through the DB-backed membership
-   * path. It runs before CSL's DB converter and only claims authentications marked with {@link
-   * #CLUSTER_ADMIN_AUTHORITY}, letting all others fall through.
-   *
-   * <p>It is registered now to prevent a future cross-chain leak on {@code /cluster/v2/**}: without
-   * it, a cluster-admin token could be treated as a DB user and inherit that user's groups, roles,
-   * and tenants on name collision.
-   */
-  @Bean
-  @Order(Ordered.HIGHEST_PRECEDENCE)
-  public CamundaAuthenticationConverter<Authentication> clusterAdminAuthenticationConverter() {
-    return new ClusterAdminAuthenticationConverter();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -39,8 +39,7 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  *
  * <p>All paths under {@code /cluster/v2/**} require HTTP Basic authentication against the
  * statically configured cluster-admin users ({@code camunda.security.cluster-admin.basic.users}).
- * Registered only under the basic authentication method (the default); under OIDC this chain is not
- * present and cluster-admin OIDC support follows in #57708.
+ * Registered only under the basic authentication method (the default)
  *
  * <p><strong>Isolation:</strong> keep the cluster-admin user store isolated as a plain in-memory
  * object behind a dedicated, parent-less {@link ProviderManager} for this chain. Do not expose it

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.authentication.config;
 
+import io.camunda.authentication.clusteradmin.ClusterAdminConverterConfiguration;
+import io.camunda.authentication.clusteradmin.ClusterAdminOidcSecurityConfiguration;
 import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
 import io.camunda.authentication.config.spi.AdminUserPresenceAdapter;
 import io.camunda.authentication.config.spi.AuthorizationRepositoryAdapter;
@@ -69,6 +71,8 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
   SaasCspModeCompatibility.class,
   PhysicalTenantSecurityConfiguration.class,
   ClusterAdminSecurityConfiguration.class,
+  ClusterAdminOidcSecurityConfiguration.class,
+  ClusterAdminConverterConfiguration.class,
 })
 public class WebSecurityConfig {
 

--- a/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverterTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import static io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+class ClusterAdminJwtAuthenticationConverterTest {
+
+  private static final String CLIENT_ID_CLAIM = "client_id";
+  private static final String GROUPS_CLAIM = "groups";
+
+  private static ClusterAdminJwtAuthenticationConverter converter(final Environment env) {
+    final var props =
+        ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM);
+    return new ClusterAdminJwtAuthenticationConverter(props, CLIENT_ID_CLAIM, GROUPS_CLAIM);
+  }
+
+  @Test
+  void shouldGrantWhenClientIdMatches() {
+    // given
+    final var converter = converter(env(Map.of("...oidc.clients[0]", "ops-client")));
+
+    // when
+    final JwtAuthenticationToken token =
+        (JwtAuthenticationToken) converter.convert(jwt(Map.of("client_id", "ops-client")));
+
+    // then
+    assertThat(authorities(token)).contains(CLUSTER_ADMIN_AUTHORITY);
+    assertThat(token.getName()).isEqualTo("ops-client");
+  }
+
+  @Test
+  void shouldGrantWhenGroupMatches() {
+    // given
+    final var converter = converter(env(Map.of("...oidc.groups[0]", "camunda-admins")));
+
+    // when — group matches even though the client id is not configured
+    final JwtAuthenticationToken token =
+        (JwtAuthenticationToken)
+            converter.convert(
+                jwt(Map.of("client_id", "some-client", "groups", List.of("camunda-admins"))));
+
+    // then
+    assertThat(authorities(token)).contains(CLUSTER_ADMIN_AUTHORITY);
+    assertThat(token.getName()).isEqualTo("some-client");
+  }
+
+  @Test
+  void shouldGrantWhenGenericClaimMatches() {
+    // given
+    final var converter =
+        converter(
+            env(
+                Map.of(
+                    "...oidc.claims[0].name", "roles",
+                    "...oidc.claims[0].value", "cluster-admin")));
+
+    // when
+    final JwtAuthenticationToken token =
+        (JwtAuthenticationToken)
+            converter.convert(jwt(Map.of("sub", "svc", "roles", List.of("cluster-admin"))));
+
+    // then
+    assertThat(authorities(token)).contains(CLUSTER_ADMIN_AUTHORITY);
+  }
+
+  @Test
+  void shouldNotGrantWhenNothingMatches() {
+    // given
+    final var converter =
+        converter(
+            env(
+                Map.of(
+                    "...oidc.clients[0]", "ops-client",
+                    "...oidc.groups[0]", "camunda-admins",
+                    "...oidc.claims[0].name", "roles",
+                    "...oidc.claims[0].value", "cluster-admin")));
+
+    // when — a valid token that matches no configured client, group, or claim
+    final JwtAuthenticationToken token =
+        (JwtAuthenticationToken)
+            converter.convert(
+                jwt(
+                    Map.of(
+                        "client_id", "stranger",
+                        "groups", List.of("other-group"),
+                        "roles", List.of("reader"))));
+
+    // then — authenticated, but no cluster-admin authority (chain will 403, not 401)
+    assertThat(token.isAuthenticated()).isTrue();
+    assertThat(authorities(token)).doesNotContain(CLUSTER_ADMIN_AUTHORITY);
+    assertThat(token.getName()).isEqualTo("stranger");
+  }
+
+  @Test
+  void shouldFallBackToSubjectForNameWhenNoClientId() {
+    // given — only a generic claim matcher; no client-id-claim needed
+    final var converter =
+        converter(
+            env(
+                Map.of(
+                    "...oidc.claims[0].name", "roles",
+                    "...oidc.claims[0].value", "cluster-admin")));
+
+    // when — token has no client_id claim, matched by group-less generic claim
+    final JwtAuthenticationToken token =
+        (JwtAuthenticationToken)
+            converter.convert(
+                jwt(Map.of("sub", "service-account", "roles", List.of("cluster-admin"))));
+
+    // then — name falls back to the subject
+    assertThat(authorities(token)).contains(CLUSTER_ADMIN_AUTHORITY);
+    assertThat(token.getName()).isEqualTo("service-account");
+  }
+
+  @Test
+  void shouldGrantWhenClientIdClaimUnconfiguredAndGenericClaimMatches() {
+    // given — only a generic claim matcher and NO provider client-id-claim (null); the converter
+    // must not fail trying to read a client id it was never told how to find
+    final var props =
+        ClusterAdminOidcProperties.loadAndValidate(
+            env(
+                Map.of(
+                    "...oidc.claims[0].name", "roles",
+                    "...oidc.claims[0].value", "cluster-admin")),
+            null,
+            GROUPS_CLAIM);
+    final var converter = new ClusterAdminJwtAuthenticationConverter(props, null, GROUPS_CLAIM);
+
+    // when — a token carrying the matching generic claim but no client id
+    final JwtAuthenticationToken token =
+        (JwtAuthenticationToken)
+            converter.convert(jwt(Map.of("sub", "svc", "roles", List.of("cluster-admin"))));
+
+    // then — granted via the generic claim; name falls back to the subject
+    assertThat(authorities(token)).contains(CLUSTER_ADMIN_AUTHORITY);
+    assertThat(token.getName()).isEqualTo("svc");
+  }
+
+  private static List<String> authorities(final JwtAuthenticationToken token) {
+    return token.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
+  }
+
+  private static Jwt jwt(final Map<String, Object> claims) {
+    return Jwt.withTokenValue("token").header("alg", "none").claims(c -> c.putAll(claims)).build();
+  }
+
+  private static MockEnvironment env(final Map<String, String> properties) {
+    final MockEnvironment env = new MockEnvironment();
+    properties.forEach(
+        (k, v) -> env.setProperty(k.replace("...", "camunda.security.cluster-admin."), v));
+    return env;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcPropertiesTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcPropertiesTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class ClusterAdminOidcPropertiesTest {
+
+  private static final String CLIENT_ID_CLAIM = "client_id";
+  private static final String GROUPS_CLAIM = "groups";
+
+  @Test
+  void shouldReturnEmptyWhenNoOidcConfigured() {
+    // given
+    final var env = env(Map.of());
+
+    // when
+    final var props =
+        ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM);
+
+    // then
+    assertThat(props.clients()).isEmpty();
+    assertThat(props.groups()).isEmpty();
+    assertThat(props.claims()).isEmpty();
+  }
+
+  @Test
+  void shouldBindClientsGroupsAndClaims() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.oidc.clients[0]", "ops-client",
+                "camunda.security.cluster-admin.oidc.groups[0]", "camunda-admins",
+                "camunda.security.cluster-admin.oidc.claims[0].name", "roles",
+                "camunda.security.cluster-admin.oidc.claims[0].value", "cluster-admin"));
+
+    // when
+    final var props =
+        ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM);
+
+    // then
+    assertThat(props.clients()).containsExactly("ops-client");
+    assertThat(props.groups()).containsExactly("camunda-admins");
+    assertThat(props.claims()).containsExactly(new ClusterAdminClaim("roles", "cluster-admin"));
+  }
+
+  @Test
+  void shouldRejectBlankClient() {
+    // given
+    final var env = env(Map.of("camunda.security.cluster-admin.oidc.clients[0]", " "));
+
+    // when/then
+    assertThatThrownBy(
+            () -> ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("blank client");
+  }
+
+  @Test
+  void shouldRejectBlankGroup() {
+    // given
+    final var env = env(Map.of("camunda.security.cluster-admin.oidc.groups[0]", " "));
+
+    // when/then
+    assertThatThrownBy(
+            () -> ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("blank group");
+  }
+
+  @Test
+  void shouldRejectBlankClaimName() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.oidc.claims[0].name", " ",
+                "camunda.security.cluster-admin.oidc.claims[0].value", "x"));
+
+    // when/then
+    assertThatThrownBy(
+            () -> ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("name");
+  }
+
+  @Test
+  void shouldRejectBlankClaimValue() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.oidc.claims[0].name", "roles",
+                "camunda.security.cluster-admin.oidc.claims[0].value", ""));
+
+    // when/then
+    assertThatThrownBy(
+            () -> ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, GROUPS_CLAIM))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("value")
+        .hasMessageContaining("roles");
+  }
+
+  @Test
+  void shouldRejectClientsWhenProviderHasNoClientIdClaim() {
+    // given — clients configured but the provider's client-id-claim is unset
+    final var env = env(Map.of("camunda.security.cluster-admin.oidc.clients[0]", "ops-client"));
+
+    // when/then
+    assertThatThrownBy(() -> ClusterAdminOidcProperties.loadAndValidate(env, null, GROUPS_CLAIM))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("client-id-claim");
+  }
+
+  @Test
+  void shouldRejectGroupsWhenProviderHasNoGroupsClaim() {
+    // given — groups configured but the provider's groups-claim is unset
+    final var env = env(Map.of("camunda.security.cluster-admin.oidc.groups[0]", "camunda-admins"));
+
+    // when/then
+    assertThatThrownBy(() -> ClusterAdminOidcProperties.loadAndValidate(env, CLIENT_ID_CLAIM, null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("groups-claim");
+  }
+
+  @Test
+  void shouldAllowGenericClaimsWithoutProviderClaimPreconditions() {
+    // given — only generic claims; no client/group matchers, so provider claim names are irrelevant
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.oidc.claims[0].name", "roles",
+                "camunda.security.cluster-admin.oidc.claims[0].value", "cluster-admin"));
+
+    // when
+    final var props = ClusterAdminOidcProperties.loadAndValidate(env, null, null);
+
+    // then
+    assertThat(props.claims()).containsExactly(new ClusterAdminClaim("roles", "cluster-admin"));
+  }
+
+  @Test
+  void shouldAcceptDuplicateClaimNamesWithDifferentValues() {
+    // given — the same claim name with two values is a legitimate "matches admin OR ops" config,
+    // unlike a unique key; it must not be rejected
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.oidc.claims[0].name", "roles",
+                "camunda.security.cluster-admin.oidc.claims[0].value", "admin",
+                "camunda.security.cluster-admin.oidc.claims[1].name", "roles",
+                "camunda.security.cluster-admin.oidc.claims[1].value", "ops"));
+
+    // when
+    final var props = ClusterAdminOidcProperties.loadAndValidate(env, null, null);
+
+    // then
+    assertThat(props.claims())
+        .containsExactly(
+            new ClusterAdminClaim("roles", "admin"), new ClusterAdminClaim("roles", "ops"));
+  }
+
+  private static MockEnvironment env(final Map<String, String> properties) {
+    final MockEnvironment env = new MockEnvironment();
+    properties.forEach(env::setProperty);
+    return env;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
+import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Cross-chain isolation ("leak trap") for the OIDC cluster-admin chain: an existing webapp OIDC
+ * session cookie must not authenticate {@code /cluster/v2/**}, which is bearer-only. The mock
+ * {@code JwtDecoder} from {@link WebSecurityOidcTestContext} is never invoked here — the request
+ * carries a session, not a token — so no real OIDC provider is needed.
+ */
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+    })
+public class ClusterAdminOidcChainIsolationTest extends AbstractWebSecurityConfigTest {
+
+  @Test
+  public void shouldRejectWebappSessionOnClusterAdminEndpoint() {
+    // given — a session carrying an authenticated principal that even holds the cluster-admin
+    // authority, as a webapp OIDC login would leave behind (browser then holds the JSESSIONID)
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+    securityContext.setAuthentication(
+        UsernamePasswordAuthenticationToken.authenticated(
+            "webapp-user",
+            null,
+            List.of(
+                new SimpleGrantedAuthority(
+                    ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))));
+    final MockHttpSession session = new MockHttpSession();
+    session.setAttribute(
+        HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+
+    // when — that session cookie is presented to the cluster-admin API with no bearer token
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .session(session)
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then — the bearer chain binds a request-scoped, session-free context repository, so the
+    // session is ignored and the request is unauthenticated despite the cookie
+    assertThat(result)
+        .as("a webapp session cookie must not authenticate the OIDC cluster-admin API")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.clusteradmin.ClusterAdminAuthenticationConverter;
+import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.model.CamundaAuthentication;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+/**
+ * Verifies the OIDC leak-prevention path: a cluster-admin bearer token with {@link
+ * ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY} is claimed first by {@link
+ * ClusterAdminAuthenticationConverter}, which runs at {@code HIGHEST_PRECEDENCE} and returns a
+ * client principal with no memberships.
+ *
+ * <p>This prevents the token from falling through to CSL's {@code OidcTokenAuthenticationConverter}
+ * and inheriting memberships from a colliding principal. If the converter is missing from OIDC or
+ * ordered incorrectly, CSL would claim the token first and the test would fail.
+ */
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+    })
+class ClusterAdminOidcConverterWiringTest extends AbstractWebSecurityConfigTest {
+
+  private static final String COLLISION = "collision";
+
+  // The real, @Order-sorted converter chain (the mocked CamundaAuthenticationProvider from the base
+  // class does not affect these beans).
+  @Autowired private List<CamundaAuthenticationConverter<Authentication>> converters;
+
+  @Test
+  void shouldResolveClusterAdminBearerWithClusterAdminConverterFirst() {
+    // given — a bearer principal that matched the cluster-admin chain (carries the marker
+    // authority), whose client id could collide with a DB principal
+    final Jwt jwt = Jwt.withTokenValue("token").header("alg", "none").subject(COLLISION).build();
+    final Authentication principal =
+        new JwtAuthenticationToken(
+            jwt,
+            List.of(
+                new SimpleGrantedAuthority(
+                    ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY)),
+            COLLISION);
+
+    // when — the converter chain dispatches to the first converter that claims the principal
+    final CamundaAuthenticationConverter<Authentication> winner =
+        converters.stream().filter(c -> c.supports(principal)).findFirst().orElseThrow();
+
+    // then — it is our converter (registered under OIDC and ordered ahead of CSL's DB-backed one),
+    // and it produces a membership-free client principal — no colliding memberships attached
+    assertThat(winner).isInstanceOf(ClusterAdminAuthenticationConverter.class);
+
+    final CamundaAuthentication authentication = winner.convert(principal);
+    assertThat(authentication.authenticatedClientId()).isEqualTo(COLLISION);
+    assertThat(authentication.authenticatedUsername()).isNull();
+    assertThat(authentication.authenticatedGroupIds()).isEmpty();
+    assertThat(authentication.authenticatedRoleIds()).isEmpty();
+    assertThat(authentication.authenticatedTenantIds()).isEmpty();
+    assertThat(authentication.authenticatedMappingRuleIds()).isEmpty();
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/ClusterAdmin.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterAdmin.java
@@ -17,11 +17,22 @@ public class ClusterAdmin {
   /** HTTP Basic authentication for the cluster-admin API. */
   @NestedConfigurationProperty private ClusterAdminBasic basic = new ClusterAdminBasic();
 
+  /** OIDC authorization for the cluster-admin API. */
+  @NestedConfigurationProperty private ClusterAdminOidc oidc = new ClusterAdminOidc();
+
   public ClusterAdminBasic getBasic() {
     return basic;
   }
 
   public void setBasic(final ClusterAdminBasic basic) {
     this.basic = basic == null ? new ClusterAdminBasic() : basic;
+  }
+
+  public ClusterAdminOidc getOidc() {
+    return oidc;
+  }
+
+  public void setOidc(final ClusterAdminOidc oidc) {
+    this.oidc = oidc == null ? new ClusterAdminOidc() : oidc;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/ClusterAdminClaim.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterAdminClaim.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+/**
+ * A generic OIDC access-token claim matcher for cluster-admin authorization: a client is granted
+ * cluster-admin access when the token's claim {@code name} matches {@code value}.
+ *
+ * @param name the claim name (a JSONPath into the token claims)
+ * @param value the value the claim must equal (scalar) or contain (list)
+ */
+public record ClusterAdminClaim(String name, String value) {}

--- a/configuration/src/main/java/io/camunda/configuration/ClusterAdminOidc.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterAdminOidc.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.util.List;
+
+/**
+ * OIDC authorization for the cluster-admin API. Bearer tokens are validated against the default
+ * cluster-wide OIDC provider ({@code camunda.security.authentication.oidc.*}); a client is granted
+ * full cluster-admin access when the token matches any configured client id, group, or claim.
+ */
+public class ClusterAdminOidc {
+
+  /** Client ids granted cluster-admin, matched against the provider's {@code client-id-claim}. */
+  private List<String> clients = List.of();
+
+  /** Groups granted cluster-admin, matched against the provider's {@code groups-claim}. */
+  private List<String> groups = List.of();
+
+  /** Generic {@code name}/{@code value} claim matchers granting cluster-admin. */
+  private List<ClusterAdminClaim> claims = List.of();
+
+  public List<String> getClients() {
+    return clients;
+  }
+
+  public void setClients(final List<String> clients) {
+    this.clients = clients == null ? List.of() : clients;
+  }
+
+  public List<String> getGroups() {
+    return groups;
+  }
+
+  public void setGroups(final List<String> groups) {
+    this.groups = groups == null ? List.of() : groups;
+  }
+
+  public List<ClusterAdminClaim> getClaims() {
+    return claims;
+  }
+
+  public void setClaims(final List<ClusterAdminClaim> claims) {
+    this.claims = claims == null ? List.of() : claims;
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -72,6 +72,9 @@ license.key
 security.authentication.method
 security.authentication.unprotected-api
 security.cluster-admin.basic.users
+security.cluster-admin.oidc.claims
+security.cluster-admin.oidc.clients
+security.cluster-admin.oidc.groups
 security.csrf
 security.csrf.cookie-http-only
 security.csrf.enabled

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Full-stack integration tests for the cluster-admin OIDC chain ({@code /cluster/v2/**}), exercised
+ * against the real {@link io.camunda.zeebe.gateway.rest.controller.DummyClusterTopologyController}
+ * endpoint with raw bearer tokens minted by Keycloak.
+ */
+@Testcontainers
+@ZeebeIntegration
+public class ClusterAdminOidcAuthenticationIT {
+
+  private static final String PATH_CLUSTER_TOPOLOGY = "cluster/v2/topology";
+  private static final String REALM = "camunda";
+
+  // The provider claims the cluster-admin matcher reads from the token. "azp" is set by Keycloak to
+  // the authorized party (the client id) on every client_credentials token, so no mapper is needed
+  // for the client-id dimension.
+  private static final String CLIENT_ID_CLAIM = "azp";
+  private static final String GROUPS_CLAIM = "groups";
+  private static final String GENERIC_CLAIM_NAME = "roles";
+  private static final String GENERIC_CLAIM_VALUE = "cluster-admin";
+
+  // Keycloak clients. Each grants cluster-admin via exactly one dimension, plus one that matches
+  // nothing.
+  private static final String CLIENT_BY_ID = "cluster-admin-by-id";
+  private static final String CLIENT_BY_GROUP = "cluster-admin-by-group";
+  private static final String CLIENT_BY_CLAIM = "cluster-admin-by-claim";
+  private static final String CLIENT_STRANGER = "stranger";
+  private static final String CONFIGURED_GROUP = "cluster-admins";
+
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+
+  @Container
+  private static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  // purgeAfterEach = false: the tests only issue HTTP calls to the dummy endpoint and create no
+  // process data, so the inter-test cluster purge is unnecessary
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withAuthenticatedAccess()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC)
+          .withSecurityConfig(
+              c -> {
+                c.getAuthentication().getOidc().setClientIdClaim(CLIENT_ID_CLAIM);
+                c.getAuthentication().getOidc().setGroupsClaim(GROUPS_CLAIM);
+              })
+          // Only these three matchers grant cluster-admin; CLIENT_STRANGER matches none of them.
+          .withProperty("camunda.security.cluster-admin.oidc.clients[0]", CLIENT_BY_ID)
+          .withProperty("camunda.security.cluster-admin.oidc.groups[0]", CONFIGURED_GROUP)
+          .withProperty("camunda.security.cluster-admin.oidc.claims[0].name", GENERIC_CLAIM_NAME)
+          .withProperty("camunda.security.cluster-admin.oidc.claims[0].value", GENERIC_CLAIM_VALUE);
+
+  @BeforeAll
+  static void setUp() {
+    configureRealm();
+    final String issuerUri = KEYCLOAK.getAuthServerUrl() + "/realms/" + REALM;
+    // redirectUri is a mandatory field of Spring's OAuth2 client registration even in
+    // resource-server mode where no browser redirect occurs.
+    BROKER.withSecurityConfig(
+        c -> {
+          c.getAuthentication().getOidc().setIssuerUri(issuerUri);
+          c.getAuthentication().getOidc().setClientId("example");
+          c.getAuthentication().getOidc().setRedirectUri("example.com");
+        });
+    BROKER.start();
+
+    Awaitility.await("cluster-admin endpoint is serving")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(get(clusterUri(), null).statusCode())
+                    .isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED));
+  }
+
+  @Test
+  void shouldAllowWhenClientIdMatches() throws Exception {
+    // when — a valid token whose client id (azp) matches the configured cluster-admin client
+    final HttpResponse<String> response = get(clusterUri(), bearer(accessToken(CLIENT_BY_ID)));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  @Test
+  void shouldAllowWhenGroupMatches() throws Exception {
+    // when — a token carrying the configured group
+    final HttpResponse<String> response = get(clusterUri(), bearer(accessToken(CLIENT_BY_GROUP)));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  @Test
+  void shouldAllowWhenGenericClaimMatches() throws Exception {
+    // when — a token carrying the configured generic claim; neither its client id nor group matches
+    final HttpResponse<String> response = get(clusterUri(), bearer(accessToken(CLIENT_BY_CLAIM)));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  @Test
+  void shouldForbidValidTokenThatMatchesNothing() throws Exception {
+    // when — a valid token that matches no configured client, group, or claim
+    final HttpResponse<String> response = get(clusterUri(), bearer(accessToken(CLIENT_STRANGER)));
+
+    // then — authenticated, but without ROLE_CLUSTER_ADMIN the chain denies with 403
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
+  }
+
+  @Test
+  void shouldRejectMissingToken() throws Exception {
+    // when
+    final HttpResponse<String> response = get(clusterUri(), null);
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldRejectMalformedToken() throws Exception {
+    // when
+    final HttpResponse<String> response = get(clusterUri(), "Bearer not-a-valid-jwt");
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  private static void configureRealm() {
+    final RealmRepresentation realm = new RealmRepresentation();
+    realm.setRealm(REALM);
+    realm.setEnabled(true);
+    realm.setClients(
+        List.of(
+            client(CLIENT_BY_ID),
+            client(CLIENT_BY_GROUP, hardcodedClaim(GROUPS_CLAIM, CONFIGURED_GROUP)),
+            client(CLIENT_BY_CLAIM, hardcodedClaim(GENERIC_CLAIM_NAME, GENERIC_CLAIM_VALUE)),
+            client(CLIENT_STRANGER)));
+    try (final var admin = KEYCLOAK.getKeycloakAdminClient()) {
+      admin.realms().create(realm);
+    }
+  }
+
+  private static ClientRepresentation client(
+      final String clientId, final ProtocolMapperRepresentation... mappers) {
+    final ClientRepresentation client = new ClientRepresentation();
+    client.setClientId(clientId);
+    client.setEnabled(true);
+    client.setClientAuthenticatorType("client-secret");
+    client.setSecret(clientId); // secret == clientId, mirroring the shared Keycloak test fixtures
+    client.setServiceAccountsEnabled(true); // enables the client_credentials grant
+    if (mappers.length > 0) {
+      client.setProtocolMappers(List.of(mappers));
+    }
+    return client;
+  }
+
+  private static ProtocolMapperRepresentation hardcodedClaim(
+      final String claimName, final String claimValue) {
+    final ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+    mapper.setName(claimName + "-mapper");
+    mapper.setProtocol("openid-connect");
+    mapper.setProtocolMapper("oidc-hardcoded-claim-mapper");
+    mapper.setConfig(
+        Map.of(
+            "claim.name", claimName,
+            "claim.value", claimValue,
+            "jsonType.label", "String",
+            "access.token.claim", "true",
+            "id.token.claim", "true"));
+    return mapper;
+  }
+
+  private static String accessToken(final String clientId) throws Exception {
+    final String form =
+        "grant_type=client_credentials&client_id=" + clientId + "&client_secret=" + clientId;
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(
+                URI.create(
+                    KEYCLOAK.getAuthServerUrl()
+                        + "/realms/"
+                        + REALM
+                        + "/protocol/openid-connect/token"))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .POST(HttpRequest.BodyPublishers.ofString(form))
+            .build();
+    final HttpResponse<String> response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+    return JSON.readTree(response.body()).get("access_token").asText();
+  }
+
+  private static HttpResponse<String> get(final URI uri, final String authorizationHeader)
+      throws Exception {
+    final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uri).GET();
+    if (authorizationHeader != null) {
+      builder.header("Authorization", authorizationHeader);
+    }
+    return HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static String bearer(final String token) {
+    return "Bearer " + token;
+  }
+
+  // The cluster-admin API is cluster-wide and always addressed at the gateway root. restAddress()
+  // is that root (no physical-tenant prefix), so no stripping is needed here.
+  private static URI clusterUri() {
+    return BROKER.restAddress().resolve(PATH_CLUSTER_TOPOLOGY);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
@@ -140,8 +140,12 @@ public class ClusterAdminOidcAuthenticationIT {
     // when — a valid token that matches no configured client, group, or claim
     final HttpResponse<String> response = get(clusterUri(), bearer(accessToken(CLIENT_STRANGER)));
 
-    // then — authenticated, but without ROLE_CLUSTER_ADMIN the chain denies with 403
+    // then — authenticated, but without ROLE_CLUSTER_ADMIN the chain denies with 403 via the
+    // shared AuthFailureHandler (problem+json), matching the Basic chain
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_FORBIDDEN);
+    assertThat(response.headers().firstValue("content-type").orElse(""))
+        .contains("application/problem+json");
+    assertThat(response.body()).contains("\"status\":403");
   }
 
   @Test
@@ -149,8 +153,11 @@ public class ClusterAdminOidcAuthenticationIT {
     // when
     final HttpResponse<String> response = get(clusterUri(), null);
 
-    // then
+    // then — 401 via the shared handler (problem+json), not the default bearer challenge
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+    assertThat(response.headers().firstValue("content-type").orElse(""))
+        .contains("application/problem+json");
+    assertThat(response.body()).contains("\"status\":401");
   }
 
   @Test
@@ -158,8 +165,11 @@ public class ClusterAdminOidcAuthenticationIT {
     // when
     final HttpResponse<String> response = get(clusterUri(), "Bearer not-a-valid-jwt");
 
-    // then
+    // then — 401 via the shared handler (problem+json), not the default bearer challenge
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+    assertThat(response.headers().firstValue("content-type").orElse(""))
+        .contains("application/problem+json");
+    assertThat(response.body()).contains("\"status\":401");
   }
 
   private static void configureRealm() {


### PR DESCRIPTION
## What

Adds OIDC authentication/authorization to the cluster-admin API (`/cluster/v2/**`), the OIDC half of #54898 Slice 4. Under `method=oidc`, a `client_credentials` bearer token is validated against the deployment's default OIDC provider (the shared `JwtDecoder`) and granted **full** cluster-admin access when it matches a configured client id, group, or generic claim. 

Config surface (sibling of the existing `basic` tree from #57707):

```yaml
camunda.security.cluster-admin.oidc:
  clients: [ "<clientId>" ]        # matched via the provider's client-id-claim
  groups:  [ "<groupId>" ]         # matched via the provider's groups-claim
  claims:  [ { name: roles, value: cluster-admin } ]
```

## How

- A dedicated `@ConditionalOnAuthenticationMethod(OIDC)` chain on `/cluster/v2/**`; mutually exclusive with the Basic chain, so only one is ever instantiated.
- A `JwtAuthenticationConverter` grants `ROLE_CLUSTER_ADMIN` on match; unmatched valid tokens stay authenticated with no authority ⇒ **403** (missing/invalid token ⇒ 401).
- Fail-fast config validation (blank entries; a client/group matcher without its provider claim would silently lock out the API).

## Testing

Unit tests for binding/validation and the matcher (all three dimensions, including the null `client-id-claim` edge), plus a full-stack IT driving real Keycloak tokens end-to-end: 200 (match) / 403 (valid, no match) / 401 (no/bad token).

Closes #57708
