### PR TITLE
test: fix ProcessInstanceStatisticsIT flakiness

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceStatisticsIT.java
@@ -73,17 +73,24 @@ public class ProcessInstanceStatisticsIT {
     waitForProcessInstances(
         1, f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.COMPLETED));
 
-    // when
-    final var actual =
-        camundaClient.newProcessInstanceElementStatisticsRequest(processInstanceKey).send().join();
-
-    // then
-    assertThat(actual).hasSize(2);
-
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("EndEvent", 0L, 0L, 0L, 1L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The process instance may report state=COMPLETED before the flow node instance records
+    // are updated, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics for completed process")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("EndEvent", 0L, 0L, 0L, 1L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test
@@ -94,16 +101,24 @@ public class ProcessInstanceStatisticsIT {
     waitForProcessInstances(1, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE));
     waitForUserTasks(1, processDefinitionKey);
 
-    // when
-    final var actual =
-        camundaClient.newProcessInstanceElementStatisticsRequest(processInstanceKey).send().join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("UserTask", 1L, 0L, 0L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The user task record may be indexed before the flow node instance record is updated,
+    // so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics for active process")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("UserTask", 1L, 0L, 0L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test
@@ -166,16 +181,24 @@ public class ProcessInstanceStatisticsIT {
         1,
         f -> f.processDefinitionKey(processDefinitionKey).state(ProcessInstanceState.TERMINATED));
 
-    // when
-    final var actual =
-        camundaClient.newProcessInstanceElementStatisticsRequest(processInstanceKey).send().join();
-
-    // then
-    assertThat(actual).hasSize(2);
-    assertThat(actual)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("UserTask", 0L, 1L, 0L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The process instance may report state=TERMINATED before the flow node instance records
+    // are updated, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics for canceled process")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("UserTask", 0L, 1L, 0L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test
@@ -203,16 +226,24 @@ public class ProcessInstanceStatisticsIT {
     waitForProcessInstances(2, f -> f.processDefinitionKey(processDefinitionKey).state(ACTIVE));
     waitForUserTasks(6, processDefinitionKey);
 
-    // when
-    final var actual =
-        camundaClient.newProcessInstanceElementStatisticsRequest(processInstanceKey).send().join();
-
-    // then
-    assertThat(actual)
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("UserTaskMultiInstance", 3L, 0L, 0L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The user task records may be indexed before the flow node instance records are updated,
+    // so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics for multi-instance activity")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("UserTaskMultiInstance", 3L, 0L, 0L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test
@@ -256,16 +287,25 @@ public class ProcessInstanceStatisticsIT {
                             .join()
                             .items())
                     .hasSize(3));
-    // when - then
-    assertThat(
-            camundaClient
-                .newProcessInstanceElementStatisticsRequest(processInstanceKey)
-                .send()
-                .join())
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("ScriptTaskMultiInstance", 0L, 0L, 3L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+
+    // The element instance records may be updated with the incident before the flow node
+    // instance record is, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with 3 incidents on iterations only")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("ScriptTaskMultiInstance", 0L, 0L, 3L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   @Test
@@ -305,16 +345,24 @@ public class ProcessInstanceStatisticsIT {
                             .items())
                     .hasSize(1));
 
-    // when - then
-    assertThat(
-            camundaClient
-                .newProcessInstanceElementStatisticsRequest(processInstanceKey)
-                .send()
-                .join())
-        .hasSize(2)
-        .containsExactlyInAnyOrder(
-            new ProcessElementStatisticsImpl("UserTaskMultiInstance", 0L, 0L, 1L, 0L),
-            new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L));
+    // The process instance record may report hasIncident=true before the flow node instance
+    // record is updated, so we poll the element statistics endpoint.
+    Awaitility.await("should return element statistics with incident on multi-instance body")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                // when
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceElementStatisticsRequest(processInstanceKey)
+                            .send()
+                            .join())
+                    // then
+                    .hasSize(2)
+                    .containsExactlyInAnyOrder(
+                        new ProcessElementStatisticsImpl("UserTaskMultiInstance", 0L, 0L, 1L, 0L),
+                        new ProcessElementStatisticsImpl("StartEvent", 0L, 0L, 0L, 1L)));
   }
 
   private static DeploymentEvent deployResource(


### PR DESCRIPTION
## Description

Tests wait for the process instance record to reach a terminal state `COMPLETED`/`TERMINATED`, then immediately call `newProcessInstanceElementStatisticsRequest` once with no retry.

  The statistics endpoint aggregates over flow-node-instance records `ProcessInstanceServices#elementStatistics`, a separate index from the process-instance record, updated by a different exporter/handler on its own schedule. The process-instance record can flip to its terminal state before the corresponding flow-node-instance records finish indexing, so the single follow-up assertion can read stale/partial data.

  This race was already known and handled elsewhere in the same file — `shouldGetStatisticsForIncidents` documents and polls around it.

## Reference

https://camunda.slack.com/archives/C071KP5BTHB/p1784098451825729
