### PR TITLE
fix: include only exception message in actuator response

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
@@ -50,10 +50,11 @@ public final class ExportingEndpoint {
       result.join();
       return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
     } catch (final CompletionException e) {
-      return new WebEndpointResponse<>(
-          e.getCause(), WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+      final var message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+      return new WebEndpointResponse<>(message, WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
     } catch (final Exception e) {
-      return new WebEndpointResponse<>(e, WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
+      return new WebEndpointResponse<>(
+          e.getMessage(), WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -15,7 +15,11 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.gateway.admin.exporting.ExportingControlApi;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 
@@ -77,5 +81,44 @@ final class ExportingEndpointTest {
     // then
     assertThat(endpoint.post(operation, false))
         .returns(WebEndpointResponse.STATUS_NO_CONTENT, from(WebEndpointResponse::getStatus));
+  }
+
+  @ParameterizedTest
+  @MethodSource("exceptionSource")
+  void shouldReturnResponseCorrectlyWhenExceptionIsThrown(
+      final String operation, final String message) {
+    // given
+    final var service = mock(ExportingControlApi.class);
+    final var endpoint = new ExportingEndpoint(service);
+    final var exception = new RuntimeException(message);
+
+    // when
+    when(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.failedFuture(exception));
+    when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(CompletableFuture.failedFuture(new CompletionException(exception)));
+
+    // then
+    assertThat(endpoint.post(operation, false))
+        .returns(
+            WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR, from(WebEndpointResponse::getStatus))
+        .satisfies(
+            resp -> {
+              if (message != null) {
+                assertThat(resp.getBody())
+                    .isInstanceOf(String.class)
+                    .asString()
+                    .contains(exception.getMessage());
+              } else {
+                assertThat(resp.getBody()).isNull();
+              }
+            });
+  }
+
+  private static Stream<Arguments> exceptionSource() {
+    return Stream.of(ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME)
+        .flatMap(
+            operation ->
+                Stream.of("expected error", null).map(str -> Arguments.of(operation, str)));
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -34,7 +34,6 @@ final class ExportingEndpointTest {
     // when
     when(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID)).thenThrow(new RuntimeException());
     when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID)).thenThrow(new RuntimeException());
-    when(service.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID)).thenThrow(new RuntimeException());
 
     // then
     assertThat(endpoint.post(operation, false))
@@ -54,8 +53,6 @@ final class ExportingEndpointTest {
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
     when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
-    when(service.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
-        .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
 
     // then
     assertThat(endpoint.post(operation, false))
@@ -74,8 +71,6 @@ final class ExportingEndpointTest {
     when(service.pauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.completedFuture(null));
     when(service.resumeExporting(DEFAULT_PHYSICAL_TENANT_ID))
-        .thenReturn(CompletableFuture.completedFuture(null));
-    when(service.softPauseExporting(DEFAULT_PHYSICAL_TENANT_ID))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // then


### PR DESCRIPTION
## Description
Removes exception from actuator http response as it's not serializable. Replace it with the message of the cause (if exist)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57489
