### PR TITLE
test: retry Identity container start in GatewayAuthenticationNoneIT

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
@@ -105,6 +105,12 @@ public class GatewayAuthenticationNoneIT {
           .withEnv("MANAGEMENT_HEALTH_READINESSSTATE_ENABLED", "true")
           .withNetwork(NETWORK)
           .withExposedPorts(8080, 8082)
+          // Identity's realm bootstrap can fail on its first attempt: Keycloak reports ready
+          // before its admin/realm authorization layer is fully consistent, so disabling the
+          // system clients returns HTTP 403 and the container exits. A fresh start succeeds
+          // because the realm the failed attempt already created now exists in the (still
+          // running) Keycloak, so retry the container start instead of failing the whole test.
+          .withStartupAttempts(3)
           .waitingFor(
               new HttpWaitStrategy()
                   .forPort(8082)


### PR DESCRIPTION
## Description

`GatewayAuthenticationNoneIT` is flaky: the `camunda/identity` container sometimes exits during startup with `HTTP 403` in `RealmUploadInitializationService.disableSystemClients` (Keycloak reports ready before its admin/realm authorization layer is consistent). The dead container never serves `/actuator/health/readiness`, so Testcontainers times out `@BeforeAll` and the class is marked flaky. It is the only test in `zeebe/qa/integration-tests` that boots the identity image, hence the only one affected.

## Fix

Add `withStartupAttempts(3)` (matching the other Testcontainers usages in the repo). A fresh Identity start succeeds because the realm the failed attempt already created now exists in the still-running shared Keycloak — the same reason the maven flaky-rerun passes today, but localized to the container so the test run itself stays green. A Docker `--restart` policy does not work: Testcontainers aborts `start()` before Docker would recover the container.

Test-side mitigation only; the identity image should tolerate the transient 403. Relates to #57827.
