### PR TITLE
fix: resolve RDBMS exporter configuration per physical tenant

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -157,6 +157,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -37,7 +37,6 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.Ssl;
 import io.camunda.configuration.Throttle;
 import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.Write;
 import io.camunda.configuration.Zone;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -938,17 +937,16 @@ public class BrokerBasedPropertiesOverride {
     /* Load exporter config map */
 
     // 'rdbms' is a reserved exporter: it is provisioned internally and configured through
-    // camunda.data.secondary-storage.rdbms.* (resolved per physical tenant, see #57804). Reject any
-    // attempt to configure it through the generic exporter properties — unified
-    // (camunda.data.exporters.rdbms.*) or legacy (zeebe.broker.exporters.rdbms.*) — so nothing is
-    // silently ignored. At this point the reserved exporter has not been added yet, so a non-null
-    // entry can only come from user configuration.
-    if (override.getRdbmsExporter() != null
-        || data.getExporters().containsKey(RDBMS_EXPORTER_NAME)) {
-      throw new UnifiedConfigurationException(
-          "The 'rdbms' exporter is reserved and cannot be configured through the generic exporter "
-              + "properties ('camunda.data.exporters.rdbms.*' or 'zeebe.broker.exporters.rdbms.*'). "
-              + "Configure it through 'camunda.data.secondary-storage.rdbms.*'.");
+    // camunda.data.secondary-storage.rdbms.* (resolved per physical tenant, see #57804). Any
+    // attempt to configure it through the generic exporter properties is ignored: the reserved
+    // config below always wins. Here we only handle the legacy zeebe.broker.exporters.rdbms.*
+    // entry, which was copied into 'override' from the legacy properties and is about to be
+    // overwritten by the reserved config; warn so the ignored config is not silent. The unified
+    // camunda.data.exporters.rdbms.* entry lives in camunda.data.exporters and is warned about +
+    // dropped in populateFromExporters instead. At this point the reserved exporter has not been
+    // added yet, so a non-null entry can only come from user configuration.
+    if (override.getRdbmsExporter() != null) {
+      warnReservedRdbmsExporter("zeebe.broker.exporters.rdbms.*");
     }
 
     final ExporterCfg exporter = new ExporterCfg();
@@ -1132,8 +1130,28 @@ public class BrokerBasedPropertiesOverride {
       LOGGER.warn(warningMessage);
     }
 
+    final boolean rdbmsReserved =
+        camunda.getData().getSecondaryStorage().getType() == SecondaryStorageType.rdbms;
     exporters.forEach(
-        (name, exporter) -> override.getExporters().put(name, exporter.toExporterCfg()));
+        (name, exporter) -> {
+          // The reserved 'rdbms' exporter is provisioned from
+          // camunda.data.secondary-storage.rdbms.* in populateRdbmsExporter; the unified
+          // camunda.data.exporters.rdbms.* config for it is ignored and must not overwrite the
+          // reserved config. Warn (so it is not silent) and drop it.
+          if (rdbmsReserved && RDBMS_EXPORTER_NAME.equals(name)) {
+            warnReservedRdbmsExporter("camunda.data.exporters.rdbms.*");
+            return;
+          }
+          override.getExporters().put(name, exporter.toExporterCfg());
+        });
+  }
+
+  private static void warnReservedRdbmsExporter(final String genericProperty) {
+    LOGGER.warn(
+        "The 'rdbms' exporter is reserved and cannot be configured through the generic exporter "
+            + "property '{}'. This configuration is ignored; configure it through "
+            + "'camunda.data.secondary-storage.rdbms.*' instead.",
+        genericProperty);
   }
 
   private static void populateFromGlobalListeners(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -37,6 +37,7 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.Ssl;
 import io.camunda.configuration.Throttle;
 import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.UnifiedConfigurationException;
 import io.camunda.configuration.Write;
 import io.camunda.configuration.Zone;
 import io.camunda.configuration.beans.BrokerBasedProperties;
@@ -936,13 +937,24 @@ public class BrokerBasedPropertiesOverride {
 
     /* Load exporter config map */
 
-    var exporter = override.getRdbmsExporter();
-    if (exporter == null) {
-      exporter = new ExporterCfg();
-      exporter.setClassName(RDBMS_EXPORTER_CLASS_NAME);
-      exporter.setArgs(new LinkedHashMap<>());
-      override.getExporters().put(RDBMS_EXPORTER_NAME, exporter);
+    // 'rdbms' is a reserved exporter: it is provisioned internally and configured through
+    // camunda.data.secondary-storage.rdbms.* (resolved per physical tenant, see #57804). Reject any
+    // attempt to configure it through the generic exporter properties — unified
+    // (camunda.data.exporters.rdbms.*) or legacy (zeebe.broker.exporters.rdbms.*) — so nothing is
+    // silently ignored. At this point the reserved exporter has not been added yet, so a non-null
+    // entry can only come from user configuration.
+    if (override.getRdbmsExporter() != null
+        || data.getExporters().containsKey(RDBMS_EXPORTER_NAME)) {
+      throw new UnifiedConfigurationException(
+          "The 'rdbms' exporter is reserved and cannot be configured through the generic exporter "
+              + "properties ('camunda.data.exporters.rdbms.*' or 'zeebe.broker.exporters.rdbms.*'). "
+              + "Configure it through 'camunda.data.secondary-storage.rdbms.*'.");
     }
+
+    final ExporterCfg exporter = new ExporterCfg();
+    exporter.setClassName(RDBMS_EXPORTER_CLASS_NAME);
+    exporter.setArgs(new LinkedHashMap<>());
+    override.getExporters().put(RDBMS_EXPORTER_NAME, exporter);
 
     /* Override config map values */
 
@@ -953,70 +965,82 @@ public class BrokerBasedPropertiesOverride {
 
     exporter.setArgs(
         ExporterConfiguration.of(io.camunda.exporter.rdbms.ExporterConfiguration.class, args)
-            .apply(
-                config -> {
-                  config.setQueueSize(database.getQueueSize());
-                  config.setQueueMemoryLimit(database.getQueueMemoryLimit());
-                  config.setFlushInterval(database.getFlushInterval());
-                  config.setExportBatchOperationItemsOnCreation(
-                      database.isExportBatchOperationItemsOnCreation());
-                  config.setBatchOperationItemInsertBlockSize(
-                      database.getBatchOperationItemInsertBlockSize());
-                  config.setAuditLog(camunda.getData().getAuditLog().toConfiguration());
-                  config.setWaitState(camunda.getData().getWaitStates().toConfiguration());
-                  config.setHistoryDeletion(
-                      camunda.getData().getHistoryDeletion().toConfiguration());
-
-                  applyRdbmsHistoryExporterConfiguration(config.getHistory(), database);
-
-                  if (database.getProcessCache() != null) {
-                    config.getProcessCache().setMaxSize(database.getProcessCache().getMaxSize());
-                  }
-
-                  if (database.getBatchOperationCache() != null) {
-                    config
-                        .getBatchOperationCache()
-                        .setMaxSize(database.getBatchOperationCache().getMaxSize());
-                  }
-
-                  if (database.getInsertBatching() != null) {
-                    config
-                        .getInsertBatching()
-                        .setMaxAuditLogInsertBatchSize(
-                            database.getInsertBatching().getMaxAuditLogInsertBatchSize());
-                    config
-                        .getInsertBatching()
-                        .setMaxVariableInsertBatchSize(
-                            database.getInsertBatching().getMaxVariableInsertBatchSize());
-                    config
-                        .getInsertBatching()
-                        .setMaxJobInsertBatchSize(
-                            database.getInsertBatching().getMaxJobInsertBatchSize());
-                    config
-                        .getInsertBatching()
-                        .setMaxFlowNodeInsertBatchSize(
-                            database.getInsertBatching().getMaxFlowNodeInsertBatchSize());
-                  }
-
-                  if (database.getAsyncReplication() != null) {
-                    final var asyncReplication = database.getAsyncReplication();
-                    config.getAsyncReplication().setEnabled(asyncReplication.isEnabled());
-                    config
-                        .getAsyncReplication()
-                        .setPollingInterval(asyncReplication.getPollingInterval());
-                    config
-                        .getAsyncReplication()
-                        .setMinSyncReplicas(asyncReplication.getMinSyncReplicas());
-                    config.getAsyncReplication().setMaxLag(asyncReplication.getMaxLag());
-                    config
-                        .getAsyncReplication()
-                        .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
-                  }
-
-                  applyRdbmsExtensionPropertyConfiguration(
-                      config.getExtensionProperties(), camunda.getData().getExtensionProperties());
-                })
+            .apply(config -> applyRdbmsExporterConfiguration(config, camunda))
             .toArgs());
+  }
+
+  /**
+   * Builds a fully-resolved {@link io.camunda.exporter.rdbms.ExporterConfiguration} from a {@link
+   * Camunda} object, mapping {@code camunda.data.secondary-storage.rdbms.*} (plus the shared audit
+   * log, wait state, history deletion and extension property sections).
+   *
+   * <p>The RDBMS exporter is provisioned outside the Broker via Spring, so the Broker cannot pass
+   * per-physical-tenant config through the exporter context. This lets the exporter factory resolve
+   * the config per physical tenant from that tenant's {@code Camunda} instead (see #57804). It
+   * shares the same mapping as {@link #populateRdbmsExporter(BrokerBasedProperties, Camunda)} so
+   * the per-tenant object and the broker-supplied args cannot drift.
+   */
+  public static io.camunda.exporter.rdbms.ExporterConfiguration toRdbmsExporterConfiguration(
+      final Camunda camunda) {
+    return ExporterConfiguration.of(
+            io.camunda.exporter.rdbms.ExporterConfiguration.class, new LinkedHashMap<>())
+        .apply(config -> applyRdbmsExporterConfiguration(config, camunda))
+        .get();
+  }
+
+  private static void applyRdbmsExporterConfiguration(
+      final io.camunda.exporter.rdbms.ExporterConfiguration config, final Camunda camunda) {
+    final Rdbms database = camunda.getData().getSecondaryStorage().getRdbms();
+    config.setQueueSize(database.getQueueSize());
+    config.setQueueMemoryLimit(database.getQueueMemoryLimit());
+    config.setFlushInterval(database.getFlushInterval());
+    config.setExportBatchOperationItemsOnCreation(database.isExportBatchOperationItemsOnCreation());
+    config.setBatchOperationItemInsertBlockSize(database.getBatchOperationItemInsertBlockSize());
+    config.setAuditLog(camunda.getData().getAuditLog().toConfiguration());
+    config.setWaitState(camunda.getData().getWaitStates().toConfiguration());
+    config.setHistoryDeletion(camunda.getData().getHistoryDeletion().toConfiguration());
+
+    applyRdbmsHistoryExporterConfiguration(config.getHistory(), database);
+
+    if (database.getProcessCache() != null) {
+      config.getProcessCache().setMaxSize(database.getProcessCache().getMaxSize());
+    }
+
+    if (database.getBatchOperationCache() != null) {
+      config.getBatchOperationCache().setMaxSize(database.getBatchOperationCache().getMaxSize());
+    }
+
+    if (database.getInsertBatching() != null) {
+      config
+          .getInsertBatching()
+          .setMaxAuditLogInsertBatchSize(
+              database.getInsertBatching().getMaxAuditLogInsertBatchSize());
+      config
+          .getInsertBatching()
+          .setMaxVariableInsertBatchSize(
+              database.getInsertBatching().getMaxVariableInsertBatchSize());
+      config
+          .getInsertBatching()
+          .setMaxJobInsertBatchSize(database.getInsertBatching().getMaxJobInsertBatchSize());
+      config
+          .getInsertBatching()
+          .setMaxFlowNodeInsertBatchSize(
+              database.getInsertBatching().getMaxFlowNodeInsertBatchSize());
+    }
+
+    if (database.getAsyncReplication() != null) {
+      final var asyncReplication = database.getAsyncReplication();
+      config.getAsyncReplication().setEnabled(asyncReplication.isEnabled());
+      config.getAsyncReplication().setPollingInterval(asyncReplication.getPollingInterval());
+      config.getAsyncReplication().setMinSyncReplicas(asyncReplication.getMinSyncReplicas());
+      config.getAsyncReplication().setMaxLag(asyncReplication.getMaxLag());
+      config
+          .getAsyncReplication()
+          .setPauseOnMaxLagExceeded(asyncReplication.isPauseOnMaxLagExceeded());
+    }
+
+    applyRdbmsExtensionPropertyConfiguration(
+        config.getExtensionProperties(), camunda.getData().getExtensionProperties());
   }
 
   private static void applyRdbmsExtensionPropertyConfiguration(

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -8,7 +8,6 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
@@ -25,6 +24,11 @@ import io.camunda.zeebe.broker.system.configuration.engine.ValidatorsCfg;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -230,11 +234,13 @@ public class SecondaryStorageRdbmsTest {
   /**
    * The {@code rdbms} exporter is reserved and provisioned internally; it must be configured
    * through {@code camunda.data.secondary-storage.rdbms.*}. Declaring it through the generic
-   * exporter properties — unified or legacy — must fail fast rather than be silently ignored (see
-   * #57804).
+   * exporter properties — unified or legacy — is ignored (the reserved config wins) and a warning
+   * is logged rather than failing startup (see #57804).
    */
   @Nested
-  class ReservedExporterRejected {
+  class ReservedExporterIgnored {
+    private static final String RESERVED_WARNING = "'rdbms' exporter is reserved";
+
     private ApplicationContextRunner runnerWith(final String... properties) {
       return new ApplicationContextRunner()
           .withUserConfiguration(
@@ -247,44 +253,118 @@ public class SecondaryStorageRdbmsTest {
     }
 
     @Test
-    void shouldRejectUnifiedRdbmsExporterConfig() {
-      runnerWith("camunda.data.exporters.rdbms.args.queue-size=0")
-          .run(
-              context -> {
-                assertThat(context).hasFailed();
-                assertThat(context.getStartupFailure())
-                    .rootCause()
-                    .isInstanceOf(UnifiedConfigurationException.class)
-                    .hasMessageContaining("'rdbms' exporter is reserved");
-              });
+    void shouldIgnoreUnifiedRdbmsExporterConfig() {
+      try (final LogCapturer logs =
+          new LogCapturer(BrokerBasedPropertiesOverride.class.getName())) {
+        runnerWith("camunda.data.exporters.rdbms.args.queue-size=0")
+            .run(
+                context -> {
+                  assertThat(context).hasNotFailed();
+                  final ExporterCfg exporter =
+                      context.getBean(BrokerBasedProperties.class).getRdbmsExporter();
+                  assertThat(exporter).isNotNull();
+                  assertThat(exporter.getClassName())
+                      .isEqualTo("io.camunda.exporter.rdbms.RdbmsExporter");
+                  // the ignored generic queue-size=0 must not apply; the reserved config keeps the
+                  // default queue size
+                  assertThat(
+                          UnifiedConfigurationHelper.argsToRdbmsExporterConfiguration(
+                                  exporter.getArgs())
+                              .getQueueSize())
+                      .isEqualTo(1000);
+                  // the ignored config must be surfaced to the user as a warning, not silently
+                  assertThat(logs.contains(RESERVED_WARNING)).isTrue();
+                });
+      }
     }
 
     @Test
-    void shouldRejectLegacyRdbmsExporterConfig() {
-      runnerWith("zeebe.broker.exporters.rdbms.class-name=io.camunda.exporter.rdbms.RdbmsExporter")
-          .run(
-              context -> {
-                assertThat(context).hasFailed();
-                assertThat(context.getStartupFailure())
-                    .rootCause()
-                    .isInstanceOf(UnifiedConfigurationException.class)
-                    .hasMessageContaining("'rdbms' exporter is reserved");
-              });
+    void shouldIgnoreLegacyRdbmsExporterConfig() {
+      try (final LogCapturer logs =
+          new LogCapturer(BrokerBasedPropertiesOverride.class.getName())) {
+        runnerWith(
+                "zeebe.broker.exporters.rdbms.class-name=io.camunda.exporter.rdbms.RdbmsExporter")
+            .run(
+                context -> {
+                  assertThat(context).hasNotFailed();
+                  final ExporterCfg exporter =
+                      context.getBean(BrokerBasedProperties.class).getRdbmsExporter();
+                  assertThat(exporter).isNotNull();
+                  assertThat(exporter.getClassName())
+                      .isEqualTo("io.camunda.exporter.rdbms.RdbmsExporter");
+                  assertThat(logs.contains(RESERVED_WARNING)).isTrue();
+                });
+      }
     }
 
     @Test
-    void shouldRejectRdbmsExporterConfiguredPerPhysicalTenant() {
+    void shouldIgnoreRdbmsExporterConfiguredPerPhysicalTenant() {
       // the per-tenant path goes through BrokerBasedPropertiesOverride.convert (invoked per tenant
-      // by SystemContextLoader), which runs the same reserved-exporter check
+      // by SystemContextLoader), which runs the same reserved-exporter handling
       final MockEnvironment environment = new MockEnvironment();
       environment.setProperty("camunda.data.secondary-storage.type", "rdbms");
       environment.setProperty("camunda.data.exporters.rdbms.args.queue-size", "0");
       final Camunda perTenant = new Camunda();
       Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(perTenant));
 
-      assertThatThrownBy(() -> BrokerBasedPropertiesOverride.convert(perTenant))
-          .isInstanceOf(UnifiedConfigurationException.class)
-          .hasMessageContaining("'rdbms' exporter is reserved");
+      final BrokerBasedProperties props;
+      final boolean warned;
+      try (final LogCapturer logs =
+          new LogCapturer(BrokerBasedPropertiesOverride.class.getName())) {
+        props = BrokerBasedPropertiesOverride.convert(perTenant);
+        warned = logs.contains(RESERVED_WARNING);
+      }
+
+      final ExporterCfg exporter = props.getRdbmsExporter();
+      assertThat(exporter).isNotNull();
+      assertThat(exporter.getClassName()).isEqualTo("io.camunda.exporter.rdbms.RdbmsExporter");
+      // the ignored generic queue-size=0 must not apply; the reserved config keeps the default
+      assertThat(
+              UnifiedConfigurationHelper.argsToRdbmsExporterConfiguration(exporter.getArgs())
+                  .getQueueSize())
+          .isEqualTo(1000);
+      // the ignored config must be surfaced to the user as a warning, not silently
+      assertThat(warned).isTrue();
+    }
+  }
+
+  /**
+   * Captures log events emitted for a given logger via a log4j2 {@link ListAppender}, so tests can
+   * assert on messages that are logged instead of thrown (see {@link ReservedExporterIgnored}).
+   */
+  private static final class LogCapturer implements AutoCloseable {
+    private final ListAppender appender;
+    private final String loggerName;
+
+    private LogCapturer(final String loggerName) {
+      this.loggerName = loggerName;
+      appender = new ListAppender("TestAppender");
+      appender.start();
+      // Ensure a dedicated logger config exists at a level that lets WARN through; without a log4j2
+      // config file the default root level is ERROR, which would drop the warning before the
+      // appender sees it.
+      Configurator.setLevel(loggerName, Level.WARN);
+      final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+      context
+          .getConfiguration()
+          .getLoggerConfig(loggerName)
+          .addAppender(appender, Level.WARN, null);
+      context.updateLoggers();
+    }
+
+    private boolean contains(final String message) {
+      // the appender has no layout, so formatted strings live in getEvents(), not getMessages()
+      return appender.getEvents().stream()
+          .anyMatch(e -> e.getMessage().getFormattedMessage().contains(message));
+    }
+
+    @Override
+    public void close() {
+      final LoggerContext context = (LoggerContext) LogManager.getContext(false);
+      context.getConfiguration().getLoggerConfig(loggerName).removeAppender("TestAppender");
+      context.updateLoggers();
+      appender.stop();
+      appender.clear();
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -8,12 +8,12 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
-import io.camunda.db.rdbms.write.RdbmsWriterConfig;
 import io.camunda.exporter.rdbms.ExporterConfiguration;
 import io.camunda.operate.OperatePropertiesOverride;
 import io.camunda.operate.property.OperateProperties;
@@ -28,6 +28,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -223,41 +227,64 @@ public class SecondaryStorageRdbmsTest {
     }
   }
 
+  /**
+   * The {@code rdbms} exporter is reserved and provisioned internally; it must be configured
+   * through {@code camunda.data.secondary-storage.rdbms.*}. Declaring it through the generic
+   * exporter properties — unified or legacy — must fail fast rather than be silently ignored (see
+   * #57804).
+   */
   @Nested
-  @TestPropertySource(
-      properties = {
-        "camunda.data.secondary-storage.type=rdbms",
-        "zeebe.broker.exporters.rdbms.class-name=io.camunda.exporter.rdbms.RdbmsExporter"
-      })
-  class ExporterTestWithoutArgs {
-    final BrokerBasedProperties brokerBasedProperties;
-
-    ExporterTestWithoutArgs(@Autowired final BrokerBasedProperties brokerBasedProperties) {
-      this.brokerBasedProperties = brokerBasedProperties;
+  class ReservedExporterRejected {
+    private ApplicationContextRunner runnerWith(final String... properties) {
+      return new ApplicationContextRunner()
+          .withUserConfiguration(
+              UnifiedConfiguration.class,
+              UnifiedConfigurationHelper.class,
+              BrokerBasedPropertiesOverride.class)
+          .withPropertyValues("spring.profiles.active=broker")
+          .withPropertyValues("camunda.data.secondary-storage.type=rdbms")
+          .withPropertyValues(properties);
     }
 
     @Test
-    void testSecondaryStorageExporterWithoutArgsGetDefaults() {
-      final ExporterCfg exporter = brokerBasedProperties.getRdbmsExporter();
-      assertThat(exporter).isNotNull();
-      final Map<String, Object> args = exporter.getArgs();
-      assertThat(args.get("queueSize")).isEqualTo(1000);
-      assertThat(args.get("queueMemoryLimit")).isEqualTo(20);
-      assertThat(args.get("flushInterval")).isEqualTo(Duration.ofMillis(500));
-      assertThat(args.get("exportBatchOperationItemsOnCreation")).isEqualTo(true);
-      assertThat(args.get("batchOperationItemInsertBlockSize")).isEqualTo(10000);
+    void shouldRejectUnifiedRdbmsExporterConfig() {
+      runnerWith("camunda.data.exporters.rdbms.args.queue-size=0")
+          .run(
+              context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .isInstanceOf(UnifiedConfigurationException.class)
+                    .hasMessageContaining("'rdbms' exporter is reserved");
+              });
     }
 
     @Test
-    void testEngineValidatorsDefaults() {
-      final ValidatorsCfg validators =
-          brokerBasedProperties.getExperimental().getEngine().getValidators();
-      assertThat(validators.getMaxIdFieldLength())
-          .isEqualTo(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
-      assertThat(validators.getMaxNameFieldLength())
-          .isEqualTo(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
-      assertThat(validators.getMaxWorkerTypeLength())
-          .isEqualTo(RdbmsWriterConfig.DEFAULT_MAX_VARCHAR_FIELD_LENGTH);
+    void shouldRejectLegacyRdbmsExporterConfig() {
+      runnerWith("zeebe.broker.exporters.rdbms.class-name=io.camunda.exporter.rdbms.RdbmsExporter")
+          .run(
+              context -> {
+                assertThat(context).hasFailed();
+                assertThat(context.getStartupFailure())
+                    .rootCause()
+                    .isInstanceOf(UnifiedConfigurationException.class)
+                    .hasMessageContaining("'rdbms' exporter is reserved");
+              });
+    }
+
+    @Test
+    void shouldRejectRdbmsExporterConfiguredPerPhysicalTenant() {
+      // the per-tenant path goes through BrokerBasedPropertiesOverride.convert (invoked per tenant
+      // by SystemContextLoader), which runs the same reserved-exporter check
+      final MockEnvironment environment = new MockEnvironment();
+      environment.setProperty("camunda.data.secondary-storage.type", "rdbms");
+      environment.setProperty("camunda.data.exporters.rdbms.args.queue-size", "0");
+      final Camunda perTenant = new Camunda();
+      Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(perTenant));
+
+      assertThatThrownBy(() -> BrokerBasedPropertiesOverride.convert(perTenant))
+          .isInstanceOf(UnifiedConfigurationException.class)
+          .hasMessageContaining("'rdbms' exporter is reserved");
     }
   }
 

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/RdbmsExporterPhysicalTenantConfigTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/RdbmsExporterPhysicalTenantConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.exporter.rdbms.ExporterConfiguration;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Verifies that the RDBMS exporter configuration is resolved <em>per physical tenant</em> from each
+ * tenant's {@code camunda.data.secondary-storage.rdbms.*} — the exact pipeline the {@code
+ * rdbmsExporterFactory} bean uses ({@link PhysicalTenantResolver#mapValues} + {@link
+ * BrokerBasedPropertiesOverride#toRdbmsExporterConfiguration}). See #57804.
+ */
+class RdbmsExporterPhysicalTenantConfigTest {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+
+  @Test
+  void shouldResolveExporterConfigurationPerPhysicalTenant() {
+    // given three physical tenants (the default plus two named) each with its own rdbms settings
+    final MockEnvironment environment = new MockEnvironment();
+    environment.setProperty("camunda.data.secondary-storage.type", "rdbms");
+    configureTenant(environment, DEFAULT_PHYSICAL_TENANT_ID, "10", "PT1S");
+    configureTenant(environment, TENANT_A, "100", "PT2S");
+    configureTenant(environment, TENANT_B, "500", "PT9S");
+
+    final PhysicalTenantResolver resolver = PhysicalTenantResolver.of(environment, new Camunda());
+
+    // when the exporter configuration is resolved per physical tenant (as the factory bean does)
+    final Map<String, ExporterConfiguration> configByPhysicalTenant =
+        resolver.mapValues(BrokerBasedPropertiesOverride::toRdbmsExporterConfiguration);
+
+    // then every tenant's exporter configuration reflects its own settings, and the synthesized
+    // default tenant inherits the root configuration
+    assertThat(configByPhysicalTenant)
+        .containsOnlyKeys(DEFAULT_PHYSICAL_TENANT_ID, TENANT_A, TENANT_B);
+
+    assertThat(configByPhysicalTenant.get(TENANT_A).getQueueSize()).isEqualTo(100);
+    assertThat(configByPhysicalTenant.get(TENANT_A).getFlushInterval())
+        .isEqualTo(Duration.ofSeconds(2));
+
+    assertThat(configByPhysicalTenant.get(TENANT_B).getQueueSize()).isEqualTo(500);
+    assertThat(configByPhysicalTenant.get(TENANT_B).getFlushInterval())
+        .isEqualTo(Duration.ofSeconds(9));
+
+    assertThat(configByPhysicalTenant.get(DEFAULT_PHYSICAL_TENANT_ID).getQueueSize()).isEqualTo(10);
+    assertThat(configByPhysicalTenant.get(DEFAULT_PHYSICAL_TENANT_ID).getFlushInterval())
+        .isEqualTo(Duration.ofSeconds(1));
+  }
+
+  private static void configureTenant(
+      final MockEnvironment environment,
+      final String tenantId,
+      final String queueSize,
+      final String flushInterval) {
+    final String base = "camunda.physical-tenants." + tenantId + ".";
+    // A distinct storage location per tenant satisfies the secondary-storage isolation validation.
+    environment.setProperty(
+        base + "data.secondary-storage.rdbms.url", "jdbc:h2:mem:rdbms-" + tenantId);
+    environment.setProperty(base + "data.secondary-storage.rdbms.queue-size", queueSize);
+    environment.setProperty(base + "data.secondary-storage.rdbms.flush-interval", flushInterval);
+    // Each explicitly-declared tenant must carry its own security initialization block.
+    environment.setProperty(
+        base + "security.initialization.default-roles.admin.users[0]", tenantId + "-admin");
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
@@ -9,10 +9,13 @@ package io.camunda.zeebe.broker;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsServiceFactory;
+import io.camunda.exporter.rdbms.ExporterConfiguration;
 import io.camunda.exporter.rdbms.RdbmsExporterFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -33,8 +36,17 @@ public class RdbmsExporterConfiguration {
   @Bean
   public RdbmsExporterFactory rdbmsExporterFactory(
       final RdbmsServiceFactory rdbmsServiceFactory,
-      final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry) {
-    return new RdbmsExporterFactory(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
+      final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry,
+      final PhysicalTenantResolver physicalTenantResolver) {
+    // Resolve the full exporter configuration per physical tenant from that tenant's
+    // camunda.data.secondary-storage.rdbms.* config. The broker cannot pass per-physical-tenant
+    // config through the exporter context because the RDBMS exporter is provisioned via Spring, so
+    // the exporter resolves it here instead (see #57804).
+    final Map<String, ExporterConfiguration> exporterConfigByPhysicalTenantId =
+        physicalTenantResolver.mapValues(
+            BrokerBasedPropertiesOverride::toRdbmsExporterConfiguration);
+    return new RdbmsExporterFactory(
+        rdbmsServiceFactory, rdbmsSchemaManagerRegistry, exporterConfigByPhysicalTenantId);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/RdbmsExporterPositionRecoveryIT.java
@@ -30,7 +30,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import org.awaitility.Awaitility;
@@ -96,12 +95,7 @@ class RdbmsExporterPositionRecoveryIT {
             .withProperty("camunda.data.secondary-storage.rdbms.url", postgres.getJdbcUrl())
             .withProperty("camunda.data.secondary-storage.rdbms.username", postgres.getUsername())
             .withProperty("camunda.data.secondary-storage.rdbms.password", postgres.getPassword())
-            .withExporter(
-                "rdbms",
-                cfg -> {
-                  cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
-                  cfg.setArgs(Map.of("flushInterval", "PT0S"));
-                })
+            .withProperty("camunda.data.secondary-storage.rdbms.flush-interval", "PT0S")
             .withBasicAuth();
 
     testInstance.start();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AbstractAsyncReplicationIT.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import java.util.Map;
 import java.util.Objects;
 import org.assertj.core.data.Offset;
 import org.awaitility.Awaitility;
@@ -62,30 +61,36 @@ abstract class AbstractAsyncReplicationIT<R extends ReplicationClusterContainer>
 
     testInstance =
         new TestCamundaApplication()
-            .withSecondaryStorageType(SecondaryStorageType.rdbms)
-            .withProperty("camunda.data.secondary-storage.rdbms.url", cluster.getJdbcUrl())
-            .withProperty("camunda.data.secondary-storage.rdbms.username", cluster.getUsername())
-            .withProperty("camunda.data.secondary-storage.rdbms.password", cluster.getPassword())
-            .withExporter(
-                "rdbms",
+            .withUnifiedConfig(
                 cfg -> {
-                  cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
-                  cfg.setArgs(
-                      Map.of(
-                          // PT0S causes replication checks on each record which is too aggressive
-                          // and causes too much latency
-                          "flushInterval",
-                          "PT0.5S",
-                          "asyncReplication",
-                          Map.of(
-                              "enabled",
-                              true,
-                              "pollingInterval",
-                              "PT1S",
-                              "maxLag",
-                              getMaxLag().toString(),
-                              "pauseOnMaxLagExceeded",
-                              true)));
+                  cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+                  cfg.getData().getSecondaryStorage().getRdbms().setUrl(cluster.getJdbcUrl());
+                  cfg.getData().getSecondaryStorage().getRdbms().setUsername(cluster.getUsername());
+                  cfg.getData().getSecondaryStorage().getRdbms().setPassword(cluster.getPassword());
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .setFlushInterval(Duration.ofMillis(500));
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .getAsyncReplication()
+                      .setEnabled(true);
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .getAsyncReplication()
+                      .setPollingInterval(Duration.ofSeconds(1));
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .getAsyncReplication()
+                      .setMaxLag(getMaxLag());
+                  cfg.getData()
+                      .getSecondaryStorage()
+                      .getRdbms()
+                      .getAsyncReplication()
+                      .setPauseOnMaxLagExceeded(true);
                 })
             .withBasicAuth();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,7 +84,7 @@ class RdbmsExporterBatchOperationsIT {
             "",
             null,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
-            null));
+            InstantSource.system()));
     exporter.open(controller);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -63,13 +63,22 @@ class RdbmsExporterBatchOperationsIT {
     rdbmsService =
         rdbmsServiceFactory.createRdbmsService(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, new SimpleMeterRegistry());
-    exporter = new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
+    final var exporterConfiguration =
+        new ExporterConfiguration(
+            "foo",
+            Map.of("queueSize", 0, "exportBatchOperationItemsOnCreation", exportPendingItems));
+    exporter =
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            rdbmsSchemaManagerRegistry,
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                exporterConfiguration.instantiate(
+                    io.camunda.exporter.rdbms.ExporterConfiguration.class)));
     exporter.configure(
         new ExporterContext(
             null,
-            new ExporterConfiguration(
-                "foo",
-                Map.of("queueSize", 0, "exportBatchOperationItemsOnCreation", exportPendingItems)),
+            exporterConfiguration,
             new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             "",
             null,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -117,6 +117,7 @@ import io.camunda.zeebe.test.util.Strings;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -176,7 +177,7 @@ class RdbmsExporterIT {
             "",
             null,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
-            null));
+            InstantSource.system()));
     exporter.open(controller);
   }
 
@@ -1526,7 +1527,7 @@ class RdbmsExporterIT {
             "",
             null,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
-            null));
+            InstantSource.system()));
     intervalExporter.open(intervalController);
 
     // a record with ValueType.TIMER has no registered handler: the exporter updates lastPosition

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -159,11 +159,19 @@ class RdbmsExporterIT {
             DEFAULT_PHYSICAL_TENANT_ID, new SimpleMeterRegistry());
     exporterPositionMapper =
         rdbmsMapperBundles.get(DEFAULT_PHYSICAL_TENANT_ID).exporterPositionMapper();
-    exporter = new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
+    final var exporterConfiguration = new ExporterConfiguration("foo", Map.of("queueSize", 0));
+    exporter =
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            rdbmsSchemaManagerRegistry,
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                exporterConfiguration.instantiate(
+                    io.camunda.exporter.rdbms.ExporterConfiguration.class)));
     exporter.configure(
         new ExporterContext(
             null,
-            new ExporterConfiguration("foo", Map.of("queueSize", 0)),
+            exporterConfiguration,
             new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             "",
             null,
@@ -1500,12 +1508,20 @@ class RdbmsExporterIT {
     // given - create a separate exporter with interval-based flush (queueSize > 0, not per-record)
     // Use partitionId=2 to avoid interfering with other tests that use partitionId=1
     final var intervalController = new ExporterTestController();
+    final var intervalConfiguration =
+        new ExporterConfiguration("interval-flush-test", Map.of("queueSize", 100));
     final var intervalExporter =
-        new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            rdbmsSchemaManagerRegistry,
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                intervalConfiguration.instantiate(
+                    io.camunda.exporter.rdbms.ExporterConfiguration.class)));
     intervalExporter.configure(
         new ExporterContext(
             null,
-            new ExporterConfiguration("interval-flush-test", Map.of("queueSize", 100)),
+            intervalConfiguration,
             new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 2),
             "",
             null,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterPhysicalTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterPhysicalTenantIT.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.InstantSource;
 import java.util.Map;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -117,7 +118,7 @@ class RdbmsExporterPhysicalTenantIT {
             "",
             null,
             mock(MeterRegistry.class, RETURNS_DEEP_STUBS),
-            null));
+            InstantSource.system()));
     wrapper.open(new ExporterTestController());
     return wrapper;
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterPhysicalTenantIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterPhysicalTenantIT.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.exporter;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.application.commons.rdbms.MyBatisConfiguration;
+import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.camunda.cluster.PartitionId;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.exporter.rdbms.RdbmsExporterFactory;
+import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.broker.exporter.context.ExporterContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Map;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Asserts that the RDBMS exporter is fully physical-tenant aware at runtime: two physical tenants
+ * are configured with different exporter settings, and each exporter instance applies its own
+ * tenant's {@link io.camunda.exporter.rdbms.ExporterConfiguration} and writes into its own tenant
+ * database (see #57804).
+ *
+ * <p>The default tenant is configured to flush on every record ({@code queue-size=0}) while tenant
+ * B buffers ({@code queue-size} large); with no real actor scheduler nothing auto-flushes, so the
+ * config-driven flush behavior is observable deterministically right after a single export.
+ */
+@Tag("rdbms")
+@SpringJUnitConfig
+// Satisfies @ConditionalOnSecondaryStorageType(rdbms); the per-tenant config (including each
+// tenant's own url) is driven by the MockEnvironment-backed PhysicalTenantResolver below.
+@TestPropertySource(properties = "camunda.data.secondary-storage.type=rdbms")
+class RdbmsExporterPhysicalTenantIT {
+
+  private static final String TENANT_B = "tenantb";
+  private static final RecordFixtures FIXTURES = new RecordFixtures();
+
+  @MockitoBean private ActorScheduler actorScheduler;
+
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  @Autowired private RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
+  @Autowired private PhysicalTenantResolver physicalTenantResolver;
+
+  @Test
+  void shouldApplyExporterConfigurationAndIsolateWritesPerPhysicalTenant() {
+    // given the per-physical-tenant exporter config resolved exactly as the factory bean does
+    final RdbmsExporterFactory factory =
+        new RdbmsExporterFactory(
+            rdbmsServiceFactory,
+            rdbmsSchemaManagerRegistry,
+            physicalTenantResolver.mapValues(
+                BrokerBasedPropertiesOverride::toRdbmsExporterConfiguration));
+
+    // the default tenant flushes per record; tenant B buffers (see class javadoc)
+    final RdbmsExporterWrapper defaultExporter =
+        configuredExporter(factory, DEFAULT_PHYSICAL_TENANT_ID);
+    final RdbmsExporterWrapper tenantBExporter = configuredExporter(factory, TENANT_B);
+
+    final var defaultRecord = FIXTURES.getProcessInstanceStartedRecord();
+    final var tenantBRecord = FIXTURES.getProcessInstanceStartedRecord();
+    final long defaultKey = processInstanceKey(defaultRecord);
+    final long tenantBKey = processInstanceKey(tenantBRecord);
+
+    // when a record is exported through each tenant's exporter
+    defaultExporter.export(defaultRecord);
+    tenantBExporter.export(tenantBRecord);
+
+    // then the default tenant applied queue-size=0 and flushed immediately, while tenant B applied
+    // its own large queue-size and left the record buffered
+    final var defaultReader = processInstanceReader(DEFAULT_PHYSICAL_TENANT_ID);
+    final var tenantBReader = processInstanceReader(TENANT_B);
+
+    assertThat(defaultReader.findOne(defaultKey)).isPresent();
+    assertThat(tenantBReader.findOne(tenantBKey)).isEmpty();
+
+    // and writes are isolated to each tenant's own database
+    assertThat(defaultReader.findOne(tenantBKey)).isEmpty();
+    assertThat(tenantBReader.findOne(defaultKey)).isEmpty();
+  }
+
+  private RdbmsExporterWrapper configuredExporter(
+      final RdbmsExporterFactory factory, final String physicalTenantId) {
+    final RdbmsExporterWrapper wrapper = (RdbmsExporterWrapper) factory.newInstance();
+    wrapper.configure(
+        new ExporterContext(
+            null,
+            new ExporterConfiguration("rdbms", Map.of()),
+            new PartitionId(physicalTenantId, 1),
+            "",
+            null,
+            mock(MeterRegistry.class, RETURNS_DEEP_STUBS),
+            null));
+    wrapper.open(new ExporterTestController());
+    return wrapper;
+  }
+
+  private ProcessInstanceDbReader processInstanceReader(final String physicalTenantId) {
+    return rdbmsServiceFactory
+        .createRdbmsService(physicalTenantId, new SimpleMeterRegistry())
+        .getProcessInstanceReader();
+  }
+
+  private static long processInstanceKey(final io.camunda.zeebe.protocol.record.Record<?> record) {
+    return ((ProcessInstanceRecordValue) record.getValue()).getProcessInstanceKey();
+  }
+
+  @Configuration
+  @Import({MyBatisConfiguration.class, RdbmsConfiguration.class})
+  static class TestConfig {
+
+    @Bean
+    MockEnvironment mockEnvironment() {
+      final var env = new MockEnvironment();
+      // default tenant: flush on every record
+      configureTenant(env, DEFAULT_PHYSICAL_TENANT_ID, "0");
+      // tenant B: buffer (nothing auto-flushes without a real actor scheduler)
+      configureTenant(env, TENANT_B, "1000");
+      return env;
+    }
+
+    @Bean
+    @Primary
+    PhysicalTenantResolver physicalTenantResolverOverride(final MockEnvironment environment) {
+      return PhysicalTenantResolver.of(environment, new Camunda());
+    }
+
+    @Bean
+    Camunda camunda() {
+      return new Camunda();
+    }
+
+    @Bean
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+
+    private static void configureTenant(
+        final MockEnvironment env, final String tenantId, final String queueSize) {
+      final var base = "camunda.physical-tenants." + tenantId + ".data.secondary-storage.";
+      env.setProperty(base + "type", "rdbms");
+      env.setProperty(
+          base + "rdbms.url",
+          "jdbc:h2:mem:rdbms-pt-" + tenantId + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
+      env.setProperty(base + "rdbms.username", "sa");
+      env.setProperty(base + "rdbms.password", "");
+      env.setProperty(base + "rdbms.queue-size", queueSize);
+      env.setProperty(
+          "camunda.physical-tenants."
+              + tenantId
+              + ".security.initialization.default-roles.admin.users[0]",
+          tenantId + "-admin");
+    }
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -279,34 +280,24 @@ public class MultiDbConfigurator {
               rdbms.setUsername(username);
               rdbms.setPassword(password);
               rdbms.setPrefix(tablePrefix);
+              rdbms.setFlushInterval(Duration.ZERO);
+              if (retentionEnabled) {
+                rdbms.getHistory().setDefaultHistoryTTL(Duration.ofSeconds(1));
+                rdbms.getHistory().setMinHistoryCleanupInterval(Duration.ofSeconds(1));
+                rdbms.getHistory().setMaxHistoryCleanupInterval(Duration.ofSeconds(5));
+                rdbms.getHistory().setDefaultBatchOperationHistoryTTL(Duration.ofSeconds(1));
+                rdbms.getHistory().setDecisionInstanceTTL(Duration.ofSeconds(1));
+              } else {
+                rdbms.getHistory().setDefaultHistoryTTL(Duration.ofHours(1));
+                rdbms.getHistory().setMinHistoryCleanupInterval(Duration.ofHours(1));
+                rdbms.getHistory().setMaxHistoryCleanupInterval(Duration.ofHours(2));
+                rdbms.getHistory().setDefaultBatchOperationHistoryTTL(Duration.ofHours(1));
+                rdbms.getHistory().setDecisionInstanceTTL(Duration.ofHours(1));
+              }
             });
 
     testApplication.withProperty("logging.level.io.camunda.db.rdbms", "DEBUG");
     testApplication.withProperty("logging.level.org.mybatis", "DEBUG");
-
-    // Since the property override from unified configuration is not applied in this test setup, we
-    // have to build the RDBMS exporter manually
-    testApplication.withExporter(
-        "rdbms",
-        cfg -> {
-          cfg.setClassName("io.camunda.db.rdbms.exporter.RdbmsExporter");
-          cfg.setArgs(
-              Map.of(
-                  "flushInterval",
-                  "PT0S",
-                  "history",
-                  Map.of(
-                      "defaultHistoryTTL",
-                      retentionEnabled ? "PT1S" : "PT1H",
-                      "minHistoryCleanupInterval",
-                      retentionEnabled ? "PT1S" : "PT1H",
-                      "maxHistoryCleanupInterval",
-                      retentionEnabled ? "PT5S" : "PT2H",
-                      "defaultBatchOperationHistoryTTL",
-                      retentionEnabled ? "PT1S" : "PT1H",
-                      "decisionInstanceTTL",
-                      retentionEnabled ? "PT1S" : "PT1H")));
-        });
   }
 
   public String getIndexPrefix() {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
@@ -12,17 +12,21 @@ import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterInstantiationException;
 import io.camunda.zeebe.exporter.api.Exporter;
+import java.util.Map;
 
 public class RdbmsExporterFactory implements ExporterFactory {
 
   private final RdbmsServiceFactory rdbmsServiceFactory;
   private final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
+  private final Map<String, ExporterConfiguration> exporterConfigByPhysicalTenantId;
 
   public RdbmsExporterFactory(
       final RdbmsServiceFactory rdbmsServiceFactory,
-      final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry) {
+      final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry,
+      final Map<String, ExporterConfiguration> exporterConfigByPhysicalTenantId) {
     this.rdbmsServiceFactory = rdbmsServiceFactory;
     this.rdbmsSchemaManagerRegistry = rdbmsSchemaManagerRegistry;
+    this.exporterConfigByPhysicalTenantId = Map.copyOf(exporterConfigByPhysicalTenantId);
   }
 
   @Override
@@ -32,7 +36,8 @@ public class RdbmsExporterFactory implements ExporterFactory {
 
   @Override
   public Exporter newInstance() throws ExporterInstantiationException {
-    return new RdbmsExporterWrapper(rdbmsServiceFactory, rdbmsSchemaManagerRegistry);
+    return new RdbmsExporterWrapper(
+        rdbmsServiceFactory, rdbmsSchemaManagerRegistry, exporterConfigByPhysicalTenantId);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -67,6 +67,7 @@ import io.camunda.exporter.rdbms.replication.LsnReplicationControllerFactory;
 import io.camunda.exporter.rdbms.replication.ReplicationControllerFactory;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformer;
@@ -76,6 +77,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
@@ -86,24 +88,36 @@ public class RdbmsExporterWrapper implements Exporter {
 
   private final RdbmsServiceFactory rdbmsServiceFactory;
   private final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
+  private final Map<String, ExporterConfiguration> exporterConfigByPhysicalTenantId;
 
   private RdbmsExporter exporter;
   private RdbmsCacheRegistry cacheRegistry;
 
   public RdbmsExporterWrapper(
       final RdbmsServiceFactory rdbmsServiceFactory,
-      final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry) {
+      final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry,
+      final Map<String, ExporterConfiguration> exporterConfigByPhysicalTenantId) {
     this.rdbmsServiceFactory = rdbmsServiceFactory;
     this.rdbmsSchemaManagerRegistry = rdbmsSchemaManagerRegistry;
+    this.exporterConfigByPhysicalTenantId = Map.copyOf(exporterConfigByPhysicalTenantId);
   }
 
   @Override
   public void configure(final Context context) {
-    final var config = context.getConfiguration().instantiate(ExporterConfiguration.class);
-    config.validate(); // throws exception if configuration is invalid
-
     final int partitionId = context.getPartitionId();
     final var physicalTenantId = context.getPhysicalTenantId();
+
+    // The RDBMS exporter is provisioned outside the Broker via Spring, so the broker-supplied
+    // context configuration is not physical-tenant aware; resolve the config for this physical
+    // tenant from the factory-supplied map instead (see #57804).
+    final var config = exporterConfigByPhysicalTenantId.get(physicalTenantId);
+    if (config == null) {
+      throw new ExporterException(
+          "No RDBMS exporter configuration for physical tenant '%s'; known physical tenants: %s"
+              .formatted(physicalTenantId, exporterConfigByPhysicalTenantId.keySet()));
+    }
+    config.validate(); // throws exception if configuration is invalid
+
     final var rdbmsWriterConfig =
         config.createRdbmsWriterConfig(partitionId, physicalTenantId, context.clock());
     // Use the partition-scoped meter registry so the writer metrics inherit the partition and

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -64,16 +64,69 @@ class RdbmsExporterWrapperTest {
     final var configuration = new ExporterConfiguration();
     configuration.setFlushInterval(Duration.ofMillis(-1000));
     final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
-    when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
-        .thenReturn(configuration);
+    when(context.getPhysicalTenantId()).thenReturn("tenanta");
 
     final RdbmsExporterWrapper exporterWrapper =
         new RdbmsExporterWrapper(
-            mock(RdbmsServiceFactory.class), mock(RdbmsSchemaManagerRegistry.class));
+            mock(RdbmsServiceFactory.class),
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("tenanta", configuration));
 
     // when
     assertThatThrownBy(() -> exporterWrapper.configure(context))
         .hasMessageContaining("flushInterval must be a positive duration");
+  }
+
+  @Test
+  public void shouldFailWhenNoConfigurationForPhysicalTenant() {
+    // given
+    final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    when(context.getPhysicalTenantId()).thenReturn("unknowntenant");
+
+    final RdbmsExporterWrapper exporterWrapper =
+        new RdbmsExporterWrapper(
+            mock(RdbmsServiceFactory.class),
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("tenanta", new ExporterConfiguration()));
+
+    // when / then
+    assertThatThrownBy(() -> exporterWrapper.configure(context))
+        .hasMessageContaining(
+            "No RDBMS exporter configuration for physical tenant 'unknowntenant'");
+  }
+
+  @Test
+  public void shouldUseConfigurationOfTheContextPhysicalTenant() {
+    // given - two physical tenants with different queue sizes
+    final var tenantAConfig = new ExporterConfiguration();
+    tenantAConfig.setQueueSize(7);
+    final var tenantBConfig = new ExporterConfiguration();
+    tenantBConfig.setQueueSize(13);
+
+    final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsServiceFactory rdbmsServiceFactory = mock(RdbmsServiceFactory.class);
+    final RdbmsService rdbmsService = mock(RdbmsService.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsWriters rdbmsWriters = mock(RdbmsWriters.class, Mockito.RETURNS_DEEP_STUBS);
+    when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString(), any()))
+        .thenReturn(rdbmsService);
+    when(context.getPartitionId()).thenReturn(1);
+    when(context.getPhysicalTenantId()).thenReturn("tenantb");
+    when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
+
+    final RdbmsExporterWrapper exporterWrapper =
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("tenanta", tenantAConfig, "tenantb", tenantBConfig));
+
+    // when
+    exporterWrapper.configure(context);
+
+    // then - the writer config uses the context tenant's (tenant-b) queue size
+    final ArgumentCaptor<RdbmsWriterConfig> configCaptor =
+        ArgumentCaptor.forClass(RdbmsWriterConfig.class);
+    verify(rdbmsService).createWriter(configCaptor.capture());
+    assertThat(configCaptor.getValue().queueSize()).isEqualTo(13);
   }
 
   @Test
@@ -87,14 +140,15 @@ class RdbmsExporterWrapperTest {
     when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString(), any()))
         .thenReturn(rdbmsService);
 
-    when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
-        .thenReturn(configuration);
     when(context.getPartitionId()).thenReturn(1);
-    when(context.getPhysicalTenantId()).thenReturn("tenantId");
+    when(context.getPhysicalTenantId()).thenReturn("tenanta");
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("tenanta", configuration));
 
     // when
     exporterWrapper.configure(context);
@@ -169,14 +223,15 @@ class RdbmsExporterWrapperTest {
     when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString(), any()))
         .thenReturn(rdbmsService);
 
-    when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
-        .thenReturn(configuration);
     when(context.getPartitionId()).thenReturn(1);
-    when(context.getPhysicalTenantId()).thenReturn("tenantId");
+    when(context.getPhysicalTenantId()).thenReturn("tenanta");
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("tenanta", configuration));
 
     // when
     exporterWrapper.configure(context);
@@ -236,14 +291,15 @@ class RdbmsExporterWrapperTest {
     when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString(), any()))
         .thenReturn(rdbmsService);
 
-    when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
-        .thenReturn(configuration);
     when(context.getPartitionId()).thenReturn(2);
-    when(context.getPhysicalTenantId()).thenReturn("tenantId");
+    when(context.getPhysicalTenantId()).thenReturn("tenanta");
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("tenanta", configuration));
 
     // when
     exporterWrapper.configure(context);
@@ -303,14 +359,15 @@ class RdbmsExporterWrapperTest {
     when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString(), any()))
         .thenReturn(rdbmsService);
 
-    when(context.getConfiguration().instantiate(Mockito.eq(ExporterConfiguration.class)))
-        .thenReturn(configuration);
     when(context.getPartitionId()).thenReturn(1);
-    when(context.getPhysicalTenantId()).thenReturn("my-custom-tenant");
+    when(context.getPhysicalTenantId()).thenReturn("mycustomtenant");
     when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
 
     final RdbmsExporterWrapper exporterWrapper =
-        new RdbmsExporterWrapper(rdbmsServiceFactory, mock(RdbmsSchemaManagerRegistry.class));
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            mock(RdbmsSchemaManagerRegistry.class),
+            Map.of("mycustomtenant", configuration));
 
     // when
     exporterWrapper.configure(context);
@@ -320,7 +377,7 @@ class RdbmsExporterWrapperTest {
         ArgumentCaptor.forClass(RdbmsWriterConfig.class);
     verify(rdbmsService).createWriter(configCaptor.capture());
 
-    assertThat(configCaptor.getValue().physicalTenantId()).isEqualTo("my-custom-tenant");
+    assertThat(configCaptor.getValue().physicalTenantId()).isEqualTo("mycustomtenant");
   }
 
   private void assertAuditLogExportPresent(


### PR DESCRIPTION
The RDBMS exporter is provisioned outside the broker via Spring, so the broker-supplied exporter context is not physical-tenant aware
The non-connectivity settings (history TTLs, cleanup intervals, flush interval, queue size/memory limit, insert batching, caches, async replication) were shared across all physical tenants. This resolves the full `ExporterConfiguration` per physical tenant in the exporter factory (built from each tenant's `camunda.data.secondary-storage.rdbms.*`, reusing the broker-properties population so the two cannot drift), and the wrapper looks it up by physical tenant id at configure time. 
`rdbms` is a reserved exporter, so configuring it through the generic exporter properties (`camunda.data.exporters.rdbms.*` / `zeebe.broker.exporters.rdbms.*`), at the root or per tenant, is ignored with a warning.

Closes #57804
