### PR TITLE
feat: add "view documents" action to conversation history messages

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
@@ -167,10 +167,10 @@ describe('<LatestAgentMessage />', () => {
 
     const message = within(screen.getByTestId('conversation-message-msg-2'));
     expect(
-      message.getByRole('button', {name: '"doSomething" tool call.'}),
-    ).toBeDisabled();
+      message.getByRole('listitem', {name: 'doSomething'}),
+    ).toBeInTheDocument();
     expect(
-      message.getByRole('button', {name: '"noElement" tool call.'}),
-    ).toBeDisabled();
+      message.getByRole('listitem', {name: 'noElement'}),
+    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -424,10 +424,10 @@ describe('<ConversationHistory />', () => {
     const message = within(screen.getByTestId('conversation-message-1'));
     expect(message.getByText('Here are the documents.')).toBeInTheDocument();
     expect(
-      message.getByRole('button', {name: 'report.txt'}),
+      message.getByRole('listitem', {name: 'report.txt'}),
     ).toBeInTheDocument();
     expect(
-      message.getByRole('button', {name: 'screenshot.png'}),
+      message.getByRole('listitem', {name: 'screenshot.png'}),
     ).toBeInTheDocument();
   });
 
@@ -476,11 +476,11 @@ describe('<ConversationHistory />', () => {
       screen.getByTestId('conversation-message-1'),
     );
     expect(
-      assistantMessage.getByRole('button', {name: '"greet" tool call.'}),
-    ).toBeDisabled();
+      assistantMessage.getByRole('listitem', {name: 'greet'}),
+    ).toBeInTheDocument();
     expect(
-      assistantMessage.getByRole('button', {name: '"search" tool call.'}),
-    ).toBeDisabled();
+      assistantMessage.getByRole('listitem', {name: 'search'}),
+    ).toBeInTheDocument();
   });
 
   it('should render metrics when they are available for a message', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.test.tsx
@@ -36,7 +36,10 @@ function createDocumentContent(id: string, fileName: string): ContentItem {
 describe('<DocumentContent />', () => {
   it('should render nothing when there are no document entries', () => {
     const {container} = render(
-      <DocumentContent content={[{contentType: 'TEXT', text: 'hello'}]} />,
+      <DocumentContent
+        content={[{contentType: 'TEXT', text: 'hello'}]}
+        modalTitleSuffix="conversation message"
+      />,
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -45,7 +48,12 @@ describe('<DocumentContent />', () => {
   it('should render a chip for each document entry', () => {
     const doc1 = createDocumentContent('doc-1', 'report.txt');
     const doc2 = createDocumentContent('doc-2', 'screenshot.png');
-    render(<DocumentContent content={[doc1, doc2]} />);
+    render(
+      <DocumentContent
+        content={[doc1, doc2]}
+        modalTitleSuffix="conversation message"
+      />,
+    );
 
     expect(
       screen.getByRole('listitem', {name: 'report.txt'}),
@@ -60,7 +68,12 @@ describe('<DocumentContent />', () => {
       'doc-1',
       'a-very-long-document-name.txt',
     );
-    render(<DocumentContent content={[doc1]} />);
+    render(
+      <DocumentContent
+        content={[doc1]}
+        modalTitleSuffix="conversation message"
+      />,
+    );
 
     const chip = screen.getByRole('listitem', {
       name: 'a-very-long-document-name.txt',
@@ -75,7 +88,12 @@ describe('<DocumentContent />', () => {
       createDocumentContent('doc-3', 'third.txt'),
       createDocumentContent('doc-4', 'fourth.txt'),
     ];
-    render(<DocumentContent content={content} />);
+    render(
+      <DocumentContent
+        content={content}
+        modalTitleSuffix="conversation message"
+      />,
+    );
 
     expect(
       screen.getByRole('listitem', {name: 'first.txt'}),
@@ -95,7 +113,12 @@ describe('<DocumentContent />', () => {
   it('should open the document list modal when the view-documents button is clicked', async () => {
     const doc1 = createDocumentContent('doc-1', 'report.txt');
     const doc2 = createDocumentContent('doc-2', 'screenshot.png');
-    const {user} = render(<DocumentContent content={[doc1, doc2]} />);
+    const {user} = render(
+      <DocumentContent
+        content={[doc1, doc2]}
+        modalTitleSuffix="conversation message"
+      />,
+    );
 
     await user.click(screen.getByLabelText('View documents'));
 
@@ -104,6 +127,21 @@ describe('<DocumentContent />', () => {
       dialog.getByRole('heading', {
         name: '2 documents in conversation message',
       }),
+    ).toBeInTheDocument();
+  });
+
+  it('should use the modal title suffix in the document list modal heading', async () => {
+    const doc1 = createDocumentContent('doc-1', 'report.txt');
+    const doc2 = createDocumentContent('doc-2', 'screenshot.png');
+    const {user} = render(
+      <DocumentContent content={[doc1, doc2]} modalTitleSuffix="tool result" />,
+    );
+
+    await user.click(screen.getByLabelText('View documents'));
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getByRole('heading', {name: '2 documents in tool result'}),
     ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, within} from 'modules/testing-library';
+import {DocumentContent} from './DocumentContent';
+import type {AgentInstanceHistoryItem} from '@camunda/camunda-api-zod-schemas/8.10';
+
+type ContentItem = AgentInstanceHistoryItem['content'][number];
+
+function createDocumentContent(id: string, fileName: string): ContentItem {
+  return {
+    contentType: 'DOCUMENT',
+    documentReference: {
+      'camunda.document.type': 'camunda',
+      contentHash: id,
+      documentId: id,
+      storeId: 'default',
+      metadata: {
+        contentType: 'text/plain',
+        fileName,
+        size: 100,
+        expiresAt: null,
+        processDefinitionId: null,
+        processInstanceKey: null,
+        customProperties: {},
+      },
+    },
+  };
+}
+
+describe('<DocumentContent />', () => {
+  it('should render nothing when there are no document entries', () => {
+    const {container} = render(
+      <DocumentContent content={[{contentType: 'TEXT', text: 'hello'}]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render a chip for each document entry', () => {
+    const doc1 = createDocumentContent('doc-1', 'report.txt');
+    const doc2 = createDocumentContent('doc-2', 'screenshot.png');
+    render(<DocumentContent content={[doc1, doc2]} />);
+
+    expect(
+      screen.getByRole('listitem', {name: 'report.txt'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('listitem', {name: 'screenshot.png'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should truncate long document filenames in chips', () => {
+    const doc1 = createDocumentContent(
+      'doc-1',
+      'a-very-long-document-name.txt',
+    );
+    render(<DocumentContent content={[doc1]} />);
+
+    const chip = screen.getByRole('listitem', {
+      name: 'a-very-long-document-name.txt',
+    });
+    expect(chip).toHaveTextContent('a-very-lo…-name.txt');
+  });
+
+  it('should show at most 3 document chips and indicate the remaining count', () => {
+    const content = [
+      createDocumentContent('doc-1', 'first.txt'),
+      createDocumentContent('doc-2', 'second.txt'),
+      createDocumentContent('doc-3', 'third.txt'),
+      createDocumentContent('doc-4', 'fourth.txt'),
+    ];
+    render(<DocumentContent content={content} />);
+
+    expect(
+      screen.getByRole('listitem', {name: 'first.txt'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('listitem', {name: 'second.txt'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('listitem', {name: 'third.txt'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('listitem', {name: 'fourth.txt'}),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('1 more')).toBeInTheDocument();
+  });
+
+  it('should open the document list modal when the view-documents button is clicked', async () => {
+    const doc1 = createDocumentContent('doc-1', 'report.txt');
+    const doc2 = createDocumentContent('doc-2', 'screenshot.png');
+    const {user} = render(<DocumentContent content={[doc1, doc2]} />);
+
+    await user.click(screen.getByLabelText('View documents'));
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getByRole('heading', {
+        name: '2 documents in conversation message',
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {memo, useId} from 'react';
+import type {AgentInstanceHistoryItem} from '@camunda/camunda-api-zod-schemas/8.10';
+import {Document, View} from '@carbon/react/icons';
+import {
+  AttachmentsContainer,
+  AttachmentsLabel,
+  Attachment,
+  HiddenButton,
+  AttachmentsList,
+} from './styled';
+import {ModalStateManager} from 'modules/components/ModalStateManager';
+import {toDocumentInfo} from 'App/ProcessInstance/DocumentsView/documentInfo';
+import {DocumentListModal} from 'App/ProcessInstance/DocumentsView/DocumentListModal';
+import {middleTruncate} from 'App/ProcessInstance/DocumentsView/middleTruncate';
+
+const MAX_VISIBLE_DOCUMENTS = 3;
+
+type ContentItem = AgentInstanceHistoryItem['content'][number];
+
+type Props = {
+  content: ContentItem[];
+};
+
+const DocumentContent: React.FC<Props> = memo(function DocumentContent({
+  content,
+}) {
+  const id = useId();
+
+  const documents = content
+    .filter((entry) => entry.contentType === 'DOCUMENT')
+    .map(({documentReference}) => toDocumentInfo(documentReference));
+
+  if (documents.length === 0) {
+    return null;
+  }
+
+  const visibleDocuments = documents.slice(0, MAX_VISIBLE_DOCUMENTS);
+  const hiddenDocumentsCount = documents.length - visibleDocuments.length;
+
+  return (
+    <AttachmentsContainer>
+      <AttachmentsLabel id={id}>Documents</AttachmentsLabel>
+      <AttachmentsList aria-labelledby={id}>
+        {visibleDocuments.map((document, i) => (
+          <Attachment key={i} title={document.fileName}>
+            <Document size={12} />
+            {middleTruncate(document.fileName, 20)}
+          </Attachment>
+        ))}
+        {hiddenDocumentsCount > 0 && (
+          <Attachment>{hiddenDocumentsCount} more</Attachment>
+        )}
+      </AttachmentsList>
+      <ModalStateManager
+        renderLauncher={({setOpen}) => (
+          <HiddenButton
+            kind="ghost"
+            size="xs"
+            hasIconOnly
+            renderIcon={View}
+            iconDescription="View documents"
+            tooltipPosition="top"
+            tooltipAlignment="end"
+            onClick={() => setOpen(true)}
+          />
+        )}
+      >
+        {({open, setOpen}) => (
+          <DocumentListModal
+            open={open}
+            setOpen={setOpen}
+            documents={documents}
+            isFullyLoaded
+            isError={false}
+            isLoading={false}
+            variableName="conversation message"
+          />
+        )}
+      </ModalStateManager>
+    </AttachmentsContainer>
+  );
+});
+
+export {DocumentContent};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.tsx
@@ -27,10 +27,12 @@ type ContentItem = AgentInstanceHistoryItem['content'][number];
 
 type Props = {
   content: ContentItem[];
+  modalTitleSuffix: string;
 };
 
 const DocumentContent: React.FC<Props> = memo(function DocumentContent({
   content,
+  modalTitleSuffix,
 }) {
   const id = useId();
 
@@ -81,7 +83,7 @@ const DocumentContent: React.FC<Props> = memo(function DocumentContent({
             isFullyLoaded
             isError={false}
             isLoading={false}
-            variableName="conversation message"
+            variableName={modalTitleSuffix}
           />
         )}
       </ModalStateManager>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/ToolCalls.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/ToolCalls.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {ToolCalls} from './ToolCalls';
+
+describe('<ToolCalls />', () => {
+  it('should render nothing for empty tool calls', () => {
+    const {container} = render(<ToolCalls toolCalls={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render a chip for each tool call', () => {
+    render(
+      <ToolCalls
+        toolCalls={[
+          {
+            toolCallId: 'tc-1',
+            toolName: 'search_web',
+            elementId: null,
+            arguments: null,
+          },
+          {
+            toolCallId: 'tc-2',
+            toolName: 'run_query',
+            elementId: null,
+            arguments: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('listitem', {name: 'search_web'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('listitem', {name: 'run_query'}),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/ToolCalls.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/ToolCalls.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {memo, useId} from 'react';
+import type {AgentInstanceHistoryItem} from '@camunda/camunda-api-zod-schemas/8.10';
+import {Tools} from '@carbon/react/icons';
+import {
+  Attachment,
+  AttachmentsContainer,
+  AttachmentsLabel,
+  AttachmentsList,
+} from './styled';
+
+type ToolCall = AgentInstanceHistoryItem['toolCalls'][number];
+
+type Props = {
+  toolCalls: ToolCall[];
+};
+
+const ToolCalls: React.FC<Props> = memo(function DocumentContent({toolCalls}) {
+  const id = useId();
+
+  if (toolCalls.length === 0) {
+    return null;
+  }
+
+  return (
+    <AttachmentsContainer>
+      <AttachmentsLabel id={id}>Tool calls</AttachmentsLabel>
+      <AttachmentsList aria-labelledby={id}>
+        {toolCalls.map((tc) => (
+          <Attachment key={tc.toolCallId} title={tc.toolName}>
+            <Tools size={12} />
+            {tc.toolName}
+          </Attachment>
+        ))}
+      </AttachmentsList>
+    </AttachmentsContainer>
+  );
+});
+
+export {ToolCalls};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/ToolCalls.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/ToolCalls.tsx
@@ -22,7 +22,7 @@ type Props = {
   toolCalls: ToolCall[];
 };
 
-const ToolCalls: React.FC<Props> = memo(function DocumentContent({toolCalls}) {
+const ToolCalls: React.FC<Props> = memo(function ToolCalls({toolCalls}) {
   const id = useId();
 
   if (toolCalls.length === 0) {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/styled.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Button} from '@carbon/react';
+import styled from 'styled-components';
+
+const HiddenButton = styled(Button)`
+  opacity: 0;
+
+  &:focus-visible {
+    opacity: 1;
+  }
+`;
+
+const AttachmentsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+  inline-size: fit-content;
+  margin-block-start: var(--cds-spacing-04);
+
+  &:hover ${HiddenButton} {
+    opacity: 1;
+  }
+`;
+
+const AttachmentsLabel = styled.h6`
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-label-01-font-weight);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  color: var(--cds-text-secondary);
+`;
+
+const AttachmentsList = styled.ul`
+  display: contents;
+  list-style: none;
+  padding-inline-start: 0;
+`;
+
+// NOTE: These cannot reuse slightly different looking "Tag" components from Carbon,
+// because they are bigger and hide their icons on the smallest size.
+const Attachment = styled.li`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+  padding: var(--cds-spacing-01) var(--cds-spacing-03);
+  border-radius: 100px; // pill shape
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-label-01-font-weight);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  color: var(--cds-text-primary);
+  border: 1px solid var(--cds-border-subtle-01);
+  white-space: nowrap;
+
+  & > svg {
+    color: var(--cds-icon-secondary);
+  }
+`;
+
+export {
+  HiddenButton,
+  AttachmentsContainer,
+  AttachmentsLabel,
+  AttachmentsList,
+  Attachment,
+};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/getRenderableResult.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/getRenderableResult.ts
@@ -35,8 +35,11 @@ const getToolCallResult = (content: ContentItem[]): ToolCallResult | null => {
   }
 };
 
-/** Extracts a tool call result for rendering in a single-line preview. */
-const getResultPreview = (content: ContentItem[]): string => {
+/**
+ * Extracts a tool call result for rendering in a single-line preview.
+ * Returns `null` when no TEXT/OBJECT exists, but DOCUMENT content.
+ */
+const getResultPreview = (content: ContentItem[]): string | null => {
   const entry = content.find(
     (item) => item.contentType === 'TEXT' || item.contentType === 'OBJECT',
   );
@@ -45,8 +48,12 @@ const getResultPreview = (content: ContentItem[]): string => {
       return entry.text;
     case 'OBJECT':
       return JSON.stringify(entry.object);
-    default:
-      return EMPTY_RESULT_MESSAGE;
+    default: {
+      const hasDocuments = content.some(
+        (item) => item.contentType === 'DOCUMENT',
+      );
+      return hasDocuments ? null : EMPTY_RESULT_MESSAGE;
+    }
   }
 };
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
@@ -62,8 +62,24 @@ describe('<ToolResultMessage />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should show a fallback message when the result has no TEXT or OBJECT content', () => {
+  it('should show a fallback message when the result has no content at all', () => {
     render(
+      <ToolResultMessage
+        availableTools={[]}
+        toolCalls={[
+          {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
+        ]}
+        content={[]}
+      />,
+    );
+
+    expect(
+      screen.getByText('The tool call did not return content.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render document chips and open the document list modal', async () => {
+    const {user} = render(
       <ToolResultMessage
         availableTools={[]}
         toolCalls={[
@@ -93,7 +109,17 @@ describe('<ToolResultMessage />', () => {
     );
 
     expect(
-      screen.getByText('The tool call did not return content.'),
+      screen.queryByText('The tool call did not return content.'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('listitem', {name: 'report.txt'}),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('View documents'));
+
+    const dialog = within(screen.getByRole('dialog'));
+    expect(
+      dialog.getByRole('heading', {name: '1 document in tool result'}),
     ).toBeInTheDocument();
   });
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -22,6 +22,7 @@ import {
 import {Button} from '@carbon/react';
 import {getResultPreview, type ContentItem} from './getRenderableResult';
 import {ToolResultModal} from './ToolResultModal';
+import {DocumentContent} from '../MessageAttachments/DocumentContent';
 
 type ToolResultMessageProps = {
   availableTools: AgentTool[];
@@ -61,7 +62,8 @@ const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
         <Tools size={12} />
         <ToolLabel>{toolCall.toolName}</ToolLabel>
       </ToolHeader>
-      <ResultPreview>{resultPreview}</ResultPreview>
+      {resultPreview !== null && <ResultPreview>{resultPreview}</ResultPreview>}
+      <DocumentContent content={content} modalTitleSuffix="tool result" />
       <ToolActions>
         <Button
           kind="ghost"

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -112,7 +112,10 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
           }
         }
       })}
-      <DocumentContent content={content} />
+      <DocumentContent
+        content={content}
+        modalTitleSuffix="conversation message"
+      />
       <ToolCalls toolCalls={toolCalls} />
       {messageDetails.state === 'visible' && (
         <MessageDetailsModal

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -8,7 +8,7 @@
 
 import {useReducer} from 'react';
 import {Button} from '@carbon/react';
-import {Document, Maximize, Tools} from '@carbon/react/icons';
+import {Maximize} from '@carbon/react/icons';
 import type {
   AgentInstanceHistoryItem,
   AgentInstanceHistoryRole,
@@ -21,14 +21,13 @@ import {
   TextContent,
   MessageActions,
   ObjectContent,
-  AttachmentsContainer,
-  AttachmentsLabel,
-  AttachmentButton,
   MessageHeader,
 } from './styled';
 import {MarkdownMessage} from './MarkdownMessage';
 import {MessageDetailsModal} from './MessageDetailsModal';
 import {MessageMetrics} from './MessageMetrics';
+import {DocumentContent} from './MessageAttachments/DocumentContent';
+import {ToolCalls} from './MessageAttachments/ToolCalls';
 
 type Actor = Exclude<AgentInstanceHistoryRole, 'TOOL_RESULT'> | 'SYSTEM';
 type ContentItem = AgentInstanceHistoryItem['content'][number];
@@ -65,10 +64,6 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
   const [messageDetails, dispatch] = useReducer(
     messageDetailsReducer,
     initialMessageDetailsState,
-  );
-
-  const documentEntries = content.filter(
-    (entry) => entry.contentType === 'DOCUMENT',
   );
 
   return (
@@ -117,32 +112,8 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
           }
         }
       })}
-      {documentEntries.length > 0 && (
-        <AttachmentsContainer>
-          <AttachmentsLabel>Documents</AttachmentsLabel>
-          {documentEntries.map(({documentReference}) => (
-            <AttachmentButton key={documentReference.documentId} disabled>
-              <Document size={12} />
-              {documentReference.metadata.fileName}
-            </AttachmentButton>
-          ))}
-        </AttachmentsContainer>
-      )}
-      {toolCalls.length > 0 && (
-        <AttachmentsContainer>
-          <AttachmentsLabel>Tool calls</AttachmentsLabel>
-          {toolCalls.map((tc) => (
-            <AttachmentButton
-              key={tc.toolCallId}
-              aria-label={`"${tc.toolName}" tool call.`}
-              disabled
-            >
-              <Tools size={12} />
-              {tc.toolName}
-            </AttachmentButton>
-          ))}
-        </AttachmentsContainer>
-      )}
+      <DocumentContent content={content} />
+      <ToolCalls toolCalls={toolCalls} />
       {messageDetails.state === 'visible' && (
         <MessageDetailsModal
           title={messageDetails.title}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -88,49 +88,6 @@ const ObjectContent = styled.pre`
   word-break: break-word;
 `;
 
-const AttachmentsContainer = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  margin-block-start: var(--cds-spacing-04);
-  gap: var(--cds-spacing-02);
-`;
-
-const AttachmentsLabel = styled.h6`
-  font-size: var(--cds-label-01-font-size);
-  font-weight: var(--cds-label-01-font-weight);
-  line-height: var(--cds-label-01-line-height);
-  letter-spacing: var(--cds-label-01-letter-spacing);
-  color: var(--cds-text-secondary);
-`;
-
-const AttachmentButton = styled.button`
-  appearance: none;
-  background-color: transparent;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cds-spacing-02);
-  padding: var(--cds-spacing-01) var(--cds-spacing-03);
-  border-radius: 100px; // pill shape
-  font-size: var(--cds-label-01-font-size);
-  font-weight: var(--cds-label-01-font-weight);
-  line-height: var(--cds-label-01-line-height);
-  letter-spacing: var(--cds-label-01-letter-spacing);
-  color: var(--cds-link-primary);
-  border: 1px solid var(--cds-border-subtle-01);
-  white-space: nowrap;
-  cursor: pointer;
-
-  & > svg {
-    color: var(--cds-icon-secondary);
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    color: var(--cds-text-primary);
-  }
-`;
-
 const ModalContent = styled(TextContent)`
   min-height: 60vh;
   max-height: 70vh;
@@ -155,9 +112,6 @@ export {
   TextContent,
   ObjectContent,
   MessageActions,
-  AttachmentsContainer,
-  AttachmentsLabel,
-  AttachmentButton,
   ModalContent,
   ModalToolbar,
   ViewSwitcher,


### PR DESCRIPTION
## Description

This PR overhauls the attachment chips of AI agent conversation history messages. Previously, the where still considered buttons even though they were disabled all the time. Now, they are list items. Both continue to share styles between documents and tool calls lists.

- Moved tool calls into `ConversationMessage/MessageAttachments/ToolCalls.tsx`
- Moved documents into `ConversationMessage/MessageAttachments/DocumentContent.tsx`
- Added a "view documents" action to the end of document chips that opens the document-list modal.
- Integrated the `DocumentContent` component into `ToolResultMessage`, giving tool results the ability to render documents.
- Since users and tools can attach **a lot** of documents, the **chips are limited to 3 items with aggressive fileName truncation**. It should mainly serve as a quick preview for the document-list modal, instead of an exhaustive list.

## Related issues

relates #55596
