### PR TITLE
refactor: remove variable wording from shared documents view code

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageAttachments/DocumentContent.tsx
@@ -80,10 +80,7 @@ const DocumentContent: React.FC<Props> = memo(function DocumentContent({
             open={open}
             setOpen={setOpen}
             documents={documents}
-            isFullyLoaded
-            isError={false}
-            isLoading={false}
-            variableName={modalTitleSuffix}
+            labelSuffix={modalTitleSuffix}
           />
         )}
       </ModalStateManager>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/VariablesTable.tsx
@@ -152,11 +152,11 @@ const VariablesTable: React.FC<Props> = ({
                         <>
                           <PreviewDocumentButton
                             document={documentResult.document}
-                            variableName={name}
+                            labelSuffix={name}
                           />
                           <DownloadDocumentButton
                             document={documentResult.document}
-                            variableName={name}
+                            labelSuffix={name}
                           />
                         </>
                       )}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewDocumentListButton/VariableDocumentListModal.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/ViewDocumentListButton/VariableDocumentListModal.tsx
@@ -13,6 +13,11 @@ import {parseDocumentVariable} from '../parseDocumentVariable';
 import type {DocumentInfo} from 'App/ProcessInstance/DocumentsView/documentInfo';
 import {DocumentListModal} from 'App/ProcessInstance/DocumentsView/DocumentListModal';
 
+const LOADING_HINT =
+  'Loading the full variable value... More documents may exist for this variable.';
+const ERROR_HINT =
+  'Failed to load the full variable value. More documents may exist for this variable.';
+
 type Props = {
   documents: DocumentInfo[];
   isLowerBound: boolean;
@@ -28,7 +33,7 @@ const VariableDocumentListModal: React.FC<StateProps & Props> = ({
   variableKey,
   variableName,
 }) => {
-  const {data, isSuccess, isError, isLoading} = useVariable(variableKey, {
+  const {data, isError, isLoading} = useVariable(variableKey, {
     enabled: open && isLowerBound,
   });
 
@@ -50,10 +55,9 @@ const VariableDocumentListModal: React.FC<StateProps & Props> = ({
       open={open}
       setOpen={setOpen}
       documents={resolvedDocuments}
-      isFullyLoaded={!isLowerBound || isSuccess}
-      isLoading={isLoading}
-      isError={isError}
-      variableName={variableName}
+      labelSuffix={variableName}
+      loadingHint={isLoading ? LOADING_HINT : undefined}
+      errorHint={isError ? ERROR_HINT : undefined}
     />
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/tests/documentVariable.test.tsx
@@ -77,7 +77,7 @@ describe('VariablesTab document variables', () => {
 
     const variableRow = within(screen.getByTestId('variable-myDocument'));
     const downloadButton = variableRow.getByLabelText(
-      'Download document for variable myDocument',
+      'Download document for myDocument',
     );
     expect(downloadButton).toHaveAttribute(
       'href',
@@ -104,7 +104,7 @@ describe('VariablesTab document variables', () => {
 
     const variableRow = within(screen.getByTestId('variable-myDocumentList'));
     expect(
-      variableRow.queryByLabelText(/download document for variable/i),
+      variableRow.queryByLabelText(/download document for/i),
     ).not.toBeInTheDocument();
   });
 
@@ -130,7 +130,7 @@ describe('VariablesTab document variables', () => {
 
     const variableRow = within(screen.getByTestId('variable-myImage'));
     const previewButton = variableRow.getByLabelText(
-      'Preview document for variable myImage',
+      'Preview document for myImage',
     );
     expect(previewButton).toBeEnabled();
   });
@@ -157,7 +157,7 @@ describe('VariablesTab document variables', () => {
 
     const variableRow = within(screen.getByTestId('variable-myDocument'));
     const previewButton = variableRow.getByLabelText(
-      'Preview document for variable myDocument',
+      'Preview document for myDocument',
     );
     expect(previewButton).toBeDisabled();
   });
@@ -180,7 +180,7 @@ describe('VariablesTab document variables', () => {
 
     const variableRow = within(screen.getByTestId('variable-myDocumentList'));
     expect(
-      variableRow.queryByLabelText(/preview document for variable/i),
+      variableRow.queryByLabelText(/preview document for/i),
     ).not.toBeInTheDocument();
   });
 
@@ -247,10 +247,10 @@ describe('VariablesTab document variables', () => {
     expect(variableRow.getByText('Expired')).toBeInTheDocument();
 
     const downloadButton = variableRow.getByLabelText(
-      'Download document for variable myDocument',
+      'Download document for myDocument',
     );
     const previewButton = variableRow.getByLabelText(
-      'Preview document for variable myDocument',
+      'Preview document for myDocument',
     );
     expect(downloadButton).toBeDisabled();
     expect(previewButton).toBeDisabled();
@@ -280,10 +280,10 @@ describe('VariablesTab document variables', () => {
     const variableRow = within(screen.getByTestId('variable-myDocument'));
     expect(variableRow.queryByText('Expired')).not.toBeInTheDocument();
     expect(
-      variableRow.getByLabelText('Download document for variable myDocument'),
+      variableRow.getByLabelText('Download document for myDocument'),
     ).toBeEnabled();
     expect(
-      variableRow.getByLabelText('Preview document for variable myDocument'),
+      variableRow.getByLabelText('Preview document for myDocument'),
     ).toBeEnabled();
   });
 
@@ -295,13 +295,13 @@ describe('VariablesTab document variables', () => {
 
     const variableRow = within(screen.getByTestId('variable-testVariableName'));
     expect(
-      variableRow.queryByLabelText(/download document for variable/i),
+      variableRow.queryByLabelText(/download document for/i),
     ).not.toBeInTheDocument();
     expect(
       variableRow.queryByLabelText(/view documents for variable/i),
     ).not.toBeInTheDocument();
     expect(
-      variableRow.queryByLabelText(/preview document for variable/i),
+      variableRow.queryByLabelText(/preview document for/i),
     ).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/DocumentsView/DocumentListModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/DocumentsView/DocumentListModal/index.test.tsx
@@ -44,10 +44,7 @@ describe('<DocumentListModal />', () => {
         open
         setOpen={() => {}}
         documents={documents}
-        isFullyLoaded
-        isLoading={false}
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
       />,
     );
 
@@ -68,19 +65,16 @@ describe('<DocumentListModal />', () => {
         open
         setOpen={() => {}}
         documents={documents}
-        isFullyLoaded
-        isLoading={false}
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
       />,
     );
 
     const dialog = within(screen.getByRole('dialog'));
+    expect(dialog.getAllByLabelText('Preview document for files')).toHaveLength(
+      3,
+    );
     expect(
-      dialog.getAllByLabelText('Preview document for variable files'),
-    ).toHaveLength(3);
-    expect(
-      dialog.getAllByLabelText('Download document for variable files'),
+      dialog.getAllByLabelText('Download document for files'),
     ).toHaveLength(3);
   });
 
@@ -90,10 +84,7 @@ describe('<DocumentListModal />', () => {
         open
         setOpen={() => {}}
         documents={documents}
-        isFullyLoaded
-        isLoading={false}
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
       />,
     );
 
@@ -103,16 +94,14 @@ describe('<DocumentListModal />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should show a lower-bound count with a plus sign when not fully loaded', () => {
+  it('should show a lower-bound count with a plus sign when a hint is provided', () => {
     render(
       <DocumentListModal
         open
         setOpen={() => {}}
         documents={documents}
-        isFullyLoaded={false}
-        isLoading={false}
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
+        loadingHint="Loading more documents..."
       />,
     );
 
@@ -122,44 +111,38 @@ describe('<DocumentListModal />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should show a loading notice when isLoading is true', () => {
+  it('should render the loading hint when provided', () => {
     render(
       <DocumentListModal
         open
         setOpen={() => {}}
         documents={documents}
-        isFullyLoaded={false}
-        isLoading
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
+        loadingHint="Loading more documents... More documents may exist."
       />,
     );
 
     const dialog = within(screen.getByRole('dialog'));
     expect(
-      dialog.getByText(
-        'Loading the full variable value... More documents may exist for this variable.',
-      ),
+      dialog.getByText('Loading more documents... More documents may exist.'),
     ).toBeInTheDocument();
   });
 
-  it('should show an error notice when isError is true', () => {
+  it('should render the error hint when provided', () => {
     render(
       <DocumentListModal
         open
         setOpen={() => {}}
         documents={documents}
-        isFullyLoaded={false}
-        isLoading={false}
-        isError
-        variableName="files"
+        labelSuffix="files"
+        errorHint="Failed to load more documents. More documents may exist."
       />,
     );
 
     const dialog = within(screen.getByRole('dialog'));
     expect(
       dialog.getByText(
-        'Failed to load the full variable value. More documents may exist for this variable.',
+        'Failed to load more documents. More documents may exist.',
       ),
     ).toBeInTheDocument();
   });
@@ -181,10 +164,7 @@ describe('<DocumentListModal />', () => {
             isExpired: false,
           },
         ]}
-        isFullyLoaded
-        isLoading={false}
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
       />,
     );
 
@@ -220,10 +200,7 @@ describe('<DocumentListModal />', () => {
         open
         setOpen={() => {}}
         documents={documentsWithExpired}
-        isFullyLoaded
-        isLoading={false}
-        isError={false}
-        variableName="files"
+        labelSuffix="files"
       />,
     );
 
@@ -234,10 +211,10 @@ describe('<DocumentListModal />', () => {
     );
     expect(expiredItem.getByText('Expired')).toBeInTheDocument();
     expect(
-      expiredItem.getByLabelText('Preview document for variable files'),
+      expiredItem.getByLabelText('Preview document for files'),
     ).toBeDisabled();
     expect(
-      expiredItem.getByLabelText('Download document for variable files'),
+      expiredItem.getByLabelText('Download document for files'),
     ).toBeDisabled();
 
     const activeItem = within(
@@ -245,10 +222,10 @@ describe('<DocumentListModal />', () => {
     );
     expect(activeItem.queryByText('Expired')).not.toBeInTheDocument();
     expect(
-      activeItem.getByLabelText('Preview document for variable files'),
+      activeItem.getByLabelText('Preview document for files'),
     ).toBeEnabled();
     const activeDownloadLink = activeItem.getByLabelText(
-      'Download document for variable files',
+      'Download document for files',
     );
     expect(activeDownloadLink).toBeEnabled();
     expect(activeDownloadLink).toHaveAttribute('href', '/v2/documents/active');

--- a/operate/client/src/App/ProcessInstance/DocumentsView/DocumentListModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/DocumentsView/DocumentListModal/index.tsx
@@ -24,21 +24,20 @@ import {
 
 type Props = {
   documents: DocumentInfo[];
-  isFullyLoaded: boolean;
-  isLoading: boolean;
-  isError: boolean;
-  variableName: string;
+  labelSuffix: string;
+  loadingHint?: string;
+  errorHint?: string;
 };
 
 const DocumentListModal: React.FC<StateProps & Props> = ({
   open,
   setOpen,
   documents,
-  isFullyLoaded,
-  isLoading,
-  isError,
-  variableName,
+  labelSuffix,
+  loadingHint,
+  errorHint,
 }) => {
+  const isFullyLoaded = !loadingHint && !errorHint;
   const count = documents.length;
   const prefix = isFullyLoaded ? `${count}` : `${count}+`;
   const suffix = count !== 1 ? 'documents' : 'document';
@@ -47,7 +46,7 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
     <Modal
       open={open}
       onRequestClose={() => setOpen(false)}
-      modalHeading={`${prefix} ${suffix} in ${variableName}`}
+      modalHeading={`${prefix} ${suffix} in ${labelSuffix}`}
       size="md"
       passiveModal
     >
@@ -73,27 +72,17 @@ const DocumentListModal: React.FC<StateProps & Props> = ({
             </DocumentInfoBlock>
             <PreviewDocumentButton
               document={document}
-              variableName={variableName}
+              labelSuffix={labelSuffix}
             />
             <DownloadDocumentButton
               document={document}
-              variableName={variableName}
+              labelSuffix={labelSuffix}
             />
           </DocumentListItem>
         ))}
       </DocumentList>
-      {isLoading && (
-        <TruncationNotice>
-          Loading the full variable value... More documents may exist for this
-          variable.
-        </TruncationNotice>
-      )}
-      {isError && (
-        <TruncationNotice>
-          Failed to load the full variable value. More documents may exist for
-          this variable.
-        </TruncationNotice>
-      )}
+      {loadingHint && <TruncationNotice>{loadingHint}</TruncationNotice>}
+      {errorHint && <TruncationNotice>{errorHint}</TruncationNotice>}
     </Modal>
   );
 };

--- a/operate/client/src/App/ProcessInstance/DocumentsView/DocumentPreview/PreviewDocumentButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/DocumentsView/DocumentPreview/PreviewDocumentButton.test.tsx
@@ -60,33 +60,29 @@ const unknownDocument: DocumentInfo = {
 describe('<PreviewDocumentButton />', () => {
   it('should render an enabled preview button for image documents', () => {
     render(
-      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+      <PreviewDocumentButton document={imageDocument} labelSuffix="myImage" />,
     );
 
-    const button = screen.getByLabelText(
-      'Preview document for variable myImage',
-    );
+    const button = screen.getByLabelText('Preview document for myImage');
     expect(button).toBeEnabled();
   });
 
   it('should render an enabled preview button for pdf documents', () => {
     render(
-      <PreviewDocumentButton document={pdfDocument} variableName="myPdf" />,
+      <PreviewDocumentButton document={pdfDocument} labelSuffix="myPdf" />,
     );
 
-    const button = screen.getByLabelText('Preview document for variable myPdf');
+    const button = screen.getByLabelText('Preview document for myPdf');
     expect(button).toBeEnabled();
   });
 
   it('should render an enabled preview button for json documents', () => {
     render(
-      <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
+      <PreviewDocumentButton document={jsonDocument} labelSuffix="myJson" />,
       {wrapper: createWrapper()},
     );
 
-    const button = screen.getByLabelText(
-      'Preview document for variable myJson',
-    );
+    const button = screen.getByLabelText('Preview document for myJson');
     expect(button).toBeEnabled();
   });
 
@@ -94,25 +90,21 @@ describe('<PreviewDocumentButton />', () => {
     render(
       <PreviewDocumentButton
         document={unknownDocument}
-        variableName="myArchive"
+        labelSuffix="myArchive"
       />,
     );
 
-    const button = screen.getByLabelText(
-      'Preview document for variable myArchive',
-    );
+    const button = screen.getByLabelText('Preview document for myArchive');
     expect(button).toBeDisabled();
     expect(screen.getByText('Unsupported file type')).toBeInTheDocument();
   });
 
   it('should open the modal with the pdf when clicked', async () => {
     const {user} = render(
-      <PreviewDocumentButton document={pdfDocument} variableName="myPdf" />,
+      <PreviewDocumentButton document={pdfDocument} labelSuffix="myPdf" />,
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myPdf'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myPdf'));
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toBeInTheDocument();
@@ -123,12 +115,10 @@ describe('<PreviewDocumentButton />', () => {
 
   it('should open the modal with the image when clicked', async () => {
     const {user} = render(
-      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+      <PreviewDocumentButton document={imageDocument} labelSuffix="myImage" />,
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myImage'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myImage'));
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toBeInTheDocument();
@@ -140,13 +130,11 @@ describe('<PreviewDocumentButton />', () => {
     mockDownloadDocument().withSuccess('{"foo":"bar","nested":{"baz":1}}');
 
     const {user} = render(
-      <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
+      <PreviewDocumentButton document={jsonDocument} labelSuffix="myJson" />,
       {wrapper: createWrapper()},
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myJson'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myJson'));
 
     const editor = await screen.findByTestId('monaco-editor');
     expect(editor).toHaveValue(
@@ -158,13 +146,11 @@ describe('<PreviewDocumentButton />', () => {
     mockDownloadDocument().withServerError();
 
     const {user} = render(
-      <PreviewDocumentButton document={jsonDocument} variableName="myJson" />,
+      <PreviewDocumentButton document={jsonDocument} labelSuffix="myJson" />,
       {wrapper: createWrapper()},
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myJson'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myJson'));
 
     expect(
       await screen.findByText(
@@ -176,12 +162,10 @@ describe('<PreviewDocumentButton />', () => {
 
   it('should show the file name as the modal heading', async () => {
     const {user} = render(
-      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+      <PreviewDocumentButton document={imageDocument} labelSuffix="myImage" />,
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myImage'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myImage'));
 
     expect(
       screen.getByRole('heading', {name: 'Preview: photo.png'}),
@@ -199,10 +183,10 @@ describe('<PreviewDocumentButton />', () => {
     };
 
     render(
-      <PreviewDocumentButton document={expiredDocument} variableName="myDoc" />,
+      <PreviewDocumentButton document={expiredDocument} labelSuffix="myDoc" />,
     );
 
-    const button = screen.getByLabelText('Preview document for variable myDoc');
+    const button = screen.getByLabelText('Preview document for myDoc');
     expect(button).toBeDisabled();
     expect(screen.getByText('Document has expired')).toBeInTheDocument();
   });
@@ -218,10 +202,10 @@ describe('<PreviewDocumentButton />', () => {
     };
 
     render(
-      <PreviewDocumentButton document={noLinkDocument} variableName="myDoc" />,
+      <PreviewDocumentButton document={noLinkDocument} labelSuffix="myDoc" />,
     );
 
-    const button = screen.getByLabelText('Preview document for variable myDoc');
+    const button = screen.getByLabelText('Preview document for myDoc');
     expect(button).toBeDisabled();
     expect(screen.getByText('Preview unavailable')).toBeInTheDocument();
   });
@@ -229,12 +213,10 @@ describe('<PreviewDocumentButton />', () => {
   it('should track "document-previewed" events', async () => {
     const trackSpy = vi.spyOn(tracking, 'track');
     const {user} = render(
-      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+      <PreviewDocumentButton document={imageDocument} labelSuffix="myImage" />,
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myImage'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myImage'));
 
     expect(trackSpy).toHaveBeenCalledWith({
       eventName: 'document-previewed',
@@ -246,12 +228,10 @@ describe('<PreviewDocumentButton />', () => {
 
   it('should show an error notification when the image fails to load', async () => {
     const {user} = render(
-      <PreviewDocumentButton document={imageDocument} variableName="myImage" />,
+      <PreviewDocumentButton document={imageDocument} labelSuffix="myImage" />,
     );
 
-    await user.click(
-      screen.getByLabelText('Preview document for variable myImage'),
-    );
+    await user.click(screen.getByLabelText('Preview document for myImage'));
 
     const image = screen.getByRole('img', {name: 'photo.png'});
     fireEvent.error(image);

--- a/operate/client/src/App/ProcessInstance/DocumentsView/DocumentPreview/PreviewDocumentButton.tsx
+++ b/operate/client/src/App/ProcessInstance/DocumentsView/DocumentPreview/PreviewDocumentButton.tsx
@@ -27,10 +27,10 @@ function getDisabledTooltipText(document: DocumentInfo): string {
 
 type Props = {
   document: DocumentInfo;
-  variableName: string;
+  labelSuffix: string;
 };
 
-const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
+const PreviewDocumentButton: React.FC<Props> = ({document, labelSuffix}) => {
   const isDisabled =
     document.link === null || document.isExpired || document.type === 'unknown';
 
@@ -45,7 +45,7 @@ const PreviewDocumentButton: React.FC<Props> = ({document, variableName}) => {
             renderIcon={View}
             iconDescription="Preview"
             tooltipPosition="top"
-            aria-label={`Preview document for variable ${variableName}`}
+            aria-label={`Preview document for ${labelSuffix}`}
             disabled={isDisabled}
             onClick={() => {
               tracking.track({

--- a/operate/client/src/App/ProcessInstance/DocumentsView/DownloadDocumentButton/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/DocumentsView/DownloadDocumentButton/index.test.tsx
@@ -32,22 +32,20 @@ describe('<DownloadDocumentButton />', () => {
     };
 
     render(
-      <DownloadDocumentButton document={noLinkDocument} variableName="myPdf" />,
+      <DownloadDocumentButton document={noLinkDocument} labelSuffix="myPdf" />,
     );
 
-    const button = screen.getByLabelText(
-      'Download document for variable myPdf',
-    );
+    const button = screen.getByLabelText('Download document for myPdf');
     expect(button).toBeDisabled();
     expect(button.tagName).not.toBe('A');
   });
 
   it('should render a download link with correct href and filename', () => {
     render(
-      <DownloadDocumentButton document={pdfDocument} variableName="myPdf" />,
+      <DownloadDocumentButton document={pdfDocument} labelSuffix="myPdf" />,
     );
 
-    const link = screen.getByLabelText('Download document for variable myPdf');
+    const link = screen.getByLabelText('Download document for myPdf');
     expect(link).toHaveAttribute('href', '/v2/documents/pdf');
     expect(link).toHaveAttribute('download', 'report.pdf');
   });
@@ -63,15 +61,10 @@ describe('<DownloadDocumentButton />', () => {
     };
 
     render(
-      <DownloadDocumentButton
-        document={expiredDocument}
-        variableName="myPdf"
-      />,
+      <DownloadDocumentButton document={expiredDocument} labelSuffix="myPdf" />,
     );
 
-    const button = screen.getByLabelText(
-      'Download document for variable myPdf',
-    );
+    const button = screen.getByLabelText('Download document for myPdf');
     expect(button).toBeDisabled();
     expect(button.tagName).not.toBe('A');
     expect(screen.getByText('Document has expired')).toBeInTheDocument();
@@ -82,12 +75,10 @@ describe('<DownloadDocumentButton />', () => {
     window.addEventListener('click', (e) => e.preventDefault(), {once: true});
     const trackSpy = vi.spyOn(tracking, 'track');
     const {user} = render(
-      <DownloadDocumentButton document={pdfDocument} variableName="myPdf" />,
+      <DownloadDocumentButton document={pdfDocument} labelSuffix="myPdf" />,
     );
 
-    await user.click(
-      screen.getByLabelText('Download document for variable myPdf'),
-    );
+    await user.click(screen.getByLabelText('Download document for myPdf'));
 
     expect(trackSpy).toHaveBeenCalledWith({
       eventName: 'document-downloaded',

--- a/operate/client/src/App/ProcessInstance/DocumentsView/DownloadDocumentButton/index.tsx
+++ b/operate/client/src/App/ProcessInstance/DocumentsView/DownloadDocumentButton/index.tsx
@@ -18,10 +18,10 @@ function getDisabledTooltipText(document: DocumentInfo): string {
 
 type Props = {
   document: DocumentInfo;
-  variableName: string;
+  labelSuffix: string;
 };
 
-const DownloadDocumentButton: React.FC<Props> = ({document, variableName}) => {
+const DownloadDocumentButton: React.FC<Props> = ({document, labelSuffix}) => {
   const isDisabled = document.link === null || document.isExpired;
 
   const button = (
@@ -37,7 +37,7 @@ const DownloadDocumentButton: React.FC<Props> = ({document, variableName}) => {
       iconDescription="Download"
       tooltipPosition="top"
       tooltipAlignment="end"
-      aria-label={`Download document for variable ${variableName}`}
+      aria-label={`Download document for ${labelSuffix}`}
       disabled={isDisabled}
       onClick={() => {
         tracking.track({


### PR DESCRIPTION
## Description

This PR refactors the shared document visualization code under `DocumentView` to no longer reference the word variables.
- Some aria-label has had `variable` in their description, which has been dropped.
- The component prop `variableName` has been replaced with `labelSuffix`.
- The `DocumentListModal` has been reworked to accept consumer-provided loading and error hints, instead of state booleans.

## Related issues

closes #55596
