### PR TITLE
test: scope a golden scenario to a subset of files via PathFilter

### DIFF
--- a/load-tests/setup/test/README.md
+++ b/load-tests/setup/test/README.md
@@ -73,17 +73,47 @@ active; the stable entries are commented out. To enable one:
 2. `make update-golden` (or scope it: `go test -update-golden -run 'TestGoldenFiles/stable-89' ./...`).
 3. Commit the generated golden files. No other code change is needed.
 
+## Narrowing a scenario to a subset of files (`PathFilter`)
+
+Some scenarios exist only to verify one narrow area — e.g. a scenario added
+specifically to catch a regression in one template. Committing (and diffing)
+the full rendered tree for those isn't worth the review noise when only a
+handful of files are actually relevant.
+
+Set `PathFilter` on a `scenario` in `golden_test.go` to a list of path
+prefixes, relative to each chart's own output tree:
+
+```go
+{Name: "elasticsearch-no-optimize", Storage: "elasticsearch", Optimize: false,
+	PathFilter: []string{"templates/orchestration"}},
+```
+
+Only rendered manifests under those prefixes are compared or committed for
+that scenario — everything else is silently skipped, for every chart the
+scenario renders. Leave `PathFilter` unset (the default) to keep comparing
+every rendered file, exactly like today.
+
+A scenario's `PathFilter` can legitimately match nothing for one of the charts
+it renders (e.g. a filter scoped to `platform`'s templates has no matches
+when rendering `load-test-setup`) — that chart's golden subdirectory is then
+simply absent, and the test does not fail on it.
+
 ## If golden diffs become noisy in PRs
 
 These files are generated, so a chart or values change can touch many of them at
-once and dominate a PR's diff. If that becomes a review burden, mark the golden
-tree as generated so GitHub collapses it in diffs (and excludes it from language
-stats) via a `.gitattributes` entry, e.g.:
+once and dominate a PR's diff. Two options, not mutually exclusive:
 
-```
-load-tests/setup/test/golden/** linguist-generated=true
-```
+- If the scenario only needs to verify one narrow area, add a `PathFilter`
+  (above) — the golden tree for that scenario shrinks to just the relevant
+  files, so there's less to commit and less to review in the first place.
+- For diffs across many files that are all genuinely relevant, mark the golden
+  tree as generated so GitHub collapses it in diffs (and excludes it from
+  language stats) via a `.gitattributes` entry, e.g.:
 
-See GitHub's [customizing how changed files appear](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)
-and [Managing generated files in GitHub](https://medium.com/@clarkbw/managing-generated-files-in-github-1f1989c09dfd).
-We have not applied this yet — the diffs are reviewed normally for now.
+  ```
+  load-tests/setup/test/golden/** linguist-generated=true
+  ```
+
+  See GitHub's [customizing how changed files appear](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)
+  and [Managing generated files in GitHub](https://medium.com/@clarkbw/managing-generated-files-in-github-1f1989c09dfd).
+  We have not applied this yet — the diffs are reviewed normally for now.

--- a/load-tests/setup/test/README.md
+++ b/load-tests/setup/test/README.md
@@ -89,31 +89,29 @@ prefixes, relative to each chart's own output tree:
 ```
 
 Only rendered manifests under those prefixes are compared or committed for
-that scenario — everything else is silently skipped, for every chart the
-scenario renders. Leave `PathFilter` unset (the default) to keep comparing
-every rendered file, exactly like today.
+that scenario — everything else is skipped, for every chart the scenario
+renders. A non-empty `PathFilter` must match at least one rendered manifest for
+each chart it renders; otherwise the test fails. That makes typos or filters
+scoped to the wrong chart visible instead of silently removing coverage. Leave
+`PathFilter` unset (the default) to keep comparing every rendered file, exactly
+like today.
 
-A scenario's `PathFilter` can legitimately match nothing for one of the charts
-it renders (e.g. a filter scoped to `platform`'s templates has no matches
-when rendering `load-test-setup`) — that chart's golden subdirectory is then
-simply absent, and the test does not fail on it.
+## Why golden diffs are collapsed in PRs
 
-## If golden diffs become noisy in PRs
+Golden files under `golden/` are generated render snapshots, not hand-authored
+source. The repository marks them as generated in `.gitattributes`:
 
-These files are generated, so a chart or values change can touch many of them at
-once and dominate a PR's diff. Two options, not mutually exclusive:
+```
+load-tests/setup/test/golden/** linguist-generated=true
+```
 
-- If the scenario only needs to verify one narrow area, add a `PathFilter`
-  (above) — the golden tree for that scenario shrinks to just the relevant
-  files, so there's less to commit and less to review in the first place.
-- For diffs across many files that are all genuinely relevant, mark the golden
-  tree as generated so GitHub collapses it in diffs (and excludes it from
-  language stats) via a `.gitattributes` entry, e.g.:
+GitHub therefore collapses these files in PR diffs by default and excludes them
+from language statistics. This keeps reviews focused on the chart, value, or
+Makefile change that produced the snapshot update while still allowing
+reviewers to expand the generated files when they need to inspect the rendered
+manifest changes.
 
-  ```
-  load-tests/setup/test/golden/** linguist-generated=true
-  ```
-
-  See GitHub's [customizing how changed files appear](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github)
-  and [Managing generated files in GitHub](https://medium.com/@clarkbw/managing-generated-files-in-github-1f1989c09dfd).
-  We have not applied this yet — the diffs are reviewed normally for now.
+`PathFilter` is still useful when a scenario genuinely needs to verify only one
+narrow area: it reduces the committed snapshot tree and the test comparison
+scope. Do not add a `PathFilter` only to hide noisy diffs; the generated-file
+attribute already handles that.

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -30,6 +30,17 @@ var update = flag.Bool("update-golden", false,
 //
 // PhysicalTenants, when true, passes physical_tenants=true to the platform
 // template target. Only supported for rdbms secondary_storage (main version only).
+//
+// PathFilter, when set, restricts golden comparison (and, under
+// -update-golden, what gets committed) to rendered manifest paths with one of
+// these prefixes, relative to each chart's own output tree — e.g.
+// "templates/orchestration" keeps templates/orchestration/statefulset.yaml
+// but drops everything else. Use this for scenarios whose purpose is
+// verifying one narrow area (a specific bugfix's blast radius): committing
+// and diffing the full rendered tree for every combination isn't worth the
+// review noise when only a handful of files are actually relevant. Leave
+// empty (the default) to keep comparing every rendered file, unchanged from
+// today's behavior.
 type scenario struct {
 	Name            string
 	Storage         string // elasticsearch | opensearch | postgresql | none
@@ -38,6 +49,7 @@ type scenario struct {
 	Workload        string // "" = default profile; e.g. "max", "realistic"
 	SetupTarget     string // named make target for template-load-test-setup variants
 	PhysicalTenants bool
+	PathFilter      []string
 }
 
 // versionedScenario defines a scenario with a specific version
@@ -150,7 +162,7 @@ func TestGoldenFiles(t *testing.T) {
 			defer ns.Cleanup()
 
 			if s.Workload != "" {
-				renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", s.Workload)
+				renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", s.Workload, s.PathFilter)
 				return
 			}
 
@@ -158,7 +170,7 @@ func TestGoldenFiles(t *testing.T) {
 			// via their dedicated Makefile target. They render only that
 			// chart to avoid duplicating the full platform/load-tester matrix.
 			if s.SetupTarget != "" {
-				renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, s.SetupTarget, "")
+				renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, s.SetupTarget, "", s.PathFilter)
 				return
 			}
 
@@ -174,8 +186,8 @@ func TestGoldenFiles(t *testing.T) {
 				extraVars = append(extraVars, "physical_tenants=true")
 			}
 
-			renderAndAssert(t, s.Version, s.Name, "platform", ns, platformTarget, "", extraVars...)
-			renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", "", extraVars...)
+			renderAndAssert(t, s.Version, s.Name, "platform", ns, platformTarget, "", s.PathFilter, extraVars...)
+			renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", "", s.PathFilter, extraVars...)
 		})
 	}
 }
@@ -227,12 +239,14 @@ func TestInstallLoadTestSetupKeepsMakefileFlagsWhenAdditionalConfigurationIsProv
 
 // renderAndAssert renders a chart via the scaffolded Makefile's make target and
 // compares (or writes) the resulting manifest tree against the golden directory.
-// extraVars are additional make variable assignments forwarded to Render.
-func renderAndAssert(t *testing.T, version, scenario, chartName string, ns *ScaffoldedNamespace, makeTarget, workload string, extraVars ...string) {
+// pathFilter, when non-empty, restricts the comparison to that subset of
+// rendered paths (see scenario.PathFilter). extraVars are additional make
+// variable assignments forwarded to Render.
+func renderAndAssert(t *testing.T, version, scenario, chartName string, ns *ScaffoldedNamespace, makeTarget, workload string, pathFilter []string, extraVars ...string) {
 	t.Helper()
 
 	srcDir := ns.Render(t, makeTarget, workload, extraVars...)
-	assertGoldenDir(t, version, scenario, chartName, srcDir, *update)
+	assertGoldenDir(t, version, scenario, chartName, srcDir, *update, pathFilter)
 }
 
 // TestNormalize verifies that the normalize function strips expected fields

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -318,7 +318,7 @@ func TestShouldReturnNoManifestsWhenPathFilterMatchesNothing(t *testing.T) {
 
 func TestShouldMatchPathFilterByExactFileOrDirectoryPrefix(t *testing.T) {
 	// given
-	filter := []string{"Chart.yaml", "templates/orchestration"}
+	filter := []string{"./Chart.yaml", "templates/orchestration/"}
 
 	// when / then
 	require.True(t, matchesPathFilter("Chart.yaml", filter))

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -3,7 +3,9 @@ package golden
 
 import (
 	"flag"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -274,4 +276,61 @@ func TestNormalize(t *testing.T) {
 
 	// Idempotent.
 	require.Equal(t, got, normalize(got))
+}
+
+func TestShouldCollectAllManifestsWithoutPathFilter(t *testing.T) {
+	// given
+	root := t.TempDir()
+	writeTestManifest(t, root, "Chart.yaml", "name: platform\n")
+	writeTestManifest(t, root, "templates/orchestration/deployment.yaml", "kind: Deployment\n")
+
+	// when
+	manifests := collectManifests(t, root, nil)
+
+	// then
+	require.Equal(t, []string{"Chart.yaml", "templates/orchestration/deployment.yaml"}, sortedKeys(manifests))
+}
+
+func TestShouldCollectOnlyPathFilterMatches(t *testing.T) {
+	// given
+	root := t.TempDir()
+	writeTestManifest(t, root, "templates/orchestration/deployment.yaml", "kind: Deployment\n")
+	writeTestManifest(t, root, "templates/identity/deployment.yaml", "kind: Deployment\n")
+
+	// when
+	manifests := collectManifests(t, root, []string{"templates/orchestration"})
+
+	// then
+	require.Equal(t, []string{"templates/orchestration/deployment.yaml"}, sortedKeys(manifests))
+}
+
+func TestShouldReturnNoManifestsWhenPathFilterMatchesNothing(t *testing.T) {
+	// given
+	root := t.TempDir()
+	writeTestManifest(t, root, "templates/orchestration/deployment.yaml", "kind: Deployment\n")
+
+	// when
+	manifests := collectManifests(t, root, []string{"templates/missing"})
+
+	// then
+	require.Empty(t, manifests)
+}
+
+func TestShouldMatchPathFilterByExactFileOrDirectoryPrefix(t *testing.T) {
+	// given
+	filter := []string{"Chart.yaml", "templates/orchestration"}
+
+	// when / then
+	require.True(t, matchesPathFilter("Chart.yaml", filter))
+	require.True(t, matchesPathFilter("templates/orchestration/deployment.yaml", filter))
+	require.False(t, matchesPathFilter("templates/orchestration-extra/deployment.yaml", filter))
+	require.False(t, matchesPathFilter("templates/identity/deployment.yaml", filter))
+}
+
+func writeTestManifest(t *testing.T, root, rel, content string) {
+	t.Helper()
+
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }

--- a/load-tests/setup/test/goldenfiles.go
+++ b/load-tests/setup/test/goldenfiles.go
@@ -69,15 +69,36 @@ func collectManifests(t *testing.T, root string) map[string]string {
 	return manifests
 }
 
+// filterManifests keeps only entries whose relative path equals one of
+// prefixes, or sits under one of them as a directory. Returns manifests
+// unchanged if prefixes is empty.
+func filterManifests(manifests map[string]string, prefixes []string) map[string]string {
+	if len(prefixes) == 0 {
+		return manifests
+	}
+	filtered := make(map[string]string, len(manifests))
+	for rel, content := range manifests {
+		for _, prefix := range prefixes {
+			if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
+				filtered[rel] = content
+				break
+			}
+		}
+	}
+	return filtered
+}
+
 // assertGoldenDir compares the rendered manifest tree at srcDir against the
 // committed golden directory at golden/<version>/<scenario>/<chartName>/, file
 // for file. When update is true the directory is rewritten from the rendered
-// tree instead of compared.
-func assertGoldenDir(t *testing.T, version, scenario, chartName, srcDir string, update bool) {
+// tree instead of compared. pathFilter, when non-empty, narrows both the
+// rendered and (implicitly, since it's all that's ever written) committed
+// sets to paths under those prefixes — see scenario.PathFilter.
+func assertGoldenDir(t *testing.T, version, scenario, chartName, srcDir string, update bool, pathFilter []string) {
 	t.Helper()
 
 	dir := filepath.Join(goldenDir, version, scenario, chartName)
-	rendered := collectManifests(t, srcDir)
+	rendered := filterManifests(collectManifests(t, srcDir), pathFilter)
 
 	if update {
 		require.NoError(t, os.RemoveAll(dir))
@@ -88,6 +109,14 @@ func assertGoldenDir(t *testing.T, version, scenario, chartName, srcDir string, 
 				"failed to write golden file %s", dst)
 		}
 		t.Logf("updated %d golden manifest(s) in %s", len(rendered), dir)
+		return
+	}
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) && len(pathFilter) > 0 && len(rendered) == 0 {
+		// A pathFilter can legitimately match nothing for a given chart (e.g. a
+		// filter scoped to the platform chart's templates has no matches when
+		// rendering load-test-setup). No golden dir was ever committed for this
+		// chart under this filter, and nothing rendered either — consistent.
 		return
 	}
 

--- a/load-tests/setup/test/goldenfiles.go
+++ b/load-tests/setup/test/goldenfiles.go
@@ -46,9 +46,9 @@ func normalize(input string) string {
 	return strings.TrimSpace(result) + "\n"
 }
 
-// collectManifests walks a helm --output-dir tree and returns each file's
-// normalized content keyed by its path relative to the tree root.
-func collectManifests(t *testing.T, root string) map[string]string {
+// collectManifests walks a helm --output-dir tree and returns each matching
+// file's normalized content keyed by its path relative to the tree root.
+func collectManifests(t *testing.T, root string, pathFilter []string) map[string]string {
 	t.Helper()
 	manifests := map[string]string{}
 	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -59,33 +59,33 @@ func collectManifests(t *testing.T, root string) map[string]string {
 		if err != nil {
 			return err
 		}
+		rel = filepath.ToSlash(rel)
+		if !matchesPathFilter(rel, pathFilter) {
+			return nil
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
-		manifests[filepath.ToSlash(rel)] = normalize(string(data))
+		manifests[rel] = normalize(string(data))
 		return nil
 	}))
 	return manifests
 }
 
-// filterManifests keeps only entries whose relative path equals one of
-// prefixes, or sits under one of them as a directory. Returns manifests
-// unchanged if prefixes is empty.
-func filterManifests(manifests map[string]string, prefixes []string) map[string]string {
+// matchesPathFilter returns true when rel equals one of prefixes, or sits under
+// one of them as a directory. An empty filter matches every path.
+func matchesPathFilter(rel string, prefixes []string) bool {
 	if len(prefixes) == 0 {
-		return manifests
+		return true
 	}
-	filtered := make(map[string]string, len(manifests))
-	for rel, content := range manifests {
-		for _, prefix := range prefixes {
-			if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
-				filtered[rel] = content
-				break
-			}
+	for _, prefix := range prefixes {
+		prefix = filepath.ToSlash(prefix)
+		if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
+			return true
 		}
 	}
-	return filtered
+	return false
 }
 
 // assertGoldenDir compares the rendered manifest tree at srcDir against the
@@ -98,7 +98,12 @@ func assertGoldenDir(t *testing.T, version, scenario, chartName, srcDir string, 
 	t.Helper()
 
 	dir := filepath.Join(goldenDir, version, scenario, chartName)
-	rendered := filterManifests(collectManifests(t, srcDir), pathFilter)
+	rendered := collectManifests(t, srcDir, pathFilter)
+	if len(pathFilter) > 0 {
+		require.NotEmpty(t, rendered,
+			"pathFilter %v matched no rendered manifests in %s for golden/%s/%s/%s",
+			pathFilter, srcDir, version, scenario, chartName)
+	}
 
 	if update {
 		require.NoError(t, os.RemoveAll(dir))
@@ -109,14 +114,6 @@ func assertGoldenDir(t *testing.T, version, scenario, chartName, srcDir string, 
 				"failed to write golden file %s", dst)
 		}
 		t.Logf("updated %d golden manifest(s) in %s", len(rendered), dir)
-		return
-	}
-
-	if _, err := os.Stat(dir); os.IsNotExist(err) && len(pathFilter) > 0 && len(rendered) == 0 {
-		// A pathFilter can legitimately match nothing for a given chart (e.g. a
-		// filter scoped to the platform chart's templates has no matches when
-		// rendering load-test-setup). No golden dir was ever committed for this
-		// chart under this filter, and nothing rendered either — consistent.
 		return
 	}
 

--- a/load-tests/setup/test/goldenfiles.go
+++ b/load-tests/setup/test/goldenfiles.go
@@ -4,6 +4,7 @@ package golden
 import (
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -80,7 +81,7 @@ func matchesPathFilter(rel string, prefixes []string) bool {
 		return true
 	}
 	for _, prefix := range prefixes {
-		prefix = filepath.ToSlash(prefix)
+		prefix = path.Clean(filepath.ToSlash(prefix))
 		if rel == prefix || strings.HasPrefix(rel, prefix+"/") {
 			return true
 		}


### PR DESCRIPTION
## Summary

Adds `PathFilter` support for load-test golden scenarios so future narrow scenarios can compare and commit only the relevant rendered manifest paths.

The filter is applied during `collectManifests` while walking rendered files, and a non-empty `PathFilter` now fails when it matches no rendered manifests. This catches typos or filters scoped to the wrong chart instead of silently removing coverage.

The test README also explains why `golden/` files are collapsed in PRs: they are generated snapshots marked with `linguist-generated=true` in `.gitattributes`.

No scenario uses `PathFilter` yet, so the default golden comparison remains unchanged.

## Validation

- `go test -run 'Test(Normalize|ShouldCollect|ShouldReturn|ShouldMatch)' ./...` from `load-tests/setup/test`
- `make build` from `load-tests/setup/test`
- `./mvnw license:format spotless:apply -T1C`

## Checklist

- [ ] Enable backports when necessary - not applicable, test-tooling-only change to `load-tests/setup` on `main`.
- [ ] C8 Orchestration Cluster E2E Test Suite - not applicable.

## Related issues

None tracked - follow-up from [#57771](https://github.com/camunda/camunda/pull/57771#issuecomment-4978778405).
