### PR TITLE
docs(analytics-exporter): fix README gaps found during E2E test authoring

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -154,7 +154,7 @@ variables, or any other end-user data.
 
 These attributes are set on every log record:
 
-|            Attribute           |  Type  |                                               Description                                                |
+|            Attribute            |  Type  |                                               Description                                                |
 |---------------------------------|--------|----------------------------------------------------------------------------------------------------------|
 | `event.name`                    | string | Event type identifier (one of the names in the table above).                                             |
 | `camunda.log.position`          | long   | Log stream position. Used as a deduplication key.                                                        |
@@ -166,45 +166,45 @@ Beyond the common attributes above, each event type carries its own additional f
 
 **`process_instance_created`**
 
-|             Attribute              |  Type  |                Description                |
-|-------------------------------------|--------|--------------------------------------------|
-| `camunda.process.id`                | string | BPMN process ID.                            |
-| `camunda.process.version`           | long   | Deployed process version.                   |
-| `camunda.process.definition_key`    | long   | Process definition key.                     |
-| `camunda.process.instance_key`      | long   | Process instance key.                       |
+|              Attribute              |  Type  |                  Description                   |
+|-------------------------------------|--------|------------------------------------------------|
+| `camunda.process.id`                | string | BPMN process ID.                               |
+| `camunda.process.version`           | long   | Deployed process version.                      |
+| `camunda.process.definition_key`    | long   | Process definition key.                        |
+| `camunda.process.instance_key`      | long   | Process instance key.                          |
 | `camunda.process.root_instance_key` | long   | Root process instance key (for sub-processes). |
-| `camunda.tenant.id`                 | string | Tenant ID.                                  |
+| `camunda.tenant.id`                 | string | Tenant ID.                                     |
 
 **`user_task_created`**
 
-|          Attribute           |  Type  |             Description             |
-|-------------------------------|--------|----------------------------------------|
-| `camunda.process.id`          | string | BPMN process ID.                        |
-| `camunda.process.definition_key` | long | Process definition key.               |
-| `camunda.process.instance_key`  | long | Process instance key.                 |
-| `camunda.element.id`          | string | BPMN element ID of the user task.       |
-| `camunda.tenant.id`           | string | Tenant ID.                              |
+|            Attribute             |  Type  |            Description            |
+|----------------------------------|--------|-----------------------------------|
+| `camunda.process.id`             | string | BPMN process ID.                  |
+| `camunda.process.definition_key` | long   | Process definition key.           |
+| `camunda.process.instance_key`   | long   | Process instance key.             |
+| `camunda.element.id`             | string | BPMN element ID of the user task. |
+| `camunda.tenant.id`              | string | Tenant ID.                        |
 
 Note: unlike `process_instance_created`, this event does not carry `camunda.process.version`.
 
 **`adhoc_subprocess_activated`**
 
-|          Attribute           |  Type  |             Description             |
-|-------------------------------|--------|----------------------------------------|
-| `camunda.process.id`          | string | BPMN process ID.                        |
-| `camunda.process.definition_key` | long | Process definition key.               |
-| `camunda.process.instance_key`  | long | Process instance key.                 |
-| `camunda.element.id`          | string | BPMN element ID of the ad-hoc sub-process. |
-| `camunda.tenant.id`           | string | Tenant ID.                              |
+|            Attribute             |  Type  |                Description                 |
+|----------------------------------|--------|--------------------------------------------|
+| `camunda.process.id`             | string | BPMN process ID.                           |
+| `camunda.process.definition_key` | long   | Process definition key.                    |
+| `camunda.process.instance_key`   | long   | Process instance key.                      |
+| `camunda.element.id`             | string | BPMN element ID of the ad-hoc sub-process. |
+| `camunda.tenant.id`              | string | Tenant ID.                                 |
 
 **`usage_metric_exported`**
 
-|              Attribute               |  Type  |                     Description                     |
-|----------------------------------------|--------|--------------------------------------------------------|
-| `camunda.usage_metric.event_type`      | string | Metric type: `RPI` (running process instances), `EDI` (executed decision instances), or `TU` (task users). |
-| `camunda.usage_metric.count`           | long   | Count for this metric type in this export interval.     |
-| `camunda.usage_metric.interval_start`  | long   | Epoch-ms start of the export window.                    |
-| `camunda.usage_metric.interval_end`    | long   | Epoch-ms end of the export window.                      |
+|               Attribute               |  Type  |                                                Description                                                 |
+|---------------------------------------|--------|------------------------------------------------------------------------------------------------------------|
+| `camunda.usage_metric.event_type`     | string | Metric type: `RPI` (running process instances), `EDI` (executed decision instances), or `TU` (task users). |
+| `camunda.usage_metric.count`          | long   | Count for this metric type in this export interval.                                                        |
+| `camunda.usage_metric.interval_start` | long   | Epoch-ms start of the export window.                                                                       |
+| `camunda.usage_metric.interval_end`   | long   | Epoch-ms end of the export window.                                                                         |
 
 ### Heartbeat attributes
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -147,17 +147,64 @@ variables, or any other end-user data.
 | `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`   | Emitted for every new process instance.                                           |
 | `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated` | Emitted only when the activated element is an ad-hoc sub-process.                 |
 | `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`      | Emitted once per usage metric export interval. Internal reset events are skipped. |
+| `USER_TASK`                 | `CREATED`           | `user_task_created`          | Emitted for every new user task.                                                  |
 | —                           | —                   | `heartbeat`                  | Emitted periodically by the partition leader (see `heartbeat-interval`).          |
 
 ### Common log record attributes
 
 These attributes are set on every log record:
 
-|         Attribute         |  Type  |                                               Description                                                |
-|---------------------------|--------|----------------------------------------------------------------------------------------------------------|
-| `event.name`              | string | Event type identifier (one of the names in the table above).                                             |
-| `camunda.log.position`    | long   | Log stream position. Used as a deduplication key.                                                        |
-| `camunda.sequence_number` | long   | Monotonic per-partition counter incremented for each emitted event. Used for ordering and gap detection. |
+|            Attribute           |  Type  |                                               Description                                                |
+|---------------------------------|--------|----------------------------------------------------------------------------------------------------------|
+| `event.name`                    | string | Event type identifier (one of the names in the table above).                                             |
+| `camunda.log.position`          | long   | Log stream position. Used as a deduplication key.                                                        |
+| `camunda.event.sequence_number` | long   | Monotonic per-partition counter incremented for each emitted event. Used for ordering and gap detection. |
+
+### Per-event attributes
+
+Beyond the common attributes above, each event type carries its own additional fields:
+
+**`process_instance_created`**
+
+|             Attribute              |  Type  |                Description                |
+|-------------------------------------|--------|--------------------------------------------|
+| `camunda.process.id`                | string | BPMN process ID.                            |
+| `camunda.process.version`           | long   | Deployed process version.                   |
+| `camunda.process.definition_key`    | long   | Process definition key.                     |
+| `camunda.process.instance_key`      | long   | Process instance key.                       |
+| `camunda.process.root_instance_key` | long   | Root process instance key (for sub-processes). |
+| `camunda.tenant.id`                 | string | Tenant ID.                                  |
+
+**`user_task_created`**
+
+|          Attribute           |  Type  |             Description             |
+|-------------------------------|--------|----------------------------------------|
+| `camunda.process.id`          | string | BPMN process ID.                        |
+| `camunda.process.definition_key` | long | Process definition key.               |
+| `camunda.process.instance_key`  | long | Process instance key.                 |
+| `camunda.element.id`          | string | BPMN element ID of the user task.       |
+| `camunda.tenant.id`           | string | Tenant ID.                              |
+
+Note: unlike `process_instance_created`, this event does not carry `camunda.process.version`.
+
+**`adhoc_subprocess_activated`**
+
+|          Attribute           |  Type  |             Description             |
+|-------------------------------|--------|----------------------------------------|
+| `camunda.process.id`          | string | BPMN process ID.                        |
+| `camunda.process.definition_key` | long | Process definition key.               |
+| `camunda.process.instance_key`  | long | Process instance key.                 |
+| `camunda.element.id`          | string | BPMN element ID of the ad-hoc sub-process. |
+| `camunda.tenant.id`           | string | Tenant ID.                              |
+
+**`usage_metric_exported`**
+
+|              Attribute               |  Type  |                     Description                     |
+|----------------------------------------|--------|--------------------------------------------------------|
+| `camunda.usage_metric.event_type`      | string | Metric type: `RPI` (running process instances), `EDI` (executed decision instances), or `TU` (task users). |
+| `camunda.usage_metric.count`           | long   | Count for this metric type in this export interval.     |
+| `camunda.usage_metric.interval_start`  | long   | Epoch-ms start of the export window.                    |
+| `camunda.usage_metric.interval_end`    | long   | Epoch-ms end of the export window.                      |
 
 ### Heartbeat attributes
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -166,14 +166,14 @@ Beyond the common attributes above, each event type carries its own additional f
 
 **`process_instance_created`**
 
-|              Attribute              |  Type  |                  Description                   |
-|-------------------------------------|--------|------------------------------------------------|
-| `camunda.process.id`                | string | BPMN process ID.                               |
-| `camunda.process.version`           | long   | Deployed process version.                      |
-| `camunda.process.definition_key`    | long   | Process definition key.                        |
-| `camunda.process.instance_key`      | long   | Process instance key.                          |
-| `camunda.process.root_instance_key` | long   | Root process instance key (for sub-processes). |
-| `camunda.tenant.id`                 | string | Tenant ID.                                     |
+|              Attribute              |  Type  |                                                                                                 Description                                                                                                 |
+|-------------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `camunda.process.id`                | string | BPMN process ID.                                                                                                                                                                                            |
+| `camunda.process.version`           | long   | Deployed process version.                                                                                                                                                                                   |
+| `camunda.process.definition_key`    | long   | Process definition key.                                                                                                                                                                                     |
+| `camunda.process.instance_key`      | long   | Process instance key. **Known issue:** currently populated from the creation command record's own key, not the actual process instance key — see [#57838](https://github.com/camunda/camunda/issues/57838). |
+| `camunda.process.root_instance_key` | long   | Root process instance key (for sub-processes).                                                                                                                                                              |
+| `camunda.tenant.id`                 | string | Tenant ID.                                                                                                                                                                                                  |
 
 **`user_task_created`**
 

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -166,14 +166,14 @@ Beyond the common attributes above, each event type carries its own additional f
 
 **`process_instance_created`**
 
-|              Attribute              |  Type  |                                                                                                 Description                                                                                                 |
-|-------------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `camunda.process.id`                | string | BPMN process ID.                                                                                                                                                                                            |
-| `camunda.process.version`           | long   | Deployed process version.                                                                                                                                                                                   |
-| `camunda.process.definition_key`    | long   | Process definition key.                                                                                                                                                                                     |
-| `camunda.process.instance_key`      | long   | Process instance key. **Known issue:** currently populated from the creation command record's own key, not the actual process instance key — see [#57838](https://github.com/camunda/camunda/issues/57838). |
-| `camunda.process.root_instance_key` | long   | Root process instance key (for sub-processes).                                                                                                                                                              |
-| `camunda.tenant.id`                 | string | Tenant ID.                                                                                                                                                                                                  |
+|              Attribute              |  Type  |                  Description                   |
+|-------------------------------------|--------|------------------------------------------------|
+| `camunda.process.id`                | string | BPMN process ID.                               |
+| `camunda.process.version`           | long   | Deployed process version.                      |
+| `camunda.process.definition_key`    | long   | Process definition key.                        |
+| `camunda.process.instance_key`      | long   | Process instance key.                          |
+| `camunda.process.root_instance_key` | long   | Root process instance key (for sub-processes). |
+| `camunda.tenant.id`                 | string | Tenant ID.                                     |
 
 **`user_task_created`**
 

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -104,10 +104,16 @@ Open http://localhost:3333 → **Explore**
 
 ### Logs (Loki datasource)
 
+The exporter follows the OTel events convention and leaves the log body empty — `event.name`
+and every other attribute arrive as Loki **structured metadata**, not as text in the log line.
+Use a structured-metadata filter (`|`), not a line-content filter (`|=`) — the latter will
+never match and silently returns zero results.
+
 |                              Query                              |        What it shows         |
 |-----------------------------------------------------------------|------------------------------|
 | `{service_name="camunda-zeebe"}`                                | All raw analytics events     |
-| `{service_name="camunda-zeebe"} \|= "process_instance_created"` | Process instance events only |
+| `{service_name="camunda-zeebe"} \| event_name="process_instance_created"` | Process instance events only |
+| `{service_name="camunda-zeebe"} \| event_name="user_task_created"` | User task events only |
 
 ## 5. Tear down
 

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -107,7 +107,9 @@ Open http://localhost:3333 → **Explore**
 The exporter follows the OTel events convention and leaves the log body empty — `event.name`
 and every other attribute arrive as Loki **structured metadata**, not as text in the log line.
 Use a structured-metadata filter (`|`), not a line-content filter (`|=`) — the latter will
-never match and silently returns zero results.
+never match and silently returns zero results. Note that Loki sanitizes dots to underscores
+in structured metadata field names, so `event.name` is queried as `event_name` below (same
+applies to every other dotted attribute name).
 
 |                                   Query                                   |        What it shows         |
 |---------------------------------------------------------------------------|------------------------------|

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -109,11 +109,11 @@ and every other attribute arrive as Loki **structured metadata**, not as text in
 Use a structured-metadata filter (`|`), not a line-content filter (`|=`) — the latter will
 never match and silently returns zero results.
 
-|                              Query                              |        What it shows         |
-|-----------------------------------------------------------------|------------------------------|
-| `{service_name="camunda-zeebe"}`                                | All raw analytics events     |
+|                                   Query                                   |        What it shows         |
+|---------------------------------------------------------------------------|------------------------------|
+| `{service_name="camunda-zeebe"}`                                          | All raw analytics events     |
 | `{service_name="camunda-zeebe"} \| event_name="process_instance_created"` | Process instance events only |
-| `{service_name="camunda-zeebe"} \| event_name="user_task_created"` | User task events only |
+| `{service_name="camunda-zeebe"} \| event_name="user_task_created"`        | User task events only        |
 
 ## 5. Tear down
 

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -104,12 +104,9 @@ Open http://localhost:3333 → **Explore**
 
 ### Logs (Loki datasource)
 
-The exporter follows the OTel events convention and leaves the log body empty — `event.name`
-and every other attribute arrive as Loki **structured metadata**, not as text in the log line.
-Use a structured-metadata filter (`|`), not a line-content filter (`|=`) — the latter will
-never match and silently returns zero results. Note that Loki sanitizes dots to underscores
-in structured metadata field names, so `event.name` is queried as `event_name` below (same
-applies to every other dotted attribute name).
+Attributes like `event.name` arrive as Loki structured metadata (queried as `event_name`,
+dots become underscores), not as log line text — use `|` (structured-metadata filter), not
+`|=` (line-content filter), or the queries below return zero results.
 
 |                                   Query                                   |        What it shows         |
 |---------------------------------------------------------------------------|------------------------------|


### PR DESCRIPTION
## Summary

While writing E2E test scenarios for the analytics exporter against a local c8run + the exporter's own `local-test` observability stack, found several gaps between the READMEs and actual live behavior. This PR fixes the docs; no code changes.

- `zeebe/exporters/analytics-exporter/README.md`:
  - Added the missing `user_task_created` row to the **Event types** table — the event exists (`UserTaskCreatedHandler`, registered on `ValueType.USER_TASK` / `UserTaskIntent.CREATED` in `AnalyticsHandlerCatalog`), it just wasn't documented, which led to treating a valid test case as if it tested something nonexistent.
  - Fixed the sequence-number attribute name: table said `camunda.sequence_number`, actual `AttributeKey` in `AnalyticsAttributes.java` is `camunda.event.sequence_number`.
  - Added a **Per-event attributes** section documenting the fields each handler actually sets beyond the common attributes (`process_instance_created`, `user_task_created`, `adhoc_subprocess_activated`, `usage_metric_exported`) — cross-checked directly against each handler's source and `AnalyticsAttributes.java`.

- `src/test/resources/local-test/README.md`:
  - The documented example Loki queries use `|=` (line-content filter). The exporter follows the OTel events convention and leaves the log body empty — `event.name` and every attribute arrive as Loki structured metadata, not line text — so the documented queries return **zero results** when copied as-is. Switched to `|` (structured-metadata filter) and added a note explaining why.

## Context

Found while authoring E2E test scenarios for [product-hub#3750](https://github.com/camunda/product-hub/issues/3750) (APOLLO product telemetry). A separate correctness bug found during the same testing pass — `process_instance_created` reporting the wrong process instance key — is tracked independently in #57838 and is not part of this PR.

## Test plan

- [ ] Copy each example query from both READMEs into Grafana Explore against the `local-test` stack and confirm they return results.
- [ ] Confirm the new attribute tables match `AnalyticsAttributes.java` and each handler's `handle()` method.
