### PR TITLE
feat: expose late business ID assignment via REST, gRPC, and Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -22,6 +22,7 @@ import io.camunda.client.api.command.AssignClientToTenantCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingRuleToGroupStep1;
 import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1;
+import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1;
 import io.camunda.client.api.command.AssignRoleToClientCommandStep1;
 import io.camunda.client.api.command.AssignRoleToGroupCommandStep1;
 import io.camunda.client.api.command.AssignRoleToMappingRuleCommandStep1;
@@ -421,6 +422,27 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   MigrateProcessInstanceCommandStep1 newMigrateProcessInstanceCommand(long processInstanceKey);
+
+  /**
+   * Command to assign a business id to an already running process instance.
+   *
+   * <p>This allows attaching a business id to a process instance that was started without one. The
+   * assignment is rejected if the instance already has a different business id, if it is a child
+   * instance created by a call activity, or if business id uniqueness is enabled for its process
+   * definition.
+   *
+   * <pre>
+   * camundaClient
+   *  .newAssignProcessInstanceBusinessIdCommand(processInstanceKey)
+   *  .businessId("order-4711")
+   *  .send();
+   * </pre>
+   *
+   * @param processInstanceKey the key of the process instance to assign the business id to
+   * @return a builder for the command
+   */
+  AssignProcessInstanceBusinessIdCommandStep1 newAssignProcessInstanceBusinessIdCommand(
+      long processInstanceKey);
 
   /**
    * Command to cancel a process instance.

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignProcessInstanceBusinessIdCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignProcessInstanceBusinessIdCommandStep1.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.AssignProcessInstanceBusinessIdResponse;
+
+public interface AssignProcessInstanceBusinessIdCommandStep1
+    extends CommandWithCommunicationApiStep<AssignProcessInstanceBusinessIdCommandStep1> {
+
+  /**
+   * Set the business id to assign to the process instance.
+   *
+   * @param businessId the business id to assign
+   * @return the builder for this command
+   */
+  AssignProcessInstanceBusinessIdCommandStep2 businessId(final String businessId);
+
+  interface AssignProcessInstanceBusinessIdCommandStep2
+      extends FinalCommandStep<AssignProcessInstanceBusinessIdResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/AssignProcessInstanceBusinessIdResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/AssignProcessInstanceBusinessIdResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface AssignProcessInstanceBusinessIdResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -28,6 +28,7 @@ import io.camunda.client.api.command.AssignClientToTenantCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingRuleToGroupStep1;
 import io.camunda.client.api.command.AssignMappingRuleToTenantCommandStep1;
+import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1;
 import io.camunda.client.api.command.AssignRoleToClientCommandStep1;
 import io.camunda.client.api.command.AssignRoleToGroupCommandStep1;
 import io.camunda.client.api.command.AssignRoleToMappingRuleCommandStep1;
@@ -221,6 +222,7 @@ import io.camunda.client.impl.command.AssignClientToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignGroupToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignMappingRuleToGroupCommandImpl;
 import io.camunda.client.impl.command.AssignMappingRuleToTenantCommandImpl;
+import io.camunda.client.impl.command.AssignProcessInstanceBusinessIdCommandImpl;
 import io.camunda.client.impl.command.AssignRoleToClientCommandImpl;
 import io.camunda.client.impl.command.AssignRoleToGroupCommandImpl;
 import io.camunda.client.impl.command.AssignRoleToMappingRuleCommandImpl;
@@ -746,6 +748,18 @@ public final class CamundaClientImpl implements CamundaClient {
   public MigrateProcessInstanceCommandStep1 newMigrateProcessInstanceCommand(
       final long processInstanceKey) {
     return new MigrateProcessInstanceCommandImpl(
+        processInstanceKey,
+        asyncStub,
+        credentialsProvider::shouldRetryRequest,
+        httpClient,
+        config,
+        jsonMapper);
+  }
+
+  @Override
+  public AssignProcessInstanceBusinessIdCommandStep1 newAssignProcessInstanceBusinessIdCommand(
+      final long processInstanceKey) {
+    return new AssignProcessInstanceBusinessIdCommandImpl(
         processInstanceKey,
         asyncStub,
         credentialsProvider::shouldRetryRequest,

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignProcessInstanceBusinessIdCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignProcessInstanceBusinessIdCommandImpl.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.CredentialsProvider.StatusCode;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.AssignProcessInstanceBusinessIdResponse;
+import io.camunda.client.impl.RetriableClientFutureImpl;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.AssignProcessInstanceBusinessIdResponseImpl;
+import io.camunda.client.protocol.rest.ProcessInstanceBusinessIdAssignmentInstruction;
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class AssignProcessInstanceBusinessIdCommandImpl
+    implements AssignProcessInstanceBusinessIdCommandStep1,
+        AssignProcessInstanceBusinessIdCommandStep1.AssignProcessInstanceBusinessIdCommandStep2 {
+
+  private final AssignProcessInstanceBusinessIdRequest.Builder requestBuilder =
+      AssignProcessInstanceBusinessIdRequest.newBuilder();
+  private final GatewayStub asyncStub;
+  private final Predicate<StatusCode> retryPredicate;
+  private Duration requestTimeout;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final ProcessInstanceBusinessIdAssignmentInstruction httpRequestObject;
+  private boolean useRest;
+  private final long processInstanceKey;
+  private final JsonMapper jsonMapper;
+
+  public AssignProcessInstanceBusinessIdCommandImpl(
+      final long processInstanceKey,
+      final GatewayStub asyncStub,
+      final Predicate<StatusCode> retryPredicate,
+      final HttpClient httpClient,
+      final CamundaClientConfiguration config,
+      final JsonMapper jsonMapper) {
+    requestBuilder.setProcessInstanceKey(processInstanceKey);
+    this.asyncStub = asyncStub;
+    requestTimeout = config.getDefaultRequestTimeout();
+    this.retryPredicate = retryPredicate;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    httpRequestObject = new ProcessInstanceBusinessIdAssignmentInstruction();
+    useRest = config.preferRestOverGrpc();
+    this.processInstanceKey = processInstanceKey;
+    this.jsonMapper = jsonMapper;
+    requestTimeout(requestTimeout);
+  }
+
+  @Override
+  public AssignProcessInstanceBusinessIdCommandStep2 businessId(final String businessId) {
+    requestBuilder.setBusinessId(businessId);
+    httpRequestObject.setBusinessId(businessId);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<AssignProcessInstanceBusinessIdResponse> requestTimeout(
+      final Duration requestTimeout) {
+    this.requestTimeout = requestTimeout;
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<AssignProcessInstanceBusinessIdResponse> send() {
+    if (useRest) {
+      return sendRestRequest();
+    } else {
+      return sendGrpcRequest();
+    }
+  }
+
+  private CamundaFuture<AssignProcessInstanceBusinessIdResponse> sendRestRequest() {
+    final HttpCamundaFuture<AssignProcessInstanceBusinessIdResponse> result =
+        new HttpCamundaFuture<>();
+    httpClient.post(
+        "/process-instances/" + processInstanceKey + "/business-id-assignment",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        AssignProcessInstanceBusinessIdResponseImpl::new,
+        result);
+    return result;
+  }
+
+  private CamundaFuture<AssignProcessInstanceBusinessIdResponse> sendGrpcRequest() {
+    final AssignProcessInstanceBusinessIdRequest request = requestBuilder.build();
+
+    final RetriableClientFutureImpl<
+            AssignProcessInstanceBusinessIdResponse,
+            GatewayOuterClass.AssignProcessInstanceBusinessIdResponse>
+        future =
+            new RetriableClientFutureImpl<>(
+                AssignProcessInstanceBusinessIdResponseImpl::new,
+                retryPredicate,
+                streamObserver -> sendGrpcRequest(request, streamObserver));
+
+    sendGrpcRequest(request, future);
+
+    return future;
+  }
+
+  private void sendGrpcRequest(
+      final AssignProcessInstanceBusinessIdRequest request,
+      final StreamObserver<GatewayOuterClass.AssignProcessInstanceBusinessIdResponse>
+          streamObserver) {
+    asyncStub
+        .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+        .assignProcessInstanceBusinessId(request, streamObserver);
+  }
+
+  @Override
+  public AssignProcessInstanceBusinessIdCommandStep1 useRest() {
+    useRest = true;
+    return this;
+  }
+
+  @Override
+  public AssignProcessInstanceBusinessIdCommandStep1 useGrpc() {
+    useRest = false;
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/AssignProcessInstanceBusinessIdResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/AssignProcessInstanceBusinessIdResponseImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.AssignProcessInstanceBusinessIdResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
+
+public final class AssignProcessInstanceBusinessIdResponseImpl
+    implements AssignProcessInstanceBusinessIdResponse {
+
+  public AssignProcessInstanceBusinessIdResponseImpl(
+      final GatewayOuterClass.AssignProcessInstanceBusinessIdResponse response) {}
+
+  public AssignProcessInstanceBusinessIdResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/test/java/io/camunda/client/process/AssignProcessInstanceBusinessIdTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/AssignProcessInstanceBusinessIdTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.util.ClientTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
+import org.junit.Test;
+
+public class AssignProcessInstanceBusinessIdTest extends ClientTest {
+
+  private static final Long PI_KEY = 1L;
+  private static final String BUSINESS_ID = "order-4711";
+
+  @Test
+  public void shouldAssignBusinessId() {
+    // when
+    client
+        .newAssignProcessInstanceBusinessIdCommand(PI_KEY)
+        .useGrpc()
+        .businessId(BUSINESS_ID)
+        .send()
+        .join();
+
+    // then
+    final AssignProcessInstanceBusinessIdRequest request = gatewayService.getLastRequest();
+    assertThat(request.getProcessInstanceKey()).isEqualTo(PI_KEY);
+    assertThat(request.getBusinessId()).isEqualTo(BUSINESS_ID);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/process/rest/AssignProcessInstanceBusinessIdRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/AssignProcessInstanceBusinessIdRestTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.process.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.protocol.rest.ProcessInstanceBusinessIdAssignmentInstruction;
+import io.camunda.client.util.ClientRestTest;
+import org.junit.jupiter.api.Test;
+
+public class AssignProcessInstanceBusinessIdRestTest extends ClientRestTest {
+
+  private static final Long PI_KEY = 1L;
+  private static final String BUSINESS_ID = "order-4711";
+
+  @Test
+  public void shouldAssignBusinessId() {
+    // when
+    client.newAssignProcessInstanceBusinessIdCommand(PI_KEY).businessId(BUSINESS_ID).send().join();
+
+    // then
+    final ProcessInstanceBusinessIdAssignmentInstruction request =
+        gatewayService.getLastRequest(ProcessInstanceBusinessIdAssignmentInstruction.class);
+    assertThat(request.getBusinessId()).isEqualTo(BUSINESS_ID);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RecordingGatewayService.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BrokerInfo;
@@ -135,6 +137,9 @@ public final class RecordingGatewayService extends GatewayImplBase {
     addRequestHandler(
         MigrateProcessInstanceRequest.class,
         r -> MigrateProcessInstanceResponse.getDefaultInstance());
+    addRequestHandler(
+        AssignProcessInstanceBusinessIdRequest.class,
+        r -> AssignProcessInstanceBusinessIdResponse.getDefaultInstance());
     addRequestHandler(
         EvaluateDecisionRequest.class, r -> EvaluateDecisionResponse.getDefaultInstance());
     addRequestHandler(
@@ -428,6 +433,13 @@ public final class RecordingGatewayService extends GatewayImplBase {
   public void migrateProcessInstance(
       final MigrateProcessInstanceRequest request,
       final StreamObserver<MigrateProcessInstanceResponse> responseObserver) {
+    handle(request, responseObserver);
+  }
+
+  @Override
+  public void assignProcessInstanceBusinessId(
+      final AssignProcessInstanceBusinessIdRequest request,
+      final StreamObserver<AssignProcessInstanceBusinessIdResponse> responseObserver) {
     handle(request, responseObserver);
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -24,6 +24,7 @@ import static io.camunda.gateway.mapping.http.validator.MessageRequestValidator.
 import static io.camunda.gateway.mapping.http.validator.MessageRequestValidator.validateMessagePublicationRequest;
 import static io.camunda.gateway.mapping.http.validator.MultiTenancyValidator.validateTenantId;
 import static io.camunda.gateway.mapping.http.validator.MultiTenancyValidator.validateTenantIds;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateAssignProcessInstanceBusinessIdRequest;
 import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateCancelProcessInstanceRequest;
 import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest;
 import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest;
@@ -68,6 +69,7 @@ import io.camunda.gateway.protocol.model.JobUpdateRequest;
 import io.camunda.gateway.protocol.model.MessageCorrelationRequest;
 import io.camunda.gateway.protocol.model.MessagePublicationRequest;
 import io.camunda.gateway.protocol.model.ModifyProcessInstanceVariableInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceBusinessIdAssignmentInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionById;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionByKey;
@@ -102,6 +104,7 @@ import io.camunda.service.JobServices.BatchUpdateJobRequest;
 import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
 import io.camunda.service.MessageServices.PublicationMessageRequest;
+import io.camunda.service.ProcessInstanceServices.AssignProcessInstanceBusinessIdRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
@@ -813,6 +816,17 @@ public class RequestMapper {
                                 .setTargetElementId(instruction.getTargetElementId()))
                     .toList(),
                 request.getOperationReference()));
+  }
+
+  public static Either<ProblemDetail, AssignProcessInstanceBusinessIdRequest>
+      toAssignProcessInstanceBusinessId(
+          final long processInstanceKey,
+          final ProcessInstanceBusinessIdAssignmentInstruction request) {
+    return getResult(
+        validateAssignProcessInstanceBusinessIdRequest(request),
+        () ->
+            new AssignProcessInstanceBusinessIdRequest(
+                processInstanceKey, request.getBusinessId()));
   }
 
   public static Either<ProblemDetail, ProcessInstanceFilter> toRequiredProcessInstanceFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
@@ -21,6 +21,7 @@ import io.camunda.gateway.mapping.http.search.SearchQueryFilterMapper;
 import io.camunda.gateway.protocol.model.CancelProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.DirectAncestorKeyInstruction;
 import io.camunda.gateway.protocol.model.MigrateProcessInstanceMappingInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceBusinessIdAssignmentInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionById;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionByKey;
@@ -188,6 +189,18 @@ public class ProcessInstanceRequestValidator {
             validateMappingInstructions(request.getMappingInstructions(), violations);
           }
           validateOperationReference(request.getOperationReference(), violations);
+        });
+  }
+
+  public static Optional<ProblemDetail> validateAssignProcessInstanceBusinessIdRequest(
+      final ProcessInstanceBusinessIdAssignmentInstruction request) {
+    return validate(
+        violations -> {
+          if (StringUtils.isBlank(request.getBusinessId())) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("businessId"));
+          } else {
+            validateBusinessId(request.getBusinessId(), violations);
+          }
         });
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+class ProcessInstanceBusinessIdAssignmentIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldAssignBusinessIdToRunningProcessInstance() throws Exception {
+    // given - a running process instance that currently has no business id
+    final var processId = "business-id-assignment-process";
+    final var businessId = "order-98765";
+    final var processDefinition =
+        Bpmn.createExecutableProcess(processId).startEvent().userTask("task").endEvent().done();
+    deployProcessAndWaitForIt(camundaClient, processDefinition, processId + ".bpmn");
+
+    final long processInstanceKey =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceKey),
+        instances -> assertThat(instances).hasSize(1));
+
+    // when - the business id is assigned late via the dedicated REST endpoint
+    final var response =
+        assignBusinessId(processInstanceKey, "{\"businessId\":\"%s\"}".formatted(businessId));
+
+    // then - the endpoint accepts the assignment and it propagates to secondary storage
+    assertThat(response.statusCode()).isEqualTo(204);
+
+    await("business id is reflected in secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        camundaClient
+                            .newProcessInstanceGetRequest(processInstanceKey)
+                            .send()
+                            .join()
+                            .getBusinessId())
+                    .isEqualTo(businessId));
+
+    // and - re-sending the identical business id succeeds idempotently
+    final var idempotentResponse =
+        assignBusinessId(processInstanceKey, "{\"businessId\":\"%s\"}".formatted(businessId));
+    assertThat(idempotentResponse.statusCode()).isEqualTo(204);
+  }
+
+  private HttpResponse<String> assignBusinessId(final long processInstanceKey, final String body)
+      throws Exception {
+    final var base = camundaClient.getConfiguration().getRestAddress().toString();
+    final var separator = base.endsWith("/") ? "" : "/";
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(
+                new URI(
+                    base
+                        + separator
+                        + "v2/process-instances/%d/business-id-assignment"
+                            .formatted(processInstanceKey)))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString(body))
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
@@ -10,12 +10,16 @@ package io.camunda.it.client;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1;
+import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1.AssignProcessInstanceBusinessIdCommandStep2;
+import io.camunda.client.api.command.ClientException;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.Protocol;
 import java.time.Duration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -29,10 +33,8 @@ class ProcessInstanceBusinessIdAssignmentIT {
   @ValueSource(booleans = {true, false})
   void shouldAssignBusinessIdToRunningProcessInstance(final boolean useRest) {
     // given - a running process instance that currently has no business id
-    final var transport = useRest ? "rest" : "grpc";
-    final long processInstanceKey =
-        startProcessInstance("business-id-assignment-" + transport + "-process");
-    final var businessId = "order-" + transport + "-98765";
+    final long processInstanceKey = startProcessInstance("business-id-assign", useRest);
+    final var businessId = "order-" + transport(useRest) + "-98765";
 
     // when - the business id is assigned late via the Java client over the chosen transport
     assignBusinessId(processInstanceKey, businessId, useRest).send().join();
@@ -40,18 +42,64 @@ class ProcessInstanceBusinessIdAssignmentIT {
     // then - the assignment propagates to secondary storage
     awaitBusinessId(processInstanceKey, businessId);
 
-    // and - re-sending the identical business id succeeds idempotently
-    assignBusinessId(processInstanceKey, businessId, useRest).send().join();
+    assertThatNoException()
+        .describedAs("re-sending the identical business id succeeds idempotently")
+        .isThrownBy(() -> assignBusinessId(processInstanceKey, businessId, useRest).send().join());
   }
 
-  private AssignProcessInstanceBusinessIdCommandStep1.AssignProcessInstanceBusinessIdCommandStep2
-      assignBusinessId(
-          final long processInstanceKey, final String businessId, final boolean useRest) {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldRejectAssignmentToNonExistentProcessInstance(final boolean useRest) {
+    // given - a key that routes to a real partition but does not identify any instance
+    final long nonExistentKey = Protocol.encodePartitionId(Protocol.START_PARTITION_ID, 9_999_999L);
+
+    // when / then
+    assertThatThrownBy(
+            () -> assignBusinessId(nonExistentKey, "order-missing", useRest).send().join())
+        .describedAs("assigning a business id to a non-existent process instance is rejected")
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("no such process instance was found");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldRejectEmptyBusinessId(final boolean useRest) {
+    // given - a running process instance
+    final long processInstanceKey = startProcessInstance("business-id-empty", useRest);
+
+    // when / then - an empty business id is rejected early at the gateway on both transports (REST
+    // by the request validator, gRPC by the request mapper), so neither reaches the broker.
+    final var expectedMessage = useRest ? "No businessId provided" : "no business id was provided";
+    assertThatThrownBy(() -> assignBusinessId(processInstanceKey, "", useRest).send().join())
+        .describedAs("assigning an empty business id is rejected over %s", transport(useRest))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining(expectedMessage);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldRejectReassigningDifferentBusinessId(final boolean useRest) {
+    // given - a process instance that already has a business id assigned
+    final long processInstanceKey = startProcessInstance("business-id-reassign", useRest);
+    assignBusinessId(processInstanceKey, "order-original", useRest).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> assignBusinessId(processInstanceKey, "order-different", useRest).send().join())
+        .describedAs(
+            "assigning a different business id to an already-assigned instance is rejected")
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("it already has a business id assigned");
+  }
+
+  private AssignProcessInstanceBusinessIdCommandStep2 assignBusinessId(
+      final long processInstanceKey, final String businessId, final boolean useRest) {
     final var command = camundaClient.newAssignProcessInstanceBusinessIdCommand(processInstanceKey);
     return (useRest ? command.useRest() : command.useGrpc()).businessId(businessId);
   }
 
-  private long startProcessInstance(final String processId) {
+  private long startProcessInstance(final String prefix, final boolean useRest) {
+    final var processId = prefix + "-" + transport(useRest) + "-process";
     final var processDefinition =
         Bpmn.createExecutableProcess(processId).startEvent().userTask("task").endEvent().done();
     deployProcessAndWaitForIt(camundaClient, processDefinition, processId + ".bpmn");
@@ -86,5 +134,9 @@ class ProcessInstanceBusinessIdAssignmentIT {
                             .join()
                             .getBusinessId())
                     .isEqualTo(businessId));
+  }
+
+  private static String transport(final boolean useRest) {
+    return useRest ? "rest" : "grpc";
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
@@ -13,27 +13,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AssignProcessInstanceBusinessIdCommandStep1;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @MultiDbTest
 class ProcessInstanceBusinessIdAssignmentIT {
 
   private static CamundaClient camundaClient;
 
-  @Test
-  void shouldAssignBusinessIdToRunningProcessInstance() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldAssignBusinessIdToRunningProcessInstance(final boolean useRest) {
     // given - a running process instance that currently has no business id
-    final var processId = "business-id-assignment-process";
-    final var businessId = "order-98765";
+    final var transport = useRest ? "rest" : "grpc";
+    final long processInstanceKey =
+        startProcessInstance("business-id-assignment-" + transport + "-process");
+    final var businessId = "order-" + transport + "-98765";
+
+    // when - the business id is assigned late via the Java client over the chosen transport
+    assignBusinessId(processInstanceKey, businessId, useRest).send().join();
+
+    // then - the assignment propagates to secondary storage
+    awaitBusinessId(processInstanceKey, businessId);
+
+    // and - re-sending the identical business id succeeds idempotently
+    assignBusinessId(processInstanceKey, businessId, useRest).send().join();
+  }
+
+  private AssignProcessInstanceBusinessIdCommandStep1.AssignProcessInstanceBusinessIdCommandStep2
+      assignBusinessId(
+          final long processInstanceKey, final String businessId, final boolean useRest) {
+    final var command = camundaClient.newAssignProcessInstanceBusinessIdCommand(processInstanceKey);
+    return (useRest ? command.useRest() : command.useGrpc()).businessId(businessId);
+  }
+
+  private long startProcessInstance(final String processId) {
     final var processDefinition =
         Bpmn.createExecutableProcess(processId).startEvent().userTask("task").endEvent().done();
     deployProcessAndWaitForIt(camundaClient, processDefinition, processId + ".bpmn");
@@ -52,13 +70,10 @@ class ProcessInstanceBusinessIdAssignmentIT {
         f -> f.processInstanceKey(processInstanceKey),
         instances -> assertThat(instances).hasSize(1));
 
-    // when - the business id is assigned late via the dedicated REST endpoint
-    final var response =
-        assignBusinessId(processInstanceKey, "{\"businessId\":\"%s\"}".formatted(businessId));
+    return processInstanceKey;
+  }
 
-    // then - the endpoint accepts the assignment and it propagates to secondary storage
-    assertThat(response.statusCode()).isEqualTo(204);
-
+  private void awaitBusinessId(final long processInstanceKey, final String businessId) {
     await("business id is reflected in secondary storage")
         .atMost(Duration.ofMinutes(1))
         .ignoreExceptions()
@@ -71,28 +86,5 @@ class ProcessInstanceBusinessIdAssignmentIT {
                             .join()
                             .getBusinessId())
                     .isEqualTo(businessId));
-
-    // and - re-sending the identical business id succeeds idempotently
-    final var idempotentResponse =
-        assignBusinessId(processInstanceKey, "{\"businessId\":\"%s\"}".formatted(businessId));
-    assertThat(idempotentResponse.statusCode()).isEqualTo(204);
-  }
-
-  private HttpResponse<String> assignBusinessId(final long processInstanceKey, final String body)
-      throws Exception {
-    final var base = camundaClient.getConfiguration().getRestAddress().toString();
-    final var separator = base.endsWith("/") ? "" : "/";
-    final var request =
-        HttpRequest.newBuilder()
-            .uri(
-                new URI(
-                    base
-                        + separator
-                        + "v2/process-instances/%d/business-id-assignment"
-                            .formatted(processInstanceKey)))
-            .header("Content-Type", "application/json")
-            .POST(BodyPublishers.ofString(body))
-            .build();
-    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
   }
 }

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -42,6 +42,7 @@ import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.broker.RequestRetryHandler;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerAssignProcessInstanceBusinessIdRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
@@ -54,6 +55,7 @@ import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperation
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceMigrationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceModificationPlan;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
@@ -462,6 +464,16 @@ public final class ProcessInstanceServices
     return sendBrokerRequest(brokerRequest, authentication);
   }
 
+  public CompletableFuture<ProcessInstanceBusinessIdRecord> assignProcessInstanceBusinessId(
+      final AssignProcessInstanceBusinessIdRequest request,
+      final CamundaAuthentication authentication) {
+    final var brokerRequest =
+        new BrokerAssignProcessInstanceBusinessIdRequest()
+            .setProcessInstanceKey(request.processInstanceKey())
+            .setBusinessId(request.businessId());
+    return sendBrokerRequest(brokerRequest, authentication);
+  }
+
   public CompletableFuture<ProcessInstanceModificationRecord> modifyProcessInstance(
       final ProcessInstanceModifyRequest request, final CamundaAuthentication authentication) {
     final var brokerRequest =
@@ -661,6 +673,9 @@ public final class ProcessInstanceServices
       Long targetProcessDefinitionKey,
       List<ProcessInstanceMigrationMappingInstruction> mappingInstructions,
       Long operationReference) {}
+
+  public record AssignProcessInstanceBusinessIdRequest(
+      Long processInstanceKey, String businessId) {}
 
   public record ProcessInstanceModifyRequest(
       Long processInstanceKey,

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -43,6 +43,7 @@ import io.camunda.search.query.SequenceFlowQuery;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.service.ProcessInstanceServices.AssignProcessInstanceBusinessIdRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.authorization.Authorizations;
@@ -54,6 +55,7 @@ import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.api.util.StubbedTopologyManager;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerAssignProcessInstanceBusinessIdRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
@@ -61,6 +63,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteHistoryRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
@@ -668,6 +671,34 @@ public final class ProcessInstanceServiceTest {
             () -> services.deleteProcessInstance(processInstanceKey, null, authentication).join())
         .isInstanceOf(ServiceException.class)
         .hasMessage("Process Instance with key '123' not found");
+  }
+
+  @Test
+  void shouldAssignProcessInstanceBusinessId() {
+    // given
+    final long processInstanceKey = 123L;
+    final var businessId = "order-12345";
+
+    final var record =
+        new ProcessInstanceBusinessIdRecord()
+            .setProcessInstanceKey(processInstanceKey)
+            .setBusinessId(businessId);
+    final var captor = ArgumentCaptor.forClass(BrokerAssignProcessInstanceBusinessIdRequest.class);
+    when(brokerClient.sendRequest(captor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(record)));
+
+    // when
+    services
+        .assignProcessInstanceBusinessId(
+            new AssignProcessInstanceBusinessIdRequest(processInstanceKey, businessId),
+            authentication)
+        .join();
+
+    // then
+    final var brokerRequest = captor.getValue();
+    final var enrichedRecord = brokerRequest.getRequestWriter();
+    assertThat(enrichedRecord.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(enrichedRecord.getBusinessId()).isEqualTo(businessId);
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BrokerInfo;
@@ -459,6 +461,16 @@ public final class EndpointManager {
         request,
         RequestMapper::toMigrateProcessInstanceRequest,
         ResponseMapper::toMigrateProcessInstanceResponse,
+        responseObserver);
+  }
+
+  public void assignProcessInstanceBusinessId(
+      final AssignProcessInstanceBusinessIdRequest request,
+      final ServerStreamObserver<AssignProcessInstanceBusinessIdResponse> responseObserver) {
+    sendRequest(
+        request,
+        RequestMapper::toAssignProcessInstanceBusinessIdRequest,
+        ResponseMapper::toAssignProcessInstanceBusinessIdResponse,
         responseObserver);
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
@@ -200,6 +202,14 @@ public class GatewayGrpcService extends GatewayImplBase {
       final MigrateProcessInstanceRequest request,
       final StreamObserver<MigrateProcessInstanceResponse> responseObserver) {
     endpointManager.migrateProcessInstance(
+        request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
+  }
+
+  @Override
+  public void assignProcessInstanceBusinessId(
+      final AssignProcessInstanceBusinessIdRequest request,
+      final StreamObserver<AssignProcessInstanceBusinessIdResponse> responseObserver) {
+    endpointManager.assignProcessInstanceBusinessId(
         request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.gateway.cmd.InvalidBusinessIdException;
 import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerAssignProcessInstanceBusinessIdRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRetriesReques
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobTimeoutRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
@@ -468,6 +470,14 @@ public final class RequestMapper extends RequestUtil {
     return brokerRequest;
   }
 
+  public static BrokerAssignProcessInstanceBusinessIdRequest
+      toAssignProcessInstanceBusinessIdRequest(
+          final AssignProcessInstanceBusinessIdRequest grpcRequest) {
+    return new BrokerAssignProcessInstanceBusinessIdRequest()
+        .setProcessInstanceKey(grpcRequest.getProcessInstanceKey())
+        .setBusinessId(ensureRequiredBusinessIdValid(grpcRequest.getBusinessId()));
+  }
+
   public static BrokerDeleteResourceRequest toDeleteResourceRequest(
       final DeleteResourceRequest grpcRequest) {
     final var brokerRequest =
@@ -540,6 +550,13 @@ public final class RequestMapper extends RequestUtil {
           "business id exceeds the limit of %d characters".formatted(MAX_BUSINESS_ID_LENGTH));
     }
     return businessId;
+  }
+
+  public static String ensureRequiredBusinessIdValid(final String businessId) {
+    if (StringUtils.isBlank(businessId)) {
+      throw new InvalidBusinessIdException(businessId, "no business id was provided");
+    }
+    return ensureBusinessIdValid(businessId);
   }
 
   public static String ensureTenantIdSet(final String commandName, final String tenantId) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
@@ -58,6 +59,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
@@ -522,6 +524,11 @@ public final class ResponseMapper {
   public static MigrateProcessInstanceResponse toMigrateProcessInstanceResponse(
       final long key, final ProcessInstanceMigrationRecord brokerResponse) {
     return MigrateProcessInstanceResponse.getDefaultInstance();
+  }
+
+  public static AssignProcessInstanceBusinessIdResponse toAssignProcessInstanceBusinessIdResponse(
+      final long key, final ProcessInstanceBusinessIdRecord brokerResponse) {
+    return AssignProcessInstanceBusinessIdResponse.getDefaultInstance();
   }
 
   public static DeleteResourceResponse toDeleteResourceResponse(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/AssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/process/AssignProcessInstanceBusinessIdTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.api.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.gateway.RequestMapper;
+import io.camunda.zeebe.gateway.cmd.InvalidBusinessIdException;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.AssignProcessInstanceBusinessIdRequest;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import org.junit.jupiter.api.Test;
+
+public class AssignProcessInstanceBusinessIdTest {
+
+  @Test
+  public void shouldMapRequestToAssignProcessInstanceBusinessIdRequest() {
+    // given
+    final var request =
+        AssignProcessInstanceBusinessIdRequest.newBuilder()
+            .setProcessInstanceKey(1L)
+            .setBusinessId("order-42")
+            .build();
+
+    // when
+    final ProcessInstanceBusinessIdRecord record =
+        RequestMapper.toAssignProcessInstanceBusinessIdRequest(request).getRequestWriter();
+
+    // then
+    assertThat(record.getProcessInstanceKey()).isEqualTo(1L);
+    assertThat(record.getBusinessId()).isEqualTo("order-42");
+  }
+
+  @Test
+  public void shouldRejectRequestWhenBusinessIdExceedsMaxLength() {
+    // given
+    final var tooLongBusinessId = "a".repeat(257);
+    final var request =
+        AssignProcessInstanceBusinessIdRequest.newBuilder()
+            .setProcessInstanceKey(1L)
+            .setBusinessId(tooLongBusinessId)
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> RequestMapper.toAssignProcessInstanceBusinessIdRequest(request))
+        .isInstanceOf(InvalidBusinessIdException.class)
+        .hasMessageContaining("exceeds the limit of 256 characters");
+  }
+
+  @Test
+  public void shouldRejectRequestWhenBusinessIdIsBlank() {
+    // given
+    final var request =
+        AssignProcessInstanceBusinessIdRequest.newBuilder()
+            .setProcessInstanceKey(1L)
+            .setBusinessId("   ")
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> RequestMapper.toAssignProcessInstanceBusinessIdRequest(request))
+        .isInstanceOf(InvalidBusinessIdException.class)
+        .hasMessageContaining("no business id was provided");
+  }
+}

--- a/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
+++ b/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
@@ -11,7 +11,8 @@
         {"service": "gateway_protocol.Gateway", "method": "ResolveIncident"},
         {"service": "gateway_protocol.Gateway", "method": "StreamActivatedJobs"},
         {"service": "gateway_protocol.Gateway", "method": "Topology"},
-        {"service": "gateway_protocol.Gateway", "method": "MigrateProcessInstance"}
+        {"service": "gateway_protocol.Gateway", "method": "MigrateProcessInstance"},
+        {"service": "gateway_protocol.Gateway", "method": "AssignProcessInstanceBusinessId"}
       ],
       "waitForReady": true,
       "retryPolicy": {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -960,6 +960,17 @@ message MigrateProcessInstanceResponse {
 
 }
 
+message AssignProcessInstanceBusinessIdRequest {
+  // key of the process instance to assign the business id to
+  int64 processInstanceKey = 1;
+  // the business id to assign to the process instance
+  string businessId = 2;
+}
+
+message AssignProcessInstanceBusinessIdResponse {
+
+}
+
 message DeleteResourceRequest {
   // The key of the resource that should be deleted. This can either be the key
   // of a process definition, the key of a decision requirements definition or the key of a form.
@@ -1346,6 +1357,25 @@ service Gateway {
           For example, the engine cannot determine how to migrate a process instance when the instructions are: [A->B, A->C].
    */
   rpc MigrateProcessInstance (MigrateProcessInstanceRequest) returns (MigrateProcessInstanceResponse) {
+
+  }
+
+  /*
+    Assigns a business id to an already running process instance.
+
+    Errors:
+      NOT_FOUND:
+        - no process instance exists with the given key, or it is not active
+
+      FAILED_PRECONDITION:
+        - the process instance already has a different business id assigned
+        - the process instance is a child instance created by a call activity
+        - business id uniqueness is enabled for the process definition
+
+      INVALID_ARGUMENT:
+        - the business id is empty or exceeds the allowed length
+   */
+  rpc AssignProcessInstanceBusinessId (AssignProcessInstanceBusinessIdRequest) returns (AssignProcessInstanceBusinessIdResponse) {
 
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -764,6 +764,67 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.6"
 
+  /process-instances/{processInstanceKey}/business-id-assignment:
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Process instance
+      operationId: assignProcessInstanceBusinessId
+      x-required-permissions:
+        - { resourceType: PROCESS_DEFINITION, permissionType: UPDATE_PROCESS_INSTANCE }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Assign business id to process instance
+      description: |
+        Assigns a business id to an already-running process instance that currently has none.
+
+        The assignment is single and irreversible: only artifacts created after the assignment
+        (for example future jobs, user tasks, decision instances, and message subscriptions) carry
+        the business id, while existing artifacts are not retroactively enriched. Re-sending the
+        same business id succeeds as a no-op. This endpoint is only useful while business id
+        uniqueness enforcement is disabled; when it is enabled, the request is rejected with a 409
+        response.
+      parameters:
+        - name: processInstanceKey
+          in: path
+          required: true
+          description: The key of the process instance to assign the business id to.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProcessInstanceBusinessIdAssignmentInstruction'
+      responses:
+        "204":
+          description: The business id is assigned to the process instance.
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "404":
+          description: The process instance is not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: >
+            The business id assignment failed because the process instance is not eligible,
+            for example it already has a different business id, it is a call-activity child, or
+            business id uniqueness enforcement is enabled.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
   /process-instances/{processInstanceKey}/modification:
     post:
       x-eventually-consistent: false
@@ -1745,6 +1806,17 @@ components:
           addedInVersion: "8.6"
         - propertyName: targetElementId
           addedInVersion: "8.6"
+
+    ProcessInstanceBusinessIdAssignmentInstruction:
+      type: object
+      additionalProperties: false
+      description: |
+        The instruction describing the business id to assign to a running process instance.
+      properties:
+        businessId:
+          $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+      required:
+        - businessId
 
     ProcessInstanceModificationInstruction:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -342,6 +342,8 @@ paths:
     $ref: 'process-instances.yaml#/paths/~1process-instances~1search'
   /process-instances/{processInstanceKey}:
     $ref: 'process-instances.yaml#/paths/~1process-instances~1{processInstanceKey}'
+  /process-instances/{processInstanceKey}/business-id-assignment:
+    $ref: 'process-instances.yaml#/paths/~1process-instances~1{processInstanceKey}~1business-id-assignment'
   /process-instances/{processInstanceKey}/call-hierarchy:
     $ref: 'process-instances.yaml#/paths/~1process-instances~1{processInstanceKey}~1call-hierarchy'
   /process-instances/{processInstanceKey}/cancellation:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -17,6 +17,7 @@ import io.camunda.gateway.protocol.model.CancelProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.DeleteProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.IncidentSearchQuery;
 import io.camunda.gateway.protocol.model.IncidentSearchQueryResult;
+import io.camunda.gateway.protocol.model.ProcessInstanceBusinessIdAssignmentInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceCancellationBatchOperationRequest;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceDeletionBatchOperationRequest;
@@ -31,6 +32,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
+import io.camunda.service.ProcessInstanceServices.AssignProcessInstanceBusinessIdRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
@@ -99,6 +101,17 @@ public class ProcessInstanceController {
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> migrateProcessInstance(physicalTenantId, mapped));
+  }
+
+  @CamundaPostMapping(path = "/{processInstanceKey}/business-id-assignment")
+  public CompletableFuture<ResponseEntity<Object>> assignProcessInstanceBusinessId(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable final long processInstanceKey,
+      @RequestBody final ProcessInstanceBusinessIdAssignmentInstruction assignmentRequest) {
+    return RequestMapper.toAssignProcessInstanceBusinessId(processInstanceKey, assignmentRequest)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            mapped -> assignProcessInstanceBusinessId(physicalTenantId, mapped));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/modification")
@@ -426,6 +439,15 @@ public class ProcessInstanceController {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices.migrateProcessInstance(
+                request, authenticationProvider.getCamundaAuthentication()));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> assignProcessInstanceBusinessId(
+      final String physicalTenantId, final AssignProcessInstanceBusinessIdRequest request) {
+    final var processInstanceServices = serviceRegistry.processInstanceServices(physicalTenantId);
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            processInstanceServices.assignProcessInstanceBusinessId(
                 request, authenticationProvider.getCamundaAuthentication()));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -26,6 +26,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.ProcessInstanceServices.AssignProcessInstanceBusinessIdRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
@@ -39,6 +40,7 @@ import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
@@ -92,10 +94,13 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   static final String DELETE_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/deletion";
   static final String MIGRATE_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/migration";
   static final String MODIFY_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/modification";
+  static final String ASSIGN_BUSINESS_ID_URL =
+      PROCESS_INSTANCES_START_URL + "/%s/business-id-assignment";
 
   @Captor ArgumentCaptor<ProcessInstanceCreateRequest> createRequestCaptor;
   @Captor ArgumentCaptor<ProcessInstanceCancelRequest> cancelRequestCaptor;
   @Captor ArgumentCaptor<ProcessInstanceMigrateRequest> migrateRequestCaptor;
+  @Captor ArgumentCaptor<AssignProcessInstanceBusinessIdRequest> assignBusinessIdRequestCaptor;
   @Captor ArgumentCaptor<ProcessInstanceModifyRequest> modifyRequestCaptor;
   @MockitoBean ProcessInstanceServices processInstanceServices;
   @MockitoBean ServiceRegistry serviceRegistry;
@@ -1243,6 +1248,191 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldAssignProcessInstanceBusinessId() {
+    // given
+    when(processInstanceServices.assignProcessInstanceBusinessId(
+            any(AssignProcessInstanceBusinessIdRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceBusinessIdRecord()));
+
+    final var request =
+        """
+            {
+              "businessId": "order-12345"
+            }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(ASSIGN_BUSINESS_ID_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    Mockito.verify(processInstanceServices)
+        .assignProcessInstanceBusinessId(assignBusinessIdRequestCaptor.capture(), any());
+    final var capturedRequest = assignBusinessIdRequestCaptor.getValue();
+    assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
+    assertThat(capturedRequest.businessId()).isEqualTo("order-12345");
+  }
+
+  @Test
+  void shouldRejectAssignProcessInstanceBusinessIdWithoutBusinessId() {
+    // given
+    final var request = "{}";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No businessId provided.",
+                "instance":"/v2/process-instances/1/business-id-assignment"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(ASSIGN_BUSINESS_ID_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectAssignProcessInstanceBusinessIdWithBlankBusinessId() {
+    // given
+    final var request =
+        """
+            {
+              "businessId": "   "
+            }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"No businessId provided.",
+                "instance":"/v2/process-instances/1/business-id-assignment"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(ASSIGN_BUSINESS_ID_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldMapNotFoundWhenAssigningBusinessIdToUnknownProcessInstance() {
+    // given
+    final var rejectionReason =
+        "Expected to assign a business id to process instance with key '1', but no such process instance was found";
+    when(processInstanceServices.assignProcessInstanceBusinessId(
+            any(AssignProcessInstanceBusinessIdRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(rejectionReason, ServiceException.Status.NOT_FOUND)));
+
+    final var request =
+        """
+            {
+              "businessId": "order-12345"
+            }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"NOT_FOUND",
+                "status":404,
+                "detail":"%s",
+                "instance":"/v2/process-instances/1/business-id-assignment"
+             }"""
+            .formatted(rejectionReason);
+
+    // when / then
+    webClient
+        .post()
+        .uri(ASSIGN_BUSINESS_ID_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldMapConflictWhenProcessInstanceNotEligibleForBusinessIdAssignment() {
+    // given
+    final var rejectionReason =
+        "Expected to assign a business id to process instance with key '1', but it already has a business id assigned";
+    when(processInstanceServices.assignProcessInstanceBusinessId(
+            any(AssignProcessInstanceBusinessIdRequest.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new ServiceException(rejectionReason, ServiceException.Status.INVALID_STATE)));
+
+    final var request =
+        """
+            {
+              "businessId": "order-12345"
+            }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_STATE",
+                "status":409,
+                "detail":"%s",
+                "instance":"/v2/process-instances/1/business-id-assignment"
+             }"""
+            .formatted(rejectionReason);
+
+    // when / then
+    webClient
+        .post()
+        .uri(ASSIGN_BUSINESS_ID_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT)
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAssignProcessInstanceBusinessIdRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAssignProcessInstanceBusinessIdRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import org.agrona.DirectBuffer;
+
+public final class BrokerAssignProcessInstanceBusinessIdRequest
+    extends BrokerExecuteCommand<ProcessInstanceBusinessIdRecord> {
+
+  private final ProcessInstanceBusinessIdRecord requestDto = new ProcessInstanceBusinessIdRecord();
+
+  public BrokerAssignProcessInstanceBusinessIdRequest() {
+    super(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.ASSIGN);
+  }
+
+  public BrokerAssignProcessInstanceBusinessIdRequest setProcessInstanceKey(
+      final long processInstanceKey) {
+    requestDto.setProcessInstanceKey(processInstanceKey);
+    request.setKey(processInstanceKey);
+    return this;
+  }
+
+  public BrokerAssignProcessInstanceBusinessIdRequest setBusinessId(final String businessId) {
+    requestDto.setBusinessId(businessId);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceBusinessIdRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ProcessInstanceBusinessIdRecord toResponseDto(final DirectBuffer buffer) {
+    final ProcessInstanceBusinessIdRecord responseDto = new ProcessInstanceBusinessIdRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
## Description

Exposes the `AssignProcessInstanceBusinessId` operation introduced by the engine layer through all three public API surfaces:

- **REST endpoint:** `POST /process-instances/{processInstanceKey}/business-id-assignment`
- **gRPC RPC:** `AssignProcessInstanceBusinessId` in `gateway.proto`
- **Java client command:** `newAssignProcessInstanceBusinessIdCommand(processInstanceKey)`

This allows attaching a business ID to a process instance that was started without one. The operation is rejected if the instance already has a *different* business ID assigned, is a child instance created by a call activity, or if business ID uniqueness enforcement is enabled for its process definition. Re-sending the same business ID succeeds idempotently.

### Changes

- **OpenAPI spec:** New `POST /process-instances/{processInstanceKey}/business-id-assignment` endpoint with `ProcessInstanceBusinessIdAssignmentInstruction` request schema, full response/rejection status codes (204, 400, 404, 409, 500, 503), and `$ref` wired in `v2/rest-api.yaml`.
- **gRPC proto:** New `AssignProcessInstanceBusinessIdRequest/Response` messages and `rpc AssignProcessInstanceBusinessId` in `gateway.proto`. Registered in the gRPC service retry config.
- **Broker request:** `BrokerAssignProcessInstanceBusinessIdRequest` routing by `processInstanceKey`.
- **Service layer:** `ProcessInstanceServices#assignProcessInstanceBusinessId` mirroring the migrate pattern.
- **gRPC gateway:** `EndpointManager` and `GatewayGrpcService` wired to the new broker request via `RequestMapper`/`ResponseMapper`.
- **REST controller:** `ProcessInstanceController` endpoint with input validation (blank/missing `businessId` → 400).
- **Java client:** `AssignProcessInstanceBusinessIdCommandStep1/2`, `AssignProcessInstanceBusinessIdCommandImpl` (supports both REST and gRPC transports), response type, and `CamundaClient#newAssignProcessInstanceBusinessIdCommand`.
- **Tests:** Unit tests for gRPC request mapping, REST controller slice tests (happy path + rejections), Java client tests for both transports, and a `@MultiDbTest` acceptance integration test covering happy path, idempotency, non-existent key, empty business ID, and re-assignment rejection.

## Related issues

closes #57632