### PR TITLE
fix: populate rdbms exporter decision instance ttl from UC

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -994,6 +994,7 @@ public class BrokerBasedPropertiesOverride {
     history.setUsageMetricsCleanup(database.getHistory().getUsageMetricsCleanup());
     history.setUsageMetricsTTL(database.getHistory().getUsageMetricsTTL());
     history.setMaxHistoryCleanupUsage(database.getHistory().getMaxHistoryCleanupUsage());
+    history.setDecisionInstanceTTL(database.getHistory().getDecisionInstanceTTL());
   }
 
   private void populateFromMonitoring(final BrokerBasedProperties override) {

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -62,6 +62,7 @@ public class SecondaryStorageRdbmsTest {
   private static final int HISTORY_CLEANUP_BATCH_SIZE = 2000;
   private static final int HISTORY_CLEANUP_PROCESS_INSTANCE_BATCH_SIZE = 1000;
   private static final String HISTORY_USAGE_METRICS_CLEANUP_INTERVAL = "PT48H";
+  private static final String HISTORY_DECISION_INSTANCE_TTL = "PT2M";
   private static final String HISTORY_USAGE_METRICS_TTL = "PT1H";
 
   private static final int MAX_PROCESS_CACHE_SIZE = 4711;
@@ -88,6 +89,8 @@ public class SecondaryStorageRdbmsTest {
             + BATCH_OPERATION_MODIFY_PROCESS_INSTANCE_HISTORY_TTL,
         "camunda.data.secondary-storage.rdbms.history.batchOperationResolveIncidentHistoryTTL="
             + BATCH_OPERATION_RESOLVE_INCIDENT_HISTORY_TTL,
+        "camunda.data.secondary-storage.rdbms.history.decision-instance-ttl="
+            + HISTORY_DECISION_INSTANCE_TTL,
         "camunda.data.secondary-storage.rdbms.history.minHistoryCleanupInterval="
             + MIN_HISTORY_CLEANUP_INTERVAL,
         "camunda.data.secondary-storage.rdbms.history.maxHistoryCleanupInterval="
@@ -168,6 +171,8 @@ public class SecondaryStorageRdbmsTest {
           .isEqualTo(Duration.parse(HISTORY_USAGE_METRICS_CLEANUP_INTERVAL));
       assertThat(exporterConfiguration.getHistory().getUsageMetricsTTL())
           .isEqualTo(Duration.parse(HISTORY_USAGE_METRICS_TTL));
+      assertThat(exporterConfiguration.getHistory().getDecisionInstanceTTL())
+          .isEqualTo(Duration.parse(HISTORY_DECISION_INSTANCE_TTL));
 
       if (exporterConfiguration.getProcessCache() != null) {
         assertThat(exporterConfiguration.getProcessCache().getMaxSize())


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Discovered when implementing https://github.com/camunda/camunda/pull/57835 , `camunda.data.secondary-stroage.rdbms.history.decisionInstanceTTL` is not being passed to the rdbms exporter

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
