### PR TITLE
feat: extract metrics component from conversation messages with partial metrics support

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.81",
+        "@camunda/camunda-api-zod-schemas": "0.0.82",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/elements": "11.92.0",
         "@carbon/react": "1.111.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.81",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.81.tgz",
-      "integrity": "sha512-EBTwKob6ZbIOgxl8+cwkYdiXt2kEZ+zNW1FSO4slU09oxNFi01S1AP5rnAjvJ11kbxvaFFzaye8C0UggJ4TTSA==",
+      "version": "0.0.82",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.82.tgz",
+      "integrity": "sha512-CnBpTJQrpdgT6r7OoHMbaug6Z+kzGECCa4PIN1LnHCk5AfpMwZPnpXrmUqsuQ2W0kyehWOoUTyLDjNgxvWifDg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.81",
+    "@camunda/camunda-api-zod-schemas": "0.0.82",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/elements": "11.92.0",
     "@carbon/react": "1.111.0",

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.12.1",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.81",
+        "@camunda/camunda-api-zod-schemas": "0.0.82",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/elements": "11.92.0",
         "@carbon/react": "1.111.0",
@@ -459,9 +459,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.81",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.81.tgz",
-      "integrity": "sha512-EBTwKob6ZbIOgxl8+cwkYdiXt2kEZ+zNW1FSO4slU09oxNFi01S1AP5rnAjvJ11kbxvaFFzaye8C0UggJ4TTSA==",
+      "version": "0.0.82",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.82.tgz",
+      "integrity": "sha512-CnBpTJQrpdgT6r7OoHMbaug6Z+kzGECCa4PIN1LnHCk5AfpMwZPnpXrmUqsuQ2W0kyehWOoUTyLDjNgxvWifDg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.12.1",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.81",
+    "@camunda/camunda-api-zod-schemas": "0.0.82",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/elements": "11.92.0",
     "@carbon/react": "1.111.0",

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageMetrics.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageMetrics.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentInstanceHistoryItemMetrics} from '@camunda/camunda-api-zod-schemas/8.10';
+import {render, screen} from 'modules/testing-library';
+import {MessageMetrics} from './MessageMetrics';
+
+const FULL_METRICS: AgentInstanceHistoryItemMetrics = {
+  inputTokens: 12345,
+  outputTokens: 456,
+  durationMs: 2500,
+};
+
+describe('<MessageMetrics />', () => {
+  it('should render nothing when metrics is null', () => {
+    const {container} = render(<MessageMetrics metrics={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render nothing when every metric field is null', () => {
+    const {container} = render(
+      <MessageMetrics
+        metrics={{inputTokens: null, outputTokens: null, durationMs: null}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render token and duration tags when all metrics are present', async () => {
+    const {user} = render(<MessageMetrics metrics={FULL_METRICS} />);
+
+    expect(screen.getByTestId('message-token-metric')).toHaveTextContent(
+      '12,801 tokens',
+    );
+    expect(screen.getByTestId('message-duration-metric')).toHaveTextContent(
+      '2.50s',
+    );
+
+    await user.hover(screen.getByTestId('message-token-metric'));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Input: 12,345 · Output: 456',
+    );
+  });
+
+  it('should treat a null inputTokens as 0 but show --- in the tooltip', async () => {
+    const {user} = render(
+      <MessageMetrics metrics={{...FULL_METRICS, inputTokens: null}} />,
+    );
+
+    expect(screen.getByTestId('message-token-metric')).toHaveTextContent(
+      '456 tokens',
+    );
+
+    await user.hover(screen.getByTestId('message-token-metric'));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Input: --- · Output: 456',
+    );
+  });
+
+  it('should treat a null outputTokens as 0 but show --- in the tooltip', async () => {
+    const {user} = render(
+      <MessageMetrics metrics={{...FULL_METRICS, outputTokens: null}} />,
+    );
+
+    expect(screen.getByTestId('message-token-metric')).toHaveTextContent(
+      '12,345 tokens',
+    );
+
+    await user.hover(screen.getByTestId('message-token-metric'));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Input: 12,345 · Output: ---',
+    );
+  });
+
+  it('should not render the token tag when both inputTokens and outputTokens are null', () => {
+    render(
+      <MessageMetrics
+        metrics={{...FULL_METRICS, inputTokens: null, outputTokens: null}}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('message-token-metric'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('message-duration-metric')).toBeInTheDocument();
+  });
+
+  it('should not render the duration tag when durationMs is null', () => {
+    render(<MessageMetrics metrics={{...FULL_METRICS, durationMs: null}} />);
+
+    expect(screen.getByTestId('message-token-metric')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('message-duration-metric'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should format durations under 1 second in milliseconds', () => {
+    render(<MessageMetrics metrics={{...FULL_METRICS, durationMs: 999}} />);
+    expect(screen.getByTestId('message-duration-metric')).toHaveTextContent(
+      '999ms',
+    );
+  });
+
+  it('should format durations of 1 second or more in seconds with two decimals', () => {
+    render(<MessageMetrics metrics={{...FULL_METRICS, durationMs: 1000}} />);
+    expect(screen.getByTestId('message-duration-metric')).toHaveTextContent(
+      '1.00s',
+    );
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageMetrics.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageMetrics.test.tsx
@@ -47,6 +47,26 @@ describe('<MessageMetrics />', () => {
     );
   });
 
+  it('should render token and duration tags when all metrics are 0', async () => {
+    const {user} = render(
+      <MessageMetrics
+        metrics={{inputTokens: 0, outputTokens: 0, durationMs: 0}}
+      />,
+    );
+
+    expect(screen.getByTestId('message-token-metric')).toHaveTextContent(
+      '0 tokens',
+    );
+    expect(screen.getByTestId('message-duration-metric')).toHaveTextContent(
+      '0ms',
+    );
+
+    await user.hover(screen.getByTestId('message-token-metric'));
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Input: 0 · Output: 0',
+    );
+  });
+
   it('should treat a null inputTokens as 0 but show --- in the tooltip', async () => {
     const {user} = render(
       <MessageMetrics metrics={{...FULL_METRICS, inputTokens: null}} />,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageMetrics.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/MessageMetrics.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentInstanceHistoryItemMetrics} from '@camunda/camunda-api-zod-schemas/8.10';
+import {Tag, Tooltip} from '@carbon/react';
+import {memo} from 'react';
+import styled from 'styled-components';
+
+const MetricsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-02);
+  --cds-tooltip-padding-block: var(--cds-spacing-02);
+  --cds-tooltip-padding-inline: var(--cds-spacing-03);
+`;
+
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(2)}s`;
+}
+
+type Props = {
+  metrics: AgentInstanceHistoryItemMetrics | null;
+};
+
+const MessageMetrics: React.FC<Props> = memo(function MessageMetrics({
+  metrics,
+}) {
+  if (
+    metrics === null ||
+    (metrics.inputTokens === null &&
+      metrics.outputTokens === null &&
+      metrics.durationMs === null)
+  ) {
+    return null;
+  }
+
+  const totalTokensMetric =
+    (metrics.inputTokens ?? 0) + (metrics.outputTokens ?? 0);
+  const tokensTooltip = `Input: ${metrics.inputTokens?.toLocaleString() ?? '---'} · Output: ${metrics.outputTokens?.toLocaleString() ?? '---'}`;
+
+  return (
+    <MetricsContainer>
+      {(metrics.inputTokens !== null || metrics.outputTokens !== null) && (
+        <Tooltip description={tokensTooltip} align="bottom">
+          <Tag data-testid="message-token-metric" type="gray" size="sm">
+            {totalTokensMetric.toLocaleString()}
+            &nbsp;tokens
+          </Tag>
+        </Tooltip>
+      )}
+      {metrics.durationMs !== null && (
+        <Tag data-testid="message-duration-metric" type="gray" size="sm">
+          {formatDuration(metrics.durationMs)}
+        </Tag>
+      )}
+    </MetricsContainer>
+  );
+});
+
+export {MessageMetrics};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import {useReducer} from 'react';
-import {Button, Tag, Tooltip} from '@carbon/react';
+import {Button} from '@carbon/react';
 import {Document, Maximize, Tools} from '@carbon/react/icons';
 import type {
   AgentInstanceHistoryItem,
@@ -25,10 +25,10 @@ import {
   AttachmentsLabel,
   AttachmentButton,
   MessageHeader,
-  MetricsContainer,
 } from './styled';
 import {MarkdownMessage} from './MarkdownMessage';
 import {MessageDetailsModal} from './MessageDetailsModal';
+import {MessageMetrics} from './MessageMetrics';
 
 type Actor = Exclude<AgentInstanceHistoryRole, 'TOOL_RESULT'> | 'SYSTEM';
 type ContentItem = AgentInstanceHistoryItem['content'][number];
@@ -47,15 +47,11 @@ const labelByActor: Record<Actor, string> = {
   ASSISTANT: 'Assistant',
 };
 
-function formatDuration(ms: number): string {
-  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(2)}s`;
-}
-
 type ConversationMessageProps = {
   actor: Actor;
   content: ContentItem[];
   historyItemKey?: string;
-  metrics?: Metrics | null;
+  metrics?: Metrics;
   toolCalls?: ToolCall[];
 };
 
@@ -83,22 +79,7 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
     >
       <MessageHeader>
         <ActorLabel>{labelByActor[actor]}</ActorLabel>
-        {metrics !== null && (
-          <MetricsContainer>
-            <Tooltip
-              description={`Input: ${metrics.inputTokens.toLocaleString()} · Output: ${metrics.outputTokens.toLocaleString()}`}
-              align="bottom"
-            >
-              <Tag data-testid="message-token-metric" type="gray" size="sm">
-                {(metrics.inputTokens + metrics.outputTokens).toLocaleString()}
-                &nbsp;tokens
-              </Tag>
-            </Tooltip>
-            <Tag data-testid="message-duration-metric" type="gray" size="sm">
-              {formatDuration(metrics.durationMs)}
-            </Tag>
-          </MetricsContainer>
-        )}
+        <MessageMetrics metrics={metrics} />
       </MessageHeader>
       {content.map((entry, index) => {
         switch (entry.contentType) {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/styled.tsx
@@ -35,14 +35,6 @@ const MessageHeader = styled.div`
   gap: var(--cds-spacing-03);
 `;
 
-const MetricsContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: var(--cds-spacing-02);
-  --cds-tooltip-padding-block: var(--cds-spacing-02);
-  --cds-tooltip-padding-inline: var(--cds-spacing-03);
-`;
-
 const ActorLabel = styled.h5`
   font-size: var(--cds-label-01-font-size);
   font-weight: var(--cds-heading-compact-01-font-weight);
@@ -158,7 +150,6 @@ const ViewSwitcher = styled(ContentSwitcher)`
 export {
   Container,
   MessageHeader,
-  MetricsContainer,
   MessageBlock,
   ActorLabel,
   TextContent,

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.23.1",
         "@bpmn-io/form-js-viewer": "1.23.1",
-        "@camunda/camunda-api-zod-schemas": "0.0.81",
+        "@camunda/camunda-api-zod-schemas": "0.0.82",
         "@camunda/camunda-composite-components": "0.25.2",
         "@carbon/react": "1.111.0",
         "@monaco-editor/react": "4.7.0",
@@ -560,9 +560,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.81",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.81.tgz",
-      "integrity": "sha512-EBTwKob6ZbIOgxl8+cwkYdiXt2kEZ+zNW1FSO4slU09oxNFi01S1AP5rnAjvJ11kbxvaFFzaye8C0UggJ4TTSA==",
+      "version": "0.0.82",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.82.tgz",
+      "integrity": "sha512-CnBpTJQrpdgT6r7OoHMbaug6Z+kzGECCa4PIN1LnHCk5AfpMwZPnpXrmUqsuQ2W0kyehWOoUTyLDjNgxvWifDg==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.23.1",
     "@bpmn-io/form-js-viewer": "1.23.1",
-    "@camunda/camunda-api-zod-schemas": "0.0.81",
+    "@camunda/camunda-api-zod-schemas": "0.0.82",
     "@camunda/camunda-composite-components": "0.25.2",
     "@carbon/react": "1.111.0",
     "@monaco-editor/react": "4.7.0",


### PR DESCRIPTION
## Description

- Bumps `@camunda/camunda-api-zod-schemas` version in Identity, Tasklist, and Operate
- Extracts metrics in `ConversationMessage` into a dedicated `MessageMetrics` component
- Adds support for granular partial metrics
  - => Only renders individual metrics when they are set

## Related issues

closes #57703
