### PR TITLE
feat: add single-instance suspend/resume REST endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,8 @@ scripts/codeowners-utils/output/
 **/test-results
 .claude/settings.local.json
 
+# Superpowers scratch specs/plans (local workflow docs, not tracked)
+docs/superpowers/
+
 # Load test
 load-tests/setup/c8-*

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.gateway.mapping.http;
 
-import static io.camunda.gateway.mapping.http.util.KeyUtil.keyToLong;
 import static io.camunda.gateway.mapping.http.util.KeyUtil.keyToLongOrNull;
 import static io.camunda.gateway.mapping.http.validator.AdHocSubProcessActivityRequestValidator.validateAdHocSubProcessActivationRequest;
 import static io.camunda.gateway.mapping.http.validator.ClockValidator.validateClockPinRequest;
@@ -24,15 +23,6 @@ import static io.camunda.gateway.mapping.http.validator.MessageRequestValidator.
 import static io.camunda.gateway.mapping.http.validator.MessageRequestValidator.validateMessagePublicationRequest;
 import static io.camunda.gateway.mapping.http.validator.MultiTenancyValidator.validateTenantId;
 import static io.camunda.gateway.mapping.http.validator.MultiTenancyValidator.validateTenantIds;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateAssignProcessInstanceBusinessIdRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateCancelProcessInstanceRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceBatchOperationRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateResumeProcessInstanceRequest;
-import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateSuspendProcessInstanceRequest;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.createProblemDetail;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 import static io.camunda.gateway.mapping.http.validator.ResourceRequestValidator.validateResourceDeletion;
@@ -49,7 +39,6 @@ import io.camunda.gateway.mapping.http.search.SearchQueryFilterMapper;
 import io.camunda.gateway.mapping.http.validator.DocumentValidator;
 import io.camunda.gateway.protocol.model.AdHocSubProcessActivateActivitiesInstruction;
 import io.camunda.gateway.protocol.model.CamundaProblemDetail;
-import io.camunda.gateway.protocol.model.CancelProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.Changeset;
 import io.camunda.gateway.protocol.model.ClockPinRequest;
 import io.camunda.gateway.protocol.model.ConditionalEvaluationInstruction;
@@ -57,7 +46,6 @@ import io.camunda.gateway.protocol.model.DecisionEvaluationById;
 import io.camunda.gateway.protocol.model.DecisionEvaluationByKey;
 import io.camunda.gateway.protocol.model.DecisionEvaluationInstruction;
 import io.camunda.gateway.protocol.model.DeleteResourceRequest;
-import io.camunda.gateway.protocol.model.DirectAncestorKeyInstruction;
 import io.camunda.gateway.protocol.model.DocumentLinkRequest;
 import io.camunda.gateway.protocol.model.DocumentMetadata;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
@@ -70,32 +58,13 @@ import io.camunda.gateway.protocol.model.JobResultUserTask;
 import io.camunda.gateway.protocol.model.JobUpdateRequest;
 import io.camunda.gateway.protocol.model.MessageCorrelationRequest;
 import io.camunda.gateway.protocol.model.MessagePublicationRequest;
-import io.camunda.gateway.protocol.model.ModifyProcessInstanceVariableInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceBusinessIdAssignmentInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionById;
-import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionByKey;
-import io.camunda.gateway.protocol.model.ProcessInstanceCreationTerminateInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationRequest;
-import io.camunda.gateway.protocol.model.ProcessInstanceMigrationInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperationRequest;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByIdInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByKeyInstruction;
-import io.camunda.gateway.protocol.model.ResumeProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.SetVariableRequest;
 import io.camunda.gateway.protocol.model.SignalBroadcastRequest;
-import io.camunda.gateway.protocol.model.SourceElementIdInstruction;
-import io.camunda.gateway.protocol.model.SourceElementInstanceKeyInstruction;
-import io.camunda.gateway.protocol.model.SuspendProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.TenantFilterEnum;
-import io.camunda.gateway.protocol.model.UseSourceParentKeyInstruction;
 import io.camunda.gateway.protocol.model.UserTaskAssignmentRequest;
 import io.camunda.gateway.protocol.model.UserTaskCompletionRequest;
 import io.camunda.gateway.protocol.model.UserTaskUpdateRequest;
 import io.camunda.search.filter.DecisionInstanceFilter;
-import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest;
 import io.camunda.service.AdHocSubProcessActivityServices.AdHocSubProcessActivateActivitiesRequest.AdHocSubProcessActivateActivityReference;
 import io.camunda.service.ConditionalServices.EvaluateConditionalRequest;
@@ -108,31 +77,14 @@ import io.camunda.service.JobServices.BatchUpdateJobRequest;
 import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
 import io.camunda.service.MessageServices.PublicationMessageRequest;
-import io.camunda.service.ProcessInstanceServices.AssignProcessInstanceBusinessIdRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceResumeRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceSuspendRequest;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
-import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.Part;
@@ -692,238 +644,6 @@ public class RequestMapper {
         HttpStatus.INTERNAL_SERVER_ERROR, Objects.requireNonNullElse(e.getMessage(), ""), message);
   }
 
-  public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
-      final ProcessInstanceCreationInstruction request, final boolean multiTenancyEnabled) {
-    return switch (request) {
-      case final ProcessInstanceCreationInstructionById req ->
-          toCreateProcessInstance(req, multiTenancyEnabled);
-      case final ProcessInstanceCreationInstructionByKey req ->
-          toCreateProcessInstance(req, multiTenancyEnabled);
-      default ->
-          Either.left(
-              GatewayErrorMapper.createProblemDetail(
-                  HttpStatus.BAD_REQUEST,
-                  "Unsupported process instance creation instruction type: "
-                      + request.getClass().getSimpleName(),
-                  "Only process instance creation by id or key is supported."));
-    };
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
-      final ProcessInstanceCreationInstructionById request, final boolean multiTenancyEnabled) {
-    final Either<ProblemDetail, String> validationResponse =
-        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance")
-            .flatMap(
-                tenant ->
-                    validateCreateProcessInstanceRequest(request)
-                        .map(Either::<ProblemDetail, String>left)
-                        .orElseGet(() -> Either.right(tenant)));
-
-    return validationResponse.map(
-        tenantId ->
-            new ProcessInstanceCreateRequest(
-                -1L,
-                getStringOrEmpty(
-                    request, ProcessInstanceCreationInstructionById::getProcessDefinitionId),
-                getIntOrDefault(
-                    request,
-                    ProcessInstanceCreationInstructionById::getProcessDefinitionVersion,
-                    -1),
-                getMapOrEmpty(request, ProcessInstanceCreationInstructionById::getVariables),
-                tenantId,
-                request.getAwaitCompletion(),
-                request.getRequestTimeout(),
-                request.getOperationReference(),
-                request.getStartInstructions().stream()
-                    .map(
-                        instruction ->
-                            new ProcessInstanceCreationStartInstruction()
-                                .setElementId(instruction.getElementId()))
-                    .toList(),
-                request.getRuntimeInstructions().stream()
-                    .map(
-                        instruction -> {
-                          final var instructionCasted =
-                              (ProcessInstanceCreationTerminateInstruction) instruction;
-                          return new ProcessInstanceCreationRuntimeInstruction()
-                              .setType(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE)
-                              .setAfterElementId(instructionCasted.getAfterElementId());
-                        })
-                    .toList(),
-                request.getFetchVariables(),
-                request.getTags(),
-                request.getBusinessId()));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
-      final ProcessInstanceCreationInstructionByKey request, final boolean multiTenancyEnabled) {
-    final Either<ProblemDetail, String> validationResponse =
-        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance")
-            .flatMap(
-                tenant ->
-                    validateCreateProcessInstanceRequest(request)
-                        .map(Either::<ProblemDetail, String>left)
-                        .orElseGet(() -> Either.right(tenant)));
-
-    return validationResponse.map(
-        tenantId ->
-            new ProcessInstanceCreateRequest(
-                getKeyOrDefault(
-                    request, ProcessInstanceCreationInstructionByKey::getProcessDefinitionKey, -1L),
-                "",
-                -1,
-                getMapOrEmpty(request, ProcessInstanceCreationInstructionByKey::getVariables),
-                tenantId,
-                request.getAwaitCompletion(),
-                request.getRequestTimeout(),
-                request.getOperationReference(),
-                request.getStartInstructions().stream()
-                    .map(
-                        instruction ->
-                            new ProcessInstanceCreationStartInstruction()
-                                .setElementId(instruction.getElementId()))
-                    .toList(),
-                request.getRuntimeInstructions().stream()
-                    .map(
-                        instruction -> {
-                          final var instructionCasted =
-                              (ProcessInstanceCreationTerminateInstruction) instruction;
-                          return new ProcessInstanceCreationRuntimeInstruction()
-                              .setType(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE)
-                              .setAfterElementId(instructionCasted.getAfterElementId());
-                        })
-                    .toList(),
-                request.getFetchVariables(),
-                request.getTags(),
-                request.getBusinessId()));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceCancelRequest> toCancelProcessInstance(
-      final long processInstanceKey, final CancelProcessInstanceRequest request) {
-    final Long operationReference = request != null ? request.getOperationReference() : null;
-    return getResult(
-        validateCancelProcessInstanceRequest(request),
-        () -> new ProcessInstanceCancelRequest(processInstanceKey, operationReference));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceSuspendRequest> toSuspendProcessInstance(
-      final long processInstanceKey, final SuspendProcessInstanceRequest request) {
-    final Long operationReference = request != null ? request.getOperationReference() : null;
-    return getResult(
-        validateSuspendProcessInstanceRequest(request),
-        () -> new ProcessInstanceSuspendRequest(processInstanceKey, operationReference));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceResumeRequest> toResumeProcessInstance(
-      final long processInstanceKey, final ResumeProcessInstanceRequest request) {
-    final Long operationReference = request != null ? request.getOperationReference() : null;
-    return getResult(
-        validateResumeProcessInstanceRequest(request),
-        () -> new ProcessInstanceResumeRequest(processInstanceKey, operationReference));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceMigrateRequest> toMigrateProcessInstance(
-      final long processInstanceKey, final ProcessInstanceMigrationInstruction request) {
-    return getResult(
-        validateMigrateProcessInstanceRequest(request),
-        () ->
-            new ProcessInstanceMigrateRequest(
-                processInstanceKey,
-                keyToLong(request.getTargetProcessDefinitionKey()),
-                request.getMappingInstructions().stream()
-                    .map(
-                        instruction ->
-                            new ProcessInstanceMigrationMappingInstruction()
-                                .setSourceElementId(instruction.getSourceElementId())
-                                .setTargetElementId(instruction.getTargetElementId()))
-                    .toList(),
-                request.getOperationReference()));
-  }
-
-  public static Either<ProblemDetail, AssignProcessInstanceBusinessIdRequest>
-      toAssignProcessInstanceBusinessId(
-          final long processInstanceKey,
-          final ProcessInstanceBusinessIdAssignmentInstruction request) {
-    return getResult(
-        validateAssignProcessInstanceBusinessIdRequest(request),
-        () ->
-            new AssignProcessInstanceBusinessIdRequest(
-                processInstanceKey, request.getBusinessId()));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceFilter> toRequiredProcessInstanceFilter(
-      final io.camunda.gateway.protocol.model.ProcessInstanceFilter request) {
-
-    final var filter = SearchQueryFilterMapper.toRequiredProcessInstanceFilter(request);
-    if (filter.isLeft()) {
-      return Either.left(createProblemDetail(filter.getLeft()).get());
-    }
-
-    return Either.right(filter.get());
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceMigrateBatchOperationRequest>
-      toProcessInstanceMigrationBatchOperationRequest(
-          final ProcessInstanceMigrationBatchOperationRequest request) {
-    final var migrationPlan = request.getMigrationPlan();
-    return getResult(
-        validateMigrateProcessInstanceBatchOperationRequest(request),
-        () ->
-            new ProcessInstanceMigrateBatchOperationRequest(
-                toRequiredProcessInstanceFilter(request.getFilter()).get(),
-                keyToLong(migrationPlan.getTargetProcessDefinitionKey()),
-                migrationPlan.getMappingInstructions().stream()
-                    .map(
-                        instruction ->
-                            new ProcessInstanceMigrationMappingInstruction()
-                                .setSourceElementId(instruction.getSourceElementId())
-                                .setTargetElementId(instruction.getTargetElementId()))
-                    .toList()));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceModifyRequest> toModifyProcessInstance(
-      final long processInstanceKey, final ProcessInstanceModificationInstruction request) {
-    return getResult(
-        validateModifyProcessInstanceRequest(request),
-        () ->
-            new ProcessInstanceModifyRequest(
-                processInstanceKey,
-                mapProcessInstanceModificationActivateInstruction(
-                    request.getActivateInstructions()),
-                mapProcessInstanceModificationMoveInstruction(request.getMoveInstructions()),
-                request.getTerminateInstructions().stream()
-                    .map(
-                        instruction -> {
-                          final var mappedInstruction =
-                              new ProcessInstanceModificationTerminateInstruction();
-                          if (instruction
-                              instanceof
-                              final ProcessInstanceModificationTerminateByKeyInstruction byKey) {
-                            mappedInstruction.setElementInstanceKey(
-                                keyToLong(byKey.getElementInstanceKey()));
-                          } else {
-                            mappedInstruction.setElementId(
-                                ((ProcessInstanceModificationTerminateByIdInstruction) instruction)
-                                    .getElementId());
-                          }
-
-                          return mappedInstruction;
-                        })
-                    .toList(),
-                request.getOperationReference()));
-  }
-
-  public static Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest>
-      toProcessInstanceModifyBatchOperationRequest(
-          final ProcessInstanceModificationBatchOperationRequest request) {
-    return getResult(
-        validateModifyProcessInstanceBatchOperationRequest(request),
-        () ->
-            new ProcessInstanceModifyBatchOperationRequest(
-                toRequiredProcessInstanceFilter(request.getFilter()).get(),
-                mapProcessInstanceModificationMoveBatchInstruction(request.getMoveInstructions())));
-  }
-
   public static Either<ProblemDetail, DecisionEvaluationRequest> toEvaluateDecisionRequest(
       final DecisionEvaluationInstruction request, final boolean multiTenancyEnabled) {
     return switch (request) {
@@ -1065,93 +785,7 @@ public class RequestMapper {
         getBooleanOrDefault(activationRequest, JobActivationRequest::getWithLease, false));
   }
 
-  private static List<ProcessInstanceModificationActivateInstruction>
-      mapProcessInstanceModificationActivateInstruction(
-          final List<
-                  io.camunda.gateway.protocol.model.ProcessInstanceModificationActivateInstruction>
-              instructions) {
-    return instructions.stream()
-        .map(
-            instruction -> {
-              final var mappedInstruction = new ProcessInstanceModificationActivateInstruction();
-              mappedInstruction
-                  .setElementId(instruction.getElementId())
-                  .setAncestorScopeKey(getAncestorKey(instruction.getAncestorElementInstanceKey()));
-              instruction.getVariableInstructions().stream()
-                  .map(RequestMapper::mapVariableInstruction)
-                  .forEach(mappedInstruction::addVariableInstruction);
-              return mappedInstruction;
-            })
-        .toList();
-  }
-
-  private static ProcessInstanceModificationVariableInstruction mapVariableInstruction(
-      final ModifyProcessInstanceVariableInstruction variable) {
-    return new ProcessInstanceModificationVariableInstruction()
-        .setElementId(variable.getScopeId())
-        .setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variable.getVariables())));
-  }
-
-  private static Long getAncestorKey(final @Nullable String ancestorElementInstanceKey) {
-    if (ancestorElementInstanceKey == null) {
-      return -1L;
-    }
-    return keyToLong(ancestorElementInstanceKey);
-  }
-
-  private static List<ProcessInstanceModificationMoveInstruction>
-      mapProcessInstanceModificationMoveInstruction(
-          final List<io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveInstruction>
-              instructions) {
-    return instructions.stream()
-        .map(
-            instruction -> {
-              final var mappedInstruction =
-                  new ProcessInstanceModificationMoveInstruction()
-                      .setTargetElementId(instruction.getTargetElementId());
-
-              switch (instruction.getSourceElementInstruction()) {
-                case final SourceElementIdInstruction byId ->
-                    mappedInstruction.setSourceElementId(byId.getSourceElementId());
-                case final SourceElementInstanceKeyInstruction byKey ->
-                    mappedInstruction.setSourceElementInstanceKey(
-                        keyToLong(byKey.getSourceElementInstanceKey()));
-                default ->
-                    throw new IllegalStateException(
-                        "Unexpected value: " + instruction.getSourceElementInstruction());
-              }
-
-              switch (instruction.getAncestorScopeInstruction()) {
-                case null -> mappedInstruction.setAncestorScopeKey(-1);
-                case final DirectAncestorKeyInstruction direct ->
-                    mappedInstruction.setAncestorScopeKey(
-                        getAncestorKey(direct.getAncestorElementInstanceKey()));
-                case final UseSourceParentKeyInstruction sourceParent ->
-                    mappedInstruction.setUseSourceParentKeyAsAncestorScopeKey(true);
-                default -> mappedInstruction.setInferAncestorScopeFromSourceHierarchy(true);
-              }
-              instruction.getVariableInstructions().stream()
-                  .map(RequestMapper::mapVariableInstruction)
-                  .forEach(mappedInstruction::addVariableInstruction);
-              return mappedInstruction;
-            })
-        .toList();
-  }
-
-  private static List<ProcessInstanceModificationMoveInstruction>
-      mapProcessInstanceModificationMoveBatchInstruction(
-          final List<ProcessInstanceModificationMoveBatchOperationInstruction> instructions) {
-    return instructions.stream()
-        .map(
-            instruction ->
-                new ProcessInstanceModificationMoveInstruction()
-                    .setSourceElementId(instruction.getSourceElementId())
-                    .setTargetElementId(instruction.getTargetElementId())
-                    .setInferAncestorScopeFromSourceHierarchy(true))
-        .toList();
-  }
-
-  private static <R> Map<String, Object> getMapOrEmpty(
+  public static <R> Map<String, Object> getMapOrEmpty(
       final @Nullable R request, final NullableExtractor<R, Map<String, Object>> mapExtractor) {
     final Map<String, Object> value = request == null ? null : mapExtractor.apply(request);
     return value == null ? Map.of() : value;
@@ -1245,7 +879,7 @@ public class RequestMapper {
     return value == null ? defaultValue : value;
   }
 
-  private static <R> String getStringOrEmpty(
+  public static <R> String getStringOrEmpty(
       final @Nullable R request, final NullableExtractor<R, String> valueExtractor) {
     final String value = request == null ? null : valueExtractor.apply(request);
     return value == null ? "" : value;
@@ -1264,7 +898,7 @@ public class RequestMapper {
     return value == null ? defaultValue : value;
   }
 
-  private static <R> long getKeyOrDefault(
+  public static <R> long getKeyOrDefault(
       final @Nullable R request,
       final NullableExtractor<R, String> valueExtractor,
       final Long defaultValue) {
@@ -1282,7 +916,7 @@ public class RequestMapper {
     return getIntOrDefault(request, valueExtractor, 0);
   }
 
-  private static <R> int getIntOrDefault(
+  public static <R> int getIntOrDefault(
       final R request, final Function<R, Integer> valueExtractor, final Integer defaultValue) {
     final Integer value = request == null ? null : valueExtractor.apply(request);
     return value == null ? defaultValue : value;
@@ -1332,7 +966,7 @@ public class RequestMapper {
    * rejected when passed as {@link Function}.
    */
   @FunctionalInterface
-  private interface NullableExtractor<R, T> {
+  public interface NullableExtractor<R, T> {
     @Nullable T apply(R request);
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -31,6 +31,8 @@ import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestVa
 import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceRequest;
 import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceBatchOperationRequest;
 import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateResumeProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateSuspendProcessInstanceRequest;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.createProblemDetail;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateKeyFormat;
 import static io.camunda.gateway.mapping.http.validator.ResourceRequestValidator.validateResourceDeletion;
@@ -81,10 +83,12 @@ import io.camunda.gateway.protocol.model.ProcessInstanceModificationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByIdInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByKeyInstruction;
+import io.camunda.gateway.protocol.model.ResumeProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.SetVariableRequest;
 import io.camunda.gateway.protocol.model.SignalBroadcastRequest;
 import io.camunda.gateway.protocol.model.SourceElementIdInstruction;
 import io.camunda.gateway.protocol.model.SourceElementInstanceKeyInstruction;
+import io.camunda.gateway.protocol.model.SuspendProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.TenantFilterEnum;
 import io.camunda.gateway.protocol.model.UseSourceParentKeyInstruction;
 import io.camunda.gateway.protocol.model.UserTaskAssignmentRequest;
@@ -111,6 +115,8 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOpe
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceResumeRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceSuspendRequest;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -798,6 +804,22 @@ public class RequestMapper {
     return getResult(
         validateCancelProcessInstanceRequest(request),
         () -> new ProcessInstanceCancelRequest(processInstanceKey, operationReference));
+  }
+
+  public static Either<ProblemDetail, ProcessInstanceSuspendRequest> toSuspendProcessInstance(
+      final long processInstanceKey, final SuspendProcessInstanceRequest request) {
+    final Long operationReference = request != null ? request.getOperationReference() : null;
+    return getResult(
+        validateSuspendProcessInstanceRequest(request),
+        () -> new ProcessInstanceSuspendRequest(processInstanceKey, operationReference));
+  }
+
+  public static Either<ProblemDetail, ProcessInstanceResumeRequest> toResumeProcessInstance(
+      final long processInstanceKey, final ResumeProcessInstanceRequest request) {
+    final Long operationReference = request != null ? request.getOperationReference() : null;
+    return getResult(
+        validateResumeProcessInstanceRequest(request),
+        () -> new ProcessInstanceResumeRequest(processInstanceKey, operationReference));
   }
 
   public static Either<ProblemDetail, ProcessInstanceMigrateRequest> toMigrateProcessInstance(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/SimpleRequestMapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.gateway.mapping.http;
 
+import io.camunda.gateway.mapping.http.mapper.ProcessInstanceMapper;
 import io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionById;
@@ -19,6 +20,8 @@ import org.springframework.http.ProblemDetail;
 
 public class SimpleRequestMapper {
 
+  private static final ProcessInstanceMapper PROCESS_INSTANCE_MAPPER = new ProcessInstanceMapper();
+
   public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
       final io.camunda.gateway.protocol.model.simple.ProcessInstanceCreationInstruction request,
       final boolean multiTenancyEnabled) {
@@ -29,7 +32,7 @@ public class SimpleRequestMapper {
     }
 
     if (request.getProcessDefinitionId() != null && !request.getProcessDefinitionId().isBlank()) {
-      return RequestMapper.toCreateProcessInstance(
+      return PROCESS_INSTANCE_MAPPER.toCreateProcessInstance(
           (ProcessInstanceCreationInstruction)
               ProcessInstanceCreationInstructionById.Builder.create()
                   .processDefinitionId(request.getProcessDefinitionId())
@@ -50,7 +53,7 @@ public class SimpleRequestMapper {
           multiTenancyEnabled);
     }
 
-    return RequestMapper.toCreateProcessInstance(
+    return PROCESS_INSTANCE_MAPPER.toCreateProcessInstance(
         (ProcessInstanceCreationInstruction)
             ProcessInstanceCreationInstructionByKey.Builder.create()
                 .processDefinitionKey(request.getProcessDefinitionKey())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ProcessInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ProcessInstanceMapper.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.mapper;
+
+import static io.camunda.gateway.mapping.http.RequestMapper.getIntOrDefault;
+import static io.camunda.gateway.mapping.http.RequestMapper.getKeyOrDefault;
+import static io.camunda.gateway.mapping.http.RequestMapper.getMapOrEmpty;
+import static io.camunda.gateway.mapping.http.RequestMapper.getStringOrEmpty;
+import static io.camunda.gateway.mapping.http.util.KeyUtil.keyToLong;
+import static io.camunda.gateway.mapping.http.validator.MultiTenancyValidator.validateTenantId;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateAssignProcessInstanceBusinessIdRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateCancelProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceBatchOperationRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceBatchOperationRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateResumeProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.ProcessInstanceRequestValidator.validateSuspendProcessInstanceRequest;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.createProblemDetail;
+
+import io.camunda.gateway.mapping.http.GatewayErrorMapper;
+import io.camunda.gateway.mapping.http.RequestMapper;
+import io.camunda.gateway.mapping.http.search.SearchQueryFilterMapper;
+import io.camunda.gateway.protocol.model.CancelProcessInstanceRequest;
+import io.camunda.gateway.protocol.model.DirectAncestorKeyInstruction;
+import io.camunda.gateway.protocol.model.ModifyProcessInstanceVariableInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceBusinessIdAssignmentInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionById;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstructionByKey;
+import io.camunda.gateway.protocol.model.ProcessInstanceCreationTerminateInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationRequest;
+import io.camunda.gateway.protocol.model.ProcessInstanceMigrationInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperationRequest;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByIdInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByKeyInstruction;
+import io.camunda.gateway.protocol.model.ResumeProcessInstanceRequest;
+import io.camunda.gateway.protocol.model.SourceElementIdInstruction;
+import io.camunda.gateway.protocol.model.SourceElementInstanceKeyInstruction;
+import io.camunda.gateway.protocol.model.SuspendProcessInstanceRequest;
+import io.camunda.gateway.protocol.model.UseSourceParentKeyInstruction;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.service.ProcessInstanceServices.AssignProcessInstanceBusinessIdRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceResumeRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceSuspendRequest;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationMoveInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
+import io.camunda.zeebe.protocol.record.value.RuntimeInstructionType;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+
+public class ProcessInstanceMapper {
+
+  public Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
+      final ProcessInstanceCreationInstruction request, final boolean multiTenancyEnabled) {
+    return switch (request) {
+      case final ProcessInstanceCreationInstructionById req ->
+          toCreateProcessInstance(req, multiTenancyEnabled);
+      case final ProcessInstanceCreationInstructionByKey req ->
+          toCreateProcessInstance(req, multiTenancyEnabled);
+      default ->
+          Either.left(
+              GatewayErrorMapper.createProblemDetail(
+                  HttpStatus.BAD_REQUEST,
+                  "Unsupported process instance creation instruction type: "
+                      + request.getClass().getSimpleName(),
+                  "Only process instance creation by id or key is supported."));
+    };
+  }
+
+  public Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
+      final ProcessInstanceCreationInstructionById request, final boolean multiTenancyEnabled) {
+    final Either<ProblemDetail, String> validationResponse =
+        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance")
+            .flatMap(
+                tenant ->
+                    validateCreateProcessInstanceRequest(request)
+                        .map(Either::<ProblemDetail, String>left)
+                        .orElseGet(() -> Either.right(tenant)));
+
+    return validationResponse.map(
+        tenantId ->
+            new ProcessInstanceCreateRequest(
+                -1L,
+                getStringOrEmpty(
+                    request, ProcessInstanceCreationInstructionById::getProcessDefinitionId),
+                getIntOrDefault(
+                    request,
+                    ProcessInstanceCreationInstructionById::getProcessDefinitionVersion,
+                    -1),
+                getMapOrEmpty(request, ProcessInstanceCreationInstructionById::getVariables),
+                tenantId,
+                request.getAwaitCompletion(),
+                request.getRequestTimeout(),
+                request.getOperationReference(),
+                request.getStartInstructions().stream()
+                    .map(
+                        instruction ->
+                            new ProcessInstanceCreationStartInstruction()
+                                .setElementId(instruction.getElementId()))
+                    .toList(),
+                request.getRuntimeInstructions().stream()
+                    .map(
+                        instruction -> {
+                          final var instructionCasted =
+                              (ProcessInstanceCreationTerminateInstruction) instruction;
+                          return new ProcessInstanceCreationRuntimeInstruction()
+                              .setType(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE)
+                              .setAfterElementId(instructionCasted.getAfterElementId());
+                        })
+                    .toList(),
+                request.getFetchVariables(),
+                request.getTags(),
+                request.getBusinessId()));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
+      final ProcessInstanceCreationInstructionByKey request, final boolean multiTenancyEnabled) {
+    final Either<ProblemDetail, String> validationResponse =
+        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance")
+            .flatMap(
+                tenant ->
+                    validateCreateProcessInstanceRequest(request)
+                        .map(Either::<ProblemDetail, String>left)
+                        .orElseGet(() -> Either.right(tenant)));
+
+    return validationResponse.map(
+        tenantId ->
+            new ProcessInstanceCreateRequest(
+                getKeyOrDefault(
+                    request, ProcessInstanceCreationInstructionByKey::getProcessDefinitionKey, -1L),
+                "",
+                -1,
+                getMapOrEmpty(request, ProcessInstanceCreationInstructionByKey::getVariables),
+                tenantId,
+                request.getAwaitCompletion(),
+                request.getRequestTimeout(),
+                request.getOperationReference(),
+                request.getStartInstructions().stream()
+                    .map(
+                        instruction ->
+                            new ProcessInstanceCreationStartInstruction()
+                                .setElementId(instruction.getElementId()))
+                    .toList(),
+                request.getRuntimeInstructions().stream()
+                    .map(
+                        instruction -> {
+                          final var instructionCasted =
+                              (ProcessInstanceCreationTerminateInstruction) instruction;
+                          return new ProcessInstanceCreationRuntimeInstruction()
+                              .setType(RuntimeInstructionType.TERMINATE_PROCESS_INSTANCE)
+                              .setAfterElementId(instructionCasted.getAfterElementId());
+                        })
+                    .toList(),
+                request.getFetchVariables(),
+                request.getTags(),
+                request.getBusinessId()));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceSuspendRequest> toSuspendProcessInstance(
+      final long processInstanceKey, final SuspendProcessInstanceRequest request) {
+    final Long operationReference = request != null ? request.getOperationReference() : null;
+    return RequestMapper.getResult(
+        validateSuspendProcessInstanceRequest(request),
+        () -> new ProcessInstanceSuspendRequest(processInstanceKey, operationReference));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceResumeRequest> toResumeProcessInstance(
+      final long processInstanceKey, final ResumeProcessInstanceRequest request) {
+    final Long operationReference = request != null ? request.getOperationReference() : null;
+    return RequestMapper.getResult(
+        validateResumeProcessInstanceRequest(request),
+        () -> new ProcessInstanceResumeRequest(processInstanceKey, operationReference));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceCancelRequest> toCancelProcessInstance(
+      final long processInstanceKey, final CancelProcessInstanceRequest request) {
+    final Long operationReference = request != null ? request.getOperationReference() : null;
+    return RequestMapper.getResult(
+        validateCancelProcessInstanceRequest(request),
+        () -> new ProcessInstanceCancelRequest(processInstanceKey, operationReference));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceMigrateRequest> toMigrateProcessInstance(
+      final long processInstanceKey, final ProcessInstanceMigrationInstruction request) {
+    return RequestMapper.getResult(
+        validateMigrateProcessInstanceRequest(request),
+        () ->
+            new ProcessInstanceMigrateRequest(
+                processInstanceKey,
+                keyToLong(request.getTargetProcessDefinitionKey()),
+                request.getMappingInstructions().stream()
+                    .map(
+                        instruction ->
+                            new ProcessInstanceMigrationMappingInstruction()
+                                .setSourceElementId(instruction.getSourceElementId())
+                                .setTargetElementId(instruction.getTargetElementId()))
+                    .toList(),
+                request.getOperationReference()));
+  }
+
+  public Either<ProblemDetail, AssignProcessInstanceBusinessIdRequest>
+      toAssignProcessInstanceBusinessId(
+          final long processInstanceKey,
+          final ProcessInstanceBusinessIdAssignmentInstruction request) {
+    return RequestMapper.getResult(
+        validateAssignProcessInstanceBusinessIdRequest(request),
+        () ->
+            new AssignProcessInstanceBusinessIdRequest(
+                processInstanceKey, request.getBusinessId()));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceFilter> toRequiredProcessInstanceFilter(
+      final io.camunda.gateway.protocol.model.ProcessInstanceFilter request) {
+
+    final var filter = SearchQueryFilterMapper.toRequiredProcessInstanceFilter(request);
+    if (filter.isLeft()) {
+      return Either.left(createProblemDetail(filter.getLeft()).get());
+    }
+
+    return Either.right(filter.get());
+  }
+
+  public Either<ProblemDetail, ProcessInstanceMigrateBatchOperationRequest>
+      toProcessInstanceMigrationBatchOperationRequest(
+          final ProcessInstanceMigrationBatchOperationRequest request) {
+    final var migrationPlan = request.getMigrationPlan();
+    return RequestMapper.getResult(
+        validateMigrateProcessInstanceBatchOperationRequest(request),
+        () ->
+            new ProcessInstanceMigrateBatchOperationRequest(
+                toRequiredProcessInstanceFilter(request.getFilter()).get(),
+                keyToLong(migrationPlan.getTargetProcessDefinitionKey()),
+                migrationPlan.getMappingInstructions().stream()
+                    .map(
+                        instruction ->
+                            new ProcessInstanceMigrationMappingInstruction()
+                                .setSourceElementId(instruction.getSourceElementId())
+                                .setTargetElementId(instruction.getTargetElementId()))
+                    .toList()));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceModifyRequest> toModifyProcessInstance(
+      final long processInstanceKey, final ProcessInstanceModificationInstruction request) {
+    return RequestMapper.getResult(
+        validateModifyProcessInstanceRequest(request),
+        () ->
+            new ProcessInstanceModifyRequest(
+                processInstanceKey,
+                mapProcessInstanceModificationActivateInstruction(
+                    request.getActivateInstructions()),
+                mapProcessInstanceModificationMoveInstruction(request.getMoveInstructions()),
+                request.getTerminateInstructions().stream()
+                    .map(
+                        instruction -> {
+                          final var mappedInstruction =
+                              new ProcessInstanceModificationTerminateInstruction();
+                          if (instruction
+                              instanceof
+                              final ProcessInstanceModificationTerminateByKeyInstruction byKey) {
+                            mappedInstruction.setElementInstanceKey(
+                                keyToLong(byKey.getElementInstanceKey()));
+                          } else {
+                            mappedInstruction.setElementId(
+                                ((ProcessInstanceModificationTerminateByIdInstruction) instruction)
+                                    .getElementId());
+                          }
+
+                          return mappedInstruction;
+                        })
+                    .toList(),
+                request.getOperationReference()));
+  }
+
+  public Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest>
+      toProcessInstanceModifyBatchOperationRequest(
+          final ProcessInstanceModificationBatchOperationRequest request) {
+    return RequestMapper.getResult(
+        validateModifyProcessInstanceBatchOperationRequest(request),
+        () ->
+            new ProcessInstanceModifyBatchOperationRequest(
+                toRequiredProcessInstanceFilter(request.getFilter()).get(),
+                mapProcessInstanceModificationMoveBatchInstruction(request.getMoveInstructions())));
+  }
+
+  private static List<ProcessInstanceModificationActivateInstruction>
+      mapProcessInstanceModificationActivateInstruction(
+          final List<
+                  io.camunda.gateway.protocol.model.ProcessInstanceModificationActivateInstruction>
+              instructions) {
+    return instructions.stream()
+        .map(
+            instruction -> {
+              final var mappedInstruction = new ProcessInstanceModificationActivateInstruction();
+              mappedInstruction
+                  .setElementId(instruction.getElementId())
+                  .setAncestorScopeKey(getAncestorKey(instruction.getAncestorElementInstanceKey()));
+              instruction.getVariableInstructions().stream()
+                  .map(ProcessInstanceMapper::mapVariableInstruction)
+                  .forEach(mappedInstruction::addVariableInstruction);
+              return mappedInstruction;
+            })
+        .toList();
+  }
+
+  private static ProcessInstanceModificationVariableInstruction mapVariableInstruction(
+      final ModifyProcessInstanceVariableInstruction variable) {
+    return new ProcessInstanceModificationVariableInstruction()
+        .setElementId(variable.getScopeId())
+        .setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variable.getVariables())));
+  }
+
+  private static Long getAncestorKey(final @Nullable String ancestorElementInstanceKey) {
+    if (ancestorElementInstanceKey == null) {
+      return -1L;
+    }
+    return keyToLong(ancestorElementInstanceKey);
+  }
+
+  private static List<ProcessInstanceModificationMoveInstruction>
+      mapProcessInstanceModificationMoveInstruction(
+          final List<io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveInstruction>
+              instructions) {
+    return instructions.stream()
+        .map(
+            instruction -> {
+              final var mappedInstruction =
+                  new ProcessInstanceModificationMoveInstruction()
+                      .setTargetElementId(instruction.getTargetElementId());
+
+              switch (instruction.getSourceElementInstruction()) {
+                case final SourceElementIdInstruction byId ->
+                    mappedInstruction.setSourceElementId(byId.getSourceElementId());
+                case final SourceElementInstanceKeyInstruction byKey ->
+                    mappedInstruction.setSourceElementInstanceKey(
+                        keyToLong(byKey.getSourceElementInstanceKey()));
+                default ->
+                    throw new IllegalStateException(
+                        "Unexpected value: " + instruction.getSourceElementInstruction());
+              }
+
+              switch (instruction.getAncestorScopeInstruction()) {
+                case null -> mappedInstruction.setAncestorScopeKey(-1);
+                case final DirectAncestorKeyInstruction direct ->
+                    mappedInstruction.setAncestorScopeKey(
+                        getAncestorKey(direct.getAncestorElementInstanceKey()));
+                case final UseSourceParentKeyInstruction sourceParent ->
+                    mappedInstruction.setUseSourceParentKeyAsAncestorScopeKey(true);
+                default -> mappedInstruction.setInferAncestorScopeFromSourceHierarchy(true);
+              }
+              instruction.getVariableInstructions().stream()
+                  .map(ProcessInstanceMapper::mapVariableInstruction)
+                  .forEach(mappedInstruction::addVariableInstruction);
+              return mappedInstruction;
+            })
+        .toList();
+  }
+
+  private static List<ProcessInstanceModificationMoveInstruction>
+      mapProcessInstanceModificationMoveBatchInstruction(
+          final List<ProcessInstanceModificationMoveBatchOperationInstruction> instructions) {
+    return instructions.stream()
+        .map(
+            instruction ->
+                new ProcessInstanceModificationMoveInstruction()
+                    .setSourceElementId(instruction.getSourceElementId())
+                    .setTargetElementId(instruction.getTargetElementId())
+                    .setInferAncestorScopeFromSourceHierarchy(true))
+        .toList();
+  }
+}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/ProcessInstanceRequestValidator.java
@@ -35,8 +35,10 @@ import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveInstruct
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByIdInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateByKeyInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.gateway.protocol.model.ResumeProcessInstanceRequest;
 import io.camunda.gateway.protocol.model.SourceElementIdInstruction;
 import io.camunda.gateway.protocol.model.SourceElementInstanceKeyInstruction;
+import io.camunda.gateway.protocol.model.SuspendProcessInstanceRequest;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -130,6 +132,26 @@ public class ProcessInstanceRequestValidator {
 
   public static Optional<ProblemDetail> validateCancelProcessInstanceRequest(
       final CancelProcessInstanceRequest request) {
+    return validate(
+        violations -> {
+          if (request != null) {
+            validateOperationReference(request.getOperationReference(), violations);
+          }
+        });
+  }
+
+  public static Optional<ProblemDetail> validateSuspendProcessInstanceRequest(
+      final SuspendProcessInstanceRequest request) {
+    return validate(
+        violations -> {
+          if (request != null) {
+            validateOperationReference(request.getOperationReference(), violations);
+          }
+        });
+  }
+
+  public static Optional<ProblemDetail> validateResumeProcessInstanceRequest(
+      final ResumeProcessInstanceRequest request) {
     return validate(
         violations -> {
           if (request != null) {

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/ProcessInstanceMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/mapper/ProcessInstanceMapperTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.protocol.model.AdvancedStringFilter;
+import io.camunda.gateway.protocol.model.MigrateProcessInstanceMappingInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceFilter;
+import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationPlan;
+import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationRequest;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperationRequest;
+import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ProblemDetail;
+
+class ProcessInstanceMapperTest {
+
+  private final ProcessInstanceMapper mapper = new ProcessInstanceMapper();
+
+  @Test
+  void shouldMapToProcessInstanceMigrationBatchOperationRequest() {
+    // given
+    final var mappingInstruction =
+        MigrateProcessInstanceMappingInstruction.Builder.create()
+            .sourceElementId("source1")
+            .targetElementId("target1")
+            .build();
+    final var migrationPlan =
+        ProcessInstanceMigrationBatchOperationPlan.Builder.create()
+            .targetProcessDefinitionKey("123")
+            .mappingInstructions(List.of(mappingInstruction))
+            .build();
+    final var filter =
+        ProcessInstanceFilter.Builder.create()
+            .processDefinitionId(AdvancedStringFilter.Builder.create().$like("process").build())
+            .build();
+    final var batchOperationInstruction =
+        ProcessInstanceMigrationBatchOperationRequest.Builder.create()
+            .filter(filter)
+            .migrationPlan(migrationPlan)
+            .build();
+
+    // when
+    final Either<ProblemDetail, ProcessInstanceMigrateBatchOperationRequest> result =
+        mapper.toProcessInstanceMigrationBatchOperationRequest(batchOperationInstruction);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    final var request = result.get();
+    assertThat(request.targetProcessDefinitionKey()).isEqualTo(123L);
+    assertThat(request.mappingInstructions())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            instruction -> {
+              assertThat(instruction.getSourceElementId()).isEqualTo("source1");
+              assertThat(instruction.getTargetElementId()).isEqualTo("target1");
+            });
+  }
+
+  @Test
+  void shouldReturnProblemDetailForInvalidInput() {
+    // given
+    final var mappingInstruction =
+        MigrateProcessInstanceMappingInstruction.Builder.create()
+            .sourceElementId("")
+            .targetElementId("")
+            .build();
+    final var migrationPlan =
+        ProcessInstanceMigrationBatchOperationPlan.Builder.create()
+            .targetProcessDefinitionKey("123")
+            .mappingInstructions(List.of(mappingInstruction))
+            .build();
+    final var filter = ProcessInstanceFilter.Builder.create().build();
+    final var batchOperationRequest =
+        ProcessInstanceMigrationBatchOperationRequest.Builder.create()
+            .filter(filter)
+            .migrationPlan(migrationPlan)
+            .build();
+
+    // when
+    final Either<ProblemDetail, ProcessInstanceMigrateBatchOperationRequest> result =
+        mapper.toProcessInstanceMigrationBatchOperationRequest(batchOperationRequest);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    final var problemDetail = result.getLeft();
+    assertThat(problemDetail.getStatus()).isEqualTo(400); // Bad Request
+    assertThat(problemDetail.getDetail()).contains("are required");
+  }
+
+  @Test
+  void shouldMapProcessInstanceModifyBatchOperationRequest() {
+    // given
+    final var moveInstruction =
+        ProcessInstanceModificationMoveBatchOperationInstruction.Builder.create()
+            .sourceElementId("source1")
+            .targetElementId("target1")
+            .build();
+    final var filter =
+        ProcessInstanceFilter.Builder.create()
+            .processDefinitionId(AdvancedStringFilter.Builder.create().$like("process").build())
+            .build();
+    final var modificationRequest =
+        ProcessInstanceModificationBatchOperationRequest.Builder.create()
+            .filter(filter)
+            .moveInstructions(List.of(moveInstruction))
+            .build();
+
+    // when
+    final Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest> result =
+        mapper.toProcessInstanceModifyBatchOperationRequest(modificationRequest);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    final var request = result.get();
+    assertThat(request.moveInstructions())
+        .hasSize(1)
+        .first()
+        .satisfies(
+            instruction -> {
+              assertThat(instruction.getSourceElementId()).isEqualTo("source1");
+              assertThat(instruction.getTargetElementId()).isEqualTo("target1");
+              assertThat(instruction.getAncestorScopeKey()).isEqualTo(-1L);
+              assertThat(instruction.isInferAncestorScopeFromSourceHierarchy()).isTrue();
+              assertThat(instruction.isUseSourceParentKeyAsAncestorScopeKey()).isFalse();
+              assertThat(instruction.getVariableInstructions()).isEmpty();
+            });
+  }
+
+  @Test
+  void shouldNotMapProcessInstanceModifyBatchOperationRequestWhenInvalid() {
+    // given
+    // Use empty targetElementId to trigger "No targetElementId provided." validation
+    final var moveInstruction =
+        ProcessInstanceModificationMoveBatchOperationInstruction.Builder.create()
+            .sourceElementId("source1")
+            .targetElementId("")
+            .build();
+    final var filter =
+        ProcessInstanceFilter.Builder.create()
+            .processDefinitionId(AdvancedStringFilter.Builder.create().$like("process").build())
+            .build();
+    final var modificationRequest =
+        ProcessInstanceModificationBatchOperationRequest.Builder.create()
+            .filter(filter)
+            .moveInstructions(List.of(moveInstruction))
+            .build();
+
+    // when
+    final Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest> result =
+        mapper.toProcessInstanceModifyBatchOperationRequest(modificationRequest);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    final var problemDetail = result.getLeft();
+    assertThat(problemDetail.getStatus()).isEqualTo(400);
+    assertThat(problemDetail.getDetail()).isEqualTo("No targetElementId provided.");
+  }
+}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -10,7 +10,6 @@ package io.camunda.gateway.mapping.http.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
-import io.camunda.gateway.protocol.model.AdvancedStringFilter;
 import io.camunda.gateway.protocol.model.DeleteResourceRequest;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.JobChangeset;
@@ -18,165 +17,14 @@ import io.camunda.gateway.protocol.model.JobCompletionRequest;
 import io.camunda.gateway.protocol.model.JobErrorRequest;
 import io.camunda.gateway.protocol.model.JobFailRequest;
 import io.camunda.gateway.protocol.model.JobUpdateRequest;
-import io.camunda.gateway.protocol.model.MigrateProcessInstanceMappingInstruction;
-import io.camunda.gateway.protocol.model.ProcessInstanceFilter;
-import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationPlan;
-import io.camunda.gateway.protocol.model.ProcessInstanceMigrationBatchOperationRequest;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperationRequest;
-import io.camunda.gateway.protocol.model.ProcessInstanceModificationMoveBatchOperationInstruction;
 import io.camunda.gateway.protocol.model.TenantFilterEnum;
 import io.camunda.service.JobServices.UpdateJobChangeset;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOperationRequest;
-import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
-import io.camunda.zeebe.util.Either;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.ProblemDetail;
 
 class RequestMapperTest {
-
-  @Test
-  void shouldMapToProcessInstanceMigrationBatchOperationRequest() {
-    // given
-    final var mappingInstruction =
-        MigrateProcessInstanceMappingInstruction.Builder.create()
-            .sourceElementId("source1")
-            .targetElementId("target1")
-            .build();
-    final var migrationPlan =
-        ProcessInstanceMigrationBatchOperationPlan.Builder.create()
-            .targetProcessDefinitionKey("123")
-            .mappingInstructions(List.of(mappingInstruction))
-            .build();
-    final var filter =
-        ProcessInstanceFilter.Builder.create()
-            .processDefinitionId(AdvancedStringFilter.Builder.create().$like("process").build())
-            .build();
-    final var batchOperationInstruction =
-        ProcessInstanceMigrationBatchOperationRequest.Builder.create()
-            .filter(filter)
-            .migrationPlan(migrationPlan)
-            .build();
-
-    // when
-    final Either<ProblemDetail, ProcessInstanceMigrateBatchOperationRequest> result =
-        RequestMapper.toProcessInstanceMigrationBatchOperationRequest(batchOperationInstruction);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    final var request = result.get();
-    assertThat(request.targetProcessDefinitionKey()).isEqualTo(123L);
-    assertThat(request.mappingInstructions())
-        .hasSize(1)
-        .first()
-        .satisfies(
-            instruction -> {
-              assertThat(instruction.getSourceElementId()).isEqualTo("source1");
-              assertThat(instruction.getTargetElementId()).isEqualTo("target1");
-            });
-  }
-
-  @Test
-  void shouldReturnProblemDetailForInvalidInput() {
-    // given
-    final var mappingInstruction =
-        MigrateProcessInstanceMappingInstruction.Builder.create()
-            .sourceElementId("")
-            .targetElementId("")
-            .build();
-    final var migrationPlan =
-        ProcessInstanceMigrationBatchOperationPlan.Builder.create()
-            .targetProcessDefinitionKey("123")
-            .mappingInstructions(List.of(mappingInstruction))
-            .build();
-    final var filter = ProcessInstanceFilter.Builder.create().build();
-    final var batchOperationRequest =
-        ProcessInstanceMigrationBatchOperationRequest.Builder.create()
-            .filter(filter)
-            .migrationPlan(migrationPlan)
-            .build();
-
-    // when
-    final Either<ProblemDetail, ProcessInstanceMigrateBatchOperationRequest> result =
-        RequestMapper.toProcessInstanceMigrationBatchOperationRequest(batchOperationRequest);
-
-    // then
-    assertThat(result.isLeft()).isTrue();
-    final var problemDetail = result.getLeft();
-    assertThat(problemDetail.getStatus()).isEqualTo(400); // Bad Request
-    assertThat(problemDetail.getDetail()).contains("are required");
-  }
-
-  @Test
-  void shouldMapProcessInstanceModifyBatchOperationRequest() {
-    // given
-    final var moveInstruction =
-        ProcessInstanceModificationMoveBatchOperationInstruction.Builder.create()
-            .sourceElementId("source1")
-            .targetElementId("target1")
-            .build();
-    final var filter =
-        ProcessInstanceFilter.Builder.create()
-            .processDefinitionId(AdvancedStringFilter.Builder.create().$like("process").build())
-            .build();
-    final var modificationRequest =
-        ProcessInstanceModificationBatchOperationRequest.Builder.create()
-            .filter(filter)
-            .moveInstructions(List.of(moveInstruction))
-            .build();
-
-    // when
-    final Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest> result =
-        RequestMapper.toProcessInstanceModifyBatchOperationRequest(modificationRequest);
-
-    // then
-    assertThat(result.isRight()).isTrue();
-    final var request = result.get();
-    assertThat(request.moveInstructions())
-        .hasSize(1)
-        .first()
-        .satisfies(
-            instruction -> {
-              assertThat(instruction.getSourceElementId()).isEqualTo("source1");
-              assertThat(instruction.getTargetElementId()).isEqualTo("target1");
-              assertThat(instruction.getAncestorScopeKey()).isEqualTo(-1L);
-              assertThat(instruction.isInferAncestorScopeFromSourceHierarchy()).isTrue();
-              assertThat(instruction.isUseSourceParentKeyAsAncestorScopeKey()).isFalse();
-              assertThat(instruction.getVariableInstructions()).isEmpty();
-            });
-  }
-
-  @Test
-  void shouldNotMapProcessInstanceModifyBatchOperationRequestWhenInvalid() {
-    // given
-    // Use empty targetElementId to trigger "No targetElementId provided." validation
-    final var moveInstruction =
-        ProcessInstanceModificationMoveBatchOperationInstruction.Builder.create()
-            .sourceElementId("source1")
-            .targetElementId("")
-            .build();
-    final var filter =
-        ProcessInstanceFilter.Builder.create()
-            .processDefinitionId(AdvancedStringFilter.Builder.create().$like("process").build())
-            .build();
-    final var modificationRequest =
-        ProcessInstanceModificationBatchOperationRequest.Builder.create()
-            .filter(filter)
-            .moveInstructions(List.of(moveInstruction))
-            .build();
-
-    // when
-    final Either<ProblemDetail, ProcessInstanceModifyBatchOperationRequest> result =
-        RequestMapper.toProcessInstanceModifyBatchOperationRequest(modificationRequest);
-
-    // then
-    assertThat(result.isLeft()).isTrue();
-    final var problemDetail = result.getLeft();
-    assertThat(problemDetail.getStatus()).isEqualTo(400);
-    assertThat(problemDetail.getDetail()).isEqualTo("No targetElementId provided.");
-  }
 
   @Nested
   class ResourceDeletionRequestMappingTest {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -50,6 +50,8 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceW
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteHistoryRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerMigrateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerModifyProcessInstanceRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerResumeProcessInstanceRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerSuspendProcessInstanceRequest;
 import io.camunda.zeebe.gateway.validation.VariableNameLengthValidator;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationProcessInstanceMigrationPlan;
@@ -388,6 +390,30 @@ public final class ProcessInstanceServices
     return sendBrokerRequest(brokerRequest, authentication);
   }
 
+  public CompletableFuture<ProcessInstanceRecord> suspendProcessInstance(
+      final ProcessInstanceSuspendRequest request, final CamundaAuthentication authentication) {
+    final var brokerRequest =
+        new BrokerSuspendProcessInstanceRequest()
+            .setProcessInstanceKey(request.processInstanceKey());
+
+    if (request.operationReference() != null) {
+      brokerRequest.setOperationReference(request.operationReference());
+    }
+    return sendBrokerRequest(brokerRequest, authentication);
+  }
+
+  public CompletableFuture<ProcessInstanceRecord> resumeProcessInstance(
+      final ProcessInstanceResumeRequest request, final CamundaAuthentication authentication) {
+    final var brokerRequest =
+        new BrokerResumeProcessInstanceRequest()
+            .setProcessInstanceKey(request.processInstanceKey());
+
+    if (request.operationReference() != null) {
+      brokerRequest.setOperationReference(request.operationReference());
+    }
+    return sendBrokerRequest(brokerRequest, authentication);
+  }
+
   public CompletableFuture<BatchOperationCreationRecord>
       cancelProcessInstanceBatchOperationWithResult(
           final ProcessInstanceFilter filter, final CamundaAuthentication authentication) {
@@ -667,6 +693,10 @@ public final class ProcessInstanceServices
   }
 
   public record ProcessInstanceCancelRequest(Long processInstanceKey, Long operationReference) {}
+
+  public record ProcessInstanceSuspendRequest(Long processInstanceKey, Long operationReference) {}
+
+  public record ProcessInstanceResumeRequest(Long processInstanceKey, Long operationReference) {}
 
   public record ProcessInstanceMigrateRequest(
       Long processInstanceKey,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -28,6 +28,8 @@ import io.camunda.gateway.protocol.model.ProcessInstanceModificationBatchOperati
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQuery;
 import io.camunda.gateway.protocol.model.ProcessInstanceSearchQueryResult;
+import io.camunda.gateway.protocol.model.ResumeProcessInstanceRequest;
+import io.camunda.gateway.protocol.model.SuspendProcessInstanceRequest;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
@@ -90,6 +92,40 @@ public class ProcessInstanceController {
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> cancelProcessInstance(physicalTenantId, mapped));
+  }
+
+  @CamundaPostMapping(path = "/{processInstanceKey}/suspension")
+  public CompletableFuture<ResponseEntity<Object>> suspendProcessInstance(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable final long processInstanceKey,
+      @RequestBody(required = false) final SuspendProcessInstanceRequest suspendRequest) {
+    return RequestMapper.toSuspendProcessInstance(processInstanceKey, suspendRequest)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            // TODO(#57518): dispatch to suspendProcessInstance(physicalTenantId, mapped) — see
+            // ProcessInstanceServices.suspendProcessInstance — once the zeebe/engine SUSPEND
+            // processor exists. Until then, a real dispatch would time out at 504 with no
+            // SUSPEND_PROCESS_INSTANCE check (that check lives in the not-yet-existing processor).
+            ignored ->
+                CompletableFuture.completedFuture(
+                    ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()));
+  }
+
+  @CamundaPostMapping(path = "/{processInstanceKey}/resumption")
+  public CompletableFuture<ResponseEntity<Object>> resumeProcessInstance(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable final long processInstanceKey,
+      @RequestBody(required = false) final ResumeProcessInstanceRequest resumeRequest) {
+    return RequestMapper.toResumeProcessInstance(processInstanceKey, resumeRequest)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse,
+            // TODO(#57518): dispatch to resumeProcessInstance(physicalTenantId, mapped) — see
+            // ProcessInstanceServices.resumeProcessInstance — once the zeebe/engine RESUME
+            // processor exists. Until then, a real dispatch would time out at 504 with no
+            // SUSPEND_PROCESS_INSTANCE check (that check lives in the not-yet-existing processor).
+            ignored ->
+                CompletableFuture.completedFuture(
+                    ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/migration")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -9,8 +9,8 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
-import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.ResponseMapper;
+import io.camunda.gateway.mapping.http.mapper.ProcessInstanceMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.CancelProcessInstanceRequest;
@@ -63,6 +63,7 @@ public class ProcessInstanceController {
   private final ServiceRegistry serviceRegistry;
   private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final ProcessInstanceMapper processInstanceMapper;
 
   public ProcessInstanceController(
       final ServiceRegistry serviceRegistry,
@@ -71,13 +72,15 @@ public class ProcessInstanceController {
     this.serviceRegistry = serviceRegistry;
     this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
+    processInstanceMapper = new ProcessInstanceMapper();
   }
 
   @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createProcessInstance(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody final ProcessInstanceCreationInstruction request) {
-    return RequestMapper.toCreateProcessInstance(request, multiTenancyCfg.isChecksEnabled())
+    return processInstanceMapper
+        .toCreateProcessInstance(request, multiTenancyCfg.isChecksEnabled())
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> createProcessInstance(physicalTenantId, mapped));
@@ -88,7 +91,8 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey,
       @RequestBody(required = false) final CancelProcessInstanceRequest cancelRequest) {
-    return RequestMapper.toCancelProcessInstance(processInstanceKey, cancelRequest)
+    return processInstanceMapper
+        .toCancelProcessInstance(processInstanceKey, cancelRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> cancelProcessInstance(physicalTenantId, mapped));
@@ -99,7 +103,8 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey,
       @RequestBody(required = false) final SuspendProcessInstanceRequest suspendRequest) {
-    return RequestMapper.toSuspendProcessInstance(processInstanceKey, suspendRequest)
+    return processInstanceMapper
+        .toSuspendProcessInstance(processInstanceKey, suspendRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             // TODO(#57518): dispatch to suspendProcessInstance(physicalTenantId, mapped) — see
@@ -116,13 +121,16 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey,
       @RequestBody(required = false) final ResumeProcessInstanceRequest resumeRequest) {
-    return RequestMapper.toResumeProcessInstance(processInstanceKey, resumeRequest)
+    return processInstanceMapper
+        .toResumeProcessInstance(processInstanceKey, resumeRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             // TODO(#57518): dispatch to resumeProcessInstance(physicalTenantId, mapped) — see
             // ProcessInstanceServices.resumeProcessInstance — once the zeebe/engine RESUME
             // processor exists. Until then, a real dispatch would time out at 504 with no
-            // SUSPEND_PROCESS_INSTANCE check (that check lives in the not-yet-existing processor).
+            // SUSPEND_PROCESS_INSTANCE check (resume shares that same permission type — there is
+            // no separate RESUME_PROCESS_INSTANCE — that check lives in the not-yet-existing
+            // processor).
             ignored ->
                 CompletableFuture.completedFuture(
                     ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()));
@@ -133,7 +141,8 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey,
       @RequestBody final ProcessInstanceMigrationInstruction migrationRequest) {
-    return RequestMapper.toMigrateProcessInstance(processInstanceKey, migrationRequest)
+    return processInstanceMapper
+        .toMigrateProcessInstance(processInstanceKey, migrationRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> migrateProcessInstance(physicalTenantId, mapped));
@@ -144,7 +153,8 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey,
       @RequestBody final ProcessInstanceBusinessIdAssignmentInstruction assignmentRequest) {
-    return RequestMapper.toAssignProcessInstanceBusinessId(processInstanceKey, assignmentRequest)
+    return processInstanceMapper
+        .toAssignProcessInstanceBusinessId(processInstanceKey, assignmentRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> assignProcessInstanceBusinessId(physicalTenantId, mapped));
@@ -155,7 +165,8 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long processInstanceKey,
       @RequestBody final ProcessInstanceModificationInstruction modifyRequest) {
-    return RequestMapper.toModifyProcessInstance(processInstanceKey, modifyRequest)
+    return processInstanceMapper
+        .toModifyProcessInstance(processInstanceKey, modifyRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> modifyProcessInstance(physicalTenantId, mapped));
@@ -298,7 +309,8 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> cancelProcessInstancesBatchOperation(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody final ProcessInstanceCancellationBatchOperationRequest request) {
-    return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
+    return processInstanceMapper
+        .toRequiredProcessInstanceFilter(request.getFilter())
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             filter -> batchOperationCancellation(physicalTenantId, filter));
@@ -309,7 +321,8 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> resolveIncidentsBatchOperation(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody final ProcessInstanceIncidentResolutionBatchOperationRequest request) {
-    return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
+    return processInstanceMapper
+        .toRequiredProcessInstanceFilter(request.getFilter())
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             filter -> batchOperationResolveIncidents(physicalTenantId, filter));
@@ -320,7 +333,8 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> migrateProcessInstancesBatchOperation(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody final ProcessInstanceMigrationBatchOperationRequest request) {
-    return RequestMapper.toProcessInstanceMigrationBatchOperationRequest(request)
+    return processInstanceMapper
+        .toProcessInstanceMigrationBatchOperationRequest(request)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> batchOperationMigrate(physicalTenantId, mapped));
@@ -331,7 +345,8 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> modifyProcessInstancesBatchOperation(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody final ProcessInstanceModificationBatchOperationRequest request) {
-    return RequestMapper.toProcessInstanceModifyBatchOperationRequest(request)
+    return processInstanceMapper
+        .toProcessInstanceModifyBatchOperationRequest(request)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             mapped -> batchOperationModify(physicalTenantId, mapped));
@@ -342,7 +357,8 @@ public class ProcessInstanceController {
   public CompletableFuture<ResponseEntity<Object>> deleteProcessInstancesBatchOperation(
       @PhysicalTenantId final String physicalTenantId,
       @RequestBody final ProcessInstanceDeletionBatchOperationRequest request) {
-    return RequestMapper.toRequiredProcessInstanceFilter(request.getFilter())
+    return processInstanceMapper
+        .toRequiredProcessInstanceFilter(request.getFilter())
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
             filter -> batchOperationDeletion(physicalTenantId, filter));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1103,7 +1103,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldSuspendProcessInstance() {
+  void shouldReturnNotImplementedForSuspendProcessInstance() {
     // given
     final var request =
         """
@@ -1126,7 +1126,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldSuspendProcessInstanceWithNoBody() {
+  void shouldReturnNotImplementedForSuspendProcessInstanceWithNoBody() {
     // when/then — 501: the engine processor for SUSPEND doesn't exist yet (TODO #57518)
     webClient
         .post()
@@ -1176,7 +1176,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldResumeProcessInstance() {
+  void shouldReturnNotImplementedForResumeProcessInstance() {
     // given
     final var request =
         """
@@ -1199,7 +1199,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldResumeProcessInstanceWithNoBody() {
+  void shouldReturnNotImplementedForResumeProcessInstanceWithNoBody() {
     // when/then — 501: the engine processor for RESUME doesn't exist yet (TODO #57518)
     webClient
         .post()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -96,6 +96,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   static final String MODIFY_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/modification";
   static final String ASSIGN_BUSINESS_ID_URL =
       PROCESS_INSTANCES_START_URL + "/%s/business-id-assignment";
+  static final String SUSPEND_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/suspension";
+  static final String RESUME_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/resumption";
 
   @Captor ArgumentCaptor<ProcessInstanceCreateRequest> createRequestCaptor;
   @Captor ArgumentCaptor<ProcessInstanceCancelRequest> cancelRequestCaptor;
@@ -1088,6 +1090,152 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
     webClient
         .post()
         .uri(CANCEL_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldSuspendProcessInstance() {
+    // given
+    final var request =
+        """
+            {
+              "operationReference": 123
+            }""";
+
+    // when/then — 501: the engine processor for SUSPEND doesn't exist yet (TODO #57518)
+    webClient
+        .post()
+        .uri(SUSPEND_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+
+    Mockito.verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldSuspendProcessInstanceWithNoBody() {
+    // when/then — 501: the engine processor for SUSPEND doesn't exist yet (TODO #57518)
+    webClient
+        .post()
+        .uri(SUSPEND_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+
+    Mockito.verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldRejectSuspendProcessInstanceWithOperationReferenceNotValid() {
+    // given
+    final var request =
+        """
+            {
+              "operationReference": -123
+            }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"The value for operationReference is '-123' but must be > 0.",
+                "instance":"/v2/process-instances/1/suspension"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(SUSPEND_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldResumeProcessInstance() {
+    // given
+    final var request =
+        """
+            {
+              "operationReference": 123
+            }""";
+
+    // when/then — 501: the engine processor for RESUME doesn't exist yet (TODO #57518)
+    webClient
+        .post()
+        .uri(RESUME_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+
+    Mockito.verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldResumeProcessInstanceWithNoBody() {
+    // when/then — 501: the engine processor for RESUME doesn't exist yet (TODO #57518)
+    webClient
+        .post()
+        .uri(RESUME_PROCESS_URL.formatted("1"))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+
+    Mockito.verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldRejectResumeProcessInstanceWithOperationReferenceNotValid() {
+    // given
+    final var request =
+        """
+            {
+              "operationReference": -123
+            }""";
+
+    final var expectedBody =
+        """
+            {
+                "type":"about:blank",
+                "title":"INVALID_ARGUMENT",
+                "status":400,
+                "detail":"The value for operationReference is '-123' but must be > 0.",
+                "instance":"/v2/process-instances/1/resumption"
+             }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(RESUME_PROCESS_URL.formatted("1"))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerResumeProcessInstanceRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerResumeProcessInstanceRequest
+    extends BrokerExecuteCommand<ProcessInstanceRecord> {
+
+  private final ProcessInstanceRecord requestDto = new ProcessInstanceRecord();
+
+  public BrokerResumeProcessInstanceRequest() {
+    super(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.RESUME);
+  }
+
+  public BrokerResumeProcessInstanceRequest setProcessInstanceKey(final long processInstanceKey) {
+    request.setKey(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ProcessInstanceRecord toResponseDto(final DirectBuffer buffer) {
+    final ProcessInstanceRecord responseDto = new ProcessInstanceRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerSuspendProcessInstanceRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerSuspendProcessInstanceRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerSuspendProcessInstanceRequest
+    extends BrokerExecuteCommand<ProcessInstanceRecord> {
+
+  private final ProcessInstanceRecord requestDto = new ProcessInstanceRecord();
+
+  public BrokerSuspendProcessInstanceRequest() {
+    super(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.SUSPEND);
+  }
+
+  public BrokerSuspendProcessInstanceRequest setProcessInstanceKey(final long processInstanceKey) {
+    request.setKey(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ProcessInstanceRecord toResponseDto(final DirectBuffer buffer) {
+    final ProcessInstanceRecord responseDto = new ProcessInstanceRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
## Description

Implements the REST-facing wiring for single-instance suspend/resume, mirroring the existing
`cancelProcessInstance` action end to end: `BrokerSuspendProcessInstanceRequest`/
`BrokerResumeProcessInstanceRequest` (`zeebe/gateway`) → `ProcessInstanceServices.suspendProcessInstance`/
`resumeProcessInstance` (`service`) → request validation/mapping (`gateways/gateway-mapping-http`)
→ `POST /process-instances/{processInstanceKey}/suspension` and `.../resumption`
(`zeebe/gateway-rest`).

**Stacked on #57648** (OpenAPI contract for these paths) — please merge that one first; this PR's
diff will shrink to just the commits below once #57648 lands.

**Interim guard, please read before reviewing the controller:** the two new endpoints do **not**
dispatch to `ProcessInstanceServices` yet. Request validation/mapping runs normally (so
400-on-invalid-`operationReference` already works), but each `.fold(...)` success branch returns a
hardcoded `501 Not Implemented` instead, marked `// TODO(#57518)`. This is deliberate: no
`zeebe/engine` processor exists yet for `ProcessInstanceIntent.SUSPEND`/`RESUME` (separate,
already-tracked Phase 2 work — #57518/#57520/#57521), and without the guard, real traffic would
silently time out at `504` while also bypassing `SUSPEND_PROCESS_INSTANCE` authorization (which is
enforced engine-side, in that not-yet-existing processor — not in this REST/service layer, matching
this codebase's existing convention). Removing the guard once the engine processor lands is a
two-line diff per endpoint (already-built service methods are just not wired in yet).

## Checklist

- [ ] Enable backports when necessary — not applicable, this is a new feature addition (guarded,
      non-functional until #57518 lands), not a bug fix.
- [ ] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

closes #57530