### PR TITLE
fix: apply all variable filter values to process statistics requests

### DIFF
--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -204,6 +204,86 @@ describe('useProcessInstanceFilters', () => {
     });
   });
 
+  it('should map a single variable value to an equality filter', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      variableName: 'orderId',
+      variableValues: '1',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({
+      filter: {
+        variables: [{name: 'orderId', value: '1'}],
+      },
+    });
+  });
+
+  it('should map multiple variable values to an $in filter', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      variableName: 'orderId',
+      variableValues: '1,2,3',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({
+      filter: {
+        variables: [{name: 'orderId', value: {$in: ['1', '2', '3']}}],
+      },
+    });
+  });
+
+  it('should keep commas inside JSON string values', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      variableName: 'orderId',
+      variableValues: '"a,b","c"',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({
+      filter: {
+        variables: [{name: 'orderId', value: {$in: ['"a,b"', '"c"']}}],
+      },
+    });
+  });
+
+  it('should not add a variables filter for invalid variable values', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      variableName: 'orderId',
+      variableValues: 'not-json',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({filter: {}});
+  });
+
   it('should handle partial filters', () => {
     const mockFilters: ProcessInstanceFilters = {
       startDateAfter: '2023-01-01',

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -267,6 +267,23 @@ describe('useProcessInstanceFilters', () => {
     });
   });
 
+  it('should not add a variables filter when variable values are empty', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      variableName: 'orderId',
+      variableValues: '',
+    };
+
+    mockedUseFilters.mockReturnValue({
+      getFilters: () => mockFilters,
+      setFilters: vi.fn(),
+      areProcessInstanceStatesApplied: vi.fn(),
+      areDecisionInstanceStatesApplied: vi.fn(),
+    });
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual({filter: {}});
+  });
+
   it('should not add a variables filter for invalid variable values', () => {
     const mockFilters: ProcessInstanceFilters = {
       variableName: 'orderId',

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -14,6 +14,7 @@ import {
 } from '@camunda/camunda-api-zod-schemas/8.8';
 import {formatToISO} from 'modules/utils/date/formatDate';
 import {parseIds} from 'modules/utils/filter';
+import {getValidVariableValues} from 'modules/utils/filter/getValidVariableValues';
 
 function mapFiltersToRequest(
   filters: ProcessInstanceFilters,
@@ -126,14 +127,19 @@ function mapFiltersToRequest(
   }
 
   if (variableName && variableValues) {
-    const variableNames = variableName.split(',');
-    const variableVals = variableValues.split(',');
-    request.filter.variables = variableNames
-      .map((name, index) => ({
-        name,
-        value: variableVals[index] || '',
-      }))
-      .filter((variable) => variable.value !== '');
+    const values =
+      getValidVariableValues(variableValues)?.map((value) =>
+        JSON.stringify(value),
+      ) ?? [];
+
+    if (values.length > 0) {
+      request.filter.variables = [
+        {
+          name: variableName,
+          value: values.length === 1 ? values[0] : {$in: values},
+        },
+      ];
+    }
   }
 
   return request;


### PR DESCRIPTION
## Description

On the Operate Processes dashboard, filtering by a variable with multiple comma-separated values only applied the first value to the diagram's per-element statistics badges, while the instances list correctly matched all values. The same undercount affected every statistics-derived count (batch modification badges/notification/summary modal, migration view diagrams), since they all share the same filter hook.

`mapFiltersToRequest` zipped `variableName.split(',')` against `variableValues.split(',')`  with one variable name and N values, only index 0 survived. The naive split also broke JSON string values containing commas.

This PR parses the values with `getValidVariableValues` (the same utility the instances list uses) and sends a single variable condition with `$in` for multiple values, so statistics requests match the instances list for the same filter.

**Note:** this targets `stable/8.8` directly, the affected code was refactored away on `main`, where the variable filter statistics behavior is tracked separately in #57384. Not a backport.

BEFORE
<img width="1523" height="1279" alt="image" src="https://github.com/user-attachments/assets/53c16426-761c-408c-90d5-5c7e61f6dea3" />

AFTER
<img width="1522" height="1274" alt="image" src="https://github.com/user-attachments/assets/d13a1699-3ba0-4a6c-adeb-0635ec5f088f" />


Closes #57383

## Checklist

- [x] Unit tests covering single value, multiple values, commas inside JSON strings, and invalid values
- [x] `npm run lint` and affected test suites green locally