### PR TITLE
fix: fetch all entities for ownerId dropdown

### DIFF
--- a/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
@@ -12,12 +12,13 @@ import { SearchResponse } from "src/utility/api";
 import { ApiDefinition, unwrap } from "src/utility/api/request";
 import { getApiBaseUrl } from "src/configuration/urlConfig";
 import useTranslate from "src/utility/localization";
+import { QueryPage } from "@camunda/camunda-api-zod-schemas/8.10";
 
 type OwnerSelectionProps<T> = {
   id: string;
   onChange: (OwnerId: string) => void;
   onBlur: () => void;
-  searchFn: ApiDefinition<SearchResponse<T>>;
+  searchFn: ApiDefinition<SearchResponse<T>, { page: QueryPage }>;
   getId: (item: T) => string;
   itemToString: (item: T) => string;
   isEmpty?: boolean;
@@ -35,7 +36,9 @@ const OwnerSelection = <T,>({
   const { t } = useTranslate("authorizations");
   const { data, isLoading: loading } = useQuery({
     queryKey: ["ownerSelection", searchFn.name],
-    queryFn: () => unwrap(searchFn(undefined)(getApiBaseUrl())),
+    queryFn: () =>
+      // passing in the maximum limit supported by the API is a temporary fix for https://github.com/camunda/camunda/issues/56452
+      unwrap(searchFn({ page: { limit: 10000 } })(getApiBaseUrl())),
   });
 
   if (loading) {

--- a/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
+++ b/identity/client/src/pages/authorizations/modals/owner-selection/OwnerSelection.tsx
@@ -8,11 +8,11 @@
 
 import { ComboBox, TextInputSkeleton } from "@carbon/react";
 import { useQuery } from "@tanstack/react-query";
-import { SearchResponse } from "src/utility/api";
+import type { SearchResponse } from "src/utility/api";
 import { ApiDefinition, unwrap } from "src/utility/api/request";
 import { getApiBaseUrl } from "src/configuration/urlConfig";
 import useTranslate from "src/utility/localization";
-import { QueryPage } from "@camunda/camunda-api-zod-schemas/8.10";
+import type { QueryPage } from "@camunda/camunda-api-zod-schemas/8.10";
 
 type OwnerSelectionProps<T> = {
   id: string;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
**This is a temporary fix!**
Increase the fetching limit to maximum in the "create authorization" dialog.
A final fix will be implemented in https://github.com/camunda/camunda/issues/56453

closes #56452

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
