### PR TITLE
refactor: wire SystemContextLoader to a single PhysicalTenantResolver dependency

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.broker;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
@@ -73,7 +72,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory;
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
-  private final PhysicalTenantIds physicalTenantIds;
   private final WorkingDirectory workingDirectory;
 
   private Broker broker;
@@ -97,7 +95,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
           final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory,
       @Autowired(required = false) final SearchClientsProxy searchClientsProxy,
       final NodeIdProvider nodeIdProvider,
-      final PhysicalTenantIds physicalTenantIds,
       final WorkingDirectory workingDirectory) {
     this.configuration = configuration;
     this.springBrokerBridge = springBrokerBridge;
@@ -114,7 +111,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.scopedOidcClaimsProviderFactory = scopedOidcClaimsProviderFactory;
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = nodeIdProvider;
-    this.physicalTenantIds = physicalTenantIds;
     this.workingDirectory = workingDirectory;
   }
 
@@ -137,14 +133,13 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             .withCluster(cluster)
             .withBrokerClient(brokerClient)
             .withMeterRegistry(meterRegistry)
-            .withPhysicalTenants(physicalTenantResolver.getAll())
+            .withPhysicalTenantResolver(physicalTenantResolver)
             .withUserServicesForTenant(userServicesForTenant)
             .withPasswordEncoder(passwordEncoder)
             .withJwtDecoderFactory(jwtDecoderFactory)
             .withOidcClaimsProviderFactory(oidcClaimsProviderFactory)
             .withSearchClientsProxy(searchClientsProxy)
             .withNodeIdProvider(nodeIdProvider)
-            .withPhysicalTenantIds(physicalTenantIds)
             .withWorkingDirectory(workingDirectory.path())
             .withExporterDescriptors(exporterDescriptors)
             .createSystemContext();

--- a/dist/src/main/java/io/camunda/zeebe/broker/SystemContextLoader.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/SystemContextLoader.java
@@ -8,9 +8,9 @@
 package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
@@ -31,7 +31,6 @@ import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -63,14 +62,13 @@ public final class SystemContextLoader {
   private AtomixCluster cluster;
   private BrokerClient brokerClient;
   private MeterRegistry meterRegistry;
-  private Map<String, Camunda> physicalTenants;
+  private PhysicalTenantResolver physicalTenantResolver;
   private Function<String, UserServices> userServicesForTenant;
   private PasswordEncoder passwordEncoder;
   private Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
   private Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory;
   private SearchClientsProxy searchClientsProxy;
   private NodeIdProvider nodeIdProvider;
-  private PhysicalTenantIds physicalTenantIds;
   private Path workingDirectory;
   private List<ExporterDescriptor> exporterDescriptors;
 
@@ -119,9 +117,14 @@ public final class SystemContextLoader {
     return this;
   }
 
-  /** The resolved per-tenant configuration, keyed by physical tenant id. */
-  public SystemContextLoader withPhysicalTenants(final Map<String, Camunda> physicalTenants) {
-    this.physicalTenants = physicalTenants;
+  /**
+   * The resolver holding the per-tenant {@link Camunda} configuration, keyed by physical tenant id.
+   * Also passed to {@link SystemContext} as the {@link io.camunda.cluster.PhysicalTenantIds} of
+   * known tenants, since {@link PhysicalTenantResolver} implements that interface.
+   */
+  public SystemContextLoader withPhysicalTenantResolver(
+      final PhysicalTenantResolver physicalTenantResolver) {
+    this.physicalTenantResolver = physicalTenantResolver;
     return this;
   }
 
@@ -158,11 +161,6 @@ public final class SystemContextLoader {
     return this;
   }
 
-  public SystemContextLoader withPhysicalTenantIds(final PhysicalTenantIds physicalTenantIds) {
-    this.physicalTenantIds = physicalTenantIds;
-    return this;
-  }
-
   /** The broker working directory, used to resolve relative paths in overridden tenant configs. */
   public SystemContextLoader withWorkingDirectory(final Path workingDirectory) {
     this.workingDirectory = workingDirectory;
@@ -176,10 +174,8 @@ public final class SystemContextLoader {
   }
 
   public SystemContext createSystemContext() {
-    final Map<String, PhysicalTenantContext> physicalTenantContexts = new LinkedHashMap<>();
-    physicalTenants.forEach(
-        (physicalTenantId, camunda) ->
-            physicalTenantContexts.put(physicalTenantId, buildPhysicalTenantContext(camunda)));
+    final Map<String, PhysicalTenantContext> physicalTenantContexts =
+        physicalTenantResolver.mapValues(this::buildPhysicalTenantContext);
 
     return new SystemContext(
         shutdownTimeout,
@@ -195,7 +191,7 @@ public final class SystemContextLoader {
         oidcClaimsProviderFactory,
         searchClientsProxy,
         nodeIdProvider,
-        physicalTenantIds);
+        physicalTenantResolver);
   }
 
   private PhysicalTenantContext buildPhysicalTenantContext(final Camunda camunda) {

--- a/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -16,10 +17,12 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -29,8 +32,9 @@ import io.camunda.zeebe.dynamic.nodeid.Version;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
+import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,8 +123,7 @@ final class SystemContextLoaderTest {
                 PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
                 rootCamunda,
                 "tenanta",
-                tenantCamunda),
-            () -> Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, "tenanta"));
+                tenantCamunda));
 
     // when
     final SystemContext systemContext = loader.createSystemContext();
@@ -139,16 +142,19 @@ final class SystemContextLoaderTest {
       final Camunda rootCamunda,
       final BrokerCfg rootBrokerCfg,
       final Map<String, Camunda> physicalTenants) {
-    return newLoader(rootCamunda, rootBrokerCfg, physicalTenants, PhysicalTenantIds.DEFAULT);
-  }
-
-  private SystemContextLoader newLoader(
-      final Camunda rootCamunda,
-      final BrokerCfg rootBrokerCfg,
-      final Map<String, Camunda> physicalTenants,
-      final PhysicalTenantIds physicalTenantIds) {
     final var nodeIdProvider = mock(NodeIdProvider.class);
     when(nodeIdProvider.currentNodeInstance()).thenReturn(new NodeInstance(0, Version.zero()));
+    final var physicalTenantResolver = mock(PhysicalTenantResolver.class);
+    when(physicalTenantResolver.getAll()).thenReturn(physicalTenants);
+    when(physicalTenantResolver.mapValues(any()))
+        .thenAnswer(
+            invocation -> {
+              final Function<Camunda, PhysicalTenantContext> mapper = invocation.getArgument(0);
+              final Map<String, PhysicalTenantContext> out = new LinkedHashMap<>();
+              physicalTenants.forEach(
+                  (tenantId, camunda) -> out.put(tenantId, mapper.apply(camunda)));
+              return out;
+            });
 
     return new SystemContextLoader()
         .withShutdownTimeout(SystemContext.DEFAULT_SHUTDOWN_TIMEOUT)
@@ -158,7 +164,7 @@ final class SystemContextLoaderTest {
         .withCluster(mock(AtomixCluster.class))
         .withBrokerClient(mock(BrokerClient.class))
         .withMeterRegistry(new SimpleMeterRegistry())
-        .withPhysicalTenants(physicalTenants)
+        .withPhysicalTenantResolver(physicalTenantResolver)
         .withUserServicesForTenant(tenantId -> mock(UserServices.class))
         .withPasswordEncoder(mock(PasswordEncoder.class))
         .withJwtDecoderFactory(authentication -> mock(JwtDecoder.class))
@@ -166,7 +172,6 @@ final class SystemContextLoaderTest {
             authentication -> (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims)
         .withSearchClientsProxy(mock(SearchClientsProxy.class))
         .withNodeIdProvider(nodeIdProvider)
-        .withPhysicalTenantIds(physicalTenantIds)
         .withWorkingDirectory(workingDirectory)
         .withExporterDescriptors(null);
   }


### PR DESCRIPTION
## Summary
- `BrokerModuleConfiguration` wires in the single `PhysicalTenantResolver` bean only.
- `SystemContextLoader` now takes the `PhysicalTenantResolver` bean directly instead of a separate `Map<String, Camunda>` plus a duplicate `PhysicalTenantIds` reference, since both derived from the same resolver instance.
