### PR TITLE
refactor: add @Nullable and @NullMarked to RDBMS read layer

### DIFF
--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -97,6 +97,11 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -9,9 +9,13 @@ package io.camunda.db.rdbms.read.domain;
 
 import io.camunda.search.sort.SortOrder;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public record DbQueryPage(
-    Integer size, Integer from, Integer maxTotalHits, List<KeySetPagination> keySetPagination) {
+    Integer size,
+    @Nullable Integer from,
+    @Nullable Integer maxTotalHits,
+    @Nullable List<KeySetPagination> keySetPagination) {
 
   public record KeySetPagination(List<KeySetPaginationFieldEntry> entries) {}
 
@@ -30,7 +34,7 @@ public record DbQueryPage(
     public static final class Builder {
       private final String fieldName;
       private final Object fieldValue;
-      private SortOrder order;
+      private @Nullable SortOrder order;
       private boolean isSearchAfter;
 
       private Builder(final String fieldName, final Object fieldValue) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 abstract class AbstractEntityReader<T> {
 
@@ -40,7 +41,7 @@ abstract class AbstractEntityReader<T> {
   private final RdbmsReaderConfig readerConfig;
 
   public AbstractEntityReader(
-      final SearchColumn<T>[] searchableColumns, final RdbmsReaderConfig readerConfig) {
+      final SearchColumn<T> @Nullable [] searchableColumns, final RdbmsReaderConfig readerConfig) {
     final var searchColumns =
         Objects.requireNonNullElse(searchableColumns, (SearchColumn<T>[]) EMPTY_SEARCHABLE_COLUMNS);
 
@@ -122,7 +123,7 @@ abstract class AbstractEntityReader<T> {
       final DbQuerySorting<T> sort, final SearchQueryPage page) {
     final boolean isSearchAfter = page.after() != null;
     final var cursorValue = isSearchAfter ? page.after() : page.before();
-    final Object[] sortValues = Cursor.decode(cursorValue, sort.columns());
+    final Object[] sortValues = Objects.requireNonNull(Cursor.decode(cursorValue, sort.columns()));
     final List<KeySetPagination> keySetPagination = new ArrayList<>();
 
     for (int i = 0; i < sort.orderings().size(); i++) {
@@ -148,7 +149,7 @@ abstract class AbstractEntityReader<T> {
   }
 
   protected final SearchQueryResult<T> buildSearchQueryResult(
-      final long totalHits, final List<T> hits, final DbQuerySorting<T> dbSort) {
+      final long totalHits, final List<T> hits, final @Nullable DbQuerySorting<T> dbSort) {
     final var maxTotalHits = readerConfig.maxTotalHits();
     final var returnedTotalHits = totalHits > maxTotalHits ? maxTotalHits : totalHits;
     final var hasMoreItems = totalHits > maxTotalHits;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -14,6 +14,8 @@ import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPagination;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.page.SearchQueryPage.SearchQueryResultType;
 import io.camunda.search.query.SearchQueryResult;
@@ -123,7 +125,11 @@ abstract class AbstractEntityReader<T> {
       final DbQuerySorting<T> sort, final SearchQueryPage page) {
     final boolean isSearchAfter = page.after() != null;
     final var cursorValue = isSearchAfter ? page.after() : page.before();
-    final Object[] sortValues = Objects.requireNonNull(Cursor.decode(cursorValue, sort.columns()));
+    final var sortValues = Cursor.decode(cursorValue, sort.columns());
+    if (sortValues == null) {
+      throw new CamundaSearchException(
+          "Cannot paginate with an empty or malformed cursor", Reason.INVALID_ARGUMENT);
+    }
     final List<KeySetPagination> keySetPagination = new ArrayList<>();
 
     for (int i = 0; i < sort.orderings().size(); i++) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentInstanceDbReader.java
@@ -19,6 +19,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,12 +37,12 @@ public class AgentInstanceDbReader extends AbstractEntityReader<AgentInstanceEnt
   }
 
   @Override
-  public AgentInstanceEntity getByKey(
+  public @Nullable AgentInstanceEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key);
   }
 
-  public AgentInstanceEntity findOne(final long key) {
+  public @Nullable AgentInstanceEntity findOne(final long key) {
     return search(
             AgentInstanceQuery.of(
                 b -> b.filter(f -> f.agentInstanceKeys(key)).page(p -> p.from(0).size(1))))

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuditLogDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuditLogDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,8 @@ public class AuditLogDbReader extends AbstractEntityReader<AuditLogEntity>
   }
 
   @Override
-  public AuditLogEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable AuditLogEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     final var result = search(AuditLogQuery.of(b -> b.filter(f -> f.auditLogKeys(id))));
     return Optional.ofNullable(result.items())
         .flatMap(items -> items.stream().findFirst())

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationDbReader.java
@@ -21,6 +21,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +50,7 @@ public class AuthorizationDbReader extends AbstractEntityReader<AuthorizationEnt
   }
 
   @Override
-  public AuthorizationEntity getByKey(
+  public @Nullable AuthorizationEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return search(
             AuthorizationQuery.of(q -> q.filter(f -> f.authorizationKey(key)).singleResult()),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class BatchOperationDbReader extends AbstractEntityReader<BatchOperationE
   }
 
   @Override
-  public BatchOperationEntity getById(
+  public @Nullable BatchOperationEntity getById(
       final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.util.ClusterVariableUtil;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,14 +75,14 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
   }
 
   @Override
-  public ClusterVariableEntity getTenantScopedClusterVariable(
+  public @Nullable ClusterVariableEntity getTenantScopedClusterVariable(
       final String name, final String tenant, final ResourceAccessChecks resourceAccessChecks) {
     return clusterVariableMapper.get(
         ClusterVariableUtil.generateID(name, tenant, ClusterVariableScope.TENANT));
   }
 
   @Override
-  public ClusterVariableEntity getGloballyScopedClusterVariable(
+  public @Nullable ClusterVariableEntity getGloballyScopedClusterVariable(
       final String name, final ResourceAccessChecks resourceAccessChecks) {
     return clusterVariableMapper.get(
         ClusterVariableUtil.generateID(name, null, ClusterVariableScope.GLOBAL));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/Cursor.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/Cursor.java
@@ -26,7 +26,8 @@ public class Cursor<T> {
           .disable((SerializationFeature.WRITE_DATES_AS_TIMESTAMPS))
           .build();
 
-  public static <T> @Nullable String encode(final T entity, final List<SearchColumn<T>> columns) {
+  public static <T> @Nullable String encode(
+      final @Nullable T entity, final @Nullable List<SearchColumn<T>> columns) {
     if (columns == null || columns.isEmpty() || entity == null) {
       return null;
     }
@@ -45,7 +46,7 @@ public class Cursor<T> {
   }
 
   public static <T> Object @Nullable [] decode(
-      final String cursor, final List<SearchColumn<T>> columns) {
+      final @Nullable String cursor, final @Nullable List<SearchColumn<T>> columns) {
     if (columns == null || columns.isEmpty() || cursor == null || cursor.isEmpty()) {
       return null;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/Cursor.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/Cursor.java
@@ -17,6 +17,7 @@ import io.camunda.search.exception.CamundaSearchException.Reason;
 import java.util.Base64;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.jspecify.annotations.Nullable;
 
 public class Cursor<T> {
   static final JsonMapper MAPPER =
@@ -25,7 +26,7 @@ public class Cursor<T> {
           .disable((SerializationFeature.WRITE_DATES_AS_TIMESTAMPS))
           .build();
 
-  public static <T> String encode(final T entity, final List<SearchColumn<T>> columns) {
+  public static <T> @Nullable String encode(final T entity, final List<SearchColumn<T>> columns) {
     if (columns == null || columns.isEmpty() || entity == null) {
       return null;
     }
@@ -43,7 +44,8 @@ public class Cursor<T> {
     }
   }
 
-  public static <T> Object[] decode(final String cursor, final List<SearchColumn<T>> columns) {
+  public static <T> Object @Nullable [] decode(
+      final String cursor, final List<SearchColumn<T>> columns) {
     if (columns == null || columns.isEmpty() || cursor == null || cursor.isEmpty()) {
       return null;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionDbReader.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class DecisionDefinitionDbReader extends AbstractEntityReader<DecisionDef
   }
 
   @Override
-  public DecisionDefinitionEntity getByKey(
+  public @Nullable DecisionDefinitionEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceDbReader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class DecisionInstanceDbReader extends AbstractEntityReader<DecisionInsta
   }
 
   @Override
-  public DecisionInstanceEntity getById(
+  public @Nullable DecisionInstanceEntity getById(
       final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsDbReader.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
   }
 
   @Override
-  public DecisionRequirementsEntity getByKey(
+  public @Nullable DecisionRequirementsEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return getByKey(key, resourceAccessChecks, false);
   }
@@ -92,7 +93,7 @@ public class DecisionRequirementsDbReader extends AbstractEntityReader<DecisionR
   }
 
   @Override
-  public DecisionRequirementsEntity getByKey(
+  public @Nullable DecisionRequirementsEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks, final boolean includeXml) {
     return findOne(key).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DeployedResourceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DeployedResourceDbReader.java
@@ -18,6 +18,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,14 +36,14 @@ public class DeployedResourceDbReader extends AbstractEntityReader<DeployedResou
   }
 
   @Override
-  public DeployedResourceEntity getByKey(
+  public @Nullable DeployedResourceEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     LOG.trace("[RDBMS DB] Get resource with resource key {}", key);
     return deployedResourceMapper.get(key);
   }
 
   @Override
-  public DeployedResourceEntity getByKeyMetadata(
+  public @Nullable DeployedResourceEntity getByKeyMetadata(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     LOG.trace("[RDBMS DB] Get resource metadata (no content) with resource key {}", key);
     return deployedResourceMapper.getMetadata(key);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class FlowNodeInstanceDbReader extends AbstractEntityReader<FlowNodeInsta
   }
 
   @Override
-  public FlowNodeInstanceEntity getByKey(
+  public @Nullable FlowNodeInstanceEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormDbReader.java
@@ -17,6 +17,7 @@ import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,8 @@ public class FormDbReader extends AbstractEntityReader<FormEntity> implements Fo
   }
 
   @Override
-  public FormEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable FormEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GlobalListenerDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.util.GlobalListenerUtil;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class GlobalListenerDbReader extends AbstractEntityReader<GlobalListenerE
   }
 
   @Override
-  public GlobalListenerEntity getGlobalListener(
+  public @Nullable GlobalListenerEntity getGlobalListener(
       final String listenerId,
       final GlobalListenerType listenerType,
       final ResourceAccessChecks resourceAccessChecks) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupDbReader.java
@@ -23,6 +23,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,8 @@ public class GroupDbReader extends AbstractEntityReader<GroupEntity> implements 
   }
 
   @Override
-  public GroupEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable GroupEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentDbReader.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,8 @@ public class IncidentDbReader extends AbstractEntityReader<IncidentEntity>
   }
 
   @Override
-  public IncidentEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable IncidentEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingRuleDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public class MappingRuleDbReader extends AbstractEntityReader<MappingRuleEntity>
   }
 
   @Override
-  public MappingRuleEntity getById(
+  public @Nullable MappingRuleEntity getById(
       final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MessageSubscriptionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MessageSubscriptionDbReader.java
@@ -20,6 +20,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,7 @@ public class MessageSubscriptionDbReader extends AbstractEntityReader<MessageSub
   }
 
   @Override
-  public MessageSubscriptionEntity getByKey(
+  public @Nullable MessageSubscriptionEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/PersistentWebSessionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/PersistentWebSessionDbReader.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.read.service;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public class PersistentWebSessionDbReader {
 
@@ -19,7 +20,7 @@ public class PersistentWebSessionDbReader {
     this.persistentWebSessionMapper = persistentWebSessionMapper;
   }
 
-  public PersistentWebSessionEntity findById(final String sessionId) {
+  public @Nullable PersistentWebSessionEntity findById(final String sessionId) {
     return persistentWebSessionMapper.findById(sessionId);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/PersistentWebSessionRdbmsClient.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/PersistentWebSessionRdbmsClient.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.query.SearchQueryResult;
+import org.jspecify.annotations.Nullable;
 
 public class PersistentWebSessionRdbmsClient implements PersistentWebSessionClient {
 
@@ -25,7 +26,7 @@ public class PersistentWebSessionRdbmsClient implements PersistentWebSessionClie
   }
 
   @Override
-  public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
+  public @Nullable PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
     return persistentWebSessionDbReader.findById(sessionId);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionDbReader.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class ProcessDefinitionDbReader extends AbstractEntityReader<ProcessDefin
   }
 
   @Override
-  public ProcessDefinitionEntity getByKey(
+  public @Nullable ProcessDefinitionEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceDbReader.java
@@ -22,6 +22,7 @@ import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,7 @@ public class ProcessInstanceDbReader extends AbstractEntityReader<ProcessInstanc
   }
 
   @Override
-  public ProcessInstanceEntity getByKey(
+  public @Nullable ProcessInstanceEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleDbReader.java
@@ -23,6 +23,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,8 @@ public class RoleDbReader extends AbstractEntityReader<RoleEntity> implements Ro
   }
 
   @Override
-  public RoleEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable RoleEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantDbReader.java
@@ -23,6 +23,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,8 @@ public class TenantDbReader extends AbstractEntityReader<TenantEntity> implement
   }
 
   @Override
-  public TenantEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable TenantEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(id).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserDbReader.java
@@ -19,6 +19,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,8 @@ public class UserDbReader extends AbstractEntityReader<UserEntity> implements Us
   }
 
   @Override
-  public UserEntity getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable UserEntity getById(
+      final String id, final ResourceAccessChecks resourceAccessChecks) {
     return findOneByUsername(id).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserTaskDbReader.java
@@ -27,6 +27,7 @@ import io.camunda.util.NumberParsingUtil;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +45,8 @@ public class UserTaskDbReader extends AbstractEntityReader<UserTaskEntity>
   }
 
   @Override
-  public UserTaskEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable UserTaskEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key).orElse(null);
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
@@ -23,6 +23,7 @@ import io.camunda.search.sort.VariableSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,8 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
   }
 
   @Override
-  public VariableEntity getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+  public @Nullable VariableEntity getByKey(
+      final long key, final ResourceAccessChecks resourceAccessChecks) {
     return findOne(key);
   }
 
@@ -71,7 +73,7 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
         () -> variableMapper.count(dbQuery), () -> variableMapper.search(dbQuery), dbPage, dbSort);
   }
 
-  public VariableEntity findOne(final Long key) {
+  public @Nullable VariableEntity findOne(final Long key) {
     return search(
             new VariableQuery(
                 new Builder().variableKeys(key).build(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/package-info.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.db.rdbms.read.service;
+
+import org.jspecify.annotations.NullMarked;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -18,6 +18,8 @@ import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting.SortingEntry;
 import io.camunda.db.rdbms.sql.columns.ProcessInstanceSearchColumn;
 import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.ProcessInstanceSort;
@@ -196,6 +198,32 @@ class AbstractEntityReaderTest {
             new SortingEntry<>(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC),
             // Note: duplicated PROCESS_DEFINITION_NAME is ignored
             new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+  }
+
+  @Test
+  void shouldRejectEmptyAfterCursor() {
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b -> b.addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+    final SearchQueryPage page = SearchQueryPage.of(p -> p.from(0).size(10).after(""));
+
+    assertThatThrownBy(() -> reader.convertPaging(sort, page))
+        .isInstanceOf(CamundaSearchException.class)
+        .extracting(e -> ((CamundaSearchException) e).getReason())
+        .isEqualTo(Reason.INVALID_ARGUMENT);
+  }
+
+  @Test
+  void shouldRejectEmptyBeforeCursor() {
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b -> b.addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+    final SearchQueryPage page = SearchQueryPage.of(p -> p.from(0).size(10).before(""));
+
+    assertThatThrownBy(() -> reader.convertPaging(sort, page))
+        .isInstanceOf(CamundaSearchException.class)
+        .extracting(e -> ((CamundaSearchException) e).getReason())
+        .isEqualTo(Reason.INVALID_ARGUMENT);
   }
 
   // ---- Null-value keyset pagination tests ----

--- a/search/search-client-reader/pom.xml
+++ b/search/search-client-reader/pom.xml
@@ -23,5 +23,10 @@
       <artifactId>camunda-security-library-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/ClusterVariableReader.java
@@ -10,13 +10,14 @@ package io.camunda.search.clients.reader;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.jspecify.annotations.Nullable;
 
 public interface ClusterVariableReader
     extends SearchEntityReader<ClusterVariableEntity, ClusterVariableQuery> {
 
-  ClusterVariableEntity getTenantScopedClusterVariable(
+  @Nullable ClusterVariableEntity getTenantScopedClusterVariable(
       String name, String tenant, ResourceAccessChecks resourceAccessChecks);
 
-  ClusterVariableEntity getGloballyScopedClusterVariable(
+  @Nullable ClusterVariableEntity getGloballyScopedClusterVariable(
       String name, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DecisionRequirementsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DecisionRequirementsReader.java
@@ -10,10 +10,11 @@ package io.camunda.search.clients.reader;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.jspecify.annotations.Nullable;
 
 public interface DecisionRequirementsReader
     extends SearchEntityReader<DecisionRequirementsEntity, DecisionRequirementsQuery> {
 
-  DecisionRequirementsEntity getByKey(
+  @Nullable DecisionRequirementsEntity getByKey(
       final long key, final ResourceAccessChecks resourceAccessChecks, final boolean includeXml);
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DeployedResourceReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/DeployedResourceReader.java
@@ -10,12 +10,14 @@ package io.camunda.search.clients.reader;
 import io.camunda.search.entities.DeployedResourceEntity;
 import io.camunda.search.query.DeployedResourceQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.jspecify.annotations.Nullable;
 
 public interface DeployedResourceReader
     extends SearchEntityReader<DeployedResourceEntity, DeployedResourceQuery> {
 
-  DeployedResourceEntity getByKey(long key, ResourceAccessChecks resourceAccessChecks);
+  @Nullable DeployedResourceEntity getByKey(long key, ResourceAccessChecks resourceAccessChecks);
 
   /** Like {@link #getByKey} but omits the resource content payload. */
-  DeployedResourceEntity getByKeyMetadata(long key, ResourceAccessChecks resourceAccessChecks);
+  @Nullable DeployedResourceEntity getByKeyMetadata(
+      long key, ResourceAccessChecks resourceAccessChecks);
 }

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/GlobalListenerReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/GlobalListenerReader.java
@@ -11,11 +11,12 @@ import io.camunda.search.entities.GlobalListenerEntity;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.query.GlobalListenerQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.jspecify.annotations.Nullable;
 
 public interface GlobalListenerReader
     extends SearchEntityReader<GlobalListenerEntity, GlobalListenerQuery> {
 
-  GlobalListenerEntity getGlobalListener(
+  @Nullable GlobalListenerEntity getGlobalListener(
       String listenerId,
       GlobalListenerType listenerType,
       ResourceAccessChecks resourceAccessChecks);

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchEntityReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchEntityReader.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.reader;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.jspecify.annotations.Nullable;
 
 public interface SearchEntityReader<T, Q extends TypedSearchQuery<?, ?>>
     extends SearchClientReader {
@@ -20,7 +21,7 @@ public interface SearchEntityReader<T, Q extends TypedSearchQuery<?, ?>>
    *
    * @param resourceAccessChecks to be applied when retrieving the entity, if applicable
    */
-  default T getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
+  default @Nullable T getById(final String id, final ResourceAccessChecks resourceAccessChecks) {
     throw new UnsupportedOperationException("SearchClientReader#getById() not supported");
   }
 
@@ -30,7 +31,7 @@ public interface SearchEntityReader<T, Q extends TypedSearchQuery<?, ?>>
    *
    * @param resourceAccessChecks to be applied when retrieving the entity, if applicable.
    */
-  default T getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
+  default @Nullable T getByKey(final long key, final ResourceAccessChecks resourceAccessChecks) {
     throw new UnsupportedOperationException("SearchClientReader#getByKey() not supported");
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/PersistentWebSessionClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/PersistentWebSessionClient.java
@@ -9,10 +9,11 @@ package io.camunda.search.clients;
 
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import io.camunda.search.query.SearchQueryResult;
+import org.jspecify.annotations.Nullable;
 
 public interface PersistentWebSessionClient {
 
-  PersistentWebSessionEntity getPersistentWebSession(final String sessionId);
+  @Nullable PersistentWebSessionEntity getPersistentWebSession(final String sessionId);
 
   void upsertPersistentWebSession(final PersistentWebSessionEntity persistentWebSessionEntity);
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricStatisticsEntity.java
@@ -13,16 +13,20 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 public record UsageMetricStatisticsEntity(
-    long totalRpi,
-    long totalEdi,
-    long at,
-    @Nullable Map<String, UsageMetricStatisticsEntityTenant> tenants) {
+    long totalRpi, long totalEdi, long at, Map<String, UsageMetricStatisticsEntityTenant> tenants) {
 
-  public UsageMetricStatisticsEntity {
+  public UsageMetricStatisticsEntity(
+      final long totalRpi,
+      final long totalEdi,
+      final long at,
+      final @Nullable Map<String, UsageMetricStatisticsEntityTenant> tenants) {
+    this.totalRpi = totalRpi;
+    this.totalEdi = totalEdi;
+    this.at = at;
     // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
     // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
     // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
-    tenants = tenants != null ? tenants : new HashMap<>();
+    this.tenants = tenants != null ? tenants : new HashMap<>();
   }
 
   public record UsageMetricStatisticsEntityTenant(long rpi, long edi) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricStatisticsEntity.java
@@ -10,9 +10,13 @@ package io.camunda.search.entities;
 import io.camunda.util.ObjectBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public record UsageMetricStatisticsEntity(
-    long totalRpi, long totalEdi, long at, Map<String, UsageMetricStatisticsEntityTenant> tenants) {
+    long totalRpi,
+    long totalEdi,
+    long at,
+    @Nullable Map<String, UsageMetricStatisticsEntityTenant> tenants) {
 
   public UsageMetricStatisticsEntity {
     // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
@@ -10,9 +10,10 @@ package io.camunda.search.entities;
 import io.camunda.util.ObjectBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public record UsageMetricTUStatisticsEntity(
-    long totalTu, Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
+    long totalTu, @Nullable Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
 
   public UsageMetricTUStatisticsEntity {
     // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricTUStatisticsEntity.java
@@ -13,13 +13,16 @@ import java.util.Map;
 import org.jspecify.annotations.Nullable;
 
 public record UsageMetricTUStatisticsEntity(
-    long totalTu, @Nullable Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
+    long totalTu, Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
 
-  public UsageMetricTUStatisticsEntity {
+  public UsageMetricTUStatisticsEntity(
+      final long totalTu,
+      final @Nullable Map<String, UsageMetricTUStatisticsEntityTenant> tenants) {
+    this.totalTu = totalTu;
     // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
     // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
     // Immutable defaults (e.g. Map.of()) would cause UnsupportedOperationException at runtime.
-    tenants = tenants != null ? tenants : new HashMap<>();
+    this.tenants = tenants != null ? tenants : new HashMap<>();
   }
 
   public record UsageMetricTUStatisticsEntityTenant(long tu) {


### PR DESCRIPTION
## Summary

Adds nullness annotations to the RDBMS read layer so that NullAway can enforce null-safety at compile time in these packages.

- All `getByKey()`, `getById()`, and `findOne()` methods that return null on miss are annotated `@Nullable` at both the interface level (in `search-client-reader` and `search-client`) and in the RDBMS implementations
- `Cursor.encode()` and `Cursor.decode()` are annotated `@Nullable` since both return null for empty/null inputs
- `DbQueryPage` fields that legitimately accept null (`from`, `maxTotalHits`, `keySetPagination`) are annotated `@Nullable`
- `package-info.java` with `@NullMarked` added to `read.service` — NullAway enforces this at compile time with `-Xep:NullAway:ERROR`, so any future nullable return without annotation will be caught before it reaches production. `read.domain` was also attempted but dropped: it triggered 40+ uninitialized-field errors in builder classes throughout the `*DbQuery` hierarchy, too many to fix and not worth the coverage gain.