### PR TITLE
fix: reduce visible-for-testing visibility

### DIFF
--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
@@ -19,7 +19,6 @@ import static jakarta.ws.rs.HttpMethod.PUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import io.camunda.optimize.dto.optimize.query.security.CredentialsRequestDto;
 import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
@@ -243,7 +242,6 @@ public class OptimizeRequestExecutor {
     return this;
   }
 
-  @VisibleForTesting
   public OptimizeRequestExecutor withBearerToken(final String token) {
     requestHeaders.put(HttpHeaders.AUTHORIZATION, "Bearer " + token);
     authCookie = null;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/RecentlyArchivedProcessInstances.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/RecentlyArchivedProcessInstances.java
@@ -25,7 +25,7 @@ public class RecentlyArchivedProcessInstances {
   }
 
   @VisibleForTesting
-  public RecentlyArchivedProcessInstances(final Cache<Long, Boolean> recentlyArchived) {
+  RecentlyArchivedProcessInstances(final Cache<Long, Boolean> recentlyArchived) {
     this.recentlyArchived = recentlyArchived;
   }
 


### PR DESCRIPTION
## Description

This PR cleans up two `@VisibleForTesting` declarations so their visibility better reflects how they are used.

`RecentlyArchivedProcessInstances` has a constructor that exists to inject a cache from tests. Its only external caller is the same-package test, so the constructor does not need to be public. This PR narrows it to package-private while keeping the `@VisibleForTesting` annotation to document why the constructor exists.

`OptimizeRequestExecutor.withBearerToken` is different: it is used by Optimize integration tests from another package, so narrowing it to package-private would break legitimate test usage. The class itself already lives under `src/test`, so the method is test-only by source-set boundary. In that case, `@VisibleForTesting` is redundant and misleading, so this PR removes the annotation instead of changing the method visibility.

> Context: this was found while validating the proposed Checkstyle `AnnotatedDeclarationVisibility` check in [checkstyle/checkstyle#19164](https://github.com/checkstyle/checkstyle/pull/19164) against downstream projects.