### PR TITLE
feat: add ProcessInstanceSuspendProcessor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreatio
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceResumeProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceSuspendProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -172,6 +173,10 @@ public final class BpmnProcessors {
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.RESUME,
         new ProcessInstanceResumeProcessor(processingState, writers, authCheckBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE,
+        ProcessInstanceIntent.SUSPEND,
+        new ProcessInstanceSuspendProcessor(processingState, writers, authCheckBehavior));
   }
 
   private static void addBpmnStepProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public final class ProcessInstanceSuspendProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord> {
+
+  private static final String PROCESS_NOT_FOUND_MESSAGE =
+      "Expected to suspend a process instance with key '%d', but no such process was found";
+
+  private final ElementInstanceState elementInstanceState;
+  private final TypedResponseWriter responseWriter;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+
+  public ProcessInstanceSuspendProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    elementInstanceState = processingState.getElementInstanceState();
+    responseWriter = writers.response();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    this.authCheckBehavior = authCheckBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
+    final var elementInstance = elementInstanceState.getInstance(command.getKey());
+
+    if (!validateCommand(command, elementInstance)) {
+      return;
+    }
+
+    final ProcessInstanceRecord value = elementInstance.getValue();
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.SUSPENDED, value);
+    responseWriter.writeEventOnCommand(
+        command.getKey(), ProcessInstanceIntent.SUSPENDED, value, command);
+  }
+
+  private boolean validateCommand(
+      final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
+
+    if (elementInstance == null) {
+      final var reason = String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey());
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
+      return false;
+    }
+
+    final var request =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.SUSPEND_PROCESS_INSTANCE)
+            .tenantId(elementInstance.getValue().getTenantId())
+            .addResourceId(elementInstance.getValue().getBpmnProcessId())
+            .build();
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(request);
+    if (isAuthorized.isLeft()) {
+      final var rejection = isAuthorized.getLeft();
+      final String errorMessage =
+          RejectionType.NOT_FOUND.equals(rejection.type())
+              ? AuthorizationCheckBehavior.NOT_FOUND_ERROR_MESSAGE.formatted(
+                  "suspend a process instance",
+                  elementInstance.getValue().getProcessInstanceKey(),
+                  "such process")
+              : rejection.reason();
+      rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      return false;
+    }
+
+    // TODO(#57517): once SuspensionState exists, reject with INVALID_STATE if the process
+    // instance is already suspended.
+
+    return true;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -14,11 +14,13 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AsyncRequestState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -27,14 +29,20 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 public final class ProcessInstanceSuspendProcessor
     implements TypedRecordProcessor<ProcessInstanceRecord> {
 
+  private static final String MESSAGE_PREFIX =
+      "Expected to suspend a process instance with key '%d', but ";
+
   private static final String PROCESS_NOT_FOUND_MESSAGE =
-      "Expected to suspend a process instance with key '%d', but no such process was found";
+      MESSAGE_PREFIX + "no such process was found";
+  private static final String PROCESS_CANCEL_IN_PROGRESS_MESSAGE =
+      MESSAGE_PREFIX + "a cancel request is already in progress";
 
   private final ElementInstanceState elementInstanceState;
   private final TypedResponseWriter responseWriter;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final AuthorizationCheckBehavior authCheckBehavior;
+  private final AsyncRequestState asyncRequestState;
 
   public ProcessInstanceSuspendProcessor(
       final ProcessingState processingState,
@@ -45,6 +53,7 @@ public final class ProcessInstanceSuspendProcessor
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     this.authCheckBehavior = authCheckBehavior;
+    asyncRequestState = processingState.getAsyncRequestState();
   }
 
   @Override
@@ -64,7 +73,7 @@ public final class ProcessInstanceSuspendProcessor
   private boolean validateCommand(
       final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
 
-    if (elementInstance == null) {
+    if (elementInstance == null || elementInstance.isTerminating()) {
       final var reason = String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
@@ -89,8 +98,20 @@ public final class ProcessInstanceSuspendProcessor
                   elementInstance.getValue().getProcessInstanceKey(),
                   "such process")
               : rejection.reason();
+      enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
       responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      return false;
+    }
+
+    final var existingCancelRequest =
+        asyncRequestState.findRequest(
+            command.getKey(), ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.CANCEL);
+    if (existingCancelRequest.isPresent()) {
+      final var reason = String.format(PROCESS_CANCEL_IN_PROGRESS_MESSAGE, command.getKey());
+      enrichRejectionCommand(command, elementInstance.getValue());
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
       return false;
     }
 
@@ -98,5 +119,12 @@ public final class ProcessInstanceSuspendProcessor
     // instance is already suspended.
 
     return true;
+  }
+
+  private void enrichRejectionCommand(
+      final TypedRecord<ProcessInstanceRecord> command,
+      final ProcessInstanceRecord processInstanceRecord) {
+    command.getValue().setTenantId(processInstanceRecord.getTenantId());
+    command.getValue().setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -121,6 +121,10 @@ public final class ProcessInstanceSuspendProcessor
     return true;
   }
 
+  /**
+   * Enriches the command value with fields from the element instance to ensure rejection records
+   * have the proper context for audit logs export.
+   */
   private void enrichRejectionCommand(
       final TypedRecord<ProcessInstanceRecord> command,
       final ProcessInstanceRecord processInstanceRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -413,6 +413,7 @@ public final class EventAppliers implements EventApplier {
         new RuntimeInstructionInterruptedApplier(elementInstanceState));
     register(ProcessInstanceIntent.CANCELING, NOOP_EVENT_APPLIER);
     register(ProcessInstanceIntent.RESUMED, new ProcessInstanceResumedApplier());
+    register(ProcessInstanceIntent.SUSPENDED, new ProcessInstanceSuspendedApplier());
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSuspendedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSuspendedApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Stub applier for {@link ProcessInstanceIntent#SUSPENDED}.
+ *
+ * <p>TODO(#57517): mark the process instance as suspended once {@code SuspensionState} exists.
+ *
+ * <p>TODO(#57518): this applier's real implementation (including buffered-command handling) lands
+ * here.
+ */
+final class ProcessInstanceSuspendedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSuspendProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSuspendProcessInstanceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class TenantAwareSuspendProcessInstanceTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition().withMultiTenancyChecksEnabled(true);
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldSuspendInstanceForDefaultTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .create();
+
+    // when
+    final var suspended =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .forAuthorizedTenants(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .suspend();
+
+    // then
+    assertThat(suspended)
+        .describedAs("Expect that suspension was successful")
+        .hasIntent(ProcessInstanceIntent.SUSPENDED);
+  }
+
+  @Test
+  public void shouldRejectSuspendInstanceForUnauthorizedTenant() {
+    // given
+    final var tenantId = "another-tenant";
+    final var username = "username";
+    final var user = ENGINE.user().newUser(username).create().getValue();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
+    ENGINE
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId("custom-tenant")
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withTenantId("custom-tenant").create();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .expectSuspendRejection()
+            .suspend(user.getUsername());
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to suspend a process instance with key '%s', but no such process was found"
+                .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldSuspendInstanceForSpecificTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType("test"))
+                .endEvent()
+                .done())
+        .withTenantId("custom-tenant")
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("process").withTenantId("custom-tenant").create();
+
+    // when
+    final var suspended =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .forAuthorizedTenants("custom-tenant")
+            .suspend();
+
+    // then
+    assertThat(suspended)
+        .describedAs("Expect that suspension was successful")
+        .hasIntent(ProcessInstanceIntent.SUSPENDED);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandRejectionTest.java
@@ -573,6 +573,77 @@ public final class ProcessInstanceCommandRejectionTest {
   }
 
   @Test
+  public void shouldRejectSuspendIfProcessInstanceIsAlreadyCanceling() {
+    // given
+    final var processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("a", t -> t.zeebeJobType("a"))
+                .done());
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    engine.writeRecords(
+        cancelProcessInstanceCommand(processInstanceKey),
+        suspendProcessInstanceCommand(processInstanceKey));
+
+    // then
+    final var rejectedCommand =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SUSPEND)
+            .onlyCommandRejections()
+            .withRecordKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(rejectedCommand)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                "Expected to suspend a process instance with key '%d', but a cancel request is already in progress",
+                processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectSuspendIfProcessInstanceIsTerminating() {
+    // given (synthetic situation - is not expected in regular processing)
+    final var processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("a", t -> t.zeebeJobType("a"))
+                .endEvent()
+                .done());
+
+    final var processInstanceActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    // when
+    engine.writeRecords(
+        terminateElementCommand(processInstanceActivated),
+        suspendProcessInstanceCommand(processInstanceKey));
+
+    // then
+    final var rejectedCommand =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SUSPEND)
+            .onlyCommandRejections()
+            .withRecordKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(rejectedCommand)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            String.format(
+                "Expected to suspend a process instance with key '%d', but no such process was found",
+                processInstanceKey));
+  }
+
+  @Test
   public void shouldRejectTerminateIfElementIsTerminated() {
     // given
     final var processInstanceKey =
@@ -623,6 +694,12 @@ public final class ProcessInstanceCommandRejectionTest {
   private RecordToWrite cancelProcessInstanceCommand(final long processInstanceKey) {
     return RecordToWrite.command()
         .processInstance(ProcessInstanceIntent.CANCEL, new ProcessInstanceRecord())
+        .key(processInstanceKey);
+  }
+
+  private RecordToWrite suspendProcessInstanceCommand(final long processInstanceKey) {
+    return RecordToWrite.command()
+        .processInstance(ProcessInstanceIntent.SUSPEND, new ProcessInstanceRecord())
         .key(processInstanceKey);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendAuthorizationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
+import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ProcessInstanceSuspendAuthorizationTest {
+  private static final String PROCESS_ID = "processId";
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withResetRecordingExporterTestWatcherMode(
+              ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
+          .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Before
+  public void before() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask().endEvent().done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldBeAuthorizedToSuspendInstanceWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .suspend(DEFAULT_USER.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SUSPENDED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToSuspendInstanceWithUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.SUSPEND_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        PROCESS_ID);
+
+    // when
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SUSPENDED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToSuspendInstanceIfNoPermissions() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var user = createUser();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .expectSuspendRejection()
+            .suspend(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'SUSPEND_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                .formatted(PROCESS_ID));
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
+      final String resourceId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(matcher)
+        .withResourceId(resourceId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private long createProcessInstance() {
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/SuspendProcessInstanceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.SUSPENDED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public final class SuspendProcessInstanceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldSuspendProcessInstance() {
+    // given
+    final String processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId).startEvent().userTask().endEvent().done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    final Record<ProcessInstanceRecordValue> suspended =
+        ENGINE.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // then
+    assertThat(suspended.getIntent()).isEqualTo(SUSPENDED);
+    Assertions.assertThat(suspended.getValue())
+        .hasBpmnProcessId(processId)
+        .hasProcessInstanceKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectSuspendIfProcessInstanceNotFound() {
+    // given
+    final long nonExistentKey = -1L;
+
+    // when
+    final Record<ProcessInstanceRecordValue> rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(nonExistentKey)
+            .onPartition(1)
+            .expectSuspendRejection()
+            .suspend();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasIntent(ProcessInstanceIntent.SUSPEND)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.io.IOException;
@@ -179,10 +178,7 @@ public class EventAppliersTest {
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent))
-            // todo delete this filter after the suspend applier is implemented
-            //  (https://github.com/camunda/camunda/issues/57506)
-            .filter(intent -> intent != ProcessInstanceIntent.SUSPENDED);
+            .filter(intent -> !(intent instanceof CheckpointIntent));
 
     // when
     eventAppliers.registerEventAppliers(mock(MutableProcessingState.class));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -322,6 +322,24 @@ public final class ProcessInstanceClient {
                 .withProcessInstanceKey(processInstanceKey)
                 .getFirst();
 
+    public static final Function<Long, Record<ProcessInstanceRecordValue>> SUSPENDED_EXPECTATION =
+        (processInstanceKey) ->
+            RecordingExporter.processInstanceRecords()
+                .withRecordKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.SUSPENDED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst();
+
+    public static final Function<Long, Record<ProcessInstanceRecordValue>>
+        SUSPEND_REJECTION_EXPECTATION =
+            (processInstanceKey) ->
+                RecordingExporter.processInstanceRecords()
+                    .onlyCommandRejections()
+                    .withIntent(ProcessInstanceIntent.SUSPEND)
+                    .withRecordKey(processInstanceKey)
+                    .withProcessInstanceKey(processInstanceKey)
+                    .getFirst();
+
     public static final Function<Long, Record<ErrorRecordValue>> ERROR_EXPECTATION =
         (processInstanceKey) ->
             RecordingExporter.errorRecords().withIntent(ErrorIntent.CREATED).getFirst();
@@ -353,6 +371,8 @@ public final class ProcessInstanceClient {
     private Function<Long, Record<ProcessInstanceRecordValue>> expectation = SUCCESS_EXPECTATION;
     private Function<Long, Record<ProcessInstanceRecordValue>> resumeExpectation =
         RESUMED_EXPECTATION;
+    private Function<Long, Record<ProcessInstanceRecordValue>> suspendExpectation =
+        SUSPENDED_EXPECTATION;
 
     public ExistingInstanceClient(final CommandWriter writer, final long processInstanceKey) {
       this.writer = writer;
@@ -403,6 +423,56 @@ public final class ProcessInstanceClient {
     public Record<ProcessInstanceRecordValue> resume(final String username) {
       writeResumeCommandWithUserKey(username);
       return resumeExpectation.apply(processInstanceKey);
+    }
+
+    public ExistingInstanceClient expectSuspendRejection() {
+      suspendExpectation = SUSPEND_REJECTION_EXPECTATION;
+      return this;
+    }
+
+    public Record<ProcessInstanceRecordValue> suspend() {
+      writeSuspendCommand();
+      return suspendExpectation.apply(processInstanceKey);
+    }
+
+    public Record<ProcessInstanceRecordValue> suspend(final String username) {
+      writeSuspendCommandWithUserKey(username);
+      return suspendExpectation.apply(processInstanceKey);
+    }
+
+    private void writeSuspendCommand() {
+      if (partition == DEFAULT_PARTITION) {
+        partition =
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getPartitionId();
+      }
+
+      writer.writeCommandOnPartition(
+          partition,
+          processInstanceKey,
+          ProcessInstanceIntent.SUSPEND,
+          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
+          authorizedTenants);
+    }
+
+    private void writeSuspendCommandWithUserKey(final String username) {
+      if (partition == DEFAULT_PARTITION) {
+        partition =
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getPartitionId();
+      }
+
+      writer.writeCommandOnPartition(
+          partition,
+          processInstanceKey,
+          ProcessInstanceIntent.SUSPEND,
+          username,
+          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
+          authorizedTenants);
     }
 
     private void writeCancelCommand() {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_SUSPENDED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_SUSPENDED_v1.golden
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Stub applier for {@link ProcessInstanceIntent#SUSPENDED}.
+ *
+ * <p>TODO(#57517): mark the process instance as suspended once {@code SuspensionState} exists.
+ *
+ * <p>TODO(#57518): this applier's real implementation (including buffered-command handling) lands
+ * here.
+ */
+final class ProcessInstanceSuspendedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {}
+}


### PR DESCRIPTION
## Description

Adds `ProcessInstanceSuspendProcessor`, the entry-point processor for suspending a process instance. It validates the instance exists (and isn't already terminating, or racing an in-flight cancel) and that the caller has the `SUSPEND_PROCESS_INSTANCE` permission, then emits `SUSPENDED`. Also adds a stub `ProcessInstanceSuspendedApplier` (registered in `EventAppliers`) so the event has a registered applier — the real state mutation (marking the instance suspended, buffered-command handling) is deferred to #57517 and #57518, tracked via `TODO`s in the code.

This intentionally omits `ProcessInstanceCancelProcessor`'s root-instance and call-activity/hierarchy checks — suspending a non-root instance or a call activity directly is valid for this feature, per design discussion. See the design spec for the full reasoning: `docs/superpowers/specs/2026-07-15-process-instance-suspend-processor-design.md`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57519