### PR TITLE
feat: add ProcessInstanceResumeProcessor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreatio
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceResumeProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -167,6 +168,10 @@ public final class BpmnProcessors {
         ProcessInstanceIntent.CANCEL,
         new ProcessInstanceCancelProcessor(
             processingState, writers, asyncRequestBehavior, authCheckBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE,
+        ProcessInstanceIntent.RESUME,
+        new ProcessInstanceResumeProcessor(processingState, writers, authCheckBehavior));
   }
 
   private static void addBpmnStepProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public final class ProcessInstanceResumeProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord> {
+
+  private static final String MESSAGE_PREFIX =
+      "Expected to resume a process instance with key '%d', but ";
+
+  private static final String PROCESS_NOT_FOUND_MESSAGE =
+      MESSAGE_PREFIX + "no such process was found";
+
+  private final ElementInstanceState elementInstanceState;
+  private final TypedResponseWriter responseWriter;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+
+  public ProcessInstanceResumeProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    elementInstanceState = processingState.getElementInstanceState();
+    responseWriter = writers.response();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    this.authCheckBehavior = authCheckBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
+    final var elementInstance = elementInstanceState.getInstance(command.getKey());
+
+    if (!validateCommand(command, elementInstance)) {
+      return;
+    }
+
+    final ProcessInstanceRecord value = elementInstance.getValue();
+
+    // TODO(#57517): reject with INVALID_STATE if the process instance is not currently SUSPENDED,
+    // once SuspensionState exists to read the current status from.
+    // TODO(#57792): append a DRAIN command instead of writing RESUMED directly, once chunked
+    // draining of buffered commands is implemented.
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
+    responseWriter.writeEventOnCommand(
+        command.getKey(), ProcessInstanceIntent.RESUMED, value, command);
+  }
+
+  private boolean validateCommand(
+      final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
+
+    if (elementInstance == null) {
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
+      responseWriter.writeRejectionOnCommand(
+          command,
+          RejectionType.NOT_FOUND,
+          String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
+      return false;
+    }
+
+    final var request =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.SUSPEND_PROCESS_INSTANCE)
+            .tenantId(elementInstance.getValue().getTenantId())
+            .addResourceId(elementInstance.getValue().getBpmnProcessId())
+            .build();
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(request);
+    if (isAuthorized.isLeft()) {
+      final var rejection = isAuthorized.getLeft();
+      final String errorMessage =
+          RejectionType.NOT_FOUND.equals(rejection.type())
+              ? AuthorizationCheckBehavior.NOT_FOUND_ERROR_MESSAGE.formatted(
+                  "resume a process instance",
+                  elementInstance.getValue().getProcessInstanceKey(),
+                  "such process")
+              : rejection.reason();
+      rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -102,11 +102,22 @@ public final class ProcessInstanceResumeProcessor
                   elementInstance.getValue().getProcessInstanceKey(),
                   "such process")
               : rejection.reason();
+      enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
       responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
       return false;
     }
 
     return true;
+  }
+
+  /**
+   * Enriches the command value with fields from the element instance to ensure rejection records
+   * have the proper context for audit logs export.
+   */
+  private void enrichRejectionCommand(
+      final TypedRecord<ProcessInstanceRecord> command,
+      final ProcessInstanceRecord processInstanceRecord) {
+    command.getValue().setTenantId(processInstanceRecord.getTenantId());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -72,7 +72,7 @@ public final class ProcessInstanceResumeProcessor
   private boolean validateCommand(
       final TypedRecord<ProcessInstanceRecord> command, final ElementInstance elementInstance) {
 
-    if (elementInstance == null) {
+    if (elementInstance == null || elementInstance.getParentKey() > 0) {
       rejectionWriter.appendRejection(
           command,
           RejectionType.NOT_FOUND,
@@ -119,5 +119,6 @@ public final class ProcessInstanceResumeProcessor
       final TypedRecord<ProcessInstanceRecord> command,
       final ProcessInstanceRecord processInstanceRecord) {
     command.getValue().setTenantId(processInstanceRecord.getTenantId());
+    command.getValue().setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -402,6 +402,7 @@ public final class EventAppliers implements EventApplier {
         RuntimeInstructionIntent.INTERRUPTED,
         new RuntimeInstructionInterruptedApplier(elementInstanceState));
     register(ProcessInstanceIntent.CANCELING, NOOP_EVENT_APPLIER);
+    register(ProcessInstanceIntent.RESUMED, new ProcessInstanceResumedApplier());
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Stub applier for {@link ProcessInstanceIntent#RESUMED}.
+ *
+ * <p>TODO(#57517): mark the process instance as no longer suspended once {@code SuspensionState}
+ * exists.
+ *
+ * <p>TODO(#57518): this applier's real implementation (including buffered-command handling) lands
+ * here.
+ */
+final class ProcessInstanceResumedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeAuthorizationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterMode;
+import io.camunda.zeebe.engine.util.EngineRule.ResetRecordingExporterTestWatcherMode;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ProcessInstanceResumeAuthorizationTest {
+  private static final String PROCESS_ID = "processId";
+
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withResetRecordingExporterTestWatcherMode(
+              ResetRecordingExporterTestWatcherMode.BEFORE_ALL_TESTS_AND_AFTER_EACH_TEST)
+          .withIdentitySetup(ResetRecordingExporterMode.NO_RESET_AFTER_IDENTITY_SETUP)
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Before
+  public void before() {
+    engine
+        .deployment()
+        .withXmlResource(
+            "process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask().endEvent().done())
+        .deploy(DEFAULT_USER.getUsername());
+  }
+
+  @Test
+  public void shouldBeAuthorizedToResumeInstanceWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+
+    // when
+    engine.processInstance().withInstanceKey(processInstanceKey).resume(DEFAULT_USER.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedToResumeInstanceWithUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.SUSPEND_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        PROCESS_ID);
+
+    // when
+    engine.processInstance().withInstanceKey(processInstanceKey).resume(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.RESUMED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToResumeInstanceIfNoPermissions() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var user = createUser();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .expectResumeRejection()
+            .resume(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'SUSPEND_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                .formatted(PROCESS_ID));
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
+      final String resourceId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(matcher)
+        .withResourceId(resourceId)
+        .create(DEFAULT_USER.getUsername());
+  }
+
+  private long createProcessInstance() {
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeAuthorizationTest.java
@@ -129,7 +129,7 @@ public class ProcessInstanceResumeAuthorizationTest {
   }
 
   @Test
-  public void shouldEnrichRejectionWithTenantIdWhenUnauthorized() {
+  public void shouldEnrichRejectionWithTenantIdAndRootProcessInstanceKeyWhenUnauthorized() {
     // given
     engine
         .deployment()
@@ -158,6 +158,9 @@ public class ProcessInstanceResumeAuthorizationTest {
     // then
     Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
     Assertions.assertThat(rejection.getValue()).hasTenantId(TENANT);
+    assertThat(rejection.getValue().getRootProcessInstanceKey())
+        .describedAs("a root process instance's own key is also its rootProcessInstanceKey")
+        .isEqualTo(processInstanceKey);
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeAuthorizationTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 public class ProcessInstanceResumeAuthorizationTest {
   private static final String PROCESS_ID = "processId";
+  private static final String TENANT = "custom-tenant";
 
   private static final ConfiguredUser DEFAULT_USER =
       new ConfiguredUser(
@@ -125,6 +126,38 @@ public class ProcessInstanceResumeAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'SUSPEND_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
+  }
+
+  @Test
+  public void shouldEnrichRejectionWithTenantIdWhenUnauthorized() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            "tenant-process.bpmn",
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask().endEvent().done())
+        .withTenantId(TENANT)
+        .deploy(DEFAULT_USER.getUsername());
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withTenantId(TENANT)
+            .create(DEFAULT_USER.getUsername());
+    final var user = createUser();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .forAuthorizedTenants(TENANT)
+            .expectResumeRejection()
+            .resume(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    Assertions.assertThat(rejection.getValue()).hasTenantId(TENANT);
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeRejectionCommandTest.java
@@ -10,8 +10,11 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -31,6 +34,39 @@ public class ProcessInstanceResumeRejectionCommandTest {
         ENGINE
             .processInstance()
             .withInstanceKey(-1)
+            .onPartition(1)
+            .expectResumeRejection()
+            .resume();
+
+    // then
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceIntent.RESUME)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectResumeWhenKeyIsNotAProcessInstance() {
+    // given - a process instance with a user task, whose element instance key is NOT the process
+    // instance's own key
+    final var processId = Strings.newRandomValidBpmnId();
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId).startEvent().userTask("task").endEvent().done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+    final var userTaskElementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getKey();
+
+    // when - try to resume using the user task's element instance key, not the process instance's
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(userTaskElementInstanceKey)
             .onPartition(1)
             .expectResumeRejection()
             .resume();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeRejectionCommandTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeRejectionCommandTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class ProcessInstanceResumeRejectionCommandTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectResumeWhenProcessInstanceNotFound() {
+    // when - try to resume a non-existing process instance
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(-1)
+            .onPartition(1)
+            .expectResumeRejection()
+            .resume();
+
+    // then
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceIntent.RESUME)
+        .hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -180,10 +180,9 @@ public class EventAppliersTest {
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent))
-            // todo delete these filters after the suspend/resume appliers are implemented
+            // todo delete this filter after the suspend applier is implemented
             //  (https://github.com/camunda/camunda/issues/57506)
-            .filter(intent -> intent != ProcessInstanceIntent.SUSPENDED)
-            .filter(intent -> intent != ProcessInstanceIntent.RESUMED);
+            .filter(intent -> intent != ProcessInstanceIntent.SUSPENDED);
 
     // when
     eventAppliers.registerEventAppliers(mock(MutableProcessingState.class));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -326,6 +326,24 @@ public final class ProcessInstanceClient {
         (processInstanceKey) ->
             RecordingExporter.errorRecords().withIntent(ErrorIntent.CREATED).getFirst();
 
+    public static final Function<Long, Record<ProcessInstanceRecordValue>> RESUMED_EXPECTATION =
+        (processInstanceKey) ->
+            RecordingExporter.processInstanceRecords()
+                .withRecordKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.RESUMED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst();
+
+    public static final Function<Long, Record<ProcessInstanceRecordValue>>
+        RESUME_REJECTION_EXPECTATION =
+            (processInstanceKey) ->
+                RecordingExporter.processInstanceRecords()
+                    .onlyCommandRejections()
+                    .withIntent(ProcessInstanceIntent.RESUME)
+                    .withRecordKey(processInstanceKey)
+                    .withProcessInstanceKey(processInstanceKey)
+                    .getFirst();
+
     private static final int DEFAULT_PARTITION = -1;
     private final CommandWriter writer;
     private final long processInstanceKey;
@@ -333,6 +351,8 @@ public final class ProcessInstanceClient {
     private String[] authorizedTenants;
     private int partition = DEFAULT_PARTITION;
     private Function<Long, Record<ProcessInstanceRecordValue>> expectation = SUCCESS_EXPECTATION;
+    private Function<Long, Record<ProcessInstanceRecordValue>> resumeExpectation =
+        RESUMED_EXPECTATION;
 
     public ExistingInstanceClient(final CommandWriter writer, final long processInstanceKey) {
       this.writer = writer;
@@ -355,6 +375,11 @@ public final class ProcessInstanceClient {
       return this;
     }
 
+    public ExistingInstanceClient expectResumeRejection() {
+      resumeExpectation = RESUME_REJECTION_EXPECTATION;
+      return this;
+    }
+
     public Record<ProcessInstanceRecordValue> cancel() {
       writeCancelCommand();
       return expectation.apply(processInstanceKey);
@@ -368,6 +393,16 @@ public final class ProcessInstanceClient {
     public Record<ErrorRecordValue> cancelWithError() {
       writeCancelCommand();
       return ERROR_EXPECTATION.apply(processInstanceKey);
+    }
+
+    public Record<ProcessInstanceRecordValue> resume() {
+      writeResumeCommand();
+      return resumeExpectation.apply(processInstanceKey);
+    }
+
+    public Record<ProcessInstanceRecordValue> resume(final String username) {
+      writeResumeCommandWithUserKey(username);
+      return resumeExpectation.apply(processInstanceKey);
     }
 
     private void writeCancelCommand() {
@@ -400,6 +435,41 @@ public final class ProcessInstanceClient {
           partition,
           processInstanceKey,
           ProcessInstanceIntent.CANCEL,
+          username,
+          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
+          authorizedTenants);
+    }
+
+    private void writeResumeCommand() {
+      if (partition == DEFAULT_PARTITION) {
+        partition =
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getPartitionId();
+      }
+
+      writer.writeCommandOnPartition(
+          partition,
+          processInstanceKey,
+          ProcessInstanceIntent.RESUME,
+          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
+          authorizedTenants);
+    }
+
+    private void writeResumeCommandWithUserKey(final String username) {
+      if (partition == DEFAULT_PARTITION) {
+        partition =
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getPartitionId();
+      }
+
+      writer.writeCommandOnPartition(
+          partition,
+          processInstanceKey,
+          ProcessInstanceIntent.RESUME,
           username,
           new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
           authorizedTenants);

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMED_v1.golden
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Stub applier for {@link ProcessInstanceIntent#RESUMED}.
+ *
+ * <p>TODO(#57517): mark the process instance as no longer suspended once {@code SuspensionState}
+ * exists.
+ *
+ * <p>TODO(#57518): this applier's real implementation (including buffered-command handling) lands
+ * here.
+ */
+final class ProcessInstanceResumedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {}
+}


### PR DESCRIPTION
## Description

Adds `ProcessInstanceResumeProcessor`, which handles the `RESUME` process instance command: it checks
the `SUSPEND_PROCESS_INSTANCE` permission (reused deliberately — there is no separate
`RESUME_PROCESS_INSTANCE` permission) and validates the process instance exists, then emits a `RESUMED`
event directly.

Also adds `ProcessInstanceResumedApplier` as an intentional stub, and wires both into
`BpmnProcessors`/`EventAppliers`.

Two things are deliberately deferred, since their prerequisites don't exist yet, and are called out with
TODOs in the code:
- Rejecting when the instance isn't currently `SUSPENDED` — blocked on `SuspensionState`
  (#57517).
- Real applier state / appending a `DRAIN` command instead of `RESUMED` directly — blocked on the
  appliers task (#57518) and tracked separately for the drain step itself (#57792).

No root/child-instance restriction and no `AsyncRequestBehavior` — intentionally omitted; Resume doesn't
have `ProcessInstanceCancelProcessor`'s async multi-step semantics (yet).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57520