### PR TITLE
feat: add audit-log transformer for process instance suspend/resume

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -50,6 +50,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -422,6 +423,36 @@ public class AuditLogProcessOperationsIT {
         processInstanceKey,
         processInstance.getProcessDefinitionKey(),
         SERVICE_TASKS_PROCESS_ID);
+  }
+
+  @Test
+  @Disabled(
+      "Blocked on the process-instance SUSPEND/RESUME REST endpoint and CamundaClient command "
+          + "(tracked by phase issue https://github.com/camunda/camunda/issues/57508); "
+          + "CamundaClient has no newSuspendProcessInstanceCommand yet, so a real test body "
+          + "would not compile. Enable once the client command lands.")
+  void shouldTrackProcessInstanceSuspension(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // TODO(#57508): once client.newSuspendProcessInstanceCommand(processInstanceKey) exists,
+    // mirror shouldTrackProcessInstanceCancellation above: start a process instance, send the
+    // suspend command, then assert an AuditLogOperationTypeEnum.SUSPEND entry for
+    // AuditLogEntityTypeEnum.PROCESS_INSTANCE via awaitAuditLogEntry(...) +
+    // assertProcessInstanceAuditLog(...).
+  }
+
+  @Test
+  @Disabled(
+      "Blocked on the process-instance SUSPEND/RESUME REST endpoint and CamundaClient command "
+          + "(tracked by phase issue https://github.com/camunda/camunda/issues/57508); "
+          + "CamundaClient has no newResumeProcessInstanceCommand yet, so a real test body "
+          + "would not compile. Enable once the client command lands.")
+  void shouldTrackProcessInstanceResumption(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    // TODO(#57508): once client.newResumeProcessInstanceCommand(processInstanceKey) exists,
+    // mirror shouldTrackProcessInstanceCancellation above: start and suspend a process instance,
+    // send the resume command, then assert an AuditLogOperationTypeEnum.RESUME entry for
+    // AuditLogEntityTypeEnum.PROCESS_INSTANCE via awaitAuditLogEntry(...) +
+    // assertProcessInstanceAuditLog(...).
   }
 
   // ========================================================================================

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -50,7 +50,6 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -426,33 +425,69 @@ public class AuditLogProcessOperationsIT {
   }
 
   @Test
-  @Disabled(
-      "Blocked on the process-instance SUSPEND/RESUME REST endpoint and CamundaClient command "
-          + "(tracked by phase issue https://github.com/camunda/camunda/issues/57508); "
-          + "CamundaClient has no newSuspendProcessInstanceCommand yet, so a real test body "
-          + "would not compile. Enable once the client command lands.")
   void shouldTrackProcessInstanceSuspension(
       @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
-    // TODO(#57508): once client.newSuspendProcessInstanceCommand(processInstanceKey) exists,
-    // mirror shouldTrackProcessInstanceCancellation above: start a process instance, send the
-    // suspend command, then assert an AuditLogOperationTypeEnum.SUSPEND entry for
-    // AuditLogEntityTypeEnum.PROCESS_INSTANCE via awaitAuditLogEntry(...) +
-    // assertProcessInstanceAuditLog(...).
+    // given - start a process instance
+    final var processInstance = createProcessInstance(client, SERVICE_TASKS_PROCESS_ID);
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(processInstanceKey).tenantId(TENANT_A), 1);
+
+    // when - suspend the process instance
+    client.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then - wait for audit log entry and verify
+    final var auditLogItems =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+            AuditLogOperationTypeEnum.SUSPEND,
+            String.valueOf(processInstanceKey));
+
+    assertThat(auditLogItems).isNotEmpty();
+    final var auditLog = auditLogItems.stream().findFirst().orElseThrow();
+    assertProcessInstanceAuditLog(
+        auditLog,
+        AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+        AuditLogOperationTypeEnum.SUSPEND,
+        processInstanceKey,
+        processInstance.getProcessDefinitionKey(),
+        SERVICE_TASKS_PROCESS_ID);
   }
 
   @Test
-  @Disabled(
-      "Blocked on the process-instance SUSPEND/RESUME REST endpoint and CamundaClient command "
-          + "(tracked by phase issue https://github.com/camunda/camunda/issues/57508); "
-          + "CamundaClient has no newResumeProcessInstanceCommand yet, so a real test body "
-          + "would not compile. Enable once the client command lands.")
   void shouldTrackProcessInstanceResumption(
       @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
-    // TODO(#57508): once client.newResumeProcessInstanceCommand(processInstanceKey) exists,
-    // mirror shouldTrackProcessInstanceCancellation above: start and suspend a process instance,
-    // send the resume command, then assert an AuditLogOperationTypeEnum.RESUME entry for
-    // AuditLogEntityTypeEnum.PROCESS_INSTANCE via awaitAuditLogEntry(...) +
-    // assertProcessInstanceAuditLog(...).
+    // given - start and suspend a process instance
+    final var processInstance = createProcessInstance(client, SERVICE_TASKS_PROCESS_ID);
+    final var processInstanceKey = processInstance.getProcessInstanceKey();
+
+    waitForProcessInstancesToStart(
+        client, f -> f.processInstanceKey(processInstanceKey).tenantId(TENANT_A), 1);
+
+    client.newSuspendProcessInstanceCommand(processInstanceKey).send().join();
+
+    // when - resume the process instance
+    client.newResumeProcessInstanceCommand(processInstanceKey).send().join();
+
+    // then - wait for audit log entry and verify
+    final var auditLogItems =
+        awaitAuditLogEntry(
+            client,
+            AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+            AuditLogOperationTypeEnum.RESUME,
+            String.valueOf(processInstanceKey));
+
+    assertThat(auditLogItems).isNotEmpty();
+    final var auditLog = auditLogItems.stream().findFirst().orElseThrow();
+    assertProcessInstanceAuditLog(
+        auditLog,
+        AuditLogEntityTypeEnum.PROCESS_INSTANCE,
+        AuditLogOperationTypeEnum.RESUME,
+        processInstanceKey,
+        processInstance.getProcessDefinitionKey(),
+        SERVICE_TASKS_PROCESS_ID);
   }
 
   // ========================================================================================

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/AuditLogInfo.java
@@ -115,6 +115,10 @@ public record AuditLogInfo(
           // ProcessInstance
           Map.entry(ProcessInstanceIntent.CANCELING, AuditLogOperationType.CANCEL),
           Map.entry(ProcessInstanceIntent.CANCEL, AuditLogOperationType.CANCEL),
+          Map.entry(ProcessInstanceIntent.SUSPENDED, AuditLogOperationType.SUSPEND),
+          Map.entry(ProcessInstanceIntent.SUSPEND, AuditLogOperationType.SUSPEND),
+          Map.entry(ProcessInstanceIntent.RESUMED, AuditLogOperationType.RESUME),
+          Map.entry(ProcessInstanceIntent.RESUME, AuditLogOperationType.RESUME),
 
           // ProcessInstanceMigration
           Map.entry(ProcessInstanceMigrationIntent.MIGRATED, AuditLogOperationType.MIGRATE),

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerConfigs.java
@@ -131,6 +131,12 @@ public class AuditLogTransformerConfigs {
           .withIntents(ProcessInstanceIntent.CANCELING)
           .withRejections(ProcessInstanceIntent.CANCEL, RejectionType.INVALID_STATE);
 
+  public static final TransformerConfig PROCESS_INSTANCE_SUSPEND_RESUME_CONFIG =
+      TransformerConfig.with(ValueType.PROCESS_INSTANCE)
+          .withIntents(ProcessInstanceIntent.SUSPENDED, ProcessInstanceIntent.RESUMED)
+          .withRejections(ProcessInstanceIntent.SUSPEND, ProcessInstanceIntent.RESUME)
+          .withRejectionTypes(RejectionType.INVALID_STATE);
+
   public static final TransformerConfig PROCESS_INSTANCE_CREATION_CONFIG =
       TransformerConfig.with(PROCESS_INSTANCE_CREATION)
           .withIntents(ProcessInstanceCreationIntent.CREATED);

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerRegistry.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/AuditLogTransformerRegistry.java
@@ -111,6 +111,7 @@ public final class AuditLogTransformerRegistry {
         ProcessInstanceCreationAuditLogTransformer::new,
         ProcessInstanceMigrationAuditLogTransformer::new,
         ProcessInstanceModificationAuditLogTransformer::new,
+        ProcessInstanceSuspendResumeAuditLogTransformer::new,
         UserTaskAuditLogTransformer::new,
         VariableAddUpdateAuditLogTransformer::new);
   }

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformer.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.auditlog.transformers;
+
+import static io.camunda.zeebe.exporter.common.auditlog.transformers.AuditLogTransformerConfigs.PROCESS_INSTANCE_SUSPEND_RESUME_CONFIG;
+
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+public class ProcessInstanceSuspendResumeAuditLogTransformer
+    implements AuditLogTransformer<ProcessInstanceRecordValue> {
+
+  @Override
+  public TransformerConfig config() {
+    return PROCESS_INSTANCE_SUSPEND_RESUME_CONFIG;
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
@@ -104,10 +104,10 @@ class ProcessInstanceSuspendResumeAuditLogTransformerTest {
                     .withIntent(ProcessInstanceIntent.SUSPEND)
                     .withValue(recordValue));
 
-    // when
-    final var log = transformer.create(record);
+    // when / then
+    assertThat(transformer.supports(record)).isTrue();
 
-    // then
+    final var log = transformer.create(record);
     assertThat(log.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
     assertThat(log.getResult())
         .isEqualTo(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.auditlog.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
 import io.camunda.zeebe.protocol.record.Record;
@@ -109,7 +110,6 @@ class ProcessInstanceSuspendResumeAuditLogTransformerTest {
 
     final var log = transformer.create(record);
     assertThat(log.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
-    assertThat(log.getResult())
-        .isEqualTo(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
+    assertThat(log.getResult()).isEqualTo(AuditLogOperationResult.FAIL);
   }
 }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.common.auditlog.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
+import io.camunda.zeebe.exporter.common.auditlog.AuditLogEntry;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceSuspendResumeAuditLogTransformerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ProcessInstanceSuspendResumeAuditLogTransformer transformer =
+      new ProcessInstanceSuspendResumeAuditLogTransformer();
+
+  @Test
+  void shouldTransformProcessInstanceSuspendedRecord() {
+    // given
+    final ProcessInstanceRecordValue recordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withProcessDefinitionKey(123L)
+            .withBpmnProcessId("bpmn-process-id")
+            .withProcessInstanceKey(234L)
+            .withTenantId("tenant-1")
+            .build();
+
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r -> r.withIntent(ProcessInstanceIntent.SUSPENDED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getProcessDefinitionId()).isEqualTo("bpmn-process-id");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(123L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(234L);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
+    assertThat(entity.getRootProcessInstanceKey())
+        .isPositive()
+        .isEqualTo(record.getValue().getRootProcessInstanceKey());
+  }
+
+  @Test
+  void shouldTransformProcessInstanceResumedRecord() {
+    // given
+    final ProcessInstanceRecordValue recordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withProcessDefinitionKey(123L)
+            .withBpmnProcessId("bpmn-process-id")
+            .withProcessInstanceKey(234L)
+            .withTenantId("tenant-1")
+            .build();
+
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r -> r.withIntent(ProcessInstanceIntent.RESUMED).withValue(recordValue));
+
+    // when
+    final var entity = AuditLogEntry.of(record);
+    transformer.transform(record, entity);
+
+    // then
+    assertThat(entity.getProcessDefinitionId()).isEqualTo("bpmn-process-id");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(123L);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(234L);
+    assertThat(entity.getOperationType()).isEqualTo(AuditLogOperationType.RESUME);
+  }
+
+  @Test
+  void shouldTransformRejectedSuspendCommand() {
+    // given
+    final ProcessInstanceRecordValue recordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withProcessInstanceKey(234L)
+            .build();
+
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.COMMAND_REJECTION)
+                    .withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.SUSPEND)
+                    .withValue(recordValue));
+
+    // when
+    final var log = transformer.create(record);
+
+    // then
+    assertThat(log.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
+    assertThat(log.getResult())
+        .isEqualTo(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.FAIL);
+  }
+}

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/auditlog/transformers/ProcessInstanceSuspendResumeAuditLogTransformerTest.java
@@ -112,4 +112,30 @@ class ProcessInstanceSuspendResumeAuditLogTransformerTest {
     assertThat(log.getOperationType()).isEqualTo(AuditLogOperationType.SUSPEND);
     assertThat(log.getResult()).isEqualTo(AuditLogOperationResult.FAIL);
   }
+
+  @Test
+  void shouldTransformRejectedResumeCommand() {
+    // given
+    final ProcessInstanceRecordValue recordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withProcessInstanceKey(234L)
+            .build();
+
+    final Record<ProcessInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.COMMAND_REJECTION)
+                    .withRejectionType(RejectionType.INVALID_STATE)
+                    .withIntent(ProcessInstanceIntent.RESUME)
+                    .withValue(recordValue));
+
+    // when / then
+    assertThat(transformer.supports(record)).isTrue();
+
+    final var log = transformer.create(record);
+    assertThat(log.getOperationType()).isEqualTo(AuditLogOperationType.RESUME);
+    assertThat(log.getResult()).isEqualTo(AuditLogOperationResult.FAIL);
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessInstanceCan
 import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessInstanceCreationAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessInstanceMigrationAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessInstanceModificationAuditLogTransformer;
+import io.camunda.zeebe.exporter.common.auditlog.transformers.ProcessInstanceSuspendResumeAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.ResourceAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.RoleAuditLogTransformer;
 import io.camunda.zeebe.exporter.common.auditlog.transformers.RoleEntityAuditLogTransformer;
@@ -132,6 +133,8 @@ class RdbmsExporterWrapperTest {
             Map.entry(
                 ProcessInstanceModificationAuditLogTransformer.class,
                 ValueType.PROCESS_INSTANCE_MODIFICATION),
+            Map.entry(
+                ProcessInstanceSuspendResumeAuditLogTransformer.class, ValueType.PROCESS_INSTANCE),
             Map.entry(ProcessAuditLogTransformer.class, ValueType.PROCESS),
             Map.entry(ResourceAuditLogTransformer.class, ValueType.RESOURCE),
             Map.entry(RoleAuditLogTransformer.class, ValueType.ROLE),


### PR DESCRIPTION
## Description

Adds audit-log coverage for `ProcessInstanceIntent.SUSPEND`/`SUSPENDED`/`RESUME`/`RESUMED` (and their rejections), modeled on the existing `ProcessInstanceCancelAuditLogTransformer` (same record value type, no custom `transform()` needed) and `BatchOperationLifecycleManagementAuditLogTransformer` (combining a suspend+resume pair into one `TransformerConfig`).

- New `PROCESS_INSTANCE_SUSPEND_RESUME_CONFIG` in `AuditLogTransformerConfigs`, covering `SUSPENDED`/`RESUMED` events and `SUSPEND`/`RESUME` rejections (`RejectionType.INVALID_STATE`)
- New `ProcessInstanceSuspendResumeAuditLogTransformer` implementing `AuditLogTransformer<ProcessInstanceRecordValue>`
- Registered in `AuditLogTransformerRegistry`'s all-partition (instance-scoped) transformer list
- 4 new `AuditLogInfo.OPERATION_TYPE_MAP` entries (`SUSPEND`/`SUSPENDED` → `SUSPEND`, `RESUME`/`RESUMED` → `RESUME`)
- Unit tests modeled on `ProcessInstanceCancelAuditLogTransformerTest`/`BatchOperationLifecycleManagementAuditLogTransformerTest`, covering both the success and rejection path for each operation
- Real, passing acceptance tests in `AuditLogProcessOperationsIT` (`shouldTrackProcessInstanceSuspension`, `shouldTrackProcessInstanceResumption`), using `CamundaClient.newSuspendProcessInstanceCommand`/`newResumeProcessInstanceCommand`, run against real Testcontainers-backed ES/OS/RDBMS (22/22 passing in the full class)
- Fixed `RdbmsExporterWrapperTest`'s hardcoded expected-transformer map to include the new transformer (its ES/OS sibling test derives this dynamically from the registry; this one didn't, so it needed a matching update)

**Scope decision:** only `RejectionType.INVALID_STATE` is registered, matching existing `PROCESS_INSTANCE_CANCEL_CONFIG`/`USER_TASK_CONFIG`/`INCIDENT_RESOLUTION_CONFIG` precedent. The real suspend/resume engine processors mostly reject with `NOT_FOUND` for a missing/terminating instance — that rejection path will not produce an audit entry, same known gap `CANCEL` already has. This was a deliberate call, not an oversight.

No per-backend split needed: `DefaultExporterResourceProvider` (ES/OS) and `RdbmsExporterWrapper` (RDBMS) both consume `AuditLogTransformerRegistry.createAllPartitionTransformers()`, so the single transformer covers both.

## Checklist
- [ ] Enable backports when necessary (n/a — feature, not a bug fix)
- [ ] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite

## Related issues

closes #57610