### PR TITLE
feat: add single-instance suspend/resume commands to CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -76,6 +76,7 @@ import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResolveProcessInstanceIncidentsCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
+import io.camunda.client.api.command.ResumeProcessInstanceCommandStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
@@ -450,6 +451,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   SuspendProcessInstanceCommandStep1 newSuspendProcessInstanceCommand(long processInstanceKey);
+
+  /**
+   * Command to resume a process instance.
+   *
+   * <pre>
+   * camundaClient
+   *  .newResumeProcessInstanceCommand(processInstanceKey)
+   *  .send();
+   * </pre>
+   *
+   * @param processInstanceKey the key which identifies the corresponding process instance
+   * @return a builder for the command
+   */
+  ResumeProcessInstanceCommandStep1 newResumeProcessInstanceCommand(long processInstanceKey);
 
   /**
    * Command to delete a process instance history.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -79,6 +79,7 @@ import io.camunda.client.api.command.ResumeBatchOperationStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
+import io.camunda.client.api.command.SuspendProcessInstanceCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableDeletionCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
@@ -435,6 +436,20 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   CancelProcessInstanceCommandStep1 newCancelInstanceCommand(long processInstanceKey);
+
+  /**
+   * Command to suspend a process instance.
+   *
+   * <pre>
+   * camundaClient
+   *  .newSuspendProcessInstanceCommand(processInstanceKey)
+   *  .send();
+   * </pre>
+   *
+   * @param processInstanceKey the key which identifies the corresponding process instance
+   * @return a builder for the command
+   */
+  SuspendProcessInstanceCommandStep1 newSuspendProcessInstanceCommand(long processInstanceKey);
 
   /**
    * Command to delete a process instance history.

--- a/clients/java/src/main/java/io/camunda/client/api/command/ResumeProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ResumeProcessInstanceCommandStep1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.ResumeProcessInstanceResponse;
+
+public interface ResumeProcessInstanceCommandStep1
+    extends CommandWithOperationReferenceStep<ResumeProcessInstanceCommandStep1>,
+        FinalCommandStep<ResumeProcessInstanceResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/command/SuspendProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/SuspendProcessInstanceCommandStep1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.SuspendProcessInstanceResponse;
+
+public interface SuspendProcessInstanceCommandStep1
+    extends CommandWithOperationReferenceStep<SuspendProcessInstanceCommandStep1>,
+        FinalCommandStep<SuspendProcessInstanceResponse> {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ResumeProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ResumeProcessInstanceResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface ResumeProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/client/api/response/SuspendProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/SuspendProcessInstanceResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface SuspendProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -85,6 +85,7 @@ import io.camunda.client.api.command.ResetClockCommandStep1;
 import io.camunda.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.client.api.command.ResolveProcessInstanceIncidentsCommandStep1;
 import io.camunda.client.api.command.ResumeBatchOperationStep1;
+import io.camunda.client.api.command.ResumeProcessInstanceCommandStep1;
 import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.StreamJobsCommandStep1;
@@ -279,6 +280,7 @@ import io.camunda.client.impl.command.ResetClockCommandImpl;
 import io.camunda.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.client.impl.command.ResolveProcessInstanceIncidentsCommandImpl;
 import io.camunda.client.impl.command.ResumeBatchOperationCommandImpl;
+import io.camunda.client.impl.command.ResumeProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.client.impl.command.StatusRequestImpl;
 import io.camunda.client.impl.command.StreamJobsCommandImpl;
@@ -772,6 +774,12 @@ public final class CamundaClientImpl implements CamundaClient {
       final long processInstanceKey) {
     return new SuspendProcessInstanceCommandImpl(
         processInstanceKey, config, httpClient, jsonMapper);
+  }
+
+  @Override
+  public ResumeProcessInstanceCommandStep1 newResumeProcessInstanceCommand(
+      final long processInstanceKey) {
+    return new ResumeProcessInstanceCommandImpl(processInstanceKey, config, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -89,6 +89,7 @@ import io.camunda.client.api.command.SetVariablesCommandStep1;
 import io.camunda.client.api.command.StatusRequestStep1;
 import io.camunda.client.api.command.StreamJobsCommandStep1;
 import io.camunda.client.api.command.SuspendBatchOperationStep1;
+import io.camunda.client.api.command.SuspendProcessInstanceCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableDeletionCommandStep1;
 import io.camunda.client.api.command.TenantScopedClusterVariableUpdateCommandStep1;
@@ -282,6 +283,7 @@ import io.camunda.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.client.impl.command.StatusRequestImpl;
 import io.camunda.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.client.impl.command.SuspendBatchOperationCommandImpl;
+import io.camunda.client.impl.command.SuspendProcessInstanceCommandImpl;
 import io.camunda.client.impl.command.TenantScopedCreateClusterVariableImpl;
 import io.camunda.client.impl.command.TenantScopedDeleteClusterVariableImpl;
 import io.camunda.client.impl.command.TenantScopedUpdateClusterVariableImpl;
@@ -763,6 +765,13 @@ public final class CamundaClientImpl implements CamundaClient {
         httpClient,
         config,
         jsonMapper);
+  }
+
+  @Override
+  public SuspendProcessInstanceCommandStep1 newSuspendProcessInstanceCommand(
+      final long processInstanceKey) {
+    return new SuspendProcessInstanceCommandImpl(
+        processInstanceKey, config, httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ResumeProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ResumeProcessInstanceCommandImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.ResumeProcessInstanceCommandStep1;
+import io.camunda.client.api.response.ResumeProcessInstanceResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.ResumeProcessInstanceResponseImpl;
+import io.camunda.client.protocol.rest.ResumeProcessInstanceRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ResumeProcessInstanceCommandImpl implements ResumeProcessInstanceCommandStep1 {
+
+  private final long processInstanceKey;
+  private final ResumeProcessInstanceRequest httpRequestObject;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ResumeProcessInstanceCommandImpl(
+      final long processInstanceKey,
+      final CamundaClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
+    this.processInstanceKey = processInstanceKey;
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    httpRequestObject = new ResumeProcessInstanceRequest();
+    requestTimeout(config.getDefaultRequestTimeout());
+  }
+
+  @Override
+  public ResumeProcessInstanceCommandStep1 operationReference(final long operationReference) {
+    httpRequestObject.setOperationReference(operationReference);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<ResumeProcessInstanceResponse> requestTimeout(
+      final Duration requestTimeout) {
+    ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<ResumeProcessInstanceResponse> send() {
+    final HttpCamundaFuture<ResumeProcessInstanceResponse> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/process-instances/" + processInstanceKey + "/resumption",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        ResumeProcessInstanceResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/SuspendProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/SuspendProcessInstanceCommandImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.command.SuspendProcessInstanceCommandStep1;
+import io.camunda.client.api.response.SuspendProcessInstanceResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.response.SuspendProcessInstanceResponseImpl;
+import io.camunda.client.protocol.rest.SuspendProcessInstanceRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class SuspendProcessInstanceCommandImpl implements SuspendProcessInstanceCommandStep1 {
+
+  private final long processInstanceKey;
+  private final SuspendProcessInstanceRequest httpRequestObject;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public SuspendProcessInstanceCommandImpl(
+      final long processInstanceKey,
+      final CamundaClientConfiguration config,
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper) {
+    this.processInstanceKey = processInstanceKey;
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    httpRequestObject = new SuspendProcessInstanceRequest();
+    requestTimeout(config.getDefaultRequestTimeout());
+  }
+
+  @Override
+  public SuspendProcessInstanceCommandStep1 operationReference(final long operationReference) {
+    httpRequestObject.setOperationReference(operationReference);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<SuspendProcessInstanceResponse> requestTimeout(
+      final Duration requestTimeout) {
+    ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<SuspendProcessInstanceResponse> send() {
+    final HttpCamundaFuture<SuspendProcessInstanceResponse> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/process-instances/" + processInstanceKey + "/suspension",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        SuspendProcessInstanceResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ResumeProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ResumeProcessInstanceResponseImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.ResumeProcessInstanceResponse;
+
+public class ResumeProcessInstanceResponseImpl implements ResumeProcessInstanceResponse {
+
+  public ResumeProcessInstanceResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/SuspendProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/SuspendProcessInstanceResponseImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.SuspendProcessInstanceResponse;
+
+public class SuspendProcessInstanceResponseImpl implements SuspendProcessInstanceResponse {
+
+  public SuspendProcessInstanceResponseImpl(final Void nothing) {}
+}

--- a/clients/java/src/test/java/io/camunda/client/process/rest/ResumeProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/ResumeProcessInstanceRestTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.process.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.ResumeProcessInstanceRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.junit.jupiter.api.Test;
+
+public class ResumeProcessInstanceRestTest extends ClientRestTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 123L;
+
+  @Test
+  public void shouldSendResumeCommand() {
+    // when
+    client.newResumeProcessInstanceCommand(PROCESS_INSTANCE_KEY).send().join();
+
+    // then
+    final ResumeProcessInstanceRequest request =
+        gatewayService.getLastRequest(ResumeProcessInstanceRequest.class);
+    assertThat(request).isNotNull();
+  }
+
+  @Test
+  public void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getResumeProcessInstanceUrl(PROCESS_INSTANCE_KEY),
+        () -> new ProblemDetail().title("Invalid state transition").status(409));
+
+    // when / then
+    assertThatThrownBy(
+            () -> client.newResumeProcessInstanceCommand(PROCESS_INSTANCE_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid state transition");
+  }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client
+        .newResumeProcessInstanceCommand(PROCESS_INSTANCE_KEY)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final ResumeProcessInstanceRequest request =
+        gatewayService.getLastRequest(ResumeProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/process/rest/SuspendProcessInstanceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/rest/SuspendProcessInstanceRestTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.process.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.SuspendProcessInstanceRequest;
+import io.camunda.client.util.ClientRestTest;
+import io.camunda.client.util.RestGatewayPaths;
+import org.junit.jupiter.api.Test;
+
+public class SuspendProcessInstanceRestTest extends ClientRestTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 123L;
+
+  @Test
+  public void shouldSendSuspendCommand() {
+    // when
+    client.newSuspendProcessInstanceCommand(PROCESS_INSTANCE_KEY).send().join();
+
+    // then
+    final SuspendProcessInstanceRequest request =
+        gatewayService.getLastRequest(SuspendProcessInstanceRequest.class);
+    assertThat(request).isNotNull();
+  }
+
+  @Test
+  public void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getSuspendProcessInstanceUrl(PROCESS_INSTANCE_KEY),
+        () -> new ProblemDetail().title("Invalid state transition").status(409));
+
+    // when / then
+    assertThatThrownBy(
+            () -> client.newSuspendProcessInstanceCommand(PROCESS_INSTANCE_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid state transition");
+  }
+
+  @Test
+  public void shouldSetOperationReference() {
+    // given
+    final int operationReference = 456;
+
+    // when
+    client
+        .newSuspendProcessInstanceCommand(PROCESS_INSTANCE_KEY)
+        .operationReference(operationReference)
+        .execute();
+
+    // then
+    final SuspendProcessInstanceRequest request =
+        gatewayService.getLastRequest(SuspendProcessInstanceRequest.class);
+    assertThat(request.getOperationReference()).isEqualTo(operationReference);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -80,6 +80,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/process-instances/%s/cancellation";
   private static final String URL_PROCESS_INSTANCE_DELETION =
       REST_API_PATH + "/process-instances/%s/deletion";
+  private static final String URL_PROCESS_INSTANCE_SUSPENSION =
+      REST_API_PATH + "/process-instances/%s/suspension";
   private static final String URL_PROCESS_INSTANCE_CALL_HIERARCHY =
       REST_API_PATH + "/process-instances/%s/call-hierarchy";
   private static final String URL_PROCESS_INSTANCE_SEQUENCE_FLOWS =
@@ -234,6 +236,10 @@ public class RestGatewayPaths {
 
   public static String getDeleteProcessInstanceUrl(final long processInstanceKey) {
     return String.format(URL_PROCESS_INSTANCE_DELETION, processInstanceKey);
+  }
+
+  public static String getSuspendProcessInstanceUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE_SUSPENSION, processInstanceKey);
   }
 
   public static String getBroadcastSignalUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -82,6 +82,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/process-instances/%s/deletion";
   private static final String URL_PROCESS_INSTANCE_SUSPENSION =
       REST_API_PATH + "/process-instances/%s/suspension";
+  private static final String URL_PROCESS_INSTANCE_RESUMPTION =
+      REST_API_PATH + "/process-instances/%s/resumption";
   private static final String URL_PROCESS_INSTANCE_CALL_HIERARCHY =
       REST_API_PATH + "/process-instances/%s/call-hierarchy";
   private static final String URL_PROCESS_INSTANCE_SEQUENCE_FLOWS =
@@ -240,6 +242,10 @@ public class RestGatewayPaths {
 
   public static String getSuspendProcessInstanceUrl(final long processInstanceKey) {
     return String.format(URL_PROCESS_INSTANCE_SUSPENSION, processInstanceKey);
+  }
+
+  public static String getResumeProcessInstanceUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE_RESUMPTION, processInstanceKey);
   }
 
   public static String getBroadcastSignalUrl() {


### PR DESCRIPTION
## Description

Adds `newSuspendProcessInstanceCommand(long)` and `newResumeProcessInstanceCommand(long)` to the Java
`CamundaClient`, against the already-merged OpenAPI contract (#57648):

- `POST /process-instances/{processInstanceKey}/suspension`
- `POST /process-instances/{processInstanceKey}/resumption`

Both are REST-only (no gRPC — there is no gRPC surface for this feature, and none is planned as part of
this task; a future task may add one), mirroring the existing `DeleteProcessInstanceCommand` pattern
(REST-only, `operationReference` support) rather than the dual REST/gRPC `CancelProcessInstanceCommand`.

Design spec: `docs/superpowers/specs/2026-07-16-process-instance-suspend-resume-client-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-16-process-instance-suspend-resume-client.md`

**Note for reviewers:** this task (#57531) is blocked-by #57530 (the REST endpoint implementation, still
open as #57870). This PR only depends on the already-merged OpenAPI contract's generated REST stubs, not
on the endpoint's runtime behavior, so it compiles and unit-tests independently — but it will only work
end-to-end once #57870 (or its eventual replacement) merges.

## Checklist

- [ ] Enable backports when necessary — not applicable, this is a new feature addition, not a bug fix.
- [ ] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

closes #57531