### PR TITLE
feat: add suspended state and suspendedDate to process-instance data model

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -592,4 +592,22 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_process_instance_suspended_date_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}PROCESS_INSTANCE" columnName="SUSPENDED_DATE"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}PROCESS_INSTANCE">
+      <column name="SUSPENDED_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
+    </addColumn>
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/process/instance/ProcessInstanceToolsTest.java
@@ -89,6 +89,7 @@ class ProcessInstanceToolsTest extends OperationalToolsTest {
           "tenant",
           "PI_123",
           Set.of("tag1", "tag2"),
+          null,
           null);
 
   static final SearchQueryResult<ProcessInstanceEntity> SEARCH_QUERY_RESULT =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformer.java
@@ -34,7 +34,8 @@ public class ProcessInstanceEntityTransformer
         source.getTenantId(),
         source.getTreePath(),
         source.getTags(),
-        emptyToNull(source.getBusinessId()));
+        emptyToNull(source.getBusinessId()),
+        source.getSuspendedDate());
   }
 
   private static String emptyToNull(final String value) {
@@ -51,6 +52,8 @@ public class ProcessInstanceEntityTransformer
         return ProcessInstanceState.ACTIVE;
       case COMPLETED:
         return ProcessInstanceState.COMPLETED;
+      case SUSPENDED:
+        return ProcessInstanceState.SUSPENDED;
       case CANCELED:
         return ProcessInstanceState.CANCELED;
       default:

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/ProcessInstanceEntityTransformerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import java.time.OffsetDateTime;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessInstanceEntityTransformerTest {
+
+  private final ProcessInstanceEntityTransformer transformer =
+      new ProcessInstanceEntityTransformer();
+
+  @Mock private ProcessInstanceForListViewEntity entityValue;
+
+  @BeforeEach
+  void setUp() {
+    when(entityValue.getKey()).thenReturn(123L);
+    when(entityValue.getBpmnProcessId()).thenReturn("demoProcess");
+    when(entityValue.getProcessName()).thenReturn("Demo Process");
+    when(entityValue.getProcessVersion()).thenReturn(1);
+    when(entityValue.getProcessDefinitionKey()).thenReturn(456L);
+    when(entityValue.getStartDate()).thenReturn(OffsetDateTime.now());
+    when(entityValue.getState())
+        .thenReturn(io.camunda.webapps.schema.entities.listview.ProcessInstanceState.ACTIVE);
+    when(entityValue.isIncident()).thenReturn(false);
+    when(entityValue.getTenantId()).thenReturn("tenant");
+    when(entityValue.getTags()).thenReturn(Set.of());
+  }
+
+  @Test
+  void shouldMapSuspendedDate() {
+    // given
+    final var suspendedDate = OffsetDateTime.parse("2026-07-16T00:00:00Z");
+    when(entityValue.getSuspendedDate()).thenReturn(suspendedDate);
+
+    // when
+    final var transformed = transformer.apply(entityValue);
+
+    // then
+    assertThat(transformed.suspendedDate()).isEqualTo(suspendedDate);
+  }
+
+  @Test
+  void shouldMapNullSuspendedDate() {
+    // given
+    when(entityValue.getSuspendedDate()).thenReturn(null);
+
+    // when
+    final var transformed = transformer.apply(entityValue);
+
+    // then
+    assertThat(transformed.suspendedDate()).isNull();
+  }
+
+  @Test
+  void shouldMapSuspendedState() {
+    // given
+    when(entityValue.getState())
+        .thenReturn(io.camunda.webapps.schema.entities.listview.ProcessInstanceState.SUSPENDED);
+
+    // when
+    final var transformed = transformer.apply(entityValue);
+
+    // then
+    assertThat(transformed.state()).isEqualTo(ProcessInstanceState.SUSPENDED);
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -43,7 +43,9 @@ public record ProcessInstanceEntity(
     String tenantId,
     @Nullable String treePath,
     Set<String> tags,
-    @Nullable String businessId)
+    @Nullable String businessId,
+    // not set by the primary handler; populated once the exporter/appliers for SUSPEND/RESUME land.
+    @Nullable OffsetDateTime suspendedDate)
     implements TenantOwnedEntity {
 
   public ProcessInstanceEntity {
@@ -90,7 +92,8 @@ public record ProcessInstanceEntity(
         tenantId,
         treePath,
         new HashSet<>(),
-        businessId);
+        businessId,
+        null);
   }
 
   public enum ProcessInstanceState {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/ListViewTemplate.java
@@ -59,6 +59,7 @@ public class ListViewTemplate extends AbstractTemplateDescriptor implements Prio
   public static final String TAGS = "tags";
   public static final String ROOT_PROCESS_INSTANCE_KEY = "rootProcessInstanceKey";
   public static final String BUSINESS_ID = "businessId";
+  public static final String SUSPENDED_DATE = "suspendedDate";
 
   public ListViewTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -69,6 +69,11 @@ public class ProcessInstanceForListViewEntity
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String businessId;
 
+  /** Attention! This field will be filled in only for data imported after v. 8.10.0. */
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private OffsetDateTime suspendedDate;
+
   @JsonIgnore private Object[] sortValues;
 
   @Override
@@ -296,6 +301,15 @@ public class ProcessInstanceForListViewEntity
     return this;
   }
 
+  public OffsetDateTime getSuspendedDate() {
+    return suspendedDate;
+  }
+
+  public ProcessInstanceForListViewEntity setSuspendedDate(final OffsetDateTime suspendedDate) {
+    this.suspendedDate = suspendedDate;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -320,7 +334,8 @@ public class ProcessInstanceForListViewEntity
         position,
         tags,
         rootProcessInstanceKey,
-        businessId);
+        businessId,
+        suspendedDate);
   }
 
   @Override
@@ -353,6 +368,7 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(joinRelation, that.joinRelation)
         && Objects.equals(position, that.position)
         && Objects.equals(tags, that.tags)
-        && Objects.equals(businessId, that.businessId);
+        && Objects.equals(businessId, that.businessId)
+        && Objects.equals(suspendedDate, that.suspendedDate);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceState.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceState.java
@@ -10,5 +10,6 @@ package io.camunda.webapps.schema.entities.listview;
 public enum ProcessInstanceState {
   ACTIVE,
   COMPLETED,
+  SUSPENDED,
   CANCELED
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -148,6 +148,10 @@
       },
       "businessId": {
         "type": "keyword"
+      },
+      "suspendedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
       }
 		}
 	}

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
@@ -149,6 +149,10 @@
       },
       "businessId": {
         "type": "keyword"
+      },
+      "suspendedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
       }
 		}
 	}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/AbstractBatchOperationTest.java
@@ -400,7 +400,8 @@ abstract class AbstractBatchOperationTest {
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
         null, // treePath
         Set.of(), // tags
-        null); // businessId
+        null, // businessId
+        null); // suspendedDate
   }
 
   protected IncidentEntity fakeIncidentEntity(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -1563,7 +1563,8 @@ public class ResourceDeletionTest {
         TenantOwned.DEFAULT_TENANT_IDENTIFIER,
         null, // treePath
         Set.of(), // tags
-        null); // businessId
+        null, // businessId
+        null); // suspendedDate
   }
 
   private DecisionInstanceEntity createDecisionInstanceEntity(final long decisionInstanceKey) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -92,7 +92,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           "tenant",
           "PI_123",
           Set.of("tag1", "tag2"),
-          "biz-id");
+          "biz-id",
+          null);
   private static final String PROCESS_INSTANCE_ENTITY_JSON =
       """
             {
@@ -767,6 +768,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             false,
             "tenant",
             "PI_456",
+            null,
             null,
             null);
     when(processInstanceServices.getByKey(eq(processInstanceKey), any(CamundaAuthentication.class)))


### PR DESCRIPTION
## Description

Foundation/unblocker work for the "Suspend & Resume Process Instances" epic: adds a `suspended` boolean flag and `suspendedDate` timestamp to the process-instance data model, and expands `ProcessInstanceState` with a `SUSPENDED` value.

Scope, purely additive:
- **webapps-schema (ES/OS):** `SUSPENDED` added to `ProcessInstanceState`; `suspended`/`suspendedDate` added to `ListViewTemplate` constants, `ProcessInstanceForListViewEntity`, and both ES/OS `operate-list-view.json` index mappings.
- **RDBMS:** Liquibase adds `SUSPENDED`/`SUSPENDED_DATE` columns to `PROCESS_INSTANCE` (`8.10.0.xml`) — schema-only, no Java wiring, matching this repo's existing nullable/no-default `addColumn` convention.
- **search-domain:** `ProcessInstanceEntity` gains the two fields on its canonical constructor; the legacy 16-arg constructor's signature is untouched (verified: RDBMS's `ProcessInstanceMapper.xml` and one existing test already resolve to that legacy constructor, so they need no changes). `ProcessInstanceEntityTransformer` (ES/OS read path) is wired end-to-end with a new TDD-driven test.

Deliberately out of scope (left for other epic issues):
- Any exporter/processor logic that sets these fields at runtable (`#57518`, `#57525`).
- REST DTO (`ProcessInstanceResult`) mapping in `gateway-mapping-http` — blocked on the OpenAPI contract PR (#57648), which isn't merged yet, so the corresponding builder methods don't exist.
- Filter/sort/query-DSL support for the new fields.

Full design rationale and scope boundaries: `docs/superpowers/specs/2026-07-16-process-instance-suspended-state-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-16-process-instance-suspended-state.md`.

## Checklist

- [ ] Enable backports when necessary — not applicable, this is a new schema/model addition, not a bug fix.
- [ ] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

closes #57516