### PR TITLE
fix: make process test container startup timeout configurable

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -31,6 +31,7 @@ import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CAMUNDA_
 import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_MIN_HISTORY_CLEANUP_INTERVAL;
 import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME;
 
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs;
 import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
 import java.net.URI;
@@ -47,7 +48,6 @@ import org.testcontainers.utility.DockerImageName;
 
 public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
-  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
   private static final Duration DEFAULT_READINESS_TIMEOUT = Duration.ofSeconds(10);
 
   private static final String READY_ENDPOINT = "/actuator/health/status";
@@ -206,14 +206,14 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
         .withStrategy(newDefaultBrokerReadyCheck())
         .withStrategy(newDefaultTopologyReadyCheck())
-        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+        .withStartupTimeout(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
   }
 
   private WaitAllStrategy newBasicAuthWaitStrategy() {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
         .withStrategy(newBasicAuthBrokerReadyCheck())
         .withStrategy(newBasicAuthTopologyReadyCheck())
-        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+        .withStartupTimeout(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
   }
 
   public int getGrpcApiPort() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
@@ -19,6 +19,7 @@ import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CONNECTO
 import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CONNECTORS_ENV_CAMUNDA_CLIENT_REST_ADDRESS;
 import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CONNECTORS_ENV_SECRET_PREFIX;
 
+import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs;
 import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
 import java.net.URI;
@@ -32,8 +33,6 @@ import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
 import org.testcontainers.utility.DockerImageName;
 
 public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
-
-  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
 
   private static final String DEFAULT_CONNECTOR_POLLING_INTERVAL_IN_MILLIS = "500";
 
@@ -109,14 +108,14 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
         .withStrategy(new HostPortWaitStrategy())
         .withStrategy(newBasicAuthConnectorsReadyCheck())
-        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+        .withStartupTimeout(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
   }
 
   private WaitAllStrategy newDefaultWaitStrategy() {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
         .withStrategy(new HostPortWaitStrategy())
         .withStrategy(newDefaultConnectorsReadyCheck())
-        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+        .withStartupTimeout(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
   }
 
   public int getRestApiPort() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntime.java
@@ -166,6 +166,7 @@ public class CamundaProcessTestContainerRuntime
       container.withMultiTenancy();
     }
 
+    container.withStartupTimeout(builder.getContainerStartupTimeout());
     container.withEnv(builder.getCamundaEnvVars());
     builder.getCamundaExposedPorts().forEach(container::addExposedPort);
 
@@ -193,6 +194,7 @@ public class CamundaProcessTestContainerRuntime
       container.withMultiTenancy();
     }
 
+    container.withStartupTimeout(builder.getContainerStartupTimeout());
     container.withEnv(builder.getConnectorsEnvVars());
     builder.getConnectorsExposedPorts().forEach(container::addExposedPort);
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -91,6 +91,9 @@ public class CamundaProcessTestRuntimeBuilder {
   private Duration remoteRuntimeConnectionTimeout =
       CamundaProcessTestRuntimeDefaults.REMOTE_RUNTIME_CONNECTION_TIMEOUT;
 
+  private Duration containerStartupTimeout =
+      CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT;
+
   private boolean isMultiTenancyEnabled = CamundaProcessTestRuntimeDefaults.MULTI_TENANCY_ENABLED;
 
   private String coverageReportDirectory =
@@ -253,6 +256,12 @@ public class CamundaProcessTestRuntimeBuilder {
   public CamundaProcessTestRuntimeBuilder withRemoteRuntimeConnectionTimeout(
       final Duration remoteRuntimeConnectionTimeout) {
     this.remoteRuntimeConnectionTimeout = remoteRuntimeConnectionTimeout;
+    return this;
+  }
+
+  public CamundaProcessTestRuntimeBuilder withContainerStartupTimeout(
+      final Duration containerStartupTimeout) {
+    this.containerStartupTimeout = containerStartupTimeout;
     return this;
   }
 
@@ -435,6 +444,10 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public Duration getRemoteRuntimeConnectionTimeout() {
     return remoteRuntimeConnectionTimeout;
+  }
+
+  public Duration getContainerStartupTimeout() {
+    return containerStartupTimeout;
   }
 
   public String getCoverageReportDirectory() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeDefaults.java
@@ -44,6 +44,7 @@ public class CamundaProcessTestRuntimeDefaults {
   public static final URI LOCAL_CONNECTORS_REST_API_ADDRESS = URI.create("http://0.0.0.0:8086");
 
   public static final Duration DEFAULT_REMOTE_RUNTIME_CONNECTION_TIMEOUT = Duration.ofMinutes(1);
+  public static final Duration DEFAULT_CONTAINER_STARTUP_TIMEOUT = Duration.ofMinutes(1);
 
   public static final String DEFAULT_COVERAGE_REPORT_DIRECTORY = "target/coverage-report";
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestContainerRuntimeTest.java
@@ -27,6 +27,7 @@ import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -136,6 +137,26 @@ public class CamundaProcessTestContainerRuntimeTest {
         .createConnectorsContainer(
             CamundaProcessTestRuntimeDefaults.CONNECTORS_DOCKER_IMAGE_NAME,
             CamundaProcessTestRuntimeDefaults.CONNECTORS_DOCKER_IMAGE_VERSION);
+    verify(camundaContainer)
+        .withStartupTimeout(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
+    verify(connectorsContainer)
+        .withStartupTimeout(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
+  }
+
+  @Test
+  void shouldConfigureContainerStartupTimeout() {
+    // given
+    final Duration startupTimeout = Duration.ofMinutes(2);
+
+    // when
+    CamundaProcessTestContainerRuntime.newBuilder()
+        .withContainerFactory(containerFactory)
+        .withContainerStartupTimeout(startupTimeout)
+        .build();
+
+    // then
+    verify(camundaContainer).withStartupTimeout(startupTimeout);
+    verify(connectorsContainer).withStartupTimeout(startupTimeout);
   }
 
   @Test

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.configuration;
 
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,9 @@ public class CamundaProcessTestRuntimeConfiguration {
       CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_LOGGER_NAME;
 
   private boolean multiTenancyEnabled = false;
+
+  private Duration containerStartupTimeout =
+      CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT;
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
 
@@ -232,6 +236,14 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   public void setMultiTenancyEnabled(final boolean multiTenancyEnabled) {
     this.multiTenancyEnabled = multiTenancyEnabled;
+  }
+
+  public Duration getContainerStartupTimeout() {
+    return containerStartupTimeout;
+  }
+
+  public void setContainerStartupTimeout(final Duration containerStartupTimeout) {
+    this.containerStartupTimeout = containerStartupTimeout;
   }
 
   public CoverageReportConfiguration getCoverage() {

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/runtime/CamundaSpringProcessTestRuntimeBuilder.java
@@ -48,6 +48,7 @@ public class CamundaSpringProcessTestRuntimeBuilder {
         .withCamundaDockerImageName(runtimeConfiguration.getCamundaDockerImageName())
         .withCamundaEnv(runtimeConfiguration.getCamundaEnvVars())
         .withCamundaLogger(runtimeConfiguration.getCamundaLoggerName())
+        .withContainerStartupTimeout(runtimeConfiguration.getContainerStartupTimeout())
         .withMultiTenancyEnabled(runtimeConfiguration.isMultiTenancyEnabled());
 
     runtimeConfiguration.getCamundaExposedPorts().forEach(runtimeBuilder::withCamundaExposedPort);

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/CamundaSpringProcessTestRuntimeBuilderTest.java
@@ -75,6 +75,8 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
         .isEqualTo(CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION);
     assertThat(runtimeBuilder.getCamundaEnvVars()).isEmpty();
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEmpty();
+    assertThat(runtimeBuilder.getContainerStartupTimeout())
+        .isEqualTo(CamundaProcessTestRuntimeDefaults.DEFAULT_CONTAINER_STARTUP_TIMEOUT);
 
     assertThat(runtimeBuilder.isConnectorsEnabled()).isFalse();
   }
@@ -101,6 +103,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     runtimeConfiguration.setCamundaExposedPorts(camundaExposedPorts);
     runtimeConfiguration.setCamundaLoggerName("io.camunda.custom.logger.name");
     runtimeConfiguration.setConnectorsLoggerName("io.camunda.custom.logger.name");
+    runtimeConfiguration.setContainerStartupTimeout(Duration.ofMinutes(2));
 
     // when
     CamundaSpringProcessTestRuntimeBuilder.buildRuntime(runtimeBuilder, runtimeConfiguration);
@@ -112,6 +115,7 @@ public class CamundaSpringProcessTestRuntimeBuilderTest {
     assertThat(runtimeBuilder.getCamundaExposedPorts()).isEqualTo(camundaExposedPorts);
     assertThat(runtimeBuilder.getCamundaLoggerName()).isEqualTo("io.camunda.custom.logger.name");
     assertThat(runtimeBuilder.getConnectorsLoggerName()).isEqualTo("io.camunda.custom.logger.name");
+    assertThat(runtimeBuilder.getContainerStartupTimeout()).isEqualTo(Duration.ofMinutes(2));
   }
 
   @ParameterizedTest

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/CamundaProcessTestDefaultConfigurationTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/impl/config/CamundaProcessTestDefaultConfigurationTest.java
@@ -233,6 +233,7 @@ public class CamundaProcessTestDefaultConfigurationTest {
         "camunda.process-test.connectors-enabled=true",
         "camunda.process-test.camunda-docker-image-version=8.8.0-new",
         "camunda.process-test.camunda-docker-image-name=camunda/camunda-new",
+        "camunda.process-test.container-startup-timeout=PT2M",
         "io.camunda.process.test.camunda-docker-image-name=camunda/camunda-legacy",
       })
   class ShouldApplyRuntimeConfigurationWithNewPrefix {
@@ -244,6 +245,7 @@ public class CamundaProcessTestDefaultConfigurationTest {
       assertThat(configuration.isConnectorsEnabled()).isTrue();
       assertThat(configuration.getCamundaDockerImageVersion()).isEqualTo("8.8.0-new");
       assertThat(configuration.getCamundaDockerImageName()).isEqualTo("camunda/camunda-new");
+      assertThat(configuration.getContainerStartupTimeout()).isEqualTo(Duration.ofMinutes(2));
     }
   }
 


### PR DESCRIPTION
## Description

Camunda Process Test currently hard-codes a one-minute managed-container startup timeout. Consumers cannot distinguish a legitimately slow startup on constrained CI infrastructure from a hung container without replacing CPT's container setup.

Expose the timeout through both supported configuration surfaces while preserving the one-minute default:

```properties
camunda.process-test.container-startup-timeout=PT2M
```

```java
CamundaProcessTestContainerRuntime.newBuilder()
    .withContainerStartupTimeout(Duration.ofMinutes(2))
    .build();
```

The configured timeout applies consistently to managed Camunda and Connectors containers. Focused tests cover the default, Spring property binding, Spring-to-runtime propagation, and application to both container types.

This was found while root-causing the last ten failed CI runs in `camunda/camunda-7-to-8-migration-tooling`. One run failed after Camunda's health and topology readiness checks exceeded the fixed 60-second window; retries are intentionally not part of the fix.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

Related to camunda/camunda-7-to-8-migration-tooling#1776
