### PR TITLE
feat: add ProcessInstanceBufferedCommandRecord protocol scaffolding

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.io.IOException;
@@ -178,7 +179,10 @@ public class EventAppliersTest {
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent));
+            .filter(intent -> !(intent instanceof CheckpointIntent))
+            // todo delete this filter once BUFFERED/DRAINED appliers are implemented
+            //  (https://github.com/camunda/camunda/issues/57506)
+            .filter(intent -> !(intent instanceof ProcessInstanceBufferedCommandIntent));
 
     // when
     eventAppliers.registerEventAppliers(mock(MutableProcessingState.class));

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -148,7 +148,8 @@ final class TestSupport {
             ValueType.EXPRESSION,
             ValueType.JOB_METRICS_BATCH,
             ValueType.RESOURCE_REEXPORT,
-            ValueType.SECRET_REFERENCE);
+            ValueType.SECRET_REFERENCE,
+            ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -149,7 +149,8 @@ final class TestSupport {
             ValueType.EXPRESSION,
             ValueType.JOB_METRICS_BATCH,
             ValueType.RESOURCE_REEXPORT,
-            ValueType.SECRET_REFERENCE);
+            ValueType.SECRET_REFERENCE,
+            ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.impl.record.value.multiinstance.MultiInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
@@ -186,6 +187,8 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.SIGNAL -> new SignalRecord();
       case ValueType.COMMAND_DISTRIBUTION -> new CommandDistributionRecord();
       case ValueType.PROCESS_INSTANCE_BATCH -> new ProcessInstanceBatchRecord();
+      case ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND ->
+          new ProcessInstanceBufferedCommandRecord();
       case ValueType.PROCESS_INSTANCE_BUSINESS_ID -> new ProcessInstanceBusinessIdRecord();
       case ValueType.RESOURCE_DELETION -> new ResourceDeletionRecord();
       case ValueType.FORM -> new FormRecord();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBufferedCommandRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBufferedCommandRecord.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordValue
+    implements ProcessInstanceBufferedCommandRecordValue {
+
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
+  private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
+  private static final StringValue INTENT_KEY = new StringValue("intent");
+  private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1);
+  private final StringProperty tenantIdProperty =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty elementInstanceKeyProperty =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1);
+  private final EnumProperty<ValueType> valueTypeProperty =
+      new EnumProperty<>(VALUE_TYPE_KEY, ValueType.class, ValueType.NULL_VAL);
+  private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
+  private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
+      new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+
+  private final MsgPackWriter commandValueWriter = new MsgPackWriter();
+  private final MsgPackReader commandValueReader = new MsgPackReader();
+
+  public ProcessInstanceBufferedCommandRecord() {
+    super(7);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(tenantIdProperty)
+        .declareProperty(elementInstanceKeyProperty)
+        .declareProperty(valueTypeProperty)
+        .declareProperty(intentProperty)
+        .declareProperty(commandValueProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setProcessDefinitionKey(
+      final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProperty.getValue());
+  }
+
+  public ProcessInstanceBufferedCommandRecord setTenantId(final String tenantId) {
+    tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setElementInstanceKey(final long elementInstanceKey) {
+    elementInstanceKeyProperty.setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return valueTypeProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setValueType(final ValueType valueType) {
+    valueTypeProperty.setValue(valueType);
+    return this;
+  }
+
+  @Override
+  public Intent getIntent() {
+    final int intentValue = intentProperty.getValue();
+    if (intentValue < 0 || intentValue > Short.MAX_VALUE) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to read the intent, but its persisted value '%d' is not a short integer",
+              intentValue));
+    }
+    return Intent.fromProtocolValue(getValueType(), (short) intentValue);
+  }
+
+  public ProcessInstanceBufferedCommandRecord setIntent(final Intent intent) {
+    intentProperty.setValue(intent.value());
+    return this;
+  }
+
+  @Override
+  public UnifiedRecordValue getCommandValue() {
+    final var valueType = getValueType();
+    if (valueType == ValueType.NULL_VAL) {
+      return null;
+    }
+
+    final var storedCommandValue = commandValueProperty.getValue();
+    if (storedCommandValue.isEmpty()) {
+      return storedCommandValue;
+    }
+
+    final var concreteCommandValue = UnifiedRecordValue.fromValueType(valueType);
+
+    final var commandValueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = storedCommandValue.getEncodedLength();
+    commandValueBuffer.wrap(new byte[encodedLength]);
+    storedCommandValue.write(commandValueWriter.wrap(commandValueBuffer, 0));
+
+    concreteCommandValue.wrap(commandValueBuffer);
+    return concreteCommandValue;
+  }
+
+  public ProcessInstanceBufferedCommandRecord setCommandValue(
+      final UnifiedRecordValue commandValue) {
+    if (commandValue == null) {
+      commandValueProperty.reset();
+      return this;
+    }
+
+    final var valueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = commandValue.getLength();
+    valueBuffer.wrap(new byte[encodedLength]);
+
+    commandValue.write(valueBuffer, 0);
+    commandValueProperty.getValue().read(commandValueReader.wrap(valueBuffer, 0, encodedLength));
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBufferedCommandRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBufferedCommandRecord.java
@@ -145,6 +145,12 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
     }
 
     final var concreteCommandValue = UnifiedRecordValue.fromValueType(valueType);
+    if (concreteCommandValue == null) {
+      throw new IllegalStateException(
+          "Expected to read the command value, but its value type `"
+              + valueType.name()
+              + "` has no known record value class");
+    }
 
     final var commandValueBuffer = new UnsafeBuffer(0, 0);
     final int encodedLength = storedCommandValue.getEncodedLength();

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -77,6 +77,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.impl.record.value.multiinstance.MultiInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
@@ -108,6 +109,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
@@ -2839,6 +2841,84 @@ final class JsonSerializableToJsonTest {
                   "intent": "UNKNOWN",
                   "commandValue": null,
                   "authInfo":{"format":"UNKNOWN","claims":{},"authData":""}
+                }
+                """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// ProcessInstanceBufferedCommandRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // ////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessInstanceBufferedCommandRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var commandValue =
+                  new ProcessInstanceRecord()
+                      .setProcessInstanceKey(1234)
+                      .setElementId("activity")
+                      .setBpmnElementType(BpmnElementType.SERVICE_TASK);
+
+              return new ProcessInstanceBufferedCommandRecord()
+                  .setProcessInstanceKey(1234)
+                  .setProcessDefinitionKey(13)
+                  .setTenantId("tenant-1")
+                  .setElementInstanceKey(5678)
+                  .setValueType(ValueType.PROCESS_INSTANCE)
+                  .setIntent(ProcessInstanceIntent.ACTIVATE_ELEMENT)
+                  .setCommandValue(commandValue);
+            },
+        """
+                {
+                  "processInstanceKey": 1234,
+                  "processDefinitionKey": 13,
+                  "tenantId": "tenant-1",
+                  "elementInstanceKey": 5678,
+                  "valueType": "PROCESS_INSTANCE",
+                  "intent": "ACTIVATE_ELEMENT",
+                  "commandValue": {
+                    "bpmnProcessId": "",
+                    "version": -1,
+                    "processDefinitionKey": -1,
+                    "processInstanceKey": 1234,
+                    "elementId": "activity",
+                    "flowScopeKey": -1,
+                    "bpmnElementType": "SERVICE_TASK",
+                    "parentProcessInstanceKey": -1,
+                    "parentElementInstanceKey": -1,
+                    "bpmnEventType": "UNSPECIFIED",
+                    "tenantId": "<default>",
+                    "elementInstancePath":[],
+                    "processDefinitionPath": [],
+                    "callingElementPath": [],
+                    "tags": [],
+                    "rootProcessInstanceKey": -1,
+                    "businessId": "",
+                    "elementInstanceKey": -1
+                  }
+                }
+                """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////// Empty ProcessInstanceBufferedCommandRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // ////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ProcessInstanceBufferedCommandRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> new ProcessInstanceBufferedCommandRecord().setProcessInstanceKey(1234),
+        """
+                {
+                  "processInstanceKey": 1234,
+                  "processDefinitionKey": -1,
+                  "tenantId": "<default>",
+                  "elementInstanceKey": -1,
+                  "valueType": "NULL_VAL",
+                  "intent": "UNKNOWN",
+                  "commandValue": null
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBufferedCommandRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBufferedCommandRecord.golden
@@ -27,13 +27,11 @@ import org.agrona.concurrent.UnsafeBuffer;
 public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordValue
     implements ProcessInstanceBufferedCommandRecordValue {
 
-  private static final StringValue PROCESS_INSTANCE_KEY_KEY =
-      new StringValue("processInstanceKey");
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
-  private static final StringValue ELEMENT_INSTANCE_KEY_KEY =
-      new StringValue("elementInstanceKey");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY = new StringValue("elementInstanceKey");
   private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
@@ -71,8 +69,7 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
     return processInstanceKeyProperty.getValue();
   }
 
-  public ProcessInstanceBufferedCommandRecord setProcessInstanceKey(
-      final long processInstanceKey) {
+  public ProcessInstanceBufferedCommandRecord setProcessInstanceKey(final long processInstanceKey) {
     processInstanceKeyProperty.setValue(processInstanceKey);
     return this;
   }
@@ -103,8 +100,7 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
     return elementInstanceKeyProperty.getValue();
   }
 
-  public ProcessInstanceBufferedCommandRecord setElementInstanceKey(
-      final long elementInstanceKey) {
+  public ProcessInstanceBufferedCommandRecord setElementInstanceKey(final long elementInstanceKey) {
     elementInstanceKeyProperty.setValue(elementInstanceKey);
     return this;
   }
@@ -149,6 +145,12 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
     }
 
     final var concreteCommandValue = UnifiedRecordValue.fromValueType(valueType);
+    if (concreteCommandValue == null) {
+      throw new IllegalStateException(
+          "Expected to read the command value, but its value type `"
+              + valueType.name()
+              + "` has no known record value class");
+    }
 
     final var commandValueBuffer = new UnsafeBuffer(0, 0);
     final int encodedLength = storedCommandValue.getEncodedLength();
@@ -159,7 +161,8 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
     return concreteCommandValue;
   }
 
-  public ProcessInstanceBufferedCommandRecord setCommandValue(final UnifiedRecordValue commandValue) {
+  public ProcessInstanceBufferedCommandRecord setCommandValue(
+      final UnifiedRecordValue commandValue) {
     if (commandValue == null) {
       commandValueProperty.reset();
       return this;

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBufferedCommandRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBufferedCommandRecord.golden
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordValue
+    implements ProcessInstanceBufferedCommandRecordValue {
+
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("processInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  private static final StringValue ELEMENT_INSTANCE_KEY_KEY =
+      new StringValue("elementInstanceKey");
+  private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
+  private static final StringValue INTENT_KEY = new StringValue("intent");
+  private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1);
+  private final StringProperty tenantIdProperty =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty elementInstanceKeyProperty =
+      new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1);
+  private final EnumProperty<ValueType> valueTypeProperty =
+      new EnumProperty<>(VALUE_TYPE_KEY, ValueType.class, ValueType.NULL_VAL);
+  private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
+  private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
+      new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+
+  private final MsgPackWriter commandValueWriter = new MsgPackWriter();
+  private final MsgPackReader commandValueReader = new MsgPackReader();
+
+  public ProcessInstanceBufferedCommandRecord() {
+    super(7);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(tenantIdProperty)
+        .declareProperty(elementInstanceKeyProperty)
+        .declareProperty(valueTypeProperty)
+        .declareProperty(intentProperty)
+        .declareProperty(commandValueProperty);
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setProcessInstanceKey(
+      final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setProcessDefinitionKey(
+      final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProperty.getValue());
+  }
+
+  public ProcessInstanceBufferedCommandRecord setTenantId(final String tenantId) {
+    tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getElementInstanceKey() {
+    return elementInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setElementInstanceKey(
+      final long elementInstanceKey) {
+    elementInstanceKeyProperty.setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return valueTypeProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setValueType(final ValueType valueType) {
+    valueTypeProperty.setValue(valueType);
+    return this;
+  }
+
+  @Override
+  public Intent getIntent() {
+    final int intentValue = intentProperty.getValue();
+    if (intentValue < 0 || intentValue > Short.MAX_VALUE) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to read the intent, but its persisted value '%d' is not a short integer",
+              intentValue));
+    }
+    return Intent.fromProtocolValue(getValueType(), (short) intentValue);
+  }
+
+  public ProcessInstanceBufferedCommandRecord setIntent(final Intent intent) {
+    intentProperty.setValue(intent.value());
+    return this;
+  }
+
+  @Override
+  public UnifiedRecordValue getCommandValue() {
+    final var valueType = getValueType();
+    if (valueType == ValueType.NULL_VAL) {
+      return null;
+    }
+
+    final var storedCommandValue = commandValueProperty.getValue();
+    if (storedCommandValue.isEmpty()) {
+      return storedCommandValue;
+    }
+
+    final var concreteCommandValue = UnifiedRecordValue.fromValueType(valueType);
+
+    final var commandValueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = storedCommandValue.getEncodedLength();
+    commandValueBuffer.wrap(new byte[encodedLength]);
+    storedCommandValue.write(commandValueWriter.wrap(commandValueBuffer, 0));
+
+    concreteCommandValue.wrap(commandValueBuffer);
+    return concreteCommandValue;
+  }
+
+  public ProcessInstanceBufferedCommandRecord setCommandValue(final UnifiedRecordValue commandValue) {
+    if (commandValue == null) {
+      commandValueProperty.reset();
+      return this;
+    }
+
+    final var valueBuffer = new UnsafeBuffer(0, 0);
+    final int encodedLength = commandValue.getLength();
+    valueBuffer.wrap(new byte[encodedLength]);
+
+    commandValue.write(valueBuffer, 0);
+    commandValueProperty.getValue().read(commandValueReader.wrap(valueBuffer, 0, encodedLength));
+    return this;
+  }
+}

--- a/zeebe/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/ZeebeProtocolModule.java
+++ b/zeebe/protocol-jackson/src/main/java/io/camunda/zeebe/protocol/jackson/ZeebeProtocolModule.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.ImmutableAsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableNestedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceBufferedCommandRecordValue;
 
 /**
  * A Jackson module which enables your {@link ObjectMapper} to serialize and deserialize Zeebe
@@ -40,6 +41,8 @@ public final class ZeebeProtocolModule extends SimpleModule {
     setMixInAnnotation(ImmutableCommandDistributionRecordValue.Builder.class, RecordMixin.class);
     setMixInAnnotation(ImmutableAsyncRequestRecordValue.Builder.class, RecordMixin.class);
     setMixInAnnotation(ImmutableNestedRecordValue.Builder.class, RecordMixin.class);
+    setMixInAnnotation(
+        ImmutableProcessInstanceBufferedCommandRecordValue.Builder.class, RecordMixin.class);
   }
 
   @Override

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.ImmutableAsyncRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableCommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableNestedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceBufferedCommandRecordValue;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
@@ -421,6 +422,22 @@ public final class ProtocolFactory {
               .withValueType(valueType)
               .withIntent(random.nextObject(typeInfo.getIntentClass()))
               .withRecordValue(generateObject(typeInfo.getValueClass()))
+              .build();
+        });
+
+    randomizerRegistry.registerRandomizer(
+        ImmutableProcessInstanceBufferedCommandRecordValue.class,
+        () -> {
+          final var valueType = random.nextObject(ValueType.class);
+          final var typeInfo = ValueTypeMapping.get(valueType);
+          return ImmutableProcessInstanceBufferedCommandRecordValue.builder()
+              .withProcessInstanceKey(random.nextLong())
+              .withProcessDefinitionKey(random.nextLong())
+              .withTenantId(random.nextObject(String.class))
+              .withElementInstanceKey(random.nextLong())
+              .withValueType(valueType)
+              .withIntent(random.nextObject(typeInfo.getIntentClass()))
+              .withCommandValue(generateObject(typeInfo.getValueClass()))
               .build();
         });
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MultiInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBufferedCommandIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -127,6 +128,7 @@ import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MultiInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
@@ -400,6 +402,11 @@ public final class ValueTypeMapping {
         ValueType.PROCESS_INSTANCE_BUSINESS_ID,
         new Mapping<>(
             ProcessInstanceBusinessIdRecordValue.class, ProcessInstanceBusinessIdIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND,
+        new Mapping<>(
+            ProcessInstanceBufferedCommandRecordValue.class,
+            ProcessInstanceBufferedCommandIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -101,6 +101,8 @@ public interface Intent {
     map.put(ValueType.PROCESS_EVENT, ProcessEventIntent.class);
     map.put(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchIntent.class);
+    map.put(
+        ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND, ProcessInstanceBufferedCommandIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBufferedCommandIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBufferedCommandIntent.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceBufferedCommandIntent implements Intent, ProcessInstanceRelatedIntent {
+  BUFFER((short) 0, false),
+  BUFFERED((short) 1),
+  DRAIN((short) 2, false),
+  DRAINED((short) 3);
+
+  private final short value;
+  private final boolean shouldBanInstance;
+
+  ProcessInstanceBufferedCommandIntent(final short value) {
+    this(value, true);
+  }
+
+  ProcessInstanceBufferedCommandIntent(final short value, final boolean shouldBanInstance) {
+    this.value = value;
+    this.shouldBanInstance = shouldBanInstance;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case BUFFERED:
+      case DRAINED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return BUFFER;
+      case 1:
+        return BUFFERED;
+      case 2:
+        return DRAIN;
+      case 3:
+        return DRAINED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public boolean shouldBanInstanceOnError() {
+    return shouldBanInstance;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBufferedCommandRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBufferedCommandRecordValue.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import org.immutables.value.Value;
+
+/**
+ * Carries a command that arrived while its target was unable to process it immediately (e.g. a
+ * suspended process instance), so it can be replayed later via {@code DRAIN}.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableProcessInstanceBufferedCommandRecordValue.Builder.class)
+public interface ProcessInstanceBufferedCommandRecordValue
+    extends RecordValue, ProcessInstanceRelated, TenantOwned {
+
+  /**
+   * @return the key of the element instance targeted by the buffered command
+   */
+  long getElementInstanceKey();
+
+  /**
+   * @return the value type of the buffered command
+   */
+  ValueType getValueType();
+
+  /**
+   * @return the intent of the buffered command
+   */
+  Intent getIntent();
+
+  /**
+   * @return the buffered command's record value
+   */
+  RecordValue getCommandValue();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -99,6 +99,7 @@
       <validValue name="MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE">73</validValue>
       <validValue name="PROCESS_INSTANCE_BUSINESS_ID">74</validValue>
       <validValue name="SECRET_REFERENCE">75</validValue>
+      <validValue name="PROCESS_INSTANCE_BUFFERED_COMMAND">76</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -142,6 +142,10 @@ final class IntentEncodingDecodingTest {
             ProcessInstanceBusinessIdIntent.class, ProcessInstanceBusinessIdIntent::from));
     result.addAll(
         buildParameterSets(
+            ProcessInstanceBufferedCommandIntent.class,
+            ProcessInstanceBufferedCommandIntent::from));
+    result.addAll(
+        buildParameterSets(
             ProcessMessageSubscriptionIntent.class, ProcessMessageSubscriptionIntent::from));
     result.addAll(buildParameterSets(ResourceIntent.class, ResourceIntent::from));
     result.addAll(buildParameterSets(ResourceDeletionIntent.class, ResourceDeletionIntent::from));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -2020,6 +2020,8 @@ public class CompactRecordLogger {
         .append(shortenKey(value.getProcessInstanceKey()))
         .append(" elementInstanceKey: ")
         .append(shortenKey(value.getElementInstanceKey()))
+        .append(" valueType: ")
+        .append(value.getValueType())
         .append(" intent: ")
         .append(value.getIntent())
         .toString();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -119,6 +119,7 @@ import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MultiInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
@@ -283,6 +284,8 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.PROCESS_INSTANCE_CREATION, this::summarizeProcessInstanceCreation);
     valueLoggers.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::summarizeProcessInstanceModification);
+    valueLoggers.put(
+        ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND, this::summarizeProcessInstanceBufferedCommand);
     valueLoggers.put(
         ValueType.PROCESS_INSTANCE_BUSINESS_ID, this::summarizeProcessInstanceBusinessId);
     valueLoggers.put(
@@ -2008,6 +2011,18 @@ public class CompactRecordLogger {
     }
 
     return summary.toString();
+  }
+
+  private String summarizeProcessInstanceBufferedCommand(final Record<?> record) {
+    final var value = (ProcessInstanceBufferedCommandRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append(shortenKey(value.getProcessInstanceKey()))
+        .append(" elementInstanceKey: ")
+        .append(shortenKey(value.getElementInstanceKey()))
+        .append(" intent: ")
+        .append(value.getIntent())
+        .toString();
   }
 
   private String summarizeProcessInstanceBusinessId(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -2020,9 +2020,9 @@ public class CompactRecordLogger {
         .append(shortenKey(value.getProcessInstanceKey()))
         .append(" elementInstanceKey: ")
         .append(shortenKey(value.getElementInstanceKey()))
-        .append(" valueType: ")
+        .append(" ")
         .append(value.getValueType())
-        .append(" intent: ")
+        .append(" ")
         .append(value.getIntent())
         .toString();
   }


### PR DESCRIPTION
## Description

Introduces `ValueType.PROCESS_INSTANCE_BUFFERED_COMMAND` and `ProcessInstanceBufferedCommandRecord` — pure protocol scaffolding for the suspend/resume process-instance buffering gate (Phase 1 of the epic). No processor, applier, or exporter wiring yet; those are separate downstream tasks.

The record is deliberately generic rather than `ProcessInstanceRecord`-specific: it tracks the buffered command's `valueType`/`intent`/`commandValue`, mirroring `CommandDistributionRecord`'s existing "carry an arbitrary original command" shape exactly (same field names, same write/read-back serialization technique). Matching those field names verbatim lets the new record reuse existing generic infrastructure with zero new code — the Jackson `RecordMixin` (polymorphic (de)serialization) and the `ImplRecordValuePopulator`'s `intentProperty` fuzzing special-case both already key off exactly these names.

Deliberately excluded from the exported record stream: not wired into `ElasticsearchExporterConfiguration`/`OpensearchExporterConfiguration`/`CamundaExporter`/`RdbmsExporterWrapper`, and added to both ES/OS exporters' test-harness exclusion sets so their parameterized value-type tests don't choke on it.

This went through two rounds of adversarial plan-critique before implementation, which caught: a class-naming-convention conflict with `UnifiedRecordValueTest` (resolved by naming the class after the `ValueType`, per the established `PROCESS_INSTANCE_*` prefix convention), missing ES/OS exporter test-harness exclusions, and a missing Jackson polymorphic-serialization registration (resolved via the field-naming choice above). A subsequent code review also flagged and fixed a `NullPointerException` risk in `getCommandValue()` for a forward-incompatible `SBE_UNKNOWN` value type, replaced with a descriptive `IllegalStateException` matching `CommandDistributionRecord`'s diagnostic quality.

## Checklist

- [x] No backport needed (new protocol scaffolding, not a bug fix)
- [ ] N/A — doesn't touch the C8 Orchestration Cluster E2E Test Suite

## Related issues

closes #57513