### PR TITLE
feat: bundle actuator OpenAPI spec into spring boot starter jar

### DIFF
--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -197,6 +197,21 @@
       <artifactId>spring-boot-jackson</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -299,6 +314,23 @@
               </arguments>
               <classpathScope>provided</classpathScope>
               <includePluginDependencies>true</includePluginDependencies>
+            </configuration>
+          </execution>
+          <!-- Generates the actuator OpenAPI spec bundled into the packaged jar. Bound to
+               prepare-package (not test/integration-test) so it isn't skipped by -DskipTests,
+               which release builds pass. -->
+          <execution>
+            <id>generate-actuator-openapi</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <mainClass>io.camunda.client.spring.actuator.openapi.ActuatorOpenApiGenerator</mainClass>
+              <arguments>
+                <argument>${project.build.outputDirectory}</argument>
+              </arguments>
+              <classpathScope>test</classpathScope>
             </configuration>
           </execution>
         </executions>

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -195,6 +195,21 @@
       <artifactId>spring-boot-jackson</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -292,6 +307,23 @@
               </arguments>
               <classpathScope>provided</classpathScope>
               <includePluginDependencies>true</includePluginDependencies>
+            </configuration>
+          </execution>
+          <!-- Generates the actuator OpenAPI spec bundled into the packaged jar. Bound to
+               prepare-package (not test/integration-test) so it isn't skipped by -DskipTests,
+               which release builds pass. -->
+          <execution>
+            <id>generate-actuator-openapi</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <mainClass>io.camunda.client.spring.actuator.openapi.ActuatorOpenApiGenerator</mainClass>
+              <arguments>
+                <argument>${project.build.outputDirectory}</argument>
+              </arguments>
+              <classpathScope>test</classpathScope>
             </configuration>
           </execution>
         </executions>

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -203,11 +203,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-actuator-autoconfigure</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <scope>test</scope>
@@ -229,6 +224,10 @@
             <!-- test-only: present so the actuator @ConditionalOnClass matches in tests; it has no
                  compile-time reference, so dependency-analyze cannot see it is used -->
             <dependency>org.springframework.boot:spring-boot-actuator-autoconfigure</dependency>
+            <!-- test-only: classpath-activated by ActuatorOpenApiGenerator's embedded web server
+                 and springdoc autoconfig, not referenced directly in compiled test sources -->
+            <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
+            <dependency>org.springdoc:springdoc-openapi-starter-webmvc-ui</dependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -330,6 +330,9 @@
                 <argument>${project.build.outputDirectory}</argument>
               </arguments>
               <classpathScope>test</classpathScope>
+              <!-- The generator class lives under src/test/java, so it isn't compiled when
+                   -Dmaven.test.skip skips test compilation; skip this execution too in that case. -->
+              <skip>${maven.test.skip}</skip>
             </configuration>
           </execution>
         </executions>

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -204,7 +204,7 @@
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -227,7 +227,7 @@
             <!-- test-only: classpath-activated by ActuatorOpenApiGenerator's embedded web server
                  and springdoc autoconfig, not referenced directly in compiled test sources -->
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
-            <dependency>org.springdoc:springdoc-openapi-starter-webmvc-ui</dependency>
+            <dependency>org.springdoc:springdoc-openapi-starter-webmvc-api</dependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.actuator.openapi;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Generates the OpenAPI document for the actuator endpoints this starter contributes (currently
+ * {@code JobWorkerController}, id {@code jobworkers}) and writes it under {@code
+ * <outputDirectory>/openapi/actuator-openapi.yaml}, so it ships inside the packaged jar.
+ *
+ * <p>Invoked via {@code exec-maven-plugin} bound to the {@code prepare-package} phase (see this
+ * module's pom.xml), running before {@code jar:jar} so the generated file lands in {@code
+ * target/classes} in time to be bundled. Runs on every {@code package}/{@code install}/{@code
+ * deploy}, including release builds that pass {@code -DskipTests=true} — unlike a JUnit test bound
+ * to the {@code test} phase, this is not skipped by that flag.
+ */
+public final class ActuatorOpenApiGenerator {
+
+  private ActuatorOpenApiGenerator() {}
+
+  public static void main(final String[] args) throws IOException, InterruptedException {
+    if (args.length != 1) {
+      throw new IllegalArgumentException("Expected exactly one argument: the output directory");
+    }
+
+    final Path outputPath = Path.of(args[0], "openapi", "actuator-openapi.yaml");
+
+    final ConfigurableApplicationContext context =
+        new SpringApplicationBuilder(OpenApiGenerationApplication.class)
+            .web(WebApplicationType.SERVLET)
+            .properties(
+                "server.port=0",
+                "management.endpoints.web.exposure.include=*",
+                "springdoc.show-actuator=true",
+                "spring.main.banner-mode=off")
+            .run(args);
+    try {
+      final Integer port = context.getEnvironment().getProperty("local.server.port", Integer.class);
+      final HttpRequest request =
+          HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/v3/api-docs.yaml"))
+              .GET()
+              .build();
+      final HttpResponse<String> response =
+          HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+      final String spec = response.body();
+
+      if (response.statusCode() != 200 || spec == null || spec.isBlank()) {
+        throw new IllegalStateException(
+            "Failed to generate actuator OpenAPI spec, status=" + response.statusCode());
+      }
+      if (!spec.contains("/actuator/jobworkers")) {
+        throw new IllegalStateException(
+            "Generated actuator OpenAPI spec is missing the expected jobworkers endpoint");
+      }
+
+      Files.createDirectories(outputPath.getParent());
+      Files.writeString(outputPath, spec, StandardCharsets.UTF_8);
+    } finally {
+      context.close();
+    }
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
@@ -24,6 +24,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -61,12 +62,17 @@ public final class ActuatorOpenApiGenerator {
             .run();
     try {
       final Integer port = context.getEnvironment().getProperty("local.server.port", Integer.class);
+      if (port == null) {
+        throw new IllegalStateException("Embedded server did not report a local.server.port");
+      }
+      final HttpClient client =
+          HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
       final HttpRequest request =
           HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/v3/api-docs.yaml"))
+              .timeout(Duration.ofSeconds(10))
               .GET()
               .build();
-      final HttpResponse<String> response =
-          HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+      final HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
       final String spec = response.body();
 
       if (response.statusCode() != 200 || spec == null || spec.isBlank()) {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
@@ -55,10 +55,10 @@ public final class ActuatorOpenApiGenerator {
             .web(WebApplicationType.SERVLET)
             .properties(
                 "server.port=0",
-                "management.endpoints.web.exposure.include=*",
+                "management.endpoints.web.exposure.include=jobworkers",
                 "springdoc.show-actuator=true",
                 "spring.main.banner-mode=off")
-            .run(args);
+            .run();
     try {
       final Integer port = context.getEnvironment().getProperty("local.server.port", Integer.class);
       final HttpRequest request =

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/ActuatorOpenApiGenerator.java
@@ -79,9 +79,12 @@ public final class ActuatorOpenApiGenerator {
         throw new IllegalStateException(
             "Failed to generate actuator OpenAPI spec, status=" + response.statusCode());
       }
-      if (!spec.contains("/actuator/jobworkers")) {
+      if (!spec.contains("/actuator/jobworkers")
+          || !spec.contains("/actuator/jobworkers/{")
+          || !spec.contains("get:")
+          || !spec.contains("post:")) {
         throw new IllegalStateException(
-            "Generated actuator OpenAPI spec is missing the expected jobworkers endpoint");
+            "Generated actuator OpenAPI spec is missing expected jobworkers operations");
       }
 
       Files.createDirectories(outputPath.getParent());

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/OpenApiGenerationApplication.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/actuator/openapi/OpenApiGenerationApplication.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.actuator.openapi;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Boots a real embedded web server with this starter's auto-configuration, actuator, and springdoc
+ * active, so {@link ActuatorOpenApiGenerator} can capture the OpenAPI document for the actuator
+ * endpoints this module contributes (e.g. {@code JobWorkerController}). Not a functional
+ * application, purely a build-time generation fixture.
+ */
+@SpringBootApplication
+public class OpenApiGenerationApplication {}


### PR DESCRIPTION
## Summary

This starter ships actuator endpoints (currently `JobWorkerController`, id `jobworkers`) with no OpenAPI documentation, so consumers have to read the source or boot their own app with springdoc to see the shape of `GET/POST /actuator/jobworkers`. The packaged jar now bundles a generated OpenAPI spec (`openapi/actuator-openapi.yaml`) describing every actuator endpoint this starter contributes.

## Why generation runs via exec-maven-plugin, not a JUnit test

A `@SpringBootTest`-based generator was the first approach, but release builds (`camunda-platform-release.yml`) run `release:perform` with `-DskipTests=true`, which the parent pom maps to `skipUTs`/`skipITs` both `true`. Anything bound to the `test` or `integration-test` phase — a JUnit test, or a `springdoc-openapi-maven-plugin` execution bound the conventional way — is a no-op on an actual release, so the spec would never make it into a published jar.

Generation instead reuses this module's existing `exec-maven-plugin` generator pattern (already used for `JobWorkerPermutationsGenerator`), with a new execution bound to `prepare-package`. That phase runs regardless of `-DskipTests`, and it runs before `jar:jar`, so `ActuatorOpenApiGenerator` can boot a minimal Spring Boot app (`OpenApiGenerationApplication`), hit `/v3/api-docs.yaml`, and write the result straight into `target/classes/openapi/` in time to be packaged.

The three new test-scope deps (`spring-boot-starter-web`, `spring-boot-actuator-autoconfigure`, `springdoc-openapi-starter-webmvc-ui`) exist only to boot that generator app; they don't leak into the published jar's runtime dependencies.

## Test plan

- `./mvnw verify -pl clients/camunda-spring-boot-starter -Dtest=ActuatorOpenApiGenerator` isn't applicable (it's a `main()`, not a JUnit test) — verified instead via `./mvnw package -pl clients/camunda-spring-boot-starter -DskipTests=true` (simulating the release flag) and confirming `openapi/actuator-openapi.yaml` is present in the built jar with all 4 `jobworkers` operations.
- `./mvnw verify -pl clients/camunda-spring-boot-starter -DskipTests=false` — 757/757 tests pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Sonnet_5_(200K)-D97757?logo=claude&logoColor=white)