### PR TITLE
fix: ping the owning medic in the per-run AlwaysGreen Slack message

### DIFF
--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -30,7 +30,10 @@ const MEDIC = {
   '@camunda/monorepo-devops-team': '<!subteam^S07D6C6B18T|monorepo-devops-medic>',
   '@camunda/core-features': '<!subteam^S08P2CU9V8W|core-features-medic>',
 };
-const medicMention = (owner) => MEDIC[owner] || MEDIC['@camunda/monorepo-devops-team'];
+// No fallback: an unmapped/missing owner (e.g. the "unknown" default) must not
+// silently page monorepo-devops-medic. Returns '' (nothing to concatenate) when
+// there's no mapping, so callers don't need to worry about spacing either.
+const medicMention = (owner) => (MEDIC[owner] ? ` ${MEDIC[owner]}` : '');
 
 const CATALOG = {
   product: {
@@ -150,7 +153,7 @@ function slackText(m) {
   ]
     .filter(Boolean)
     .join(' · ');
-  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner} ${medicMention(m.owner)}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
+  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner}${medicMention(m.owner)}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
 }
 
 const gh = (args) => exec('gh', args, {maxBuffer: 64 * 1024 * 1024});

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -23,6 +23,15 @@ const ASK = 'https://camunda.slack.com/archives/C0AQ378VBEV'; // #ask-alwaysgree
 const RELIABILITY =
   'https://camunda.slack.com/archives/C0AK0AVKRL0'; // #alwaysgreen-reliability
 
+// Owner→medic Slack subteam map — keep in sync with alwaysgreen-streak-detector.yml.
+const MEDIC = {
+  '@camunda/test-automation-team': '<!subteam^S09UF0EV0HG|test-automation-medic>',
+  '@camunda/distribution': '<!subteam^S053K7C7QKU|distribution-medic>',
+  '@camunda/monorepo-devops-team': '<!subteam^S07D6C6B18T|monorepo-devops-medic>',
+  '@camunda/core-features': '<!subteam^S08P2CU9V8W|core-features-medic>',
+};
+const medicMention = (owner) => MEDIC[owner] || MEDIC['@camunda/monorepo-devops-team'];
+
 const CATALOG = {
   product: {
     title: 'Real failure — likely your change',
@@ -141,7 +150,7 @@ function slackText(m) {
   ]
     .filter(Boolean)
     .join(' · ');
-  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
+  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner} ${medicMention(m.owner)}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
 }
 
 const gh = (args) => exec('gh', args, {maxBuffer: 64 * 1024 * 1024});


### PR DESCRIPTION
## Summary

- The per-run AlwaysGreen failure message (`post-failure-feedback`/`feedback.mjs`), posted to `#alwaysgreen-reliability` on every failure of the Helm chart Integration Tests status job, rendered `owner_team` as plain text only — it never actually pinged anyone in Slack.
- The only mechanism that pings a real medic subteam is `alwaysgreen-streak-detector.yml`, and only after 3 consecutive failures on a branch (`STREAK_THRESHOLD`). A one-off failure got a text-only, non-pinging message.
- Since #57799 correctly routes E2E failures to `@camunda/test-automation-team` vs Helm/install failures to `@camunda/distribution`, this closes the loop so that attribution actually reaches the right medic on the very first failure too, not just once a streak forms.

## How it works

Reuses the exact owner→medic Slack subteam map already defined in `alwaysgreen-streak-detector.yml` (`MEDIC_TEST_AUTOMATION`, `MEDIC_DISTRIBUTION`, `MEDIC_MONOREPO_DEVOPS`, `MEDIC_CORE_FEATURES`) inside `feedback.mjs`, and appends the resolved `<!subteam^ID|alias>` mention next to the `Owner:` field in the Slack-rendered message only (the GitHub job-summary/PR-comment markdown rendering is untouched, so PR comments don't show raw Slack mention syntax).

This only affects the one existing caller of `post-failure-feedback` in the repo — the `helm-deploy-status` (`Observe Helm chart Integration Tests status`) job in `docker-build-helm-integration.yml` — so no other workflow's alerting behavior changes.

## Test plan

- [ ] Trigger a Helm install failure → verify the Slack message pings `distribution-medic`.
- [ ] Trigger a Playwright E2E failure after install → verify the Slack message pings `test-automation-medic`.
- [ ] Confirm the PR comment / job summary rendering is unaffected (plain `@camunda/...` text, no raw subteam syntax).

🤖 Generated with [Claude Code](https://claude.com/claude-code)