### PR TITLE
fix: ping the owning medic in the per-run AlwaysGreen Slack message (backport stable/8.7)

### DIFF
--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -23,6 +23,15 @@ const ASK = 'https://camunda.slack.com/archives/C0AQ378VBEV'; // #ask-alwaysgree
 const RELIABILITY =
   'https://camunda.slack.com/archives/C0AK0AVKRL0'; // #alwaysgreen-reliability
 
+// Owner→medic Slack subteam map — keep in sync with alwaysgreen-streak-detector.yml.
+const MEDIC = {
+  '@camunda/test-automation-team': '<!subteam^S09UF0EV0HG|test-automation-medic>',
+  '@camunda/distribution': '<!subteam^S053K7C7QKU|distribution-medic>',
+  '@camunda/monorepo-devops-team': '<!subteam^S07D6C6B18T|monorepo-devops-medic>',
+  '@camunda/core-features': '<!subteam^S08P2CU9V8W|core-features-medic>',
+};
+const medicMention = (owner) => MEDIC[owner] || MEDIC['@camunda/monorepo-devops-team'];
+
 const CATALOG = {
   product: {
     title: 'Real failure — likely your change',
@@ -141,7 +150,7 @@ function slackText(m) {
   ]
     .filter(Boolean)
     .join(' · ');
-  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
+  return `${m.emoji} *AlwaysGreen — ${m.title}*\n*Stage:* \`${m.stage}\` · *Category:* \`${m.category}\` · *Owner:* ${m.owner} ${medicMention(m.owner)}${prLink}\n*Evidence:* ${ev}\n*Next steps:*\n${steps}\n${links}`;
 }
 
 const gh = (args) => exec('gh', args, {maxBuffer: 64 * 1024 * 1024});


### PR DESCRIPTION
Backport of #57901 to `stable/8.7`.

## Summary

- The per-run AlwaysGreen failure message posted to `#alwaysgreen-reliability` rendered `owner_team` as plain text — it never actually pinged anyone in Slack. The real medic ping only fired via `alwaysgreen-streak-detector.yml` after 3 consecutive failures.
- Reuses the same owner→medic Slack subteam map already in `alwaysgreen-streak-detector.yml` inside `feedback.mjs`, so the immediate per-run Slack message also pings the right medic on the first failure, not just once a streak forms.
- Only affects the one caller of `post-failure-feedback` (the `Observe Helm chart Integration Tests status` job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)