### PR TITLE
feat: add POST /v2/secrets/resolve endpoint

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -47,6 +47,7 @@ import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
+import io.camunda.service.SecretServices;
 import io.camunda.service.SignalServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TopologyServices;
@@ -400,6 +401,16 @@ public class CamundaServicesConfiguration {
                           brokerClient,
                           securityContextProvider,
                           search,
+                          executor,
+                          converter))
+                  .secretServices(
+                      tenantId,
+                      new SecretServices(
+                          tenantId,
+                          brokerClient,
+                          securityContextProvider,
+                          authorizationChecker,
+                          cslProperties.getAuthorizations(),
                           executor,
                           converter))
                   .signalServices(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -63,9 +63,13 @@ import io.camunda.gateway.protocol.model.Partition.HealthEnum;
 import io.camunda.gateway.protocol.model.Partition.RoleEnum;
 import io.camunda.gateway.protocol.model.Partition.StateEnum;
 import io.camunda.gateway.protocol.model.ProcessInstanceReference;
+import io.camunda.gateway.protocol.model.ResolvedSecret;
 import io.camunda.gateway.protocol.model.ResourceResult;
 import io.camunda.gateway.protocol.model.RoleCreateResult;
 import io.camunda.gateway.protocol.model.RoleUpdateResult;
+import io.camunda.gateway.protocol.model.SecretErrorCode;
+import io.camunda.gateway.protocol.model.SecretResolutionError;
+import io.camunda.gateway.protocol.model.SecretResolveResult;
 import io.camunda.gateway.protocol.model.SignalBroadcastResult;
 import io.camunda.gateway.protocol.model.TenantCreateResult;
 import io.camunda.gateway.protocol.model.TenantUpdateResult;
@@ -77,6 +81,8 @@ import io.camunda.search.entities.DeployedResourceEntity;
 import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentErrorResponse;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
+import io.camunda.service.SecretServices;
+import io.camunda.service.SecretServices.SecretResolution;
 import io.camunda.service.TopologyServices.Broker;
 import io.camunda.service.TopologyServices.Partition;
 import io.camunda.service.TopologyServices.Topology;
@@ -664,6 +670,38 @@ public final class ResponseMapper {
     return AuthorizationCreateResult.Builder.create()
         .authorizationKey(keyToString(authorizationRecord.getAuthorizationKey()))
         .build();
+  }
+
+  public static SecretResolveResult toSecretResolveResult(final SecretResolution resolution) {
+    final var resolved =
+        resolution.resolved().stream()
+            .map(
+                secret ->
+                    ResolvedSecret.Builder.create()
+                        .reference(secret.reference())
+                        .value(secret.value())
+                        .build())
+            .toList();
+    final var errors =
+        resolution.errors().stream().map(ResponseMapper::toSecretResolutionError).toList();
+    return SecretResolveResult.Builder.create().resolved(resolved).errors(errors).build();
+  }
+
+  private static SecretResolutionError toSecretResolutionError(
+      final SecretServices.SecretResolutionError error) {
+    return SecretResolutionError.Builder.create()
+        .reference(error.reference())
+        .code(toSecretErrorCode(error.code()))
+        .message(error.message())
+        .build();
+  }
+
+  private static SecretErrorCode toSecretErrorCode(final SecretServices.SecretErrorCode code) {
+    return switch (code) {
+      case NOT_FOUND -> SecretErrorCode.NOT_FOUND;
+      case ACCESS_DENIED -> SecretErrorCode.ACCESS_DENIED;
+      case INVALID_REF -> SecretErrorCode.INVALID_REF;
+    };
   }
 
   public static UserCreateResult toUserCreateResponse(final UserRecord userRecord) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -700,7 +700,7 @@ public final class ResponseMapper {
     return switch (code) {
       case NOT_FOUND -> SecretErrorCode.NOT_FOUND;
       case ACCESS_DENIED -> SecretErrorCode.ACCESS_DENIED;
-      case INVALID_REF -> SecretErrorCode.INVALID_REF;
+      case INVALID_REFERENCE -> SecretErrorCode.INVALID_REFERENCE;
     };
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/SecretRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/SecretRequestValidator.java
@@ -8,7 +8,6 @@
 package io.camunda.gateway.mapping.http.validator;
 
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
-import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 
 import io.camunda.gateway.protocol.model.SecretResolveRequest;
@@ -30,14 +29,6 @@ public final class SecretRequestValidator {
    */
   public static final int MAX_BATCH_SIZE = 20;
 
-  /**
-   * Bounds the length of a single reference string. Each reference is used as an authorization
-   * resource id and (once a real store is wired) a store lookup key, so an unbounded string must
-   * not reach either. Matches the length cap sibling validators use for similarly-purposed fields
-   * (see {@link RequestValidator#validateBusinessId}).
-   */
-  public static final int MAX_REFERENCE_LENGTH = 256;
-
   private SecretRequestValidator() {}
 
   public static Optional<ProblemDetail> validateSecretResolveRequest(
@@ -56,12 +47,6 @@ public final class SecretRequestValidator {
           }
           if (references.stream().anyMatch(Objects::isNull)) {
             violations.add("The references list must not contain null entries.");
-            return;
-          }
-          if (references.stream()
-              .anyMatch(reference -> reference.length() > MAX_REFERENCE_LENGTH)) {
-            violations.add(
-                ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("reference", MAX_REFERENCE_LENGTH));
           }
         });
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/SecretRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/SecretRequestValidator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.gateway.mapping.http.validator;
+
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+
+import io.camunda.gateway.protocol.model.SecretResolveRequest;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.http.ProblemDetail;
+
+public final class SecretRequestValidator {
+
+  /**
+   * Bounds the number of per-reference authorization checks a single resolve request can trigger.
+   *
+   * <p>This is the sole source of truth for the cap in code. The {@code maxItems: 20} on {@code
+   * SecretResolveRequest.references} in {@code secrets.yaml} documents the same limit in the API
+   * contract, but it is <b>not enforced by the generated request model</b>: the model tree used by
+   * the controller does not emit array-size ({@code @Size}) constraints, so the cap must be checked
+   * here. Keep the two values in sync — {@code SecretRequestValidatorSpecSyncTest} guards against
+   * drift between them.
+   */
+  public static final int MAX_BATCH_SIZE = 20;
+
+  /**
+   * Bounds the length of a single reference string. Each reference is used as an authorization
+   * resource id and (once a real store is wired) a store lookup key, so an unbounded string must
+   * not reach either. Matches the length cap sibling validators use for similarly-purposed fields
+   * (see {@link RequestValidator#validateBusinessId}).
+   */
+  public static final int MAX_REFERENCE_LENGTH = 256;
+
+  private SecretRequestValidator() {}
+
+  public static Optional<ProblemDetail> validateSecretResolveRequest(
+      final SecretResolveRequest request) {
+    return validate(
+        violations -> {
+          final var references = request == null ? null : request.getReferences();
+          if (references == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("references"));
+            return;
+          }
+          if (references.size() > MAX_BATCH_SIZE) {
+            violations.add(
+                "At most %d references may be requested in a single batch, but %d were provided."
+                    .formatted(MAX_BATCH_SIZE, references.size()));
+          }
+          if (references.stream().anyMatch(Objects::isNull)) {
+            violations.add("The references list must not contain null entries.");
+            return;
+          }
+          if (references.stream()
+              .anyMatch(reference -> reference.length() > MAX_REFERENCE_LENGTH)) {
+            violations.add(
+                ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("reference", MAX_REFERENCE_LENGTH));
+          }
+        });
+  }
+}

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
@@ -12,6 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.protocol.model.ActivatedJobResult;
 import io.camunda.gateway.protocol.model.UserTaskProperties;
+import io.camunda.service.SecretServices;
+import io.camunda.service.SecretServices.SecretResolution;
+import io.camunda.service.SecretServices.SecretResolutionError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResponse;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
@@ -25,6 +28,7 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -33,6 +37,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ResponseMapperTest {
@@ -733,6 +738,33 @@ class ResponseMapperTest {
       assertThat(response.getBatchOperation().getBatchOperationType()).isNotNull();
       assertThat(response.getBatchOperation().getBatchOperationType().name())
           .isEqualTo(batchOperationType.name());
+    }
+  }
+
+  @Nested
+  class SecretMappingTest {
+
+    /**
+     * The service and the generated REST model each declare their own {@code SecretErrorCode} enum,
+     * bridged by {@link ResponseMapper#toSecretResolveResult}. Keep them in sync: mapping drift is
+     * expected to be caught at build time (exhaustive switch / missing enum symbols), and this test
+     * additionally pins each service code to a REST code with the identical name.
+     */
+    @ParameterizedTest
+    @EnumSource(SecretServices.SecretErrorCode.class)
+    void shouldMapEverySecretErrorCodeToMatchingRestCode(
+        final SecretServices.SecretErrorCode code) {
+      // given a resolution carrying an error for the code
+      final var resolution =
+          new SecretResolution(
+              List.of(), List.of(new SecretResolutionError("camunda.secrets.x", code, "message")));
+
+      // when
+      final var result = ResponseMapper.toSecretResolveResult(resolution);
+
+      // then the mapped REST code exists and has the identical name
+      assertThat(result.getErrors()).hasSize(1);
+      assertThat(result.getErrors().get(0).getCode().name()).isEqualTo(code.name());
     }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.api.search.enums.PermissionType.REVEAL;
+import static io.camunda.client.api.search.enums.ResourceType.SECRET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * End-to-end authorization coverage for {@code POST /v2/secrets/resolve} against a real
+ * authorization-enabled broker. Unlike {@code SecretControllerTest} and {@code SecretServicesTest}
+ * (which mock the authorization stack), this exercises the real per-reference {@code SECRET:REVEAL}
+ * check so the security guarantee is proven, not assumed.
+ *
+ * <p>The secret backend is mocked in Phase 1 (#56567): references in the service's mock allow-list
+ * ({@code camunda.secrets.token} etc.) resolve to a placeholder value; authorization is real.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class SecretAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final ObjectMapper JSON =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  // Resolvable by the mock backend (see SecretServices#MOCK_RESOLVABLE_REFERENCES).
+  private static final String GRANTED_REFERENCE = "camunda.secrets.token";
+  private static final String OTHER_REFERENCE = "camunda.secrets.a";
+
+  private static final String REVEAL_USER = "revealUser";
+  private static final String WILDCARD_USER = "wildcardUser";
+  private static final String NO_PERMISSION_USER = "noPermissionUser";
+
+  @UserDefinition
+  private static final TestUser REVEAL_USER_DEF =
+      new TestUser(
+          REVEAL_USER,
+          "password",
+          // Granted REVEAL on GRANTED_REFERENCE only — not on OTHER_REFERENCE.
+          List.of(new Permissions(SECRET, REVEAL, List.of(GRANTED_REFERENCE))));
+
+  @UserDefinition
+  private static final TestUser WILDCARD_USER_DEF =
+      new TestUser(
+          WILDCARD_USER,
+          "password",
+          // Granted REVEAL on all references via the "*" wildcard.
+          List.of(new Permissions(SECRET, REVEAL, List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser NO_PERMISSION_USER_DEF =
+      new TestUser(NO_PERMISSION_USER, "password", List.of());
+
+  @Test
+  void shouldResolveReferenceWhenAuthorizedOnThatReference(
+      @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
+    // when a user with SECRET:REVEAL on the reference resolves it
+    final var response = resolve(client, REVEAL_USER, List.of(GRANTED_REFERENCE));
+
+    // then it succeeds with the (mocked) value and no errors
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(references(body.get("resolved"))).containsExactly(GRANTED_REFERENCE);
+    assertThat(body.get("errors")).isEmpty();
+  }
+
+  @Test
+  void shouldDenyReferenceWhenNotAuthorizedAtAll(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when an authenticated user without any SECRET grant resolves a reference
+    final var response = resolve(client, NO_PERMISSION_USER, List.of(GRANTED_REFERENCE));
+
+    // then the endpoint still returns 200 but the reference is ACCESS_DENIED, with no value leaked
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(body.get("resolved")).isEmpty();
+    assertThat(body.get("errors")).hasSize(1);
+    assertThat(body.get("errors").get(0).get("reference").asText()).isEqualTo(GRANTED_REFERENCE);
+    assertThat(body.get("errors").get(0).get("code").asText()).isEqualTo("ACCESS_DENIED");
+  }
+
+  @Test
+  void shouldEnforceAuthorizationPerReferenceResourceId(
+      @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
+    // when a user granted only on GRANTED_REFERENCE resolves a batch of both references
+    final var response = resolve(client, REVEAL_USER, List.of(GRANTED_REFERENCE, OTHER_REFERENCE));
+
+    // then only the granted reference resolves; the other is denied independently
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(references(body.get("resolved"))).containsExactly(GRANTED_REFERENCE);
+    assertThat(body.get("errors")).hasSize(1);
+    assertThat(body.get("errors").get(0).get("reference").asText()).isEqualTo(OTHER_REFERENCE);
+    assertThat(body.get("errors").get(0).get("code").asText()).isEqualTo("ACCESS_DENIED");
+  }
+
+  @Test
+  void shouldResolveAnyReferenceWithWildcardGrant(
+      @Authenticated(WILDCARD_USER) final CamundaClient client) throws Exception {
+    // when a user granted SECRET:REVEAL:* resolves a reference it was not explicitly granted
+    final var response = resolve(client, WILDCARD_USER, List.of(OTHER_REFERENCE));
+
+    // then the wildcard grant authorizes it and it resolves with no errors
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(references(body.get("resolved"))).containsExactly(OTHER_REFERENCE);
+    assertThat(body.get("errors")).isEmpty();
+  }
+
+  @Test
+  void shouldRejectUnauthenticatedRequest(@Authenticated(REVEAL_USER) final CamundaClient client)
+      throws Exception {
+    // when the resolve endpoint is called without credentials — the injected client is used only to
+    // discover the broker's REST base address; the request below carries no Authorization header
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/secrets/resolve"))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString("{\"references\": [\"" + GRANTED_REFERENCE + "\"]}"))
+            .build();
+    final var response = HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+
+    // then it is rejected as unauthorized
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldNotAllowDownstreamCachingOfResolvedSecrets(
+      @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
+    // The response body carries secret values, so it must never be cached by an intermediary proxy
+    // or browser. We do not set cache headers on the controller: they are expected from the shared
+    // Spring Security filter chain (Cache-Control: no-cache, no-store, max-age=0, must-revalidate).
+
+    // when a secret-bearing response is returned
+    final var response = resolve(client, REVEAL_USER, List.of(GRANTED_REFERENCE));
+
+    // then it forbids downstream storage
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.headers().firstValue("Cache-Control"))
+        .as("resolve responses carry secret values and must not be cached downstream")
+        .hasValueSatisfying(value -> assertThat(value).contains("no-store"));
+  }
+
+  /**
+   * Issues a raw HTTP call to {@code POST /v2/secrets/resolve} authenticated as the given user. The
+   * endpoint has no fluent Java client method yet.
+   */
+  private static HttpResponse<String> resolve(
+      final CamundaClient client, final String username, final List<String> references)
+      throws Exception {
+    final var body = JSON.writeValueAsString(Map.of("references", references));
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/secrets/resolve"))
+            .header("Content-Type", "application/json")
+            .header("Authorization", basicAuthentication(username))
+            .POST(BodyPublishers.ofString(body))
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
+  private static JsonNode read(final String body) throws Exception {
+    return JSON.readTree(body);
+  }
+
+  private static List<String> references(final JsonNode array) {
+    return StreamSupport.stream(array.spliterator(), false)
+        .map(item -> item.get("reference").asText())
+        .toList();
+  }
+
+  private static String basicAuthentication(final String username) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":password").getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static URI createUri(final CamundaClient client, final String path)
+      throws URISyntaxException {
+    final String base = client.getConfiguration().getRestAddress().toString();
+    final String separator = base.endsWith("/") ? "" : "/";
+    return new URI(base + separator + path);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -60,6 +60,8 @@ class SecretAuthorizationIT {
   // Resolvable by the mock backend (see SecretServices#MOCK_RESOLVABLE_REFERENCES).
   private static final String GRANTED_REFERENCE = "camunda.secrets.token";
   private static final String OTHER_REFERENCE = "camunda.secrets.a";
+  // Not in SecretServices#MOCK_RESOLVABLE_REFERENCES, so a wildcard-authorized lookup misses.
+  private static final String UNKNOWN_REFERENCE = "camunda.secrets.doesnotexist";
 
   private static final String REVEAL_USER = "revealUser";
   private static final String WILDCARD_USER = "wildcardUser";
@@ -139,6 +141,22 @@ class SecretAuthorizationIT {
     final var body = read(response.body());
     assertThat(references(body.get("resolved"))).containsExactly(OTHER_REFERENCE);
     assertThat(body.get("errors")).isEmpty();
+  }
+
+  @Test
+  void shouldReportNotFoundForAuthorizedUnknownReference(
+      @Authenticated(WILDCARD_USER) final CamundaClient client) throws Exception {
+    // when a wildcard-authorized user resolves a reference the mock backend does not know
+    final var response = resolve(client, WILDCARD_USER, List.of(UNKNOWN_REFERENCE));
+
+    // then it is NOT_FOUND rather than ACCESS_DENIED, exercising the third error code through the
+    // full stack (authorization granted, mock lookup misses)
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(body.get("resolved")).isEmpty();
+    assertThat(body.get("errors")).hasSize(1);
+    assertThat(body.get("errors").get(0).get("reference").asText()).isEqualTo(UNKNOWN_REFERENCE);
+    assertThat(body.get("errors").get(0).get("code").asText()).isEqualTo("NOT_FOUND");
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.exception.ErrorMapper;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves a deduplicated batch of {@code camunda.secrets.<name>} references, checking {@code
+ * SECRET:REVEAL} per reference. Each reference succeeds or fails independently; a denied or
+ * unresolvable reference is reported in {@link SecretResolution#errors()} rather than failing the
+ * batch.
+ *
+ * <p><b>Phase 1 scope (#56567):</b> the per-reference authorization, deduplication, reference
+ * validation and per-reference outcome routing are real. The secret value lookup itself is
+ * <b>mocked</b> ({@link #mockResolve}); this endpoint does not yet use the {@code SecretStore}
+ * wiring — that lands with #56561 / #57199. The sibling {@code SECRET:READ} list endpoint (#56568)
+ * reuses this authorization/validation shape.
+ */
+public class SecretServices extends PhysicalTenantScopedApiServices<SecretServices> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SecretServices.class);
+
+  private static final String REFERENCE_PREFIX = "camunda.secrets.";
+
+  // The <name> segment of a reference: a single, non-empty token of alphanumeric characters and
+  // underscores. Deliberately narrow — the reference is used as an authorization resource id and
+  // (once a real store is wired) a store lookup key, so pattern/glob characters ('*', '%'),
+  // whitespace and dots must never reach either. Kept identical to the engine detector's
+  // single-segment camunda.secrets.<name> pattern (see SecretReferenceLiteralValidator) so both
+  // subsystems agree on what counts as a valid reference name for the same syntax.
+  private static final Pattern REFERENCE_NAME_PATTERN = Pattern.compile("[\\p{Alnum}_]+");
+
+  // Phase 1 only: the references the mocked backend pretends to know. Any other authorized, valid
+  // reference resolves to NOT_FOUND. Removed once a real SecretStore is wired (#56561/#57199).
+  private static final Set<String> MOCK_RESOLVABLE_REFERENCES =
+      Set.of("camunda.secrets.token", "camunda.secrets.a", "camunda.secrets.b");
+
+  private final AuthorizationChecker authorizationChecker;
+  private final AuthorizationsConfiguration authorizationsConfig;
+
+  public SecretServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final AuthorizationChecker authorizationChecker,
+      final AuthorizationsConfiguration authorizationsConfig,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    super(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+    this.authorizationChecker = authorizationChecker;
+    this.authorizationsConfig = authorizationsConfig;
+  }
+
+  /**
+   * Resolves the given references. Duplicates are resolved once (server-side deduplication). The
+   * returned {@link SecretResolution} always describes every distinct reference exactly once,
+   * across {@code resolved} and {@code errors}.
+   *
+   * <p>Synchronous today (no broker round-trip while the backend is mocked), but returns a future
+   * like every other action method on this base class so the signature does not have to break once
+   * the real, likely I/O-bound {@code SecretStore} lookup replaces {@link #mockResolve}
+   * (#56561/#57199).
+   */
+  public CompletableFuture<SecretResolution> resolve(
+      final List<String> references, final CamundaAuthentication authentication) {
+    try {
+      final var distinct = new LinkedHashSet<>(references);
+      final List<ResolvedSecret> resolved = new ArrayList<>();
+      final List<SecretResolutionError> errors = new ArrayList<>();
+
+      final List<String> validReferences = new ArrayList<>();
+      for (final var reference : distinct) {
+        if (isValidReference(reference)) {
+          validReferences.add(reference);
+        } else {
+          errors.add(
+              new SecretResolutionError(
+                  reference, SecretErrorCode.INVALID_REF, "The secret reference is malformed."));
+        }
+      }
+      if (validReferences.isEmpty()) {
+        return CompletableFuture.completedFuture(new SecretResolution(resolved, errors));
+      }
+
+      // Authorize before any lookup so an unauthorized caller never receives a value or learns
+      // whether the secret exists. A single query covers the whole batch instead of one
+      // authorization round-trip per reference.
+      final var authorizedReferences = resolveAuthorizedReferences(validReferences, authentication);
+
+      for (final var reference : validReferences) {
+        if (!authorizedReferences.contains(reference)) {
+          LOG.debug(
+              "Denied secret reveal of '{}' for {}",
+              reference,
+              authentication.formattedPrincipal());
+          errors.add(
+              new SecretResolutionError(
+                  reference,
+                  SecretErrorCode.ACCESS_DENIED,
+                  "The caller is not authorized to reveal the secret reference."));
+          continue;
+        }
+        mockResolve(reference)
+            .ifPresentOrElse(
+                value -> {
+                  LOG.debug(
+                      "Revealed secret '{}' to {}", reference, authentication.formattedPrincipal());
+                  resolved.add(new ResolvedSecret(reference, value));
+                },
+                () ->
+                    errors.add(
+                        new SecretResolutionError(
+                            reference,
+                            SecretErrorCode.NOT_FOUND,
+                            "No secret was found for the reference.")));
+      }
+      return CompletableFuture.completedFuture(new SecretResolution(resolved, errors));
+    } catch (final Exception ex) {
+      return CompletableFuture.failedFuture(ErrorMapper.mapError(ex));
+    }
+  }
+
+  /**
+   * Returns the subset of {@code validReferences} the caller holds {@code SECRET:REVEAL} on. Issues
+   * at most one authorization query for the whole batch, mirroring the bulk-fetch-then-
+   * locally-match pattern {@code DefaultResourceAccessProvider} uses for search pre-filtering,
+   * rather than one query per reference.
+   */
+  private Set<String> resolveAuthorizedReferences(
+      final List<String> validReferences, final CamundaAuthentication authentication) {
+    // Unlike other domains, secrets are refused rather than opened up when authorization is
+    // disabled cluster-wide: a secret value must never be revealed without an explicit, checked
+    // grant.
+    if (!authorizationsConfig.isEnabled()) {
+      return Set.of();
+    }
+    final var authorizedScopes =
+        authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            authentication, SECRET_REVEAL_AUTHORIZATION);
+    if (authorizedScopes.contains(AuthorizationScope.WILDCARD)) {
+      // A SECRET:REVEAL:* grant authorizes every reference in the batch.
+      return new LinkedHashSet<>(validReferences);
+    }
+    final var authorizedResourceIds =
+        authorizedScopes.stream()
+            .filter(scope -> scope.getMatcher() == AuthorizationResourceMatcher.ID)
+            .map(AuthorizationScope::getResourceId)
+            .collect(Collectors.toSet());
+    return validReferences.stream()
+        .filter(authorizedResourceIds::contains)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static boolean isValidReference(final String reference) {
+    if (reference == null || !reference.startsWith(REFERENCE_PREFIX)) {
+      return false;
+    }
+    final var name = reference.substring(REFERENCE_PREFIX.length());
+    return REFERENCE_NAME_PATTERN.matcher(name).matches();
+  }
+
+  /**
+   * Mocked secret lookup for Phase 1. Resolves only an explicit allow-list of references to a
+   * deterministic placeholder value so dependent work (inbound connectors) can integrate against a
+   * live endpoint; every other authorized, valid reference yields {@code NOT_FOUND}, exercising the
+   * real not-found path rather than fabricating a value for an arbitrary reference. The value is
+   * scoped by physical tenant so the mock cannot mask a cross-tenant leak once the real {@code
+   * SecretStore} (which is itself registered per physical tenant) replaces it. TODO(#56561/#57199):
+   * replace with {@code SecretStore.resolve(...)} once store is configured.
+   */
+  private Optional<String> mockResolve(final String reference) {
+    if (!MOCK_RESOLVABLE_REFERENCES.contains(reference)) {
+      return Optional.empty();
+    }
+    final var name = reference.substring(REFERENCE_PREFIX.length());
+    return Optional.of("mock-value-for-" + name + "-in-tenant-" + getPhysicalTenantId());
+  }
+
+  /** The per-reference outcome of a resolve request. */
+  public record SecretResolution(
+      List<ResolvedSecret> resolved, List<SecretResolutionError> errors) {}
+
+  public record ResolvedSecret(String reference, String value) {}
+
+  public record SecretResolutionError(String reference, SecretErrorCode code, String message) {}
+
+  /**
+   * The typed reason a reference could not be resolved. Mirrors the {@code secret-store} SPI's
+   * {@code SecretErrorCode}; kept independent so the service module does not depend on the store
+   * SPI while the backend is mocked.
+   */
+  public enum SecretErrorCode {
+    NOT_FOUND,
+    ACCESS_DENIED,
+    INVALID_REF
+  }
+}

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +42,19 @@ import org.slf4j.LoggerFactory;
  * wiring — that lands with #56561 / #57199. The sibling {@code SECRET:READ} list endpoint (#56568)
  * reuses this authorization/validation shape.
  */
+@NullMarked
 public class SecretServices extends PhysicalTenantScopedApiServices<SecretServices> {
+
+  /**
+   * Bounds the length of a single reference string. Each reference is used as an authorization
+   * resource id and (once a real store is wired) a store lookup key, so an unbounded string must
+   * not reach either. Enforced here (rather than only at the request-validation layer) so an
+   * over-long reference is reported as a per-reference {@link SecretErrorCode#INVALID_REFERENCE}
+   * like every other malformed reference, instead of failing the whole batch. Mirrored by the
+   * {@code maxLength: 256} on {@code SecretResolveRequest.references} items in {@code
+   * secrets.yaml}; kept in sync by {@code SecretRequestValidatorSpecSyncTest}.
+   */
+  public static final int MAX_REFERENCE_LENGTH = 256;
 
   private static final Logger LOG = LoggerFactory.getLogger(SecretServices.class);
 
@@ -105,7 +118,9 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
         } else {
           errors.add(
               new SecretResolutionError(
-                  reference, SecretErrorCode.INVALID_REF, "The secret reference is malformed."));
+                  reference,
+                  SecretErrorCode.INVALID_REFERENCE,
+                  "The secret reference is malformed."));
         }
       }
       if (validReferences.isEmpty()) {
@@ -158,11 +173,12 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
    */
   private Set<String> resolveAuthorizedReferences(
       final List<String> validReferences, final CamundaAuthentication authentication) {
-    // Unlike other domains, secrets are refused rather than opened up when authorization is
-    // disabled cluster-wide: a secret value must never be revealed without an explicit, checked
-    // grant.
+    // Matches DocumentServices#hasDocumentPermission: when authorization is disabled
+    // cluster-wide, every reference is treated as authorized rather than denied. A deny-all here
+    // would make the endpoint unusable in authorization-disabled setups (e.g. C8Run's default),
+    // which the epic this endpoint serves explicitly targets.
     if (!authorizationsConfig.isEnabled()) {
-      return Set.of();
+      return new LinkedHashSet<>(validReferences);
     }
     final var authorizedScopes =
         authorizationChecker.retrieveAuthorizedAuthorizationScopes(
@@ -182,7 +198,9 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   private static boolean isValidReference(final String reference) {
-    if (reference == null || !reference.startsWith(REFERENCE_PREFIX)) {
+    if (reference == null
+        || reference.length() > MAX_REFERENCE_LENGTH
+        || !reference.startsWith(REFERENCE_PREFIX)) {
       return false;
     }
     final var name = reference.substring(REFERENCE_PREFIX.length());
@@ -222,6 +240,6 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   public enum SecretErrorCode {
     NOT_FOUND,
     ACCESS_DENIED,
-    INVALID_REF
+    INVALID_REFERENCE
   }
 }

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -8,8 +8,10 @@
 package io.camunda.service.authorization;
 
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.COMPONENT;
+import static io.camunda.security.api.model.authz.AuthorizationResourceType.SECRET;
 import static io.camunda.security.api.model.authz.PermissionType.ACCESS;
 import static io.camunda.security.api.model.authz.PermissionType.READ_TASK_LISTENER;
+import static io.camunda.security.api.model.authz.PermissionType.REVEAL;
 
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
@@ -108,6 +110,9 @@ public abstract class Authorizations {
 
   public static final RequiredAuthorization<RoleEntity> ROLE_READ_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.role().read());
+
+  public static final RequiredAuthorization<Object> SECRET_REVEAL_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(SECRET).permissionType(REVEAL));
 
   public static final RequiredAuthorization<TenantEntity> TENANT_READER_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.tenant().read());

--- a/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/DefaultServiceRegistry.java
@@ -35,6 +35,7 @@ import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
+import io.camunda.service.SecretServices;
 import io.camunda.service.SignalServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TopologyServices;
@@ -79,6 +80,7 @@ public record DefaultServiceRegistry(
     Map<String, ProcessInstanceServices> processInstanceByTenant,
     Map<String, ResourceServices> resourceByTenant,
     Map<String, RoleServices> roleByTenant,
+    Map<String, SecretServices> secretByTenant,
     Map<String, SignalServices> signalByTenant,
     Map<String, TenantServices> tenantByTenant,
     Map<String, TopologyServices> topologyByTenant,
@@ -235,6 +237,11 @@ public record DefaultServiceRegistry(
   }
 
   @Override
+  public SecretServices secretServices(final String physicalTenantId) {
+    return byTenant(secretByTenant, physicalTenantId);
+  }
+
+  @Override
   public SignalServices signalServices(final String physicalTenantId) {
     return byTenant(signalByTenant, physicalTenantId);
   }
@@ -340,6 +347,7 @@ public record DefaultServiceRegistry(
     private final Map<String, ProcessInstanceServices> processInstanceByTenant = new HashMap<>();
     private final Map<String, ResourceServices> resourceByTenant = new HashMap<>();
     private final Map<String, RoleServices> roleByTenant = new HashMap<>();
+    private final Map<String, SecretServices> secretByTenant = new HashMap<>();
     private final Map<String, SignalServices> signalByTenant = new HashMap<>();
     private final Map<String, TenantServices> tenantByTenant = new HashMap<>();
     private final Map<String, TopologyServices> topologyByTenant = new HashMap<>();
@@ -497,6 +505,11 @@ public record DefaultServiceRegistry(
       return this;
     }
 
+    public Builder secretServices(final String tenantId, final SecretServices service) {
+      secretByTenant.put(tenantId, service);
+      return this;
+    }
+
     public Builder signalServices(final String tenantId, final SignalServices service) {
       signalByTenant.put(tenantId, service);
       return this;
@@ -566,6 +579,7 @@ public record DefaultServiceRegistry(
           Map.copyOf(processInstanceByTenant),
           Map.copyOf(resourceByTenant),
           Map.copyOf(roleByTenant),
+          Map.copyOf(secretByTenant),
           Map.copyOf(signalByTenant),
           Map.copyOf(tenantByTenant),
           Map.copyOf(topologyByTenant),

--- a/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
+++ b/service/src/main/java/io/camunda/service/registry/ServiceRegistry.java
@@ -35,6 +35,7 @@ import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
+import io.camunda.service.SecretServices;
 import io.camunda.service.SignalServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TopologyServices;
@@ -107,6 +108,8 @@ public interface ServiceRegistry {
   ResourceServices resourceServices(String physicalTenantId);
 
   RoleServices roleServices(String physicalTenantId);
+
+  SecretServices secretServices(String physicalTenantId);
 
   SignalServices signalServices(String physicalTenantId);
 

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.SecretServices.ResolvedSecret;
+import io.camunda.service.SecretServices.SecretErrorCode;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SecretServicesTest {
+
+  private static final String PHYSICAL_TENANT_ID = "testtenant";
+
+  private final AuthorizationChecker authorizationChecker = mock(AuthorizationChecker.class);
+  private final AuthorizationsConfiguration authorizationsConfig =
+      new AuthorizationsConfiguration();
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+
+  private SecretServices services;
+
+  @BeforeEach
+  void before() {
+    services = newSecretServices(PHYSICAL_TENANT_ID);
+  }
+
+  private SecretServices newSecretServices(final String physicalTenantId) {
+    return new SecretServices(
+        physicalTenantId,
+        mock(BrokerClient.class),
+        mock(SecurityContextProvider.class),
+        authorizationChecker,
+        authorizationsConfig,
+        mock(ApiServicesExecutorProvider.class),
+        null);
+  }
+
+  private void grantReveal(final String... references) {
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(Arrays.stream(references).map(AuthorizationScope::id).toList());
+  }
+
+  private void grantRevealWildcard() {
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(List.of(AuthorizationScope.WILDCARD));
+  }
+
+  private void denyAllReveals() {
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(List.of());
+  }
+
+  @Test
+  void shouldDeduplicateReferences() {
+    // given authorization passes for every reference
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.a", "camunda.secrets.b");
+
+    // when the same reference appears multiple times
+    final var resolution =
+        services
+            .resolve(
+                List.of("camunda.secrets.a", "camunda.secrets.a", "camunda.secrets.b"),
+                authentication)
+            .join();
+
+    // then it is resolved exactly once
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference)
+        .containsExactly("camunda.secrets.a", "camunda.secrets.b");
+    assertThat(resolution.errors()).isEmpty();
+    // and the authorization query runs once for the whole batch, not once per distinct reference
+    verify(authorizationChecker, times(1)).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldResolveAuthorizedReference() {
+    // given authorization passes for the reference
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the (mocked) value is returned, scoped to this tenant
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved()).hasSize(1);
+    assertThat(resolution.resolved().get(0).reference()).isEqualTo("camunda.secrets.token");
+    assertThat(resolution.resolved().get(0).value())
+        .isEqualTo("mock-value-for-token-in-tenant-" + PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  void shouldScopeMockedValuesByPhysicalTenant() {
+    // given two SecretServices instances scoped to different physical tenants, both authorized
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.token");
+    final var otherTenantServices = newSecretServices("othertenant");
+
+    // when the same reference is resolved under each tenant
+    final var value =
+        services
+            .resolve(List.of("camunda.secrets.token"), authentication)
+            .join()
+            .resolved()
+            .get(0)
+            .value();
+    final var otherValue =
+        otherTenantServices
+            .resolve(List.of("camunda.secrets.token"), authentication)
+            .join()
+            .resolved()
+            .get(0)
+            .value();
+
+    // then the resolved values differ per tenant — the mock never returns an identical value
+    // across tenants, which would otherwise mask a cross-tenant leak
+    assertThat(value).isNotEqualTo(otherValue);
+  }
+
+  @Test
+  void shouldRouteUnknownReferenceToNotFound() {
+    // given authorization passes but the reference is not one the mock backend knows
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.unknown");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.unknown"), authentication).join();
+
+    // then it is reported as NOT_FOUND rather than resolved to a fabricated value
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).reference()).isEqualTo("camunda.secrets.unknown");
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldRouteDeniedReferenceToErrorsWithoutFailingOthers() {
+    // given authorization passes for one reference and is denied for another
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.a");
+
+    // when
+    final var resolution =
+        services
+            .resolve(List.of("camunda.secrets.a", "camunda.secrets.denied"), authentication)
+            .join();
+
+    // then the denied reference is an error while the other still resolves
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference)
+        .containsExactly("camunda.secrets.a");
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).reference()).isEqualTo("camunda.secrets.denied");
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldReturnAccessDeniedForDeniedNonExistentReference() {
+    // given a reference the mock backend does not know AND the caller is not authorized for it
+    authorizationsConfig.setEnabled(true);
+    denyAllReveals();
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.doesnotexist"), authentication).join();
+
+    // then it is ACCESS_DENIED, never NOT_FOUND — authorization is checked before any lookup, so a
+    // denied caller can never distinguish a missing secret from one they simply cannot reveal (no
+    // existence oracle)
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    // the lookup is never consulted for a denied reference
+    verify(authorizationChecker).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldRejectReferenceNamesWithPatternCharactersAsInvalid() {
+    // given a batch that is entirely malformed
+    authorizationsConfig.setEnabled(true);
+
+    // when references carry pattern/glob or whitespace characters in the name segment
+    final var resolution =
+        services
+            .resolve(
+                List.of("camunda.secrets.*", "camunda.secrets.a%b", "camunda.secrets.a b"),
+                authentication)
+            .join();
+
+    // then all are INVALID_REF and none is ever authorized (they must not reach the resource-id
+    // check or, later, a store lookup) — no authorization query is even issued for the batch
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors())
+        .extracting(SecretServices.SecretResolutionError::code)
+        .containsOnly(SecretErrorCode.INVALID_REF);
+    verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldRouteMalformedReferenceToErrorsBeforeAuthorization() {
+    // given a batch that is entirely malformed
+    authorizationsConfig.setEnabled(true);
+
+    // when a malformed reference is included
+    final var resolution =
+        services.resolve(List.of("not.a.secret", "camunda.secrets.a.b"), authentication).join();
+
+    // then both are INVALID_REF and no authorization query is issued for the batch
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors())
+        .extracting(SecretServices.SecretResolutionError::code)
+        .containsOnly(SecretErrorCode.INVALID_REF);
+    verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldAuthorizeExactlyTheGrantedResourceId() {
+    // given the caller is granted REVEAL only on a different reference
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.other");
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the ungranted reference is denied — matching is by exact resource id, not a blanket
+    // allow once any grant exists
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldAuthorizeAnyReferenceWithWildcardGrant() {
+    // given a SECRET:REVEAL:* wildcard grant
+    authorizationsConfig.setEnabled(true);
+    grantRevealWildcard();
+
+    // when resolving references the caller was never explicitly granted
+    final var resolution =
+        services
+            .resolve(List.of("camunda.secrets.token", "camunda.secrets.a"), authentication)
+            .join();
+
+    // then the wildcard authorizes every reference in the batch
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved())
+        .extracting(ResolvedSecret::reference)
+        .containsExactlyInAnyOrder("camunda.secrets.token", "camunda.secrets.a");
+  }
+
+  @Test
+  void shouldRefuseToRevealWhenAuthorizationIsDisabled() {
+    // given authorization is disabled cluster-wide. Unlike other domains, secrets must never be
+    // revealed without an explicit, checked grant, so this is a deny rather than an open-allow.
+    authorizationsConfig.setEnabled(false);
+
+    // when
+    final var resolution = services.resolve(List.of("camunda.secrets.a"), authentication).join();
+
+    // then the reference is denied and the checker (which cannot be trusted while disabled) is
+    // never consulted
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  // Covers the response-body facet of the no-leak AC only. The other facets (no secret value in
+  // logs, exported records, or persistence) are not observable while the backend is mocked and are
+  // deferred to the store wiring (#56561/#57199).
+  void shouldNotExposeSecretValuesInErrorEntries() {
+    // given a denied reference (no value should ever be produced for it)
+    authorizationsConfig.setEnabled(true);
+    denyAllReveals();
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.denied"), authentication).join();
+
+    // then values only ever live in resolved entries; error entries carry metadata only
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors().get(0).message()).doesNotContain("mock-value-for-");
+  }
+}

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -210,13 +210,53 @@ public class SecretServicesTest {
                 authentication)
             .join();
 
-    // then all are INVALID_REF and none is ever authorized (they must not reach the resource-id
+    // then all are INVALID_REFERENCE and none is ever authorized (they must not reach the
+    // resource-id
     // check or, later, a store lookup) — no authorization query is even issued for the batch
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors())
         .extracting(SecretServices.SecretResolutionError::code)
-        .containsOnly(SecretErrorCode.INVALID_REF);
+        .containsOnly(SecretErrorCode.INVALID_REFERENCE);
     verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldRejectReferenceExceedingMaxLengthAsInvalid() {
+    // given authorization would otherwise pass for every reference
+    authorizationsConfig.setEnabled(true);
+
+    // when a reference is one character longer than MAX_REFERENCE_LENGTH
+    final var reference = referenceOfLength(SecretServices.MAX_REFERENCE_LENGTH + 1);
+    final var resolution = services.resolve(List.of(reference), authentication).join();
+
+    // then it is INVALID_REFERENCE, consistent with every other malformed reference, and no
+    // authorization query is issued
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.INVALID_REFERENCE);
+    verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
+  }
+
+  @Test
+  void shouldAcceptReferenceAtMaxLength() {
+    // given authorization passes and the reference is exactly at MAX_REFERENCE_LENGTH
+    authorizationsConfig.setEnabled(true);
+    final var reference = referenceOfLength(SecretServices.MAX_REFERENCE_LENGTH);
+    grantReveal(reference);
+
+    // when
+    final var resolution = services.resolve(List.of(reference), authentication).join();
+
+    // then the boundary is inclusive: NOT_FOUND (mock backend doesn't know it), not
+    // INVALID_REFERENCE
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  private static String referenceOfLength(final int totalLength) {
+    final var prefix = "camunda.secrets.";
+    return prefix + "a".repeat(totalLength - prefix.length());
   }
 
   @Test
@@ -228,11 +268,11 @@ public class SecretServicesTest {
     final var resolution =
         services.resolve(List.of("not.a.secret", "camunda.secrets.a.b"), authentication).join();
 
-    // then both are INVALID_REF and no authorization query is issued for the batch
+    // then both are INVALID_REFERENCE and no authorization query is issued for the batch
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors())
         .extracting(SecretServices.SecretResolutionError::code)
-        .containsOnly(SecretErrorCode.INVALID_REF);
+        .containsOnly(SecretErrorCode.INVALID_REFERENCE);
     verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
   }
 
@@ -272,19 +312,20 @@ public class SecretServicesTest {
   }
 
   @Test
-  void shouldRefuseToRevealWhenAuthorizationIsDisabled() {
-    // given authorization is disabled cluster-wide. Unlike other domains, secrets must never be
-    // revealed without an explicit, checked grant, so this is a deny rather than an open-allow.
+  void shouldAllowRevealWhenAuthorizationIsDisabled() {
+    // given authorization is disabled cluster-wide. Matches DocumentServices#hasDocumentPermission:
+    // a deny-all here would make the endpoint unusable in authorization-disabled setups (e.g.
+    // C8Run's default), which the epic this endpoint serves explicitly targets.
     authorizationsConfig.setEnabled(false);
 
     // when
     final var resolution = services.resolve(List.of("camunda.secrets.a"), authentication).join();
 
-    // then the reference is denied and the checker (which cannot be trusted while disabled) is
+    // then the reference is resolved and the checker (which cannot be trusted while disabled) is
     // never consulted
-    assertThat(resolution.resolved()).isEmpty();
-    assertThat(resolution.errors()).hasSize(1);
-    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(resolution.errors()).isEmpty();
+    assertThat(resolution.resolved()).hasSize(1);
+    assertThat(resolution.resolved().get(0).reference()).isEqualTo("camunda.secrets.a");
     verify(authorizationChecker, never()).retrieveAuthorizedAuthorizationScopes(any(), any());
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -72,6 +72,7 @@ tags:
   - name: Recovery
   - name: Resource
   - name: Role
+  - name: Secret
   - name: Setup
   - name: Signal
   - name: System
@@ -408,6 +409,10 @@ paths:
     $ref: 'roles.yaml#/paths/~1roles~1{roleId}~1users~1search'
   /roles/{roleId}/users/{username}:
     $ref: 'roles.yaml#/paths/~1roles~1{roleId}~1users~1{username}'
+
+  # Secret endpoints
+  /secrets/resolve:
+    $ref: 'secrets.yaml#/paths/~1secrets~1resolve'
 
   # Setup endpoints
   /setup/user:

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -20,9 +20,10 @@ paths:
 
         Each reference is authorized and resolved independently. For valid requests, the endpoint
         always responds with HTTP 200: successfully resolved references are returned in `resolved`,
-        while references that could not be resolved (for example not found, or the caller lacks
-        `SECRET:REVEAL` on that reference) are returned in `errors`. A failure of one reference
-        never fails the others; requests that violate the request schema are rejected with HTTP 400.
+        while references that could not be resolved (for example not found, malformed or over-long,
+        or the caller lacks `SECRET:REVEAL` on that reference) are returned in `errors`. A failure of
+        one reference never fails the others. Only structurally invalid requests are rejected with
+        HTTP 400: a missing or non-array `references` field, more than 20 references, or a null entry.
 
         This endpoint is an alpha feature and may be subject to change in future releases.
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -7,6 +7,7 @@ paths:
       tags:
         - Secret
       operationId: resolveSecrets
+      x-permission-enforcement: filter
       x-required-permissions:
         - { resourceType: SECRET, permissionType: REVEAL }
       security:
@@ -24,6 +25,9 @@ paths:
         never fails the others; requests that violate the request schema are rejected with HTTP 400.
 
         This endpoint is an alpha feature and may be subject to change in future releases.
+
+        Phase 1: the secret backend is mocked. Only a fixed allow-list of references resolves;
+        every other authorized, valid reference returns `NOT_FOUND`.
       requestBody:
         required: true
         content:
@@ -120,8 +124,8 @@ components:
 
         - `NOT_FOUND`: no secret exists for the reference.
         - `ACCESS_DENIED`: the caller lacks `SECRET:REVEAL` on the reference.
-        - `INVALID_REF`: the reference is malformed.
+        - `INVALID_REFERENCE`: the reference is malformed.
       enum:
         - NOT_FOUND
         - ACCESS_DENIED
-        - INVALID_REF
+        - INVALID_REFERENCE

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -1,0 +1,127 @@
+## Endpoint definitions
+
+paths:
+  /secrets/resolve:
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Secret
+      operationId: resolveSecrets
+      x-required-permissions:
+        - { resourceType: SECRET, permissionType: REVEAL }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Resolve secrets (alpha)
+      description: |
+        Resolve a deduplicated batch of `camunda.secrets.*` references for the caller's
+        physical tenant in a single round-trip.
+
+        Each reference is authorized and resolved independently. For valid requests, the endpoint
+        always responds with HTTP 200: successfully resolved references are returned in `resolved`,
+        while references that could not be resolved (for example not found, or the caller lacks
+        `SECRET:REVEAL` on that reference) are returned in `errors`. A failure of one reference
+        never fails the others; requests that violate the request schema are rejected with HTTP 400.
+
+        This endpoint is an alpha feature and may be subject to change in future releases.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretResolveRequest'
+      responses:
+        "200":
+          description: |
+            The batch was processed. Per-reference outcomes are split between `resolved` and
+            `errors`; this status is returned even when some or all references failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretResolveResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
+components:
+  schemas:
+    SecretResolveRequest:
+      type: object
+      required:
+        - references
+      properties:
+        references:
+          type: array
+          maxItems: 20
+          description: |
+            The secret references to resolve, each of the form `camunda.secrets.<name>`.
+            Duplicate references are deduplicated by the server and resolved once.
+            At most 20 references may be requested in a single batch.
+          items:
+            type: string
+            maxLength: 256
+            description: A secret reference of the form `camunda.secrets.<name>`.
+    SecretResolveResult:
+      type: object
+      required:
+        - resolved
+        - errors
+      description: The per-reference outcome of a resolve request.
+      properties:
+        resolved:
+          type: array
+          description: The references that were successfully resolved.
+          items:
+            $ref: '#/components/schemas/ResolvedSecret'
+        errors:
+          type: array
+          description: The references that could not be resolved, each with a typed error code.
+          items:
+            $ref: '#/components/schemas/SecretResolutionError'
+    ResolvedSecret:
+      type: object
+      required:
+        - reference
+        - value
+      properties:
+        reference:
+          type: string
+          description: The resolved secret reference of the form `camunda.secrets.<name>`.
+        value:
+          type: string
+          description: The resolved secret value.
+    SecretResolutionError:
+      type: object
+      required:
+        - reference
+        - code
+        - message
+      properties:
+        reference:
+          type: string
+          description: The secret reference that could not be resolved.
+        code:
+          $ref: '#/components/schemas/SecretErrorCode'
+        message:
+          type: string
+          description: |
+            A human-readable description of the failure. Never contains the secret value;
+            only error metadata (codes, names) is included.
+    SecretErrorCode:
+      type: string
+      description: |
+        The typed reason a reference could not be resolved.
+
+        - `NOT_FOUND`: no secret exists for the reference.
+        - `ACCESS_DENIED`: the caller lacks `SECRET:REVEAL` on the reference.
+        - `INVALID_REF`: the reference is malformed.
+      enum:
+        - NOT_FOUND
+        - ACCESS_DENIED
+        - INVALID_REF

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SecretController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SecretController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.mapping.http.ResponseMapper;
+import io.camunda.gateway.mapping.http.validator.SecretRequestValidator;
+import io.camunda.gateway.protocol.model.SecretResolveRequest;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/secrets")
+public class SecretController {
+
+  private final ServiceRegistry serviceRegistry;
+  private final CamundaAuthenticationProvider authenticationProvider;
+
+  public SecretController(
+      final ServiceRegistry serviceRegistry,
+      final CamundaAuthenticationProvider authenticationProvider) {
+    this.serviceRegistry = serviceRegistry;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @CamundaPostMapping(path = "/resolve")
+  public CompletableFuture<ResponseEntity<Object>> resolveSecrets(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestBody final SecretResolveRequest request) {
+    return SecretRequestValidator.validateSecretResolveRequest(request)
+        .<CompletableFuture<ResponseEntity<Object>>>map(
+            RestErrorMapper::mapProblemToCompletedResponse)
+        .orElseGet(() -> resolve(physicalTenantId, request.getReferences()));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> resolve(
+      final String physicalTenantId, final List<String> references) {
+    final var secretServices = serviceRegistry.secretServices(physicalTenantId);
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () -> secretServices.resolve(references, authentication),
+        ResponseMapper::toSecretResolveResult,
+        HttpStatus.OK);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretControllerTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.gateway.mapping.http.validator.SecretRequestValidator.MAX_BATCH_SIZE;
-import static io.camunda.gateway.mapping.http.validator.SecretRequestValidator.MAX_REFERENCE_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -218,44 +217,6 @@ public class SecretControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldRejectReferenceExceedingMaxLength() {
-    // given a single reference one character longer than the maximum
-    final var reference = referenceOfLength(MAX_REFERENCE_LENGTH + 1);
-
-    // when / then the request is rejected before reaching the service
-    webClient
-        .post()
-        .uri(RESOLVE_URL)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{ \"references\": [\"" + reference + "\"] }")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest();
-    verifyNoInteractions(secretServices);
-  }
-
-  @Test
-  void shouldAcceptReferenceAtMaxLength() {
-    // given a single reference exactly at the maximum length
-    when(secretServices.resolve(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new SecretResolution(List.of(), List.of())));
-    final var reference = referenceOfLength(MAX_REFERENCE_LENGTH);
-
-    // when / then the boundary is inclusive and the request reaches the service
-    webClient
-        .post()
-        .uri(RESOLVE_URL)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{ \"references\": [\"" + reference + "\"] }")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isOk();
-    verify(secretServices).resolve(any(), any());
-  }
-
-  @Test
   void shouldRejectNullReferences() {
     // given a request whose references are explicitly null (bypasses the model's @NotNull because
     // the controller does not run @Valid)
@@ -311,10 +272,5 @@ public class SecretControllerTest extends RestControllerTest {
     return IntStream.rangeClosed(1, count)
         .mapToObj(i -> "\"camunda.secrets.s" + i + "\"")
         .collect(Collectors.joining(","));
-  }
-
-  private static String referenceOfLength(final int totalLength) {
-    final var prefix = "camunda.secrets.";
-    return prefix + "a".repeat(totalLength - prefix.length());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretControllerTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.gateway.mapping.http.validator.SecretRequestValidator.MAX_BATCH_SIZE;
+import static io.camunda.gateway.mapping.http.validator.SecretRequestValidator.MAX_REFERENCE_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.service.SecretServices;
+import io.camunda.service.SecretServices.ResolvedSecret;
+import io.camunda.service.SecretServices.SecretErrorCode;
+import io.camunda.service.SecretServices.SecretResolution;
+import io.camunda.service.SecretServices.SecretResolutionError;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(value = SecretController.class)
+public class SecretControllerTest extends RestControllerTest {
+
+  static final String RESOLVE_URL = "/v2/secrets/resolve";
+
+  @Captor ArgumentCaptor<List<String>> referencesCaptor;
+  @MockitoBean SecretServices secretServices;
+  @MockitoBean CamundaSecurityLibraryProperties cslProperties;
+  @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean ServiceRegistry serviceRegistry;
+
+  @BeforeEach
+  void setupServices() {
+    lenient().when(serviceRegistry.secretServices(any())).thenReturn(secretServices);
+    when(authenticationProvider.getCamundaAuthentication())
+        .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @Test
+  void shouldReturnMixedOutcomesWithHttp200() {
+    // given a batch that resolves one reference and fails two independently
+    when(secretServices.resolve(any(), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new SecretResolution(
+                    List.of(new ResolvedSecret("camunda.secrets.a", "value-a")),
+                    List.of(
+                        new SecretResolutionError(
+                            "camunda.secrets.missing", SecretErrorCode.NOT_FOUND, "not found"),
+                        new SecretResolutionError(
+                            "camunda.secrets.denied", SecretErrorCode.ACCESS_DENIED, "denied")))));
+
+    final var expectedBody =
+        """
+        {
+          "resolved": [
+            { "reference": "camunda.secrets.a", "value": "value-a" }
+          ],
+          "errors": [
+            { "reference": "camunda.secrets.missing", "code": "NOT_FOUND", "message": "not found" },
+            { "reference": "camunda.secrets.denied", "code": "ACCESS_DENIED", "message": "denied" }
+          ]
+        }""";
+
+    // when / then a partial failure is not a 4xx/5xx
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            { "references": ["camunda.secrets.a", "camunda.secrets.missing", "camunda.secrets.denied"] }""")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnHttp200WhenAllReferencesFail() {
+    // given every reference fails
+    when(secretServices.resolve(any(), any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new SecretResolution(
+                    List.of(),
+                    List.of(
+                        new SecretResolutionError(
+                            "camunda.secrets.denied", SecretErrorCode.ACCESS_DENIED, "denied")))));
+
+    // when / then still HTTP 200
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            { "references": ["camunda.secrets.denied"] }""")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+  }
+
+  @Test
+  void shouldForwardReferencesToService() {
+    // given
+    when(secretServices.resolve(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new SecretResolution(List.of(), List.of())));
+
+    // when
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            { "references": ["camunda.secrets.a", "camunda.secrets.b"] }""")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    // then the raw references are forwarded (server-side deduplication happens in the service)
+    verify(secretServices)
+        .resolve(referencesCaptor.capture(), eq(AUTHENTICATION_WITH_DEFAULT_TENANT));
+    assertThat(referencesCaptor.getValue())
+        .containsExactly("camunda.secrets.a", "camunda.secrets.b");
+  }
+
+  @Test
+  void shouldReturnEmptyResultForEmptyBatch() {
+    // given an empty batch is a valid no-op
+    when(secretServices.resolve(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new SecretResolution(List.of(), List.of())));
+
+    // when / then it resolves to HTTP 200 with empty outcomes
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            { "references": [] }""")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "resolved": [], "errors": [] }""",
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldRejectBatchExceedingMaxItems() {
+    // given a batch one larger than the maximum
+    final var references = referencesJson(MAX_BATCH_SIZE + 1);
+
+    // when / then the request is rejected before reaching the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{ \"references\": [" + references + "] }")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+    verifyNoInteractions(secretServices);
+  }
+
+  @Test
+  void shouldAcceptBatchAtMaxItems() {
+    // given a batch exactly at the maximum
+    when(secretServices.resolve(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new SecretResolution(List.of(), List.of())));
+    final var references = referencesJson(MAX_BATCH_SIZE);
+
+    // when / then the boundary is inclusive and the request reaches the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{ \"references\": [" + references + "] }")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+    verify(secretServices).resolve(any(), any());
+  }
+
+  @Test
+  void shouldRejectReferenceExceedingMaxLength() {
+    // given a single reference one character longer than the maximum
+    final var reference = referenceOfLength(MAX_REFERENCE_LENGTH + 1);
+
+    // when / then the request is rejected before reaching the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{ \"references\": [\"" + reference + "\"] }")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+    verifyNoInteractions(secretServices);
+  }
+
+  @Test
+  void shouldAcceptReferenceAtMaxLength() {
+    // given a single reference exactly at the maximum length
+    when(secretServices.resolve(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new SecretResolution(List.of(), List.of())));
+    final var reference = referenceOfLength(MAX_REFERENCE_LENGTH);
+
+    // when / then the boundary is inclusive and the request reaches the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{ \"references\": [\"" + reference + "\"] }")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+    verify(secretServices).resolve(any(), any());
+  }
+
+  @Test
+  void shouldRejectNullReferences() {
+    // given a request whose references are explicitly null (bypasses the model's @NotNull because
+    // the controller does not run @Valid)
+
+    // when / then it is a 400 rather than a 500 and never reaches the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{ \"references\": null }")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+    verifyNoInteractions(secretServices);
+  }
+
+  @Test
+  void shouldRejectNullRequestBody() {
+    // given a literal JSON null body (deserialized as a null request, bypassing the model @NotNull)
+
+    // when / then it is a 400 rather than a 500 and never reaches the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("null")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+    verifyNoInteractions(secretServices);
+  }
+
+  @Test
+  void shouldRejectReferencesContainingNullEntry() {
+    // given a batch with a null entry among valid references
+
+    // when / then the whole request is rejected before reaching the service
+    webClient
+        .post()
+        .uri(RESOLVE_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{ \"references\": [\"camunda.secrets.a\", null] }")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+    verifyNoInteractions(secretServices);
+  }
+
+  private static String referencesJson(final int count) {
+    return IntStream.rangeClosed(1, count)
+        .mapToObj(i -> "\"camunda.secrets.s" + i + "\"")
+        .collect(Collectors.joining(","));
+  }
+
+  private static String referenceOfLength(final int totalLength) {
+    final var prefix = "camunda.secrets.";
+    return prefix + "a".repeat(totalLength - prefix.length());
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretRequestValidatorSpecSyncTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretRequestValidatorSpecSyncTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.gateway.mapping.http.validator.SecretRequestValidator;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link SecretRequestValidator#MAX_BATCH_SIZE} and {@link
+ * SecretRequestValidator#MAX_REFERENCE_LENGTH} are the only real enforcement of the {@code
+ * maxItems}/{@code maxLength} declared on {@code SecretResolveRequest.references} in {@code
+ * secrets.yaml}: the generated request model does not emit array-size or length constraints, so
+ * nothing else fails the build if the two drift apart. This test is that guard.
+ *
+ * <p>Reads {@code secrets.yaml} as plain text (it is bundled onto this module's classpath by the
+ * {@code zeebe-gateway-protocol} dependency) rather than through an OpenAPI parser: the file is a
+ * fragment referenced piecemeal by {@code rest-api.yaml} ($ref per path item, not per schema), so a
+ * full-spec parse does not reliably resolve its schemas back onto a single root document.
+ */
+class SecretRequestValidatorSpecSyncTest {
+
+  private static final String SECRETS_YAML_CLASSPATH_RESOURCE = "v2/secrets.yaml";
+
+  @Test
+  void shouldMatchMaxBatchSizeDeclaredInSpec() {
+    // given the maxItems declared on SecretResolveRequest.references in secrets.yaml
+    final var maxItems = extractIntValue("maxItems");
+
+    // then the validator's cap matches it exactly
+    assertThat(maxItems).isEqualTo(SecretRequestValidator.MAX_BATCH_SIZE);
+  }
+
+  @Test
+  void shouldMatchMaxReferenceLengthDeclaredInSpec() {
+    // given the maxLength declared on each references item in secrets.yaml
+    final var maxLength = extractIntValue("maxLength");
+
+    // then the validator's cap matches it exactly
+    assertThat(maxLength).isEqualTo(SecretRequestValidator.MAX_REFERENCE_LENGTH);
+  }
+
+  private static int extractIntValue(final String yamlKey) {
+    final var pattern = Pattern.compile(yamlKey + ":\\s*(\\d+)");
+    final Matcher matcher = pattern.matcher(secretsYaml());
+    if (!matcher.find()) {
+      throw new AssertionError(
+          "Expected '%s' to declare a '%s' constraint, but none was found."
+              .formatted(SECRETS_YAML_CLASSPATH_RESOURCE, yamlKey));
+    }
+    final var value = Integer.parseInt(matcher.group(1));
+    if (matcher.find()) {
+      throw new AssertionError(
+          "Expected '%s' to declare exactly one '%s' constraint, but found more than one. "
+                  .formatted(SECRETS_YAML_CLASSPATH_RESOURCE, yamlKey)
+              + "Narrow this test's extraction so it targets the right occurrence.");
+    }
+    return value;
+  }
+
+  private static String secretsYaml() {
+    try (var in =
+        SecretRequestValidatorSpecSyncTest.class
+            .getClassLoader()
+            .getResourceAsStream(SECRETS_YAML_CLASSPATH_RESOURCE)) {
+      if (in == null) {
+        throw new AssertionError(
+            "Classpath resource not found: " + SECRETS_YAML_CLASSPATH_RESOURCE);
+      }
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretRequestValidatorSpecSyncTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretRequestValidatorSpecSyncTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.gateway.mapping.http.validator.SecretRequestValidator;
+import io.camunda.service.SecretServices;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -18,11 +19,11 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /**
- * {@link SecretRequestValidator#MAX_BATCH_SIZE} and {@link
- * SecretRequestValidator#MAX_REFERENCE_LENGTH} are the only real enforcement of the {@code
- * maxItems}/{@code maxLength} declared on {@code SecretResolveRequest.references} in {@code
- * secrets.yaml}: the generated request model does not emit array-size or length constraints, so
- * nothing else fails the build if the two drift apart. This test is that guard.
+ * {@link SecretRequestValidator#MAX_BATCH_SIZE} and {@link SecretServices#MAX_REFERENCE_LENGTH} are
+ * the only real enforcement of the {@code maxItems}/{@code maxLength} declared on {@code
+ * SecretResolveRequest.references} in {@code secrets.yaml}: the generated request model does not
+ * emit array-size or length constraints, so nothing else fails the build if the two drift apart.
+ * This test is that guard.
  *
  * <p>Reads {@code secrets.yaml} as plain text (it is bundled onto this module's classpath by the
  * {@code zeebe-gateway-protocol} dependency) rather than through an OpenAPI parser: the file is a
@@ -47,8 +48,8 @@ class SecretRequestValidatorSpecSyncTest {
     // given the maxLength declared on each references item in secrets.yaml
     final var maxLength = extractIntValue("maxLength");
 
-    // then the validator's cap matches it exactly
-    assertThat(maxLength).isEqualTo(SecretRequestValidator.MAX_REFERENCE_LENGTH);
+    // then the service's cap matches it exactly
+    assertThat(maxLength).isEqualTo(SecretServices.MAX_REFERENCE_LENGTH);
   }
 
   private static int extractIntValue(final String yamlKey) {


### PR DESCRIPTION


related to #56567

## Description
Adds the POST /v2/secrets/resolve gateway REST endpoint

- Validates and deduplicates batched secret references (max 20 per request, enforced in code since the generated OpenAPI model doesn't emit array-size constraints — guarded by a new spec-sync test against drift).
- Authorizes each reference individually via SECRET:REVEAL before any lookup, so unauthorized callers can't distinguish a missing secret from a denied one.
- Always returns HTTP 200 with per-reference resolved[]/errors[] results.
- SecretServices.resolve is async (CompletableFuture), matching the standard controller dispatch pattern (RequestExecutor.executeServiceMethod) used elsewhere (e.g. ClusterVariableController).
- Secret value lookup is currently mocked; the real SecretStore lands in [#56561](https://github.com/camunda/camunda/issues/56561)/[#57199](https://github.com/camunda/camunda/issues/57199).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56567
