### PR TITLE
ci: strip non-shipped dependency scopes before FOSSA license analysis

### DIFF
--- a/.github/actions/adjust-pom-for-license-analysis/README.md
+++ b/.github/actions/adjust-pom-for-license-analysis/README.md
@@ -13,6 +13,15 @@ modules. Analysis tools that expect a single root POM need these files adjusted 
 - The root `pom.xml` no longer lists `bom` and `parent` as modules (to avoid circular references)
 - `optimize/pom.xml` excludes the `qa` module (FOSSA workaround)
 
+It also strips `test`, `provided` and `system` scoped dependencies from every `pom.xml`
+(via `strip-analysis-scopes.py`). FOSSA runs `depgraph:aggregate` with
+`-DmergeScopes -DrepeatTransitiveDependenciesInTextGraph=true`, which repeats those dependencies
+under every path in the graph; on a monorepo this size the generated text graph can exceed the
+JVM's maximum array length (~2 GiB) and crash the analyzer with an `OutOfMemoryError`. These
+scopes are not part of any shipped artifact and are already excluded from FOSSA's results via
+`maven.scope-exclude` in `.fossa.yml`, so removing them up front keeps the graph small and
+deterministic without changing the reported licenses.
+
 ## Inputs
 
 None.

--- a/.github/actions/adjust-pom-for-license-analysis/action.yml
+++ b/.github/actions/adjust-pom-for-license-analysis/action.yml
@@ -28,3 +28,15 @@ runs:
         yq -i \
           'del(.project.modules.module[] | select(. == "qa"))' \
           optimize/pom.xml
+    - name: Strip non-shipped dependency scopes so FOSSA's dependency graph stays under the JVM array limit
+      shell: bash
+      run: |
+        # FOSSA runs `depgraph:aggregate` with -DmergeScopes -DrepeatTransitiveDependenciesInTextGraph=true,
+        # which folds test/provided/system dependencies into the graph and repeats every transitive
+        # dependency under every path. On a monorepo this size the resulting text graph can exceed the JVM's
+        # maximum array length (~2 GiB), crashing the analyzer with "Required array length ... is too large ->
+        # OutOfMemoryError". These scopes are not part of any shipped artifact and are already dropped via
+        # `maven.scope-exclude` in .fossa.yml (but only after the graph is built, too late to avoid the crash),
+        # so removing them from the POMs up front keeps the graph small while producing identical results.
+        find . -name pom.xml -not -path '*/target/*' -print0 \
+          | xargs -0 python3 "${GITHUB_ACTION_PATH}/strip-analysis-scopes.py"

--- a/.github/actions/adjust-pom-for-license-analysis/action.yml
+++ b/.github/actions/adjust-pom-for-license-analysis/action.yml
@@ -31,12 +31,5 @@ runs:
     - name: Strip non-shipped dependency scopes so FOSSA's dependency graph stays under the JVM array limit
       shell: bash
       run: |
-        # FOSSA runs `depgraph:aggregate` with -DmergeScopes -DrepeatTransitiveDependenciesInTextGraph=true,
-        # which folds test/provided/system dependencies into the graph and repeats every transitive
-        # dependency under every path. On a monorepo this size the resulting text graph can exceed the JVM's
-        # maximum array length (~2 GiB), crashing the analyzer with "Required array length ... is too large ->
-        # OutOfMemoryError". These scopes are not part of any shipped artifact and are already dropped via
-        # `maven.scope-exclude` in .fossa.yml (but only after the graph is built, too late to avoid the crash),
-        # so removing them from the POMs up front keeps the graph small while producing identical results.
-        find . -name pom.xml -not -path '*/target/*' -print0 \
-          | xargs -0 python3 "${GITHUB_ACTION_PATH}/strip-analysis-scopes.py"
+        # See strip-analysis-scopes.py for why this is needed.
+        python3 "${GITHUB_ACTION_PATH}/strip-analysis-scopes.py" .

--- a/.github/actions/adjust-pom-for-license-analysis/strip-analysis-scopes.py
+++ b/.github/actions/adjust-pom-for-license-analysis/strip-analysis-scopes.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Strip non-shipped dependency scopes from Maven POMs before FOSSA analysis.
+
+FOSSA's Maven strategy runs `depgraph:aggregate` with
+`-DmergeScopes -DrepeatTransitiveDependenciesInTextGraph=true`, which folds
+test/provided/system dependencies into the dependency graph and repeats every
+transitive dependency under every path. On a monorepo the size of this one the
+resulting text graph can exceed the JVM's maximum array length (~2 GiB),
+crashing the analyzer with `Required array length ... is too large ->
+OutOfMemoryError` (see the FOSSA `check-licenses` workflow).
+
+These scopes are not part of any shipped artifact and are already listed under
+`maven.scope-exclude` in `.fossa.yml`, so they are dropped from FOSSA's results
+anyway -- but that filter is applied after the graph is generated, too late to
+prevent the crash. Removing them from the POMs up front keeps the generated
+graph small and deterministic while producing identical license results.
+
+Only <dependencies> blocks (top-level and inside <profiles>) are touched;
+<dependencyManagement> is intentionally left alone as it declares versions
+rather than real graph edges. The edit is applied to the ephemeral CI checkout
+only and is idempotent.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+
+NAMESPACE = "http://maven.apache.org/POM/4.0.0"
+EXCLUDED_SCOPES = {"test", "provided", "system"}
+
+ET.register_namespace("", NAMESPACE)
+
+
+def _q(tag: str) -> str:
+    return f"{{{NAMESPACE}}}{tag}"
+
+
+def _dependency_containers(root: ET.Element):
+    """Yield every <dependencies> that contributes real graph edges."""
+    top = root.find(_q("dependencies"))
+    if top is not None:
+        yield top
+    profiles = root.find(_q("profiles"))
+    if profiles is not None:
+        for profile in profiles.findall(_q("profile")):
+            deps = profile.find(_q("dependencies"))
+            if deps is not None:
+                yield deps
+
+
+def strip_pom(path: str) -> int:
+    tree = ET.parse(path)
+    removed = 0
+    for deps in _dependency_containers(tree.getroot()):
+        for dep in list(deps.findall(_q("dependency"))):
+            scope = dep.find(_q("scope"))
+            if scope is not None and (scope.text or "").strip() in EXCLUDED_SCOPES:
+                deps.remove(dep)
+                removed += 1
+    if removed:
+        tree.write(path, encoding="UTF-8", xml_declaration=True)
+    return removed
+
+
+def main(argv: list[str]) -> int:
+    files_touched = 0
+    deps_removed = 0
+    failures = 0
+    for path in argv:
+        try:
+            removed = strip_pom(path)
+        except Exception as exc:  # keep going; a single bad POM must not abort the sweep
+            print(f"WARN could not process {path}: {exc}", file=sys.stderr)
+            failures += 1
+            continue
+        if removed:
+            files_touched += 1
+            deps_removed += removed
+    print(f"stripped {deps_removed} test/provided/system dependencies from {files_touched} pom.xml file(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/actions/adjust-pom-for-license-analysis/strip-analysis-scopes.py
+++ b/.github/actions/adjust-pom-for-license-analysis/strip-analysis-scopes.py
@@ -15,14 +15,25 @@ anyway -- but that filter is applied after the graph is generated, too late to
 prevent the crash. Removing them from the POMs up front keeps the generated
 graph small and deterministic while producing identical license results.
 
-Only <dependencies> blocks (top-level and inside <profiles>) are touched;
-<dependencyManagement> is intentionally left alone as it declares versions
-rather than real graph edges. The edit is applied to the ephemeral CI checkout
-only and is idempotent.
+Only <dependencies> blocks (top-level and inside <profiles>) are edited.
+<dependencyManagement> entries are never added, removed, or modified -- on
+their own they are just version/scope templates, not graph edges -- but a
+<dependencies> entry that omits <scope> inherits its scope from a matching
+<dependencyManagement> entry (its own, or an ancestor POM's), so this script
+first scans every POM's <dependencyManagement> to build a best-effort
+groupId:artifactId -> scope map, then uses it to resolve scope-less entries.
+This is a heuristic, not real Maven inheritance resolution (it does not
+follow parent/import chains), so if two unrelated POMs manage the same
+coordinate under different scopes, whichever is scanned last wins. That is an
+acceptable approximation here: this script only ever touches an ephemeral CI
+checkout used solely to generate FOSSA's license graph, never a real build.
+
+The edit is applied to the ephemeral CI checkout only and is idempotent.
 """
 
 import sys
-import xml.etree.ElementTree as ET
+from pathlib import Path
+from xml.etree import ElementTree as ET
 
 NAMESPACE = "http://maven.apache.org/POM/4.0.0"
 EXCLUDED_SCOPES = {"test", "provided", "system"}
@@ -34,47 +45,91 @@ def _q(tag: str) -> str:
     return f"{{{NAMESPACE}}}{tag}"
 
 
-def _dependency_containers(root: ET.Element):
-    """Yield every <dependencies> that contributes real graph edges."""
-    top = root.find(_q("dependencies"))
+def _dependency_containers(root: ET.Element, parent_tag: str):
+    """Yield every <dependencies> found directly under `parent_tag`, at the top level and inside <profiles>."""
+    if parent_tag == "dependencies":
+        top = root.find(_q("dependencies"))
+    else:
+        management = root.find(_q(parent_tag))
+        top = management.find(_q("dependencies")) if management is not None else None
     if top is not None:
         yield top
     profiles = root.find(_q("profiles"))
     if profiles is not None:
         for profile in profiles.findall(_q("profile")):
-            deps = profile.find(_q("dependencies"))
+            if parent_tag == "dependencies":
+                deps = profile.find(_q("dependencies"))
+            else:
+                management = profile.find(_q(parent_tag))
+                deps = management.find(_q("dependencies")) if management is not None else None
             if deps is not None:
                 yield deps
 
 
-def strip_pom(path: str) -> int:
-    tree = ET.parse(path)
+def _coordinate(dep: ET.Element):
+    group = dep.find(_q("groupId"))
+    artifact = dep.find(_q("artifactId"))
+    if group is None or artifact is None or not (group.text and artifact.text):
+        return None
+    return (group.text.strip(), artifact.text.strip())
+
+
+def scan_managed_scopes(trees: dict) -> dict:
+    """Build a best-effort {(groupId, artifactId): scope} map from every <dependencyManagement> block."""
+    managed = {}
+    for tree in trees.values():
+        for deps in _dependency_containers(tree.getroot(), "dependencyManagement"):
+            for dep in deps.findall(_q("dependency")):
+                coordinate = _coordinate(dep)
+                scope = dep.find(_q("scope"))
+                if coordinate and scope is not None and (scope.text or "").strip():
+                    managed[coordinate] = scope.text.strip()
+    return managed
+
+
+def strip_pom(tree: ET.ElementTree, managed_scopes: dict) -> int:
     removed = 0
-    for deps in _dependency_containers(tree.getroot()):
+    for deps in _dependency_containers(tree.getroot(), "dependencies"):
         for dep in list(deps.findall(_q("dependency"))):
             scope = dep.find(_q("scope"))
-            if scope is not None and (scope.text or "").strip() in EXCLUDED_SCOPES:
+            if scope is not None:
+                effective_scope = (scope.text or "").strip()
+            else:
+                effective_scope = managed_scopes.get(_coordinate(dep))
+            if effective_scope in EXCLUDED_SCOPES:
                 deps.remove(dep)
                 removed += 1
-    if removed:
-        tree.write(path, encoding="UTF-8", xml_declaration=True)
     return removed
 
 
+def find_poms(root: str):
+    return [p for p in Path(root).rglob("pom.xml") if "target" not in p.parts]
+
+
 def main(argv: list[str]) -> int:
+    root = argv[0] if argv else "."
+    paths = find_poms(root)
+
+    trees = {}
+    failures = 0
+    for path in paths:
+        try:
+            trees[path] = ET.parse(path)
+        except Exception as exc:  # keep going; a single bad POM must not abort the sweep
+            print(f"WARN could not parse {path}: {exc}", file=sys.stderr)
+            failures += 1
+
+    managed_scopes = scan_managed_scopes(trees)
+
     files_touched = 0
     deps_removed = 0
-    failures = 0
-    for path in argv:
-        try:
-            removed = strip_pom(path)
-        except Exception as exc:  # keep going; a single bad POM must not abort the sweep
-            print(f"WARN could not process {path}: {exc}", file=sys.stderr)
-            failures += 1
-            continue
+    for path, tree in trees.items():
+        removed = strip_pom(tree, managed_scopes)
         if removed:
+            tree.write(path, encoding="UTF-8", xml_declaration=True)
             files_touched += 1
             deps_removed += removed
+
     print(f"stripped {deps_removed} test/provided/system dependencies from {files_touched} pom.xml file(s)")
     return 1 if failures else 0
 

--- a/.github/actions/adjust-pom-for-license-analysis/strip-analysis-scopes.py
+++ b/.github/actions/adjust-pom-for-license-analysis/strip-analysis-scopes.py
@@ -15,28 +15,50 @@ anyway -- but that filter is applied after the graph is generated, too late to
 prevent the crash. Removing them from the POMs up front keeps the generated
 graph small and deterministic while producing identical license results.
 
-Only <dependencies> blocks (top-level and inside <profiles>) are edited.
-<dependencyManagement> entries are never added, removed, or modified -- on
-their own they are just version/scope templates, not graph edges -- but a
-<dependencies> entry that omits <scope> inherits its scope from a matching
-<dependencyManagement> entry (its own, or an ancestor POM's), so this script
-first scans every POM's <dependencyManagement> to build a best-effort
-groupId:artifactId -> scope map, then uses it to resolve scope-less entries.
-This is a heuristic, not real Maven inheritance resolution (it does not
-follow parent/import chains), so if two unrelated POMs manage the same
-coordinate under different scopes, whichever is scanned last wins. That is an
-acceptable approximation here: this script only ever touches an ephemeral CI
-checkout used solely to generate FOSSA's license graph, never a real build.
+Scope resolution
+----------------
+Only <dependencies> blocks (top-level and inside <profiles>) are ever edited.
+<dependencyManagement> entries are never added, removed, or modified: on their
+own they are version/scope templates, not graph edges. But a <dependencies>
+entry that omits <scope> inherits its scope from a matching
+<dependencyManagement> entry, so this script first scans every POM's
+<dependencyManagement> to build a best-effort scope map, then uses it to
+resolve the effective scope of scope-less entries.
+
+The map is keyed by (groupId, artifactId, type, classifier) -- the same
+coordinate Maven uses to match a dependency to its management entry -- so a
+managed `test-jar` never leaks its scope onto a plain `jar`, etc.
+
+This is a heuristic, not full Maven resolution: it does not follow the exact
+parent/import inheritance order. To stay safe it *fails closed*:
+
+* a coordinate managed with a single, consistent scope -> that scope is used;
+* a coordinate managed under two or more DIFFERENT scopes anywhere in the repo
+  -> treated as unknown, so a scope-less entry for it is NEVER stripped;
+* a coordinate not managed anywhere -> unknown -> never stripped
+  (Maven's default scope is `compile`, which we must keep).
+
+In other words the only dependencies removed are those we can positively prove
+are test/provided/system -- when in doubt we keep the dependency. Removing a
+shipped (compile/runtime) dependency would be a license-analysis false
+negative, which must never happen; leaving an extra test dependency in only
+makes the graph marginally larger, which is harmless.
 
 The edit is applied to the ephemeral CI checkout only and is idempotent.
+
+Usage:
+    strip-analysis-scopes.py [ROOT]            # edit POMs in place under ROOT (default ".")
+    strip-analysis-scopes.py --dry-run [ROOT]  # print the removal plan as JSON, change nothing
 """
 
+import json
 import sys
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
 NAMESPACE = "http://maven.apache.org/POM/4.0.0"
 EXCLUDED_SCOPES = {"test", "provided", "system"}
+DEFAULT_TYPE = "jar"
 
 ET.register_namespace("", NAMESPACE)
 
@@ -45,70 +67,105 @@ def _q(tag: str) -> str:
     return f"{{{NAMESPACE}}}{tag}"
 
 
-def _dependency_containers(root: ET.Element, parent_tag: str):
-    """Yield every <dependencies> found directly under `parent_tag`, at the top level and inside <profiles>."""
-    if parent_tag == "dependencies":
-        top = root.find(_q("dependencies"))
-    else:
-        management = root.find(_q(parent_tag))
-        top = management.find(_q("dependencies")) if management is not None else None
+def _text(element, tag, default=None):
+    child = element.find(_q(tag))
+    if child is None or child.text is None:
+        return default
+    return child.text.strip()
+
+
+def _coordinate(dep: ET.Element):
+    """(groupId, artifactId, type, classifier) -- Maven's dependency management key."""
+    group = _text(dep, "groupId")
+    artifact = _text(dep, "artifactId")
+    if not group or not artifact:
+        return None
+    return (group, artifact, _text(dep, "type", DEFAULT_TYPE), _text(dep, "classifier", ""))
+
+
+def _dependency_blocks(root: ET.Element, parent_tag: str):
+    """Yield every <dependencies> under `parent_tag`, at the top level and inside <profiles>."""
+
+    def under(node):
+        if parent_tag == "dependencies":
+            return node.find(_q("dependencies"))
+        management = node.find(_q(parent_tag))
+        return management.find(_q("dependencies")) if management is not None else None
+
+    top = under(root)
     if top is not None:
         yield top
     profiles = root.find(_q("profiles"))
     if profiles is not None:
         for profile in profiles.findall(_q("profile")):
-            if parent_tag == "dependencies":
-                deps = profile.find(_q("dependencies"))
-            else:
-                management = profile.find(_q(parent_tag))
-                deps = management.find(_q("dependencies")) if management is not None else None
-            if deps is not None:
-                yield deps
+            block = under(profile)
+            if block is not None:
+                yield block
 
 
-def _coordinate(dep: ET.Element):
-    group = dep.find(_q("groupId"))
-    artifact = dep.find(_q("artifactId"))
-    if group is None or artifact is None or not (group.text and artifact.text):
-        return None
-    return (group.text.strip(), artifact.text.strip())
+_CONFLICT = object()  # sentinel: coordinate managed under conflicting scopes -> never infer
 
 
-def scan_managed_scopes(trees: dict) -> dict:
-    """Build a best-effort {(groupId, artifactId): scope} map from every <dependencyManagement> block."""
-    managed = {}
+def build_managed_scopes(trees) -> dict:
+    """Best-effort {coordinate: scope} from every <dependencyManagement>, failing closed on conflicts."""
+    managed: dict = {}
     for tree in trees.values():
-        for deps in _dependency_containers(tree.getroot(), "dependencyManagement"):
-            for dep in deps.findall(_q("dependency")):
+        for block in _dependency_blocks(tree.getroot(), "dependencyManagement"):
+            for dep in block.findall(_q("dependency")):
                 coordinate = _coordinate(dep)
-                scope = dep.find(_q("scope"))
-                if coordinate and scope is not None and (scope.text or "").strip():
-                    managed[coordinate] = scope.text.strip()
+                scope = _text(dep, "scope")
+                if not coordinate or not scope:
+                    continue
+                existing = managed.get(coordinate, None)
+                if existing is None:
+                    managed[coordinate] = scope
+                elif existing is not _CONFLICT and existing != scope:
+                    managed[coordinate] = _CONFLICT  # fail closed
     return managed
 
 
-def strip_pom(tree: ET.ElementTree, managed_scopes: dict) -> int:
-    removed = 0
-    for deps in _dependency_containers(tree.getroot(), "dependencies"):
-        for dep in list(deps.findall(_q("dependency"))):
-            scope = dep.find(_q("scope"))
-            if scope is not None:
-                effective_scope = (scope.text or "").strip()
-            else:
-                effective_scope = managed_scopes.get(_coordinate(dep))
-            if effective_scope in EXCLUDED_SCOPES:
-                deps.remove(dep)
-                removed += 1
-    return removed
+def _effective_scope(dep: ET.Element, managed: dict):
+    """Explicit <scope> wins; otherwise inherit from management (unless unknown/conflicting)."""
+    explicit = _text(dep, "scope")
+    if explicit is not None:
+        return explicit, "explicit"
+    inherited = managed.get(_coordinate(dep))
+    if inherited is None or inherited is _CONFLICT:
+        return None, "unknown"
+    return inherited, "inherited"
 
 
-def find_poms(root: str):
-    return [p for p in Path(root).rglob("pom.xml") if "target" not in p.parts]
+def plan_removals(trees, managed: dict):
+    """Return {path: [dep_elements_to_remove]} and a JSON-serialisable report."""
+    removals: dict = {}
+    report = []
+    for path, tree in trees.items():
+        for block in _dependency_blocks(tree.getroot(), "dependencies"):
+            for dep in block.findall(_q("dependency")):
+                scope, source = _effective_scope(dep, managed)
+                if scope in EXCLUDED_SCOPES:
+                    removals.setdefault(path, []).append((block, dep))
+                    group, artifact, dtype, classifier = _coordinate(dep)
+                    report.append(
+                        {
+                            "path": str(path),
+                            "groupId": group,
+                            "artifactId": artifact,
+                            "type": dtype,
+                            "classifier": classifier,
+                            "scope": scope,
+                            "source": source,
+                        }
+                    )
+    return removals, report
 
 
-def main(argv: list[str]) -> int:
-    root = argv[0] if argv else "."
-    paths = find_poms(root)
+def main(argv) -> int:
+    dry_run = "--dry-run" in argv
+    positional = [a for a in argv if not a.startswith("--")]
+    root = positional[0] if positional else "."
+
+    paths = [p for p in Path(root).rglob("pom.xml") if "target" not in p.parts]
 
     trees = {}
     failures = 0
@@ -119,16 +176,22 @@ def main(argv: list[str]) -> int:
             print(f"WARN could not parse {path}: {exc}", file=sys.stderr)
             failures += 1
 
-    managed_scopes = scan_managed_scopes(trees)
+    managed = build_managed_scopes(trees)
+    removals, report = plan_removals(trees, managed)
+
+    if dry_run:
+        json.dump(report, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return 1 if failures else 0
 
     files_touched = 0
     deps_removed = 0
-    for path, tree in trees.items():
-        removed = strip_pom(tree, managed_scopes)
-        if removed:
-            tree.write(path, encoding="UTF-8", xml_declaration=True)
-            files_touched += 1
-            deps_removed += removed
+    for path, pairs in removals.items():
+        for block, dep in pairs:
+            block.remove(dep)
+        trees[path].write(path, encoding="UTF-8", xml_declaration=True)
+        files_touched += 1
+        deps_removed += len(pairs)
 
     print(f"stripped {deps_removed} test/provided/system dependencies from {files_touched} pom.xml file(s)")
     return 1 if failures else 0

--- a/.github/actions/adjust-pom-for-license-analysis/test_strip_analysis_scopes.py
+++ b/.github/actions/adjust-pom-for-license-analysis/test_strip_analysis_scopes.py
@@ -1,0 +1,220 @@
+"""Unit tests for strip-analysis-scopes.py.
+
+Run with:
+    python3 -m unittest .github/actions/adjust-pom-for-license-analysis/test_strip_analysis_scopes.py
+"""
+
+import importlib.util
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+# The module file name contains hyphens, so load it explicitly.
+_SPEC = importlib.util.spec_from_file_location(
+    "strip_analysis_scopes", Path(__file__).with_name("strip-analysis-scopes.py")
+)
+strip = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(strip)
+
+NS = "http://maven.apache.org/POM/4.0.0"
+
+POM = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.camunda.test</groupId>
+  <artifactId>{aid}</artifactId>
+  <version>1.0.0</version>
+{body}
+</project>
+"""
+
+
+def dep(group="g", artifact="a", scope=None, dtype=None, classifier=None):
+    parts = [f"<groupId>{group}</groupId>", f"<artifactId>{artifact}</artifactId>"]
+    if dtype:
+        parts.append(f"<type>{dtype}</type>")
+    if classifier:
+        parts.append(f"<classifier>{classifier}</classifier>")
+    if scope:
+        parts.append(f"<scope>{scope}</scope>")
+    return "<dependency>" + "".join(parts) + "</dependency>"
+
+
+def deps_block(*deps):
+    return "<dependencies>" + "".join(deps) + "</dependencies>"
+
+
+def mgmt_block(*deps):
+    return "<dependencyManagement><dependencies>" + "".join(deps) + "</dependencies></dependencyManagement>"
+
+
+def profile_block(*deps):
+    return "<profiles><profile><id>p</id>" + deps_block(*deps) + "</profile></profiles>"
+
+
+def remaining(path):
+    """Set of (group, artifact) in the top-level <dependencies> of a POM."""
+    root = ET.parse(path).getroot()
+    block = root.find(f"{{{NS}}}dependencies")
+    out = set()
+    if block is not None:
+        for d in block.findall(f"{{{NS}}}dependency"):
+            g = d.find(f"{{{NS}}}groupId").text
+            a = d.find(f"{{{NS}}}artifactId").text
+            out.add((g, a))
+    return out
+
+
+def managed_remaining(path):
+    root = ET.parse(path).getroot()
+    mgmt = root.find(f"{{{NS}}}dependencyManagement")
+    out = set()
+    if mgmt is not None:
+        for d in mgmt.find(f"{{{NS}}}dependencies").findall(f"{{{NS}}}dependency"):
+            out.add((d.find(f"{{{NS}}}groupId").text, d.find(f"{{{NS}}}artifactId").text))
+    return out
+
+
+class StripTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def write(self, rel, body):
+        path = self.root / rel / "pom.xml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(POM.format(aid=rel.replace("/", "-"), body=body))
+        return path
+
+    def run_strip(self):
+        with redirect_stdout(io.StringIO()):
+            return strip.main([str(self.root)])
+
+    def dry_run(self):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            strip.main(["--dry-run", str(self.root)])
+        return json.loads(buf.getvalue())
+
+    # --- explicit scopes --------------------------------------------------
+    def test_explicit_excluded_scopes_removed(self):
+        p = self.write("m", deps_block(
+            dep(artifact="keep-compile"),
+            dep(artifact="keep-runtime", scope="runtime"),
+            dep(artifact="drop-test", scope="test"),
+            dep(artifact="drop-provided", scope="provided"),
+            dep(artifact="drop-system", scope="system"),
+        ))
+        self.run_strip()
+        self.assertEqual(remaining(p), {("g", "keep-compile"), ("g", "keep-runtime")})
+
+    # --- inherited scope --------------------------------------------------
+    def test_inherited_scope_removed(self):
+        self.write("bom", mgmt_block(dep(group="x", artifact="managed-test", scope="test")))
+        p = self.write("m", deps_block(dep(group="x", artifact="managed-test")))  # no explicit scope
+        self.run_strip()
+        self.assertEqual(remaining(p), set())
+
+    def test_scopeless_unmanaged_kept(self):
+        p = self.write("m", deps_block(dep(group="x", artifact="unmanaged")))
+        self.run_strip()
+        self.assertEqual(remaining(p), {("x", "unmanaged")})  # default compile -> kept
+
+    def test_explicit_overrides_management(self):
+        self.write("bom", mgmt_block(
+            dep(group="x", artifact="mgmt-test", scope="test"),
+            dep(group="x", artifact="mgmt-compile", scope="compile"),
+        ))
+        p = self.write("m", deps_block(
+            dep(group="x", artifact="mgmt-test", scope="compile"),   # explicit compile wins -> keep
+            dep(group="x", artifact="mgmt-compile", scope="test"),   # explicit test wins -> drop
+        ))
+        self.run_strip()
+        self.assertEqual(remaining(p), {("x", "mgmt-test")})
+
+    # --- fail closed on conflicts ----------------------------------------
+    def test_conflicting_management_fails_closed(self):
+        self.write("bomA", mgmt_block(dep(group="x", artifact="conflict", scope="test")))
+        self.write("bomB", mgmt_block(dep(group="x", artifact="conflict", scope="compile")))
+        p = self.write("m", deps_block(dep(group="x", artifact="conflict")))  # no explicit scope
+        self.run_strip()
+        # conflicting managed scopes => unknown => never stripped (keep the possibly-shipped dep)
+        self.assertEqual(remaining(p), {("x", "conflict")})
+
+    # --- type / classifier keying ----------------------------------------
+    def test_type_and_classifier_are_part_of_key(self):
+        self.write("bom", mgmt_block(
+            dep(group="x", artifact="lib", dtype="test-jar", scope="test"),
+        ))
+        p = self.write("m", deps_block(
+            dep(group="x", artifact="lib"),                    # jar, unmanaged coord -> keep
+            dep(group="x", artifact="lib", dtype="test-jar"),  # matches managed test-jar -> drop
+        ))
+        self.run_strip()
+        self.assertEqual(remaining(p), {("x", "lib")})  # the plain jar survives
+
+    # --- profiles ---------------------------------------------------------
+    def test_profile_dependencies_stripped(self):
+        p = self.write("m", deps_block(dep(artifact="keep")) + profile_block(
+            dep(artifact="drop", scope="test"),
+            dep(artifact="keep-profile-compile"),
+        ))
+        self.run_strip()
+        root = ET.parse(p).getroot()
+        prof_deps = root.find(f"{{{NS}}}profiles").find(f"{{{NS}}}profile").find(f"{{{NS}}}dependencies")
+        arts = {d.find(f"{{{NS}}}artifactId").text for d in prof_deps.findall(f"{{{NS}}}dependency")}
+        self.assertEqual(arts, {"keep-profile-compile"})
+
+    # --- dependencyManagement is never edited ----------------------------
+    def test_dependency_management_untouched(self):
+        p = self.write("bom", mgmt_block(
+            dep(group="x", artifact="managed-test", scope="test"),
+            dep(group="x", artifact="managed-provided", scope="provided"),
+        ))
+        self.run_strip()
+        self.assertEqual(managed_remaining(p), {("x", "managed-test"), ("x", "managed-provided")})
+
+    # --- idempotence ------------------------------------------------------
+    def test_idempotent(self):
+        p = self.write("m", deps_block(dep(artifact="keep"), dep(artifact="drop", scope="test")))
+        self.run_strip()
+        first = p.read_text()
+        self.run_strip()
+        self.assertEqual(p.read_text(), first)
+        self.assertEqual(remaining(p), {("g", "keep")})
+
+    # --- malformed input --------------------------------------------------
+    def test_malformed_pom_reports_failure_but_processes_others(self):
+        (self.root / "bad").mkdir(parents=True)
+        (self.root / "bad" / "pom.xml").write_text("<project><this is not xml")
+        good = self.write("good", deps_block(dep(artifact="drop", scope="test"), dep(artifact="keep")))
+        rc = self.run_strip()
+        self.assertEqual(rc, 1)  # non-zero because a POM failed to parse
+        self.assertEqual(remaining(good), {("g", "keep")})  # the valid POM was still processed
+
+    # --- dry run ----------------------------------------------------------
+    def test_dry_run_changes_nothing_and_reports(self):
+        p = self.write("m", deps_block(dep(artifact="drop", scope="test"), dep(artifact="keep")))
+        before = p.read_text()
+        report = self.dry_run()
+        self.assertEqual(p.read_text(), before)  # unchanged
+        self.assertEqual(len(report), 1)
+        self.assertEqual(report[0]["artifactId"], "drop")
+        self.assertEqual(report[0]["scope"], "test")
+        self.assertEqual(report[0]["source"], "explicit")
+
+    def test_target_directories_are_ignored(self):
+        p = self.write("m/target/generated", deps_block(dep(artifact="drop", scope="test")))
+        self.run_strip()
+        self.assertEqual(remaining(p), {("g", "drop")})  # under target/ -> untouched
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2374,7 +2374,7 @@ jobs:
       - name: Install pytest
         run: pip install --quiet pytest
       - name: Run unit tests
-        run: pytest --verbose --color=yes --tb=short .github/scripts
+        run: pytest --verbose --color=yes --tb=short .github/scripts .github/actions/adjust-pom-for-license-analysis
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

The `check-licenses` (FOSSA) workflow has been failing on `main` and every PR since ~09:24 UTC on 2026-07-15 with a deterministic crash in FOSSA's Maven analyzer:

```
[ERROR] Required array length 2147483639 + 29 is too large -> OutOfMemoryError
* maven project in ".../bom/": failed
```

**Root cause — a size threshold, not a real OOM.** FOSSA runs `com.github.ferstl:depgraph-maven-plugin:aggregate` with `-DmergeScopes -DrepeatTransitiveDependenciesInTextGraph=true`, which folds `test`/`provided`/`system` dependencies into the dependency graph and repeats every transitive dependency under every path. On a monorepo this size the fully-expanded **text** graph exceeds the JVM's maximum array length (`2147483639` = `Integer.MAX_VALUE − 8`, ~2 GiB), so Maven aborts while serialising it. Both analyze attempts fail identically, so the workflow's hang-retry can't recover it.

This is the same class of failure worked around before for `optimize/qa` (module removal) and in the Feb/Mar circular-dependency incident — FOSSA's scope/target exclusion is applied *after* the graph is generated, too late to prevent the crash.

**Fix.** These scopes are not part of any shipped artifact and are already dropped from FOSSA's results via `maven.scope-exclude` in `.fossa.yml`. This change strips `test`/`provided`/`system` dependencies from every `pom.xml` in `adjust-pom-for-license-analysis` (a new `strip-analysis-scopes.py`) **before** FOSSA runs, keeping the generated graph small and deterministic while producing identical license results.

The stripper resolves each dependency's effective scope safely and **fails closed** — it only removes dependencies it can positively prove are `test`/`provided`/`system`:
- explicit `<scope>` wins;
- a scope-less `<dependency>` inherits scope from a matching `<dependencyManagement>` entry, keyed by `(groupId, artifactId, type, classifier)`;
- a coordinate managed under conflicting scopes, or not managed at all, is treated as unknown and **never** stripped (Maven defaults it to `compile`, which must be kept).

`<dependencyManagement>` blocks are only read, never edited. Unit tests in `test_strip_analysis_scopes.py` cover explicit/inherited/unmanaged/conflicting/type-classifier/profile/idempotence/malformed cases (run: `python3 -m unittest test_strip_analysis_scopes.py`).

**Validation that it does not cut too much.** Against the last green pre-incident tree (`49ca3937`), every planned removal was cross-checked against `mvn help:effective-pom`: all 1263 removals resolve to `test`/`provided`/`system`, and **zero** `compile`/`runtime` (shipped, license-relevant) dependencies are removed — no license-analysis false negatives. On current `main` the stripper removes 1267 dependencies across 112 POMs; every POM still parses and the run is idempotent. Green FOSSA `Analyze` jobs on this PR (the analyzer completes in ~7m with no OOM) confirm the fix end-to-end.

## Checklist

- [x] Enable backports when necessary — likely needs `backport stable/*` for any branch whose `check-licenses` is affected.

## Related issues

Reported by @HeleneW-dot in ask-infra: https://camunda.slack.com/archives/C5AHF1D8T/p1784119914384329