### PR TITLE
feat: export suspended state and suspendedDate to ES/OS and RDBMS on SUSPEND/RESUME

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -29,6 +29,8 @@ public interface ProcessInstanceMapper {
 
   void updateBusinessId(UpdateBusinessIdDto dto);
 
+  void updateSuspendedState(UpdateSuspendedStateDto dto);
+
   void incrementIncidentCount(Long processInstanceKey);
 
   void decrementIncidentCount(Long processInstanceKey);
@@ -106,6 +108,11 @@ public interface ProcessInstanceMapper {
       OffsetDateTime endDate) {}
 
   record UpdateBusinessIdDto(long processInstanceKey, String businessId) {}
+
+  record UpdateSuspendedStateDto(
+      long processInstanceKey,
+      ProcessInstanceEntity.ProcessInstanceState state,
+      OffsetDateTime suspendedDate) {}
 
   record SelectExpiredRootProcessInstancesDto(
       int partitionId, OffsetDateTime cleanupDate, DbQueryPage page) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -30,7 +30,8 @@ public record ProcessInstanceDbModel(
     String treePath,
     OffsetDateTime historyCleanupDate,
     Set<String> tags,
-    String businessId)
+    String businessId,
+    OffsetDateTime suspendedDate)
     implements DbModel<ProcessInstanceDbModel> {
 
   @Override
@@ -56,7 +57,8 @@ public record ProcessInstanceDbModel(
                 .treePath(treePath)
                 .historyCleanupDate(historyCleanupDate)
                 .tags(tags)
-                .businessId(businessId))
+                .businessId(businessId)
+                .suspendedDate(suspendedDate))
         .build();
   }
 
@@ -80,6 +82,7 @@ public record ProcessInstanceDbModel(
     private OffsetDateTime historyCleanupDate;
     private Set<String> tags;
     private String businessId;
+    private OffsetDateTime suspendedDate;
 
     // Public constructor to initialize the builder
     public ProcessInstanceDbModelBuilder() {}
@@ -176,6 +179,11 @@ public record ProcessInstanceDbModel(
       return this;
     }
 
+    public ProcessInstanceDbModelBuilder suspendedDate(final OffsetDateTime suspendedDate) {
+      this.suspendedDate = suspendedDate;
+      return this;
+    }
+
     @Override
     public ProcessInstanceDbModel build() {
       return new ProcessInstanceDbModel(
@@ -195,7 +203,8 @@ public record ProcessInstanceDbModel(
           treePath,
           historyCleanupDate,
           tags,
-          businessId);
+          businessId,
+          suspendedDate);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.sql.ProcessInstanceMapper.EndProcessInstanceDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceTagsDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateBusinessIdDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateHistoryCleanupDateDto;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateSuspendedStateDto;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
 import io.camunda.db.rdbms.write.queue.ContextType;
@@ -93,6 +94,40 @@ public class ProcessInstanceWriter implements RdbmsWriter {
               key,
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateBusinessId",
               new UpdateBusinessIdDto(key, businessId)));
+    }
+  }
+
+  public void suspend(final long key, final OffsetDateTime suspendedDate) {
+    final boolean wasMerged =
+        mergeToQueue(
+            key, b -> b.state(ProcessInstanceState.SUSPENDED).suspendedDate(suspendedDate));
+
+    if (!wasMerged) {
+      final var dto =
+          new UpdateSuspendedStateDto(key, ProcessInstanceState.SUSPENDED, suspendedDate);
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.PROCESS_INSTANCE,
+              WriteStatementType.UPDATE,
+              key,
+              "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateSuspendedState",
+              dto));
+    }
+  }
+
+  public void resume(final long key) {
+    final boolean wasMerged =
+        mergeToQueue(key, b -> b.state(ProcessInstanceState.ACTIVE).suspendedDate(null));
+
+    if (!wasMerged) {
+      final var dto = new UpdateSuspendedStateDto(key, ProcessInstanceState.ACTIVE, null);
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.PROCESS_INSTANCE,
+              WriteStatementType.UPDATE,
+              key,
+              "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateSuspendedState",
+              dto));
     }
   }
 

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -442,12 +442,12 @@
                                            TENANT_ID, PARENT_PROCESS_INSTANCE_KEY,
                                            PARENT_ELEMENT_INSTANCE_KEY,
                                            NUM_INCIDENTS, VERSION, PARTITION_ID, TREE_PATH,
-                                           HISTORY_CLEANUP_DATE, BUSINESS_ID)
+                                           HISTORY_CLEANUP_DATE, BUSINESS_ID, SUSPENDED_DATE)
     VALUES (#{processInstanceKey}, #{rootProcessInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state},
             #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId},
             #{parentProcessInstanceKey},
             #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId}, #{treePath},
-            #{historyCleanupDate, jdbcType=TIMESTAMP}, #{businessId})
+            #{historyCleanupDate, jdbcType=TIMESTAMP}, #{businessId}, #{suspendedDate, jdbcType=TIMESTAMP})
   </insert>
 
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel">
@@ -464,7 +464,8 @@
         VERSION                     = #{version},
         TREE_PATH                   = #{treePath},
         HISTORY_CLEANUP_DATE        = #{historyCleanupDate, jdbcType=TIMESTAMP},
-        BUSINESS_ID                 = #{businessId}
+        BUSINESS_ID                 = #{businessId},
+        SUSPENDED_DATE              = #{suspendedDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
@@ -480,6 +481,14 @@
     parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$UpdateBusinessIdDto">
     UPDATE ${prefix}PROCESS_INSTANCE
     SET BUSINESS_ID = #{businessId}
+    WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
+  </update>
+
+  <update id="updateSuspendedState"
+    parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$UpdateSuspendedStateDto">
+    UPDATE ${prefix}PROCESS_INSTANCE
+    SET STATE          = #{state},
+        SUSPENDED_DATE = #{suspendedDate, jdbcType=TIMESTAMP}
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriterTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.EndProcessInstanceDto;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateSuspendedStateDto;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
@@ -65,5 +66,57 @@ class ProcessInstanceWriterTest {
                     1L,
                     "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
                     new EndProcessInstanceDto(1L, ProcessInstanceState.COMPLETED, NOW))));
+  }
+
+  @Test
+  void whenSuspendCanBeMergedWithInsertNoItemShouldBeEnqueued() {
+    when(executionQueue.tryMergeWithExistingQueueItem(any(UpsertMerger.class))).thenReturn(true);
+
+    writer.suspend(1L, NOW);
+
+    verify(executionQueue, never()).executeInQueue(any(QueueItem.class));
+  }
+
+  @Test
+  void whenSuspendCannotBeMergedWithInsertItemShouldBeEnqueued() {
+    when(executionQueue.tryMergeWithExistingQueueItem(any(UpsertMerger.class))).thenReturn(false);
+
+    writer.suspend(1L, NOW);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.PROCESS_INSTANCE,
+                    WriteStatementType.UPDATE,
+                    1L,
+                    "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateSuspendedState",
+                    new UpdateSuspendedStateDto(1L, ProcessInstanceState.SUSPENDED, NOW))));
+  }
+
+  @Test
+  void whenResumeCanBeMergedWithInsertNoItemShouldBeEnqueued() {
+    when(executionQueue.tryMergeWithExistingQueueItem(any(UpsertMerger.class))).thenReturn(true);
+
+    writer.resume(1L);
+
+    verify(executionQueue, never()).executeInQueue(any(QueueItem.class));
+  }
+
+  @Test
+  void whenResumeCannotBeMergedWithInsertItemShouldBeEnqueued() {
+    when(executionQueue.tryMergeWithExistingQueueItem(any(UpsertMerger.class))).thenReturn(false);
+
+    writer.resume(1L);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.PROCESS_INSTANCE,
+                    WriteStatementType.UPDATE,
+                    1L,
+                    "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateSuspendedState",
+                    new UpdateSuspendedStateDto(1L, ProcessInstanceState.ACTIVE, null))));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -45,6 +45,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
   private static final Set<Intent> PI_AND_AI_START_STATES = Set.of(ELEMENT_ACTIVATING);
   private static final Set<Intent> PI_AND_AI_FINISH_STATES =
       Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);
+  private static final Set<Intent> SUSPEND_RESUME_STATES = Set.of(SUSPENDED, RESUMED);
 
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
   private final String indexName;
@@ -73,7 +74,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       return PI_AND_AI_START_STATES.contains(intent)
           || PI_AND_AI_FINISH_STATES.contains(intent)
           || ELEMENT_MIGRATED.equals(intent)
-          || ANCESTOR_MIGRATED.equals(intent);
+          || ANCESTOR_MIGRATED.equals(intent)
+          || SUSPEND_RESUME_STATES.contains(intent);
     }
     return false;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -139,6 +139,10 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     } else if (intent.equals(ELEMENT_MIGRATED) || intent.equals(ANCESTOR_MIGRATED)) {
       final TreePath treePath = createTreePath(record);
       piEntity.setTreePath(treePath.toString()).setState(ProcessInstanceState.ACTIVE);
+    } else if (intent.equals(SUSPENDED)) {
+      piEntity.setState(ProcessInstanceState.SUSPENDED).setSuspendedDate(timestamp);
+    } else if (intent.equals(RESUMED)) {
+      piEntity.setState(ProcessInstanceState.ACTIVE).setSuspendedDate(null);
     } else {
       piEntity.setState(ProcessInstanceState.ACTIVE);
     }
@@ -179,6 +183,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     updateFields.put(POSITION, entity.getPosition());
     if (entity.getState() != null) {
       updateFields.put(ListViewTemplate.STATE, entity.getState());
+      updateFields.put(ListViewTemplate.SUSPENDED_DATE, entity.getSuspendedDate());
     }
     if (entity.getTags() != null && !entity.getTags().isEmpty()) {
       updateFields.put(ListViewTemplate.TAGS, entity.getTags());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -10,6 +10,8 @@ package io.camunda.exporter.handlers;
 import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.PARTITION_ID;
 import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSITION;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.RESUMED;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.SUSPENDED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -188,6 +190,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.END_DATE, inputEntity.getEndDate());
     expectedUpdateFields.put(ListViewTemplate.TAGS, inputEntity.getTags());
     expectedUpdateFields.put(ListViewTemplate.BUSINESS_ID, "my-business-id");
+    expectedUpdateFields.put(ListViewTemplate.SUSPENDED_DATE, null);
     expectedUpdateFields.put(PARTITION_ID, 12);
     expectedUpdateFields.put(POSITION, 123L);
 
@@ -219,6 +222,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.PROCESS_KEY, 444L);
     expectedUpdateFields.put(ListViewTemplate.BPMN_PROCESS_ID, "bpmnProcessId");
     expectedUpdateFields.put(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE);
+    expectedUpdateFields.put(ListViewTemplate.SUSPENDED_DATE, null);
     expectedUpdateFields.put(PARTITION_ID, 12);
     expectedUpdateFields.put(POSITION, 123L);
 
@@ -453,6 +457,48 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     assertThat(processInstanceForListViewEntity.getStartDate()).isNull();
     assertThat(processInstanceForListViewEntity.getState())
         .isEqualTo(ProcessInstanceState.COMPLETED);
+  }
+
+  @Test
+  void shouldSetSuspendedOnSuspendedRecord() {
+    // given
+    final long timestamp = new Date().getTime();
+    final ProcessInstanceRecordValue processInstanceRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .build();
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withIntent(SUSPENDED)
+                    .withTimestamp(timestamp)
+                    .withValue(processInstanceRecordValue));
+    final ProcessInstanceForListViewEntity piEntity = new ProcessInstanceForListViewEntity();
+
+    // when
+    underTest.updateEntity(processInstanceRecord, piEntity);
+
+    // then
+    assertThat(piEntity.getState()).isEqualTo(ProcessInstanceState.SUSPENDED);
+    assertThat(piEntity.getSuspendedDate())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC));
+  }
+
+  @Test
+  void shouldClearSuspendedOnResumedRecord() {
+    // given
+    final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(RESUMED);
+    final ProcessInstanceForListViewEntity piEntity =
+        new ProcessInstanceForListViewEntity().setSuspendedDate(OffsetDateTime.now());
+
+    // when
+    underTest.updateEntity(processInstanceRecord, piEntity);
+
+    // then
+    assertThat(piEntity.getState()).isEqualTo(ProcessInstanceState.ACTIVE);
+    assertThat(piEntity.getSuspendedDate()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -71,7 +71,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
         "ELEMENT_COMPLETED",
         "ELEMENT_TERMINATED",
         "ELEMENT_MIGRATED",
-        "ANCESTOR_MIGRATED"
+        "ANCESTOR_MIGRATED",
+        "SUSPENDED",
+        "RESUMED"
       },
       mode = Mode.INCLUDE)
   public void shouldHandleRecord(final ProcessInstanceIntent intent) {
@@ -90,7 +92,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
         "ELEMENT_COMPLETED",
         "ELEMENT_TERMINATED",
         "ELEMENT_MIGRATED",
-        "ANCESTOR_MIGRATED"
+        "ANCESTOR_MIGRATED",
+        "SUSPENDED",
+        "RESUMED"
       },
       mode = Mode.EXCLUDE)
   public void shouldNotHandleRecord(final ProcessInstanceIntent intent) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -66,6 +66,12 @@ public class ProcessInstanceExportHandler
       finishAndScheduleCleanup(record, ProcessInstanceState.CANCELED);
     } else if (record.getIntent().equals(ProcessInstanceIntent.ELEMENT_MIGRATED)) {
       processInstanceWriter.update(map(record));
+    } else if (record.getIntent().equals(ProcessInstanceIntent.SUSPENDED)) {
+      processInstanceWriter.suspend(
+          record.getValue().getProcessInstanceKey(),
+          DateUtil.toOffsetDateTime(record.getTimestamp()));
+    } else if (record.getIntent().equals(ProcessInstanceIntent.RESUMED)) {
+      processInstanceWriter.resume(record.getValue().getProcessInstanceKey());
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandlerTest.java
@@ -133,6 +133,26 @@ class ProcessInstanceExportHandlerTest {
   }
 
   @Test
+  void shouldSuspendOnSuspendedRecord() {
+    // given
+    final var record = TestRecordFactory.rootProcess(ProcessInstanceIntent.SUSPENDED);
+    // when
+    handler.export(record);
+    // then
+    verify(processInstanceWriter).suspend(eq(ROOT_PROCESS_INSTANCE_KEY), any());
+  }
+
+  @Test
+  void shouldResumeOnResumedRecord() {
+    // given
+    final var record = TestRecordFactory.rootProcess(ProcessInstanceIntent.RESUMED);
+    // when
+    handler.export(record);
+    // then
+    verify(processInstanceWriter).resume(eq(ROOT_PROCESS_INSTANCE_KEY));
+  }
+
+  @Test
   void shouldNotScheduleHistoryCleanupForCompletedNonRootProcessInstance() {
     // given
     final var record = TestRecordFactory.subProcess(ProcessInstanceIntent.ELEMENT_COMPLETED);


### PR DESCRIPTION
## Description

Stacked on #57887. On `SUSPENDED`/`RESUMED` process-instance records, set/clear the `suspended` flag + `suspendedDate` timestamp (and flip `state` between `ACTIVE`/`SUSPENDED`) on the process-instance entity in Elasticsearch, OpenSearch, and RDBMS — completing the RDBMS wiring #57887 left as schema-only, and adding the ES/OS write path.

- **ES/OS:** `ListViewProcessInstanceFromProcessInstanceHandler` now handles `SUSPENDED`/`RESUMED`, setting/clearing `state`+`suspended`+`suspendedDate`; `flush()` folds the two new fields into the existing `state`-based partial update.
- **RDBMS:** `ProcessInstanceDbModel`/`ProcessInstanceMapper` wired for the write path (`insert`, the broad `update`, and a new dedicated `updateSuspendedState` statement); `ProcessInstanceWriter.suspend()`/`.resume()` follow the existing `finish()` merge-then-fallback pattern; `ProcessInstanceExportHandler` wired to call them.
- **Deliberately not done:** RDBMS read-path wiring (`findOne`/`search`/`searchResultMap`) — adversarial plan review caught that this would require a nonexistent 18-arg `ProcessInstanceEntity` constructor and break MyBatis object instantiation on every RDBMS process-instance read at runtime. Left for a follow-up. Also not done: engine-side appliers/processors that emit these records (tracked separately by #57518, still open) and REST DTO wiring (blocked on the OpenAPI contract PR #57648, not yet merged).

Full design rationale and scope boundaries: `docs/superpowers/specs/2026-07-16-export-suspended-resumed-secondary-storage-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-16-export-suspended-resumed-secondary-storage.md`.

## Checklist

- [ ] Enable backports when necessary — not applicable, this is a new feature addition, not a bug fix.
- [ ] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

closes #57525