### PR TITLE
fix: retry GCS m2-installed.tar download in restore-shared-m2

### DIFF
--- a/.github/actions/restore-shared-m2/action.yml
+++ b/.github/actions/restore-shared-m2/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         max_attempts: 5
         retry_wait_seconds: 10
-        timeout_minutes: 5
+        timeout_minutes: 1
         shell: bash
         command: |
           set -euo pipefail

--- a/.github/actions/restore-shared-m2/action.yml
+++ b/.github/actions/restore-shared-m2/action.yml
@@ -9,10 +9,21 @@ description: >-
 runs:
   using: composite
   steps:
-    - name: Restore io.camunda SNAPSHOTs from GCS
+    - name: Prepare installed directory
       shell: bash
-      run: |
-        set -euo pipefail
-        mkdir -p "${HOME}/.m2/repository/installed"
-        gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
-        tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
+      run: mkdir -p "${HOME}/.m2/repository/installed"
+
+    - name: Download m2-installed.tar from GCS
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: 5
+        retry_wait_seconds: 10
+        timeout_minutes: 5
+        shell: bash
+        command: |
+          set -euo pipefail
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
+
+    - name: Extract io.camunda SNAPSHOTs
+      shell: bash
+      run: tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -53,7 +53,7 @@ jobs:
   build:
     name: "Unit - Back End - ${{ inputs.suiteName}}"
     runs-on: gcp-perf-core-8-default
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,7 +543,7 @@ jobs:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Upload distball + SNAPSHOTs to GCS
+      - name: Upload distball to GCS
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
         env:
@@ -551,12 +551,23 @@ jobs:
         with:
           max_attempts: 5
           retry_wait_seconds: 10
-          timeout_minutes: 5
+          timeout_minutes: 2
           shell: bash
           command: |
             set -euo pipefail
             gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
               "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
+      - name: Upload SNAPSHOTs to GCS
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 1
+          shell: bash
+          command: |
+            set -euo pipefail
             gcloud storage cp m2-installed.tar \
               "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
       - name: Observe build status
@@ -1379,7 +1390,7 @@ jobs:
         with:
           max_attempts: 5
           retry_wait_seconds: 10
-          timeout_minutes: 5
+          timeout_minutes: 2
           shell: bash
           command: gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
       # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,16 +544,21 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Upload distball + SNAPSHOTs to GCS
-        shell: bash
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
         env:
           CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
-        run: |
-          set -euo pipefail
-          gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
-            "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
-          gcloud storage cp m2-installed.tar \
-            "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 5
+          shell: bash
+          command: |
+            set -euo pipefail
+            gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
+              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
+            gcloud storage cp m2-installed.tar \
+              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -1366,12 +1371,17 @@ jobs:
           minimus: true
           gcs-build-cache-auth: true
       # Download the shared distball tarball; restore-shared-m2 below handles the SNAPSHOTs.
-      - name: Download distball from GCS
+      - name: Create dist/target
         shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p dist/target
-          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
+        run: mkdir -p dist/target
+      - name: Download distball from GCS
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 5
+          shell: bash
+          command: gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
       # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below
       # (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs between jobs).
       - uses: ./.github/actions/restore-shared-m2


### PR DESCRIPTION
## Summary
- CI intermittently fails restoring/uploading the shared m2 SNAPSHOTs and distball to/from GCS with `Unable to retrieve Identity Pool subject token` / upstream request timeout (see https://camunda.slack.com/archives/C071KP5BTHB/p1784119953892839)
- Wraps every unretried `gcloud storage cp` transfer in `nick-fields/retry` (5 attempts, 10s wait), since the timeout can hit either the download or the upload side:
  - `restore-shared-m2` composite action (download of `m2-installed.tar`)
  - `ci.yml` build-distball job's upload of distball + `m2-installed.tar` to GCS (split into two steps so a failed second upload doesn't re-send the already-succeeded larger distball)
  - `ci.yml` gcp-perf shards' separate download of the distball from GCS
- On exhaustion the step still fails hard — no fallback to a full reactor build, since that would defeat the purpose of the shared-m2 optimization (#52693)
- Per-attempt `timeout_minutes` is sized to the transfer, not left at a flat 5min: 1min for `m2-installed.tar` (small), 2min for the distball (larger). This keeps worst-case retry duration (all 5 attempts failing) from eating into job budgets meant for the actual build/test work.

## Timeout increases

Retrying means a full-failure worst case now takes minutes, not seconds, so job-level `timeout-minutes` values that were sized assuming a near-instant `gcloud storage cp` needed re-checking:

| Job | File | Old | New | Why |
|---|---|---|---|---|
| `build` (unit test back-end) | `ci-webapp-run-ut-reuseable.yml` | 10min | 15min | Only calls `restore-shared-m2` (worst case ~5m40s), but the job's whole point is skipping a "~2min reactor build" via the fast-path restore. At 10min, a full-retry-exhaustion case would leave only ~2-3min for the actual Maven test run after checkout/setup-build, risking a job-level timeout kill instead of the retry action's own clean hard-fail. Bumped for headroom.

The other two jobs touching these retry sites (`build-distball` in `ci.yml`, 30min; `integration-tests`/gcp-perf shards in `ci.yml`, 30min) were left unchanged — their worst-case stacked retry duration (~16m20s) still leaves reasonable margin against their existing 30min budgets.

## Test plan
- [ ] Confirm CI jobs using these steps (build-distball, ci-zeebe, gcp-perf shards, ci-webapp unit tests) pass normally
- [ ] Optionally force a transient failure to confirm retries fire and eventual hard-fail still surfaces clearly, without the job timing out first