### PR TITLE
fix: reduce E2E worker parallelism to unblock stable/8.7 nightly flakiness

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -47,7 +47,11 @@ const changedFolders =
 export default defineConfig({
   testDir: `./tests/`,
   timeout: 12 * 60 * 1000,
-  workers: 4,
+  // stable/8.7 runs Zeebe/Elasticsearch/Operate/Tasklist as 5 separate
+  // docker-compose containers on a single CI runner (unlike 8.8+/main's
+  // unified container), so 4 parallel workers oversaturate the shared
+  // ES importer / operation executor under concurrent batch operations.
+  workers: 2,
   retries: 1,
   expect: {
     timeout: 10_000,


### PR DESCRIPTION
## Description

`stable/8.7`'s nightly E2E job ([C8 Orchestration Cluster Nightly 8.7 - E2E Tests](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-nightly-8.7-e2e.yml)) has failed 5 nights in a row (Jul 12-16), always the `E2E Tests (stable/8.7 - Tasklist v1 mode)` job, with a *different* Operate spec failing each night:

| Night | Failing test(s) |
|---|---|
| Jul 16 | `batchMoveModification.spec.ts` (Move Operation), `processInstanceMigration.spec.ts` (Auto mapping migration) |
| Jul 15 | `batchMoveModification.spec.ts` (Move Operation) |
| Jul 14 | `operations.spec.ts` (Infinite scrolling), `processInstanceModifications.spec.ts` |
| Jul 13 | `operations.spec.ts` (Retry and cancel single/multiple instances) |
| Jul 12 | `operations.spec.ts` (Retry and cancel single/multiple instances), `decisionNavigation.spec.ts` |

Every failure has the same shape: a `toBeVisible`/`toHaveText` assertion times out waiting for Operate's UI to reflect a batch operation (retry/cancel success count, migration target option, move-modification result count) after the ES importer catches up. The `batchMoveModification` failure screenshot shows the expected "10 results" text already present — captured just after the assertion's timeout window closed, confirming this is a race, not incorrect test logic.

`git log` on this directory shows **15 "stabilize"/"fix flakiness" commits over the last 6 weeks** targeting these exact files (from the repo's nightly-fix-agent), yet the failures keep recurring in a different spec each night — a whack-a-mole pattern consistent with a systemic resource constraint rather than N independent bad assertions.

**Root cause**: unlike `stable/8.8+`/`main`, which run a single unified `camunda` container, `stable/8.7`'s reusable E2E workflow (`c8-orchestration-cluster-reusable-e2e-tests.yml`) starts 5 separate `docker compose` containers (postgres, elasticsearch, zeebe @512m heap, tasklist, operate @1024m ES heap) on one `ubuntu-latest` CI runner, with no per-container CPU/memory limits. `playwright.config.ts`'s 4 parallel workers then queue batch operations against that shared, resource-constrained stack concurrently, which the importer/operation-executor can't keep up with — producing a different flaky assertion each run depending on scheduling. `stable/8.8` and `stable/8.9` are green on the identical nightly cadence, consistent with this being specific to 8.7's container topology rather than a product regression.

**Fix**: halve `workers: 4 → 2` in this branch's `playwright.config.ts` only (each `stable/*` branch carries its own copy of this file; `8.8`/`8.9`/`main` are untouched since they don't share this topology). This targets the actual contention instead of another per-assertion timeout/retry bump.

## Validation

- `npm run lint`: pre-existing errors/warnings in unrelated files (not touched by this diff); `playwright.config.ts` itself lints clean.
- Real validation is the nightly matrix holding green for a few nights, or a manual on-demand run against this branch per the suite's contributing guide.

## Related issues

None filed yet — happy to open a `kind/flake` issue cross-referencing the prior 15 stabilization commits if useful for fleet-wide visibility.

Nightly runs referenced: [Jul 16](https://github.com/camunda/camunda/actions/runs/29462511037) · [Jul 15](https://github.com/camunda/camunda/actions/runs/29379960109) · [Jul 14](https://github.com/camunda/camunda/actions/runs/29296924368) · [Jul 13](https://github.com/camunda/camunda/actions/runs/29216328943) · [Jul 12](https://github.com/camunda/camunda/actions/runs/29174493816)