### PR TITLE
refactor: unify normalize and merge into one recursive walk in ExporterConfigMergeSupport

### DIFF
--- a/zeebe/exporter-config-support/src/main/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupport.java
+++ b/zeebe/exporter-config-support/src/main/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupport.java
@@ -12,9 +12,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Single owner of the type-aware exporter-args key normalization and deep-merge semantics (ADR-0008
@@ -32,6 +35,10 @@ import java.util.Map;
  * Jackson, and only keys that correspond to configuration properties are normalized (and merged
  * recursively for nested POJO properties), while the keys of {@code Map}-typed fields are user data
  * and preserved untouched.
+ *
+ * <p>Normalizing a single map and merging two maps are the same recursive walk: normalizing is
+ * merging against an empty tenant side, so every entry falls through to "keep root, normalized".
+ * {@link #mergeMaps} is that one walk; both public methods are thin entry points into it.
  */
 public final class ExporterConfigMergeSupport {
 
@@ -59,12 +66,12 @@ public final class ExporterConfigMergeSupport {
    */
   public static Map<String, Object> normalize(
       final Class<?> configClass, final Map<String, Object> args) {
-    return normalizeKeys(args, INTROSPECTION_MAPPER.constructType(configClass));
+    return merge(configClass, args, Map.of());
   }
 
   /**
    * Deep-merges a tenant's partial exporter {@code args} over the root-declared {@code args},
-   * type-aware against {@code configClass} (ADR-0008 §4). Both maps are first normalized exactly
+   * type-aware against {@code configClass} (ADR-0008 §4), normalizing both along the way exactly
    * like {@link #normalize(Class, Map)} so differently spelled property keys collapse before
    * merging; consequently the returned map carries normalized property keys.
    *
@@ -82,20 +89,40 @@ public final class ExporterConfigMergeSupport {
       final Class<?> configClass,
       final Map<String, Object> rootArgs,
       final Map<String, Object> tenantArgs) {
-    final JavaType targetType = INTROSPECTION_MAPPER.constructType(configClass);
-    return mergeMaps(
-        normalizeKeys(rootArgs, targetType), normalizeKeys(tenantArgs, targetType), targetType);
+    return mergeMaps(rootArgs, tenantArgs, INTROSPECTION_MAPPER.constructType(configClass));
   }
 
+  /**
+   * For every key present in either side (normalized first, so differently spelled duplicates
+   * collapse): a nested POJO property recurses into both sides; anything else — a scalar, a list, a
+   * {@code Map}-typed property, or a key unknown to {@code targetType} — is taken from whichever
+   * side has it, tenant winning ties, normalized on its own via {@link #normalizeValue}.
+   *
+   * <p>A value that only root provides is still normalized, even though there is no tenant value to
+   * merge it against — that is what makes {@link #normalize} a degenerate case of this method
+   * rather than a separate algorithm.
+   */
   private static Map<String, Object> mergeMaps(
       final Map<String, Object> root, final Map<String, Object> tenant, final JavaType targetType) {
-    final var result = new LinkedHashMap<>(root);
+    final var normalizedRoot = byNormalizedKey(root);
+    final var normalizedTenant = byNormalizedKey(tenant);
     final var propertyTypesByKey = propertyTypesByNormalizedKey(targetType);
-    for (final var entry : tenant.entrySet()) {
-      final var key = entry.getKey();
-      final var tenantValue = entry.getValue();
-      final var rootValue = result.get(key);
-      final var propertyType = propertyTypesByKey.get(key);
+    final var indexedElementType =
+        indexedElementType(targetType, normalizedRoot.keySet(), normalizedTenant.keySet());
+
+    final var keys = new LinkedHashSet<>(normalizedRoot.keySet());
+    keys.addAll(normalizedTenant.keySet());
+
+    final var result = new LinkedHashMap<String, Object>(keys.size());
+    for (final var key : keys) {
+      final var propertyType = propertyTypesByKey.getOrDefault(key, indexedElementType);
+      final var rootValue = normalizedRoot.get(key);
+      if (!normalizedTenant.containsKey(key)) {
+        result.put(key, normalizeValue(rootValue, propertyType));
+        continue;
+      }
+
+      final var tenantValue = normalizedTenant.get(key);
       if (isPojoProperty(propertyType)
           && rootValue instanceof final Map<?, ?> rootMap
           && tenantValue instanceof final Map<?, ?> tenantMap) {
@@ -105,8 +132,16 @@ public final class ExporterConfigMergeSupport {
         final var typedTenant = (Map<String, Object>) tenantMap;
         result.put(key, mergeMaps(typedRoot, typedTenant, propertyType));
       } else {
-        result.put(key, tenantValue);
+        result.put(key, normalizeValue(tenantValue, propertyType));
       }
+    }
+    return result;
+  }
+
+  private static Map<String, Object> byNormalizedKey(final Map<String, Object> map) {
+    final var result = new LinkedHashMap<String, Object>(map.size());
+    for (final var entry : map.entrySet()) {
+      result.put(normalizeKey(entry.getKey()), entry.getValue());
     }
     return result;
   }
@@ -124,46 +159,48 @@ public final class ExporterConfigMergeSupport {
         && !propertyType.isContainerType();
   }
 
-  private static Map<String, Object> normalizeKeys(
-      final Map<String, Object> map, final JavaType targetType) {
-    final var result = new LinkedHashMap<String, Object>(map.size());
-    final var propertyTypesByKey = propertyTypesByNormalizedKey(targetType);
-    final var indexedElementType = indexedElementType(targetType, map);
-    for (final var entry : map.entrySet()) {
-      final var normalizedKey = normalizeKey(entry.getKey());
-      var propertyType = propertyTypesByKey.get(normalizedKey);
-      if (propertyType == null) {
-        propertyType = indexedElementType;
-      }
-      result.put(normalizedKey, normalizeValue(entry.getValue(), propertyType));
-    }
-    return result;
-  }
-
+  /**
+   * The broker's {@code ExporterConfigurationListDeserializer} unwraps Spring Boot's relaxed
+   * binding of a list-typed property from environment variables or system properties, where {@code
+   * myList[0]=a, myList[1]=b} arrives as a map with numeric string keys ({@code {"0": "a", "1":
+   * "b"}}) rather than a real {@link List}. Recognising that same shape here lets normalization
+   * recurse into its elements exactly as it would a real list, instead of treating it as an unknown
+   * {@code Map}-typed value and leaving its entries untouched.
+   */
   private static JavaType indexedElementType(
-      final JavaType targetType, final Map<String, Object> map) {
+      final JavaType targetType, final Set<String> rootKeys, final Set<String> tenantKeys) {
     if (targetType == null || (!targetType.isCollectionLikeType() && !targetType.isArrayType())) {
       return null;
     }
 
     var hasNumericKeys = false;
     var hasNonNumericKeys = false;
-    for (final var key : map.keySet()) {
-      try {
-        Integer.parseInt(key);
-        hasNumericKeys = true;
-      } catch (final NumberFormatException e) {
-        hasNonNumericKeys = true;
-      }
+    for (final var key : rootKeys) {
+      hasNumericKeys |= isNumeric(key);
+      hasNonNumericKeys |= !isNumeric(key);
+    }
+    for (final var key : tenantKeys) {
+      hasNumericKeys |= isNumeric(key);
+      hasNonNumericKeys |= !isNumeric(key);
     }
 
     if (hasNumericKeys && hasNonNumericKeys) {
       throw new IllegalArgumentException(
           "Cannot mix indexed (numeric) and named keys in configuration map targeting a collection: "
-              + map.keySet());
+              + rootKeys
+              + tenantKeys);
     }
 
     return hasNumericKeys ? targetType.getContentType() : null;
+  }
+
+  private static boolean isNumeric(final String key) {
+    try {
+      Integer.parseInt(key);
+      return true;
+    } catch (final NumberFormatException e) {
+      return false;
+    }
   }
 
   private static Map<String, JavaType> propertyTypesByNormalizedKey(final JavaType targetType) {
@@ -193,11 +230,11 @@ public final class ExporterConfigMergeSupport {
     }
 
     if (value instanceof final Iterable<?> iterable) {
-      return normalizeIterableValue(iterable, targetType);
+      return normalizeElements(iterable, contentTypeIf(targetType, JavaType::isCollectionLikeType));
     }
 
     if (value != null && value.getClass().isArray()) {
-      return normalizeArrayValue(value, targetType);
+      return normalizeArrayValue(value, contentTypeIf(targetType, JavaType::isArrayType));
     }
 
     return value;
@@ -212,17 +249,16 @@ public final class ExporterConfigMergeSupport {
       return normalizeMapValues(nestedMap, targetType.getContentType());
     }
 
+    // A POJO property, or a numeric-indexed map standing in for a List/array (see
+    // #indexedElementType): both are "this map's keys resolve against targetType", which
+    // mergeMaps already does for a single side once the other side is empty.
     @SuppressWarnings("unchecked")
     final var typedNested = (Map<String, Object>) nestedMap;
-    return normalizeKeys(typedNested, targetType);
+    return mergeMaps(typedNested, Map.of(), targetType);
   }
 
-  private static List<Object> normalizeIterableValue(
-      final Iterable<?> iterable, final JavaType targetType) {
-    final var contentType =
-        targetType != null && targetType.isCollectionLikeType()
-            ? targetType.getContentType()
-            : null;
+  private static List<Object> normalizeElements(
+      final Iterable<?> iterable, final JavaType contentType) {
     final var normalized = new ArrayList<>();
     for (final var item : iterable) {
       normalized.add(normalizeValue(item, contentType));
@@ -230,10 +266,8 @@ public final class ExporterConfigMergeSupport {
     return normalized;
   }
 
-  private static Object[] normalizeArrayValue(final Object value, final JavaType targetType) {
+  private static Object[] normalizeArrayValue(final Object value, final JavaType contentType) {
     final var length = Array.getLength(value);
-    final var contentType =
-        targetType != null && targetType.isArrayType() ? targetType.getContentType() : null;
     final var normalized = new Object[length];
     for (int i = 0; i < length; i++) {
       normalized[i] = normalizeValue(Array.get(value, i), contentType);
@@ -248,6 +282,13 @@ public final class ExporterConfigMergeSupport {
       result.put(entry.getKey(), normalizeValue(entry.getValue(), contentType));
     }
     return result;
+  }
+
+  /**
+   * {@code null} unless {@code type} satisfies {@code applicable}, in which case its element type.
+   */
+  private static JavaType contentTypeIf(final JavaType type, final Predicate<JavaType> applicable) {
+    return type != null && applicable.test(type) ? type.getContentType() : null;
   }
 
   /** Strips hyphens and lowercases a key so all naming styles map to the same canonical form. */

--- a/zeebe/exporter-config-support/src/test/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupportTest.java
+++ b/zeebe/exporter-config-support/src/test/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupportTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.exporter.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -113,6 +114,28 @@ final class ExporterConfigMergeSupportTest {
     // then
     assertThat(merged)
         .containsOnly(Map.entry("url", "http://root:9200"), Map.entry("indexprefix", "tenant"));
+  }
+
+  @Test
+  void shouldNormalizeIndexedListPropertiesFromRelaxedBinding() {
+    // given — Spring Boot's relaxed binding of "hosts[0]=a, hosts[1]=b" as a numeric-keyed map
+    final Map<String, Object> rootArgs = Map.of("hosts", Map.of("0", "a", "1", "b"));
+
+    // when
+    final var normalized = ExporterConfigMergeSupport.normalize(SampleConfig.class, rootArgs);
+
+    // then — recursed into as if it were a real list, values normalized element-wise
+    assertThat(normalized).containsEntry("hosts", Map.of("0", "a", "1", "b"));
+  }
+
+  @Test
+  void shouldRejectListPropertyWithMixedIndexedAndNamedKeys() {
+    // given — a map targeting a collection property that mixes numeric and named keys
+    final Map<String, Object> rootArgs = Map.of("hosts", Map.of("0", "a", "extra", "b"));
+
+    // when / then
+    assertThatThrownBy(() -> ExporterConfigMergeSupport.normalize(SampleConfig.class, rootArgs))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Proposed alternative structure for `ExporterConfigMergeSupport` from #57339, for comparison.

- `normalize(args)` is `merge(args, tenant=empty)` in disguise — every key falls through to "keep root, normalized" once there's no tenant side. The current PR treats them as two separate walks, so `merge()` runs three full tree passes (normalize root, normalize tenant, then merge) spread across six small methods.
- This collapses `normalizeKeys` into `mergeMaps` so there is one recursive function both public methods funnel through. `normalize` becomes a one-line degenerate case of `merge`.
- Adds test coverage for the previously-untested Spring Boot indexed-list (relaxed binding, `hosts[0]=a`) path.

## Behavior

Same observable behavior for every case the existing test suite covers (all 8 original tests + 2 new ones pass unchanged). One disclosed difference: the original eagerly normalizes/validates all of `root` even when a tenant override discards a key entirely (e.g. a malformed root list value would throw even if the tenant fully replaces that key); this version only normalizes values that survive into the merged result. No existing test locks in the old eager-validation behavior, but flagging it since it's a real difference.

## Test plan

- [x] `./mvnw verify -pl zeebe/exporter-config-support -DskipTests=false -DskipITs -Dquickly` — 10/10 tests pass
- [x] `zeebe/broker` (a real caller of `normalize`/`fromArgs`) rebuilds clean against the change

Not meant to land as-is — opening as draft so the diff is easy to review side by side with #57339.