### PR TITLE
fix: recognize Oracle physical tenants isolated by schema-per-user

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidation.java
@@ -48,6 +48,7 @@ class SecondaryStorageIsolationValidation implements CrossTenantValidation {
         });
 
     final List<String> collisions = new ArrayList<>();
+    final boolean[] anyRdbmsCollision = {false};
     tenantsByIdentity.forEach(
         (identity, tenantIds) -> {
           if (tenantIds.size() > 1) {
@@ -55,14 +56,23 @@ class SecondaryStorageIsolationValidation implements CrossTenantValidation {
                 String.format(
                     "tenants %s share the same secondary-storage location [%s]",
                     tenantIds, identity.describe()));
+            anyRdbmsCollision[0] |= identity.isRdbms();
           }
         });
 
     if (!collisions.isEmpty()) {
+      final String oracleHint =
+          anyRdbmsCollision[0]
+              ? " To isolate Oracle physical tenants by schema-per-user (distinct DB users on a "
+                  + "shared jdbc url), set data.secondary-storage.rdbms.database-vendor-id: oracle "
+                  + "on each tenant."
+              : "";
       throw new UnifiedConfigurationException(
           "Physical tenants must not share a secondary-storage location, or they would write into "
               + "the same database. Use a distinct connection, or a distinct index/table prefix per "
-              + "tenant. Conflicts: "
+              + "tenant."
+              + oracleHint
+              + " Conflicts: "
               + String.join("; ", collisions));
     }
   }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidation.java
@@ -48,21 +48,22 @@ class SecondaryStorageIsolationValidation implements CrossTenantValidation {
         });
 
     final List<String> collisions = new ArrayList<>();
-    final boolean[] anyRdbmsCollision = {false};
-    tenantsByIdentity.forEach(
-        (identity, tenantIds) -> {
-          if (tenantIds.size() > 1) {
-            collisions.add(
-                String.format(
-                    "tenants %s share the same secondary-storage location [%s]",
-                    tenantIds, identity.describe()));
-            anyRdbmsCollision[0] |= identity.isRdbms();
-          }
-        });
+    boolean anyRdbmsCollision = false;
+    for (final var entry : tenantsByIdentity.entrySet()) {
+      final StorageIdentity identity = entry.getKey();
+      final List<String> tenantIds = entry.getValue();
+      if (tenantIds.size() > 1) {
+        collisions.add(
+            String.format(
+                "tenants %s share the same secondary-storage location [%s]",
+                tenantIds, identity.describe()));
+        anyRdbmsCollision |= identity.isRdbms();
+      }
+    }
 
     if (!collisions.isEmpty()) {
       final String oracleHint =
-          anyRdbmsCollision[0]
+          anyRdbmsCollision
               ? " To isolate Oracle physical tenants by schema-per-user (distinct DB users on a "
                   + "shared jdbc url), set data.secondary-storage.rdbms.database-vendor-id: oracle "
                   + "on each tenant."

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/StorageIdentity.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/StorageIdentity.java
@@ -8,16 +8,18 @@
 package io.camunda.configuration.physicaltenants;
 
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Rdbms;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.SecondaryStorageDatabase;
 import java.util.List;
+import java.util.Locale;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
  * The minimal, location-determining tuple that decides whether two physical tenants would write
- * into the <em>same</em> secondary-storage location: {@code (type, connection, namespace)}.
+ * into the <em>same</em> secondary-storage location: {@code (type, connection, namespace, schema)}.
  *
  * <p>Two tenants resolving to equal {@code StorageIdentity} values collide — they would silently
  * double-write into the same indices/tables. The identity is deliberately minimal: adding
@@ -37,14 +39,36 @@ import org.jspecify.annotations.Nullable;
  *   <li>{@code namespace} is the within-database partition: index prefix (ES/OS) or table prefix
  *       (RDBMS). Same url + different namespace is the explicitly-allowed "shared cluster, distinct
  *       prefix" setup.
+ *   <li>{@code schema} is the <em>Oracle-only</em> per-user schema key. On Oracle, schema == user,
+ *       so two tenants isolated by distinct Oracle users on the same jdbc url (no distinct prefix,
+ *       no schema in the url) are genuinely separate locations. Because the Oracle thin driver does
+ *       not carry the schema in the url — unlike PostgreSQL's {@code currentSchema=…} — the
+ *       connecting user is the only static signal of isolation. This field is populated
+ *       <em>only</em> when the RDBMS {@code database-vendor-id} is explicitly {@code oracle}; it is
+ *       always empty for every other vendor and for ES/OS, so distinct users never falsely isolate
+ *       tenants on, e.g., PostgreSQL/MySQL (where the user does not partition storage).
+ * </ul>
+ *
+ * <p>Documented limitations of the Oracle schema key (not enforced here):
+ *
+ * <ul>
+ *   <li>Quoted, case-sensitive Oracle identifiers are not modelled — the user is folded to upper
+ *       case, matching Oracle's default unquoted-identifier behaviour.
+ *   <li>A {@code currentSchema=…} in the Oracle jdbc url overriding the connecting user is not
+ *       detected; configure a distinct table prefix in that case.
  * </ul>
  *
  * @param type the secondary-storage type
  * @param connection the normalized, sorted connection url(s)
  * @param namespace the normalized within-database partition (never {@code null}; defaults to empty)
+ * @param schema the normalized Oracle-only per-user schema (never {@code null}; empty for every
+ *     other vendor and for ES/OS)
  */
 @NullMarked
-record StorageIdentity(SecondaryStorageType type, List<String> connection, String namespace) {
+record StorageIdentity(
+    SecondaryStorageType type, List<String> connection, String namespace, String schema) {
+
+  private static final String ORACLE_VENDOR_ID = "oracle";
 
   /**
    * Extracts the storage identity of a resolved tenant, or {@code null} when the tenant has no
@@ -60,22 +84,43 @@ record StorageIdentity(SecondaryStorageType type, List<String> connection, Strin
           identityOf(
               type,
               secondaryStorage.getElasticsearch(),
-              secondaryStorage.getElasticsearch().getIndexPrefix());
+              secondaryStorage.getElasticsearch().getIndexPrefix(),
+              "");
       case opensearch ->
           identityOf(
               type,
               secondaryStorage.getOpensearch(),
-              secondaryStorage.getOpensearch().getIndexPrefix());
-      case rdbms ->
-          identityOf(type, secondaryStorage.getRdbms(), secondaryStorage.getRdbms().getPrefix());
+              secondaryStorage.getOpensearch().getIndexPrefix(),
+              "");
+      case rdbms -> {
+        final Rdbms rdbms = secondaryStorage.getRdbms();
+        yield identityOf(type, rdbms, rdbms.getPrefix(), oracleSchemaOf(rdbms));
+      }
     };
   }
 
   private static StorageIdentity identityOf(
       final SecondaryStorageType type,
       final SecondaryStorageDatabase<?> database,
-      final @Nullable String namespace) {
-    return new StorageIdentity(type, connectionOf(database), normalizeNamespace(namespace));
+      final @Nullable String namespace,
+      final String schema) {
+    return new StorageIdentity(type, connectionOf(database), normalizeNamespace(namespace), schema);
+  }
+
+  /**
+   * The Oracle schema key — the connecting user, which on Oracle <em>is</em> the schema. Returns an
+   * empty string (no distinction) unless {@code database-vendor-id} is explicitly {@code oracle},
+   * keeping distinct DB users from falsely isolating tenants on vendors where the user does not
+   * partition storage. The user is trimmed and folded to upper case, matching Oracle's default
+   * unquoted-identifier semantics; a blank user yields no distinction.
+   */
+  private static String oracleSchemaOf(final Rdbms rdbms) {
+    final String vendorId = rdbms.getDatabaseVendorId();
+    if (vendorId == null || !ORACLE_VENDOR_ID.equals(vendorId.trim().toLowerCase(Locale.ROOT))) {
+      return "";
+    }
+    final String username = rdbms.getUsername();
+    return username == null ? "" : username.trim().toUpperCase(Locale.ROOT);
   }
 
   /**
@@ -105,6 +150,14 @@ record StorageIdentity(SecondaryStorageType type, List<String> connection, Strin
   String describe() {
     final String connectionText =
         connection.size() == 1 ? connection.get(0) : connection.toString();
-    return String.format("type=%s, connection=%s, namespace='%s'", type, connectionText, namespace);
+    final String base =
+        String.format("type=%s, connection=%s, namespace='%s'", type, connectionText, namespace);
+    // the schema key only ever has a value on Oracle; omit it otherwise to keep messages terse
+    return schema.isEmpty() ? base : base + String.format(", schema='%s'", schema);
+  }
+
+  /** Whether this identity is an RDBMS location (used to tailor collision-hint messaging). */
+  boolean isRdbms() {
+    return type == SecondaryStorageType.rdbms;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/StorageIdentity.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/StorageIdentity.java
@@ -69,6 +69,7 @@ record StorageIdentity(
     SecondaryStorageType type, List<String> connection, String namespace, String schema) {
 
   private static final String ORACLE_VENDOR_ID = "oracle";
+  private static final String NO_SCHEMA = "";
 
   /**
    * Extracts the storage identity of a resolved tenant, or {@code null} when the tenant has no
@@ -85,13 +86,13 @@ record StorageIdentity(
               type,
               secondaryStorage.getElasticsearch(),
               secondaryStorage.getElasticsearch().getIndexPrefix(),
-              "");
+              NO_SCHEMA);
       case opensearch ->
           identityOf(
               type,
               secondaryStorage.getOpensearch(),
               secondaryStorage.getOpensearch().getIndexPrefix(),
-              "");
+              NO_SCHEMA);
       case rdbms -> {
         final Rdbms rdbms = secondaryStorage.getRdbms();
         yield identityOf(type, rdbms, rdbms.getPrefix(), oracleSchemaOf(rdbms));
@@ -117,10 +118,10 @@ record StorageIdentity(
   private static String oracleSchemaOf(final Rdbms rdbms) {
     final String vendorId = rdbms.getDatabaseVendorId();
     if (vendorId == null || !ORACLE_VENDOR_ID.equals(vendorId.trim().toLowerCase(Locale.ROOT))) {
-      return "";
+      return NO_SCHEMA;
     }
     final String username = rdbms.getUsername();
-    return username == null ? "" : username.trim().toUpperCase(Locale.ROOT);
+    return username == null ? NO_SCHEMA : username.trim().toUpperCase(Locale.ROOT);
   }
 
   /**

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/SecondaryStorageIsolationValidationTest.java
@@ -216,6 +216,104 @@ class SecondaryStorageIsolationValidationTest {
         .withMessageContaining("tenantb");
   }
 
+  @Test
+  void shouldPassForOracleTenantsSharingJdbcUrlButDistinctSchemaPerUser() {
+    // given two Oracle tenants on the same jdbc url with no distinct prefix and no schema in the
+    // url, isolated only by distinct DB users (Oracle: schema == user), with database-vendor-id set
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, "tenanta"),
+            "tenantb", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, "tenantb"));
+
+    // when / then the distinct Oracle users (schemas) isolate the tenants — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectOracleTenantsSharingJdbcUrlAndSameUser() {
+    // given two Oracle tenants on the same jdbc url, same prefix, and the same DB user (schema)
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, "shared"),
+            "tenantb", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, "shared"));
+
+    // when / then the same user (schema) means the same location — rejected
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldRejectOracleTenantsSharingJdbcUrlWithBlankUsers() {
+    // given two Oracle tenants on the same jdbc url with blank users — blank yields no distinction
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, ""),
+            "tenantb", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, ""));
+
+    // when / then blank users cannot isolate — rejected
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldTreatOracleUsersAsCaseInsensitive() {
+    // given two Oracle tenants whose users differ only by case — Oracle folds unquoted identifiers
+    // to upper case, so they refer to the same schema
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, "tenant"),
+            "tenantb", oracle("jdbc:oracle:thin:@db:1521/ORCL", null, "TENANT"));
+
+    // when / then case-insensitive users collapse to the same schema — rejected
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  @Test
+  void shouldRejectRdbmsTenantsWithDistinctUsersWhenVendorNotOracle() {
+    // MANDATORY REGRESSION GUARD: on a non-Oracle vendor (here unset), distinct DB users must NOT
+    // isolate — the user does not partition storage on PostgreSQL/MySQL/etc, so two tenants on the
+    // same url+prefix still collide. Guards against trading the Oracle false positive for a silent
+    // double-write (false negative) on other vendors.
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", rdbmsWithUser("jdbc:postgresql://db:5432/camunda", null, "usera"),
+            "tenantb", rdbmsWithUser("jdbc:postgresql://db:5432/camunda", null, "userb"));
+
+    // when / then distinct users on a non-Oracle vendor are still rejected
+    final var thrown =
+        assertThatExceptionOfType(UnifiedConfigurationException.class)
+            .isThrownBy(() -> validation.validate(resolved))
+            .withMessageContaining("tenanta")
+            .withMessageContaining("tenantb");
+    // the RDBMS collision message surfaces the Oracle isolation hint
+    thrown.withMessageContaining("database-vendor-id");
+  }
+
+  @Test
+  void shouldRejectRdbmsTenantsWithDistinctUsersWhenVendorIsPostgres() {
+    // regression guard: distinct users must not isolate even when the vendor is explicitly set to a
+    // non-Oracle vendor — only Oracle keys storage on the connecting user
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta",
+                rdbmsWithVendor("jdbc:postgresql://db:5432/camunda", null, "usera", "postgresql"),
+            "tenantb",
+                rdbmsWithVendor("jdbc:postgresql://db:5432/camunda", null, "userb", "postgresql"));
+
+    // when / then distinct users on PostgreSQL are still rejected
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
   // --- helpers ---------------------------------------------------------------------------------
 
   private static Camunda es(final String url, final String indexPrefix) {
@@ -233,6 +331,24 @@ class SecondaryStorageIsolationValidationTest {
     ss.setType(SecondaryStorageType.rdbms);
     ss.getRdbms().setUrl(jdbcUrl);
     ss.getRdbms().setPrefix(prefix);
+    return camunda;
+  }
+
+  private static Camunda oracle(final String jdbcUrl, final String prefix, final String username) {
+    return rdbmsWithVendor(jdbcUrl, prefix, username, "oracle");
+  }
+
+  private static Camunda rdbmsWithUser(
+      final String jdbcUrl, final String prefix, final String username) {
+    final Camunda camunda = rdbms(jdbcUrl, prefix);
+    camunda.getData().getSecondaryStorage().getRdbms().setUsername(username);
+    return camunda;
+  }
+
+  private static Camunda rdbmsWithVendor(
+      final String jdbcUrl, final String prefix, final String username, final String vendorId) {
+    final Camunda camunda = rdbmsWithUser(jdbcUrl, prefix, username);
+    camunda.getData().getSecondaryStorage().getRdbms().setDatabaseVendorId(vendorId);
     return camunda;
   }
 

--- a/db/docker-compose-init/03-grant-camunda-create-oracle-free.sql
+++ b/db/docker-compose-init/03-grant-camunda-create-oracle-free.sql
@@ -1,0 +1,17 @@
+-- Grant the restricted `camunda` Oracle matrix user permission to create,
+-- manage, and drop the per-physical-tenant users (== schemas) provisioned at
+-- test runtime by CamundaMultiDBExtension / PhysicalTenantSchemaProvisioner for
+-- @MultiDbPhysicalTenants tests. Oracle isolates physical tenants by
+-- schema-per-user (a dedicated CREATE USER per tenant), see #56402.
+--
+-- The gvenzl images create APP_USER (`camunda`) with only CONNECT/RESOURCE on
+-- its own schema, so it cannot CREATE USER / DROP USER, nor grant the
+-- CONNECT/RESOURCE roles and UNLIMITED TABLESPACE the per-PT users need. This
+-- is a throwaway test database, so a broad DBA grant is acceptable, mirroring
+-- the MySQL/MariaDB grant script (02-grant-camunda-create-mysql.sql).
+--
+-- gvenzl runs *.sql init scripts as SYS connected to the CDB root, not the app
+-- PDB where `camunda` is a local user, so switch into the PDB (FREEPDB1 for the
+-- oracle-free image) before granting.
+ALTER SESSION SET CONTAINER = FREEPDB1;
+GRANT DBA TO CAMUNDA;

--- a/db/docker-compose-init/03-grant-camunda-create-oracle-xe.sql
+++ b/db/docker-compose-init/03-grant-camunda-create-oracle-xe.sql
@@ -1,0 +1,17 @@
+-- Grant the restricted `camunda` Oracle matrix user permission to create,
+-- manage, and drop the per-physical-tenant users (== schemas) provisioned at
+-- test runtime by CamundaMultiDBExtension / PhysicalTenantSchemaProvisioner for
+-- @MultiDbPhysicalTenants tests. Oracle isolates physical tenants by
+-- schema-per-user (a dedicated CREATE USER per tenant), see #56402.
+--
+-- The gvenzl images create APP_USER (`camunda`) with only CONNECT/RESOURCE on
+-- its own schema, so it cannot CREATE USER / DROP USER, nor grant the
+-- CONNECT/RESOURCE roles and UNLIMITED TABLESPACE the per-PT users need. This
+-- is a throwaway test database, so a broad DBA grant is acceptable, mirroring
+-- the MySQL/MariaDB grant script (02-grant-camunda-create-mysql.sql).
+--
+-- gvenzl runs *.sql init scripts as SYS connected to the CDB root, not the app
+-- PDB where `camunda` is a local user, so switch into the PDB (XEPDB1 for the
+-- oracle-xe image) before granting.
+ALTER SESSION SET CONTAINER = XEPDB1;
+GRANT DBA TO CAMUNDA;

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -79,6 +79,8 @@ services:
       ORACLE_PASSWORD: sys_user_password
       APP_USER: camunda
       APP_USER_PASSWORD: camunda
+    volumes:
+      - ./docker-compose-init/03-grant-camunda-create-oracle-free.sql:/container-entrypoint-initdb.d/03-grant-camunda-create-oracle.sql:ro
     # Customize healthcheck script options for startup
     healthcheck:
       test: [ "CMD", "healthcheck.sh" ]
@@ -98,6 +100,8 @@ services:
       ORACLE_PASSWORD: sys_user_password
       APP_USER: camunda
       APP_USER_PASSWORD: camunda
+    volumes:
+      - ./docker-compose-init/03-grant-camunda-create-oracle-xe.sql:/container-entrypoint-initdb.d/03-grant-camunda-create-oracle.sql:ro
     # Customize healthcheck script options for startup
     healthcheck:
       test: [ "CMD", "healthcheck.sh" ]

--- a/qa/docs/adr/0001-multidb-multiple-physical-tenants-per-broker.md
+++ b/qa/docs/adr/0001-multidb-multiple-physical-tenants-per-broker.md
@@ -69,14 +69,21 @@ concrete primitive is dialect-specific, since "schema" has no single cross-diale
   targets that database.
 - **SQL Server (MSSQL)**: a dedicated database per PT (`CREATE DATABASE`), since MSSQL has no
   connection-URL schema selector; the PT URL targets it via `databaseName`.
-- **Oracle** — the exception: each PT gets a per-tenant **table prefix** in the shared `camunda`
-  schema, not a dedicated schema, and reuses the base connection unchanged. Oracle's schema == user,
-  so a schema-per-PT would require `CREATE USER`, which is DBA-only. More fundamentally, the
-  production `SecondaryStorageIsolationValidation` keys a storage location on
-  `(type, connection-url, table-prefix)` and deliberately ignores the connection user, so two Oracle
-  users on the same URL resolve to the *same* location and the broker refuses to start. A distinct
-  table prefix is the validator's explicitly-allowed "shared connection, distinct prefix" mode and
-  needs no privileged bootstrap.
+- **Oracle**: a dedicated **user** per PT (`CREATE USER`), which on Oracle *is* a dedicated schema;
+  the PT connects as that user with no table prefix, exactly as production isolates Oracle PTs by
+  schema-per-user. This requires a privileged (DBA-grade) base connection for the `CREATE USER` /
+  `DROP USER … CASCADE` bootstrap and an Oracle CI matrix grant. The PT's `database-vendor-id` is
+  pinned to `oracle` so the production `SecondaryStorageIsolationValidation` keys the storage
+  location on the connecting user and recognizes distinct Oracle users on the same JDBC URL as
+  distinct locations ([#56402](https://github.com/camunda/camunda/issues/56402)).
+
+  > Historical note: Oracle was originally the exception, isolated by a per-PT **table prefix** in
+  > the shared `camunda` schema, because the validator keyed a location on
+  > `(type, connection-url, table-prefix)` and deliberately ignored the connection user — so two
+  > Oracle users on the same URL collapsed to the *same* location and the broker refused to start.
+  > [#56402](https://github.com/camunda/camunda/issues/56402) taught the validator to key on the
+  > Oracle user (when `database-vendor-id: oracle`), removing that limitation and letting the harness
+  > use schema-per-user like every other dialect.
 
 The namespace name embeds a run-unique token (the same token the framework already uses for
 parallel-test isolation) plus the PT id, so concurrent CI runs never collide. RDBMS schema auto-DDL
@@ -88,7 +95,7 @@ supported RDBMS dialect, not just H2.
 
 Fresh-storage-per-run isolation — the property [#56006](https://github.com/camunda/camunda/issues/56006)
 added by hand — thus holds for every PT for free (a fresh in-memory DB on H2, a fresh per-run
-schema/database on the other dialects, a fresh per-run table prefix on Oracle).
+schema/database on the other dialects, a fresh per-run user/schema on Oracle).
 
 Constraint: the namespace name (`<run>_<ptId>`) must stay within the dialect's identifier-length
 limit — the binding constraint being Oracle's 30-character identifier cap (far stricter than, e.g.,

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -404,11 +404,10 @@ public class CamundaMultiDBExtension
    *       targeted by the PT's URL ({@code currentSchema}, the URL database segment, or {@code
    *       databaseName} respectively). The table prefix is empty — isolation is at the
    *       schema/database level.
-   *   <li>{@code RDBMS_ORACLE}: each PT gets a per-tenant table prefix ({@code
-   *       <basePrefix>_<tenantId>}) in the shared {@code camunda} schema, reusing the base
-   *       connection. Oracle's schema == user, so a schema-per-PT would need DBA-only {@code CREATE
-   *       USER}, and the production isolation check rejects two users on the same URL anyway; a
-   *       distinct prefix is the validator's allowed "shared connection, distinct prefix" mode. See
+   *   <li>{@code RDBMS_ORACLE}: each PT gets a dedicated user (== schema) named {@code
+   *       <basePrefix>_<tenantId>}, created via a privileged bootstrap connection before broker
+   *       start; the PT connects as that user (no table prefix) and pins {@code database-vendor-id:
+   *       oracle} so the production isolation check keys the location on the distinct user. See
    *       {@link PhysicalTenantSchemaProvisioner}.
    * </ul>
    *
@@ -434,6 +433,7 @@ public class CamundaMultiDBExtension
     final String ptUsername;
     final String ptPassword;
     final String ptPrefix;
+    final String ptDatabaseVendorId;
     if (databaseType == DatabaseType.RDBMS_H2) {
       // Fresh in-memory database per PT — DBs are already separate, so no prefix needed.
       ptUrl =
@@ -447,11 +447,12 @@ public class CamundaMultiDBExtension
       ptUsername = "sa";
       ptPassword = "";
       ptPrefix = testPrefix;
+      ptDatabaseVendorId = null;
     } else {
       // Per-PT isolated storage derived from the database type: a dedicated schema/database whose
       // namespace lives in the PT URL (Postgres/MySQL/MariaDB/SQL Server), or — on Oracle — a
-      // per-PT table prefix in the shared schema. The provisioner returns the prefix to apply
-      // (empty for the schema/database dialects).
+      // dedicated user/schema the PT connects as. The provisioner returns the prefix to apply
+      // (empty for every dialect) and, for Oracle, the vendor id to pin.
       final var baseRdbms =
           springApplication.unifiedConfig().getData().getSecondaryStorage().getRdbms();
       final var ptConfig =
@@ -466,6 +467,7 @@ public class CamundaMultiDBExtension
       ptUsername = ptConfig.username();
       ptPassword = ptConfig.password();
       ptPrefix = ptConfig.prefix();
+      ptDatabaseVendorId = ptConfig.databaseVendorId();
 
       // Track the provisioned namespace so afterAll can drop it best-effort, preventing schemas /
       // databases from accumulating on persistent shared instances (e.g. Aurora) across CI runs.
@@ -493,6 +495,11 @@ public class CamundaMultiDBExtension
           rdbms.setUsername(ptUsername);
           rdbms.setPassword(ptPassword);
           rdbms.setPrefix(ptPrefix);
+          if (ptDatabaseVendorId != null) {
+            // Oracle: pin the vendor so the production isolation check keys on the connecting user
+            // (schema-per-user), instead of collapsing the two PTs to a single storage location.
+            rdbms.setDatabaseVendorId(ptDatabaseVendorId);
+          }
 
           final var init = camunda.getSecurity().getInitialization();
           init.setUsers(rootInit.getUsers());

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisioner.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisioner.java
@@ -55,6 +55,9 @@ final class PhysicalTenantSchemaProvisioner {
    */
   private static final String ORACLE_VENDOR_ID = "oracle";
 
+  /** ORA-01918: "user '…' does not exist" — the expected DROP USER outcome when none is present. */
+  private static final int ORA_USER_DOES_NOT_EXIST = 1918;
+
   private PhysicalTenantSchemaProvisioner() {}
 
   /**
@@ -227,9 +230,6 @@ final class PhysicalTenantSchemaProvisioner {
         "GRANT CONNECT, RESOURCE TO " + namespace,
         "GRANT UNLIMITED TABLESPACE TO " + namespace);
   }
-
-  /** ORA-01918: "user '…' does not exist" — the expected DROP USER outcome when none is present. */
-  private static final int ORA_USER_DOES_NOT_EXIST = 1918;
 
   private static boolean isOracleUserDoesNotExist(final RuntimeException e) {
     return e.getCause() instanceof final SQLException sqlException

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisioner.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisioner.java
@@ -59,7 +59,7 @@ final class PhysicalTenantSchemaProvisioner {
 
   /**
    * Builds the namespace name for a physical tenant: {@code <basePrefix>_<tenantId>} — the schema
-   * or database name on the schema/database dialects, or the table prefix on Oracle.
+   * or database name on the schema/database dialects, or the user/schema name on Oracle.
    */
   static String buildNamespace(final String basePrefix, final String tenantId) {
     return basePrefix + "_" + tenantId;
@@ -206,16 +206,39 @@ final class PhysicalTenantSchemaProvisioner {
     try {
       executeDdl(url, adminUser, adminPass, "DROP USER " + namespace + " CASCADE");
     } catch (final RuntimeException e) {
-      // Expected when no leftover user exists (ORA-01918); recreate cleanly below.
-      LOGGER.debug("No pre-existing Oracle user '{}' to drop before create", namespace);
+      // Only ignore "user does not exist" (ORA-01918) — the expected case when there is no leftover
+      // user from a prior same-JVM rerun. Any other failure (privileges, connectivity) is real and
+      // must surface here rather than masquerading as a later CREATE USER failure.
+      if (isOracleUserDoesNotExist(e)) {
+        LOGGER.debug("No pre-existing Oracle user '{}' to drop before create", namespace);
+      } else {
+        throw e;
+      }
     }
     executeDdl(
         url,
         adminUser,
         adminPass,
-        "CREATE USER " + namespace + " IDENTIFIED BY \"" + userPassword + "\"",
+        "CREATE USER "
+            + namespace
+            + " IDENTIFIED BY \""
+            + escapeOracleQuotedLiteral(userPassword)
+            + "\"",
         "GRANT CONNECT, RESOURCE TO " + namespace,
         "GRANT UNLIMITED TABLESPACE TO " + namespace);
+  }
+
+  /** ORA-01918: "user '…' does not exist" — the expected DROP USER outcome when none is present. */
+  private static final int ORA_USER_DOES_NOT_EXIST = 1918;
+
+  private static boolean isOracleUserDoesNotExist(final RuntimeException e) {
+    return e.getCause() instanceof final SQLException sqlException
+        && sqlException.getErrorCode() == ORA_USER_DOES_NOT_EXIST;
+  }
+
+  /** Escapes a double-quoted Oracle literal by doubling any embedded double quotes. */
+  private static String escapeOracleQuotedLiteral(final String value) {
+    return value.replace("\"", "\"\"");
   }
 
   /**

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisioner.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisioner.java
@@ -11,6 +11,7 @@ import io.camunda.qa.util.multidb.CamundaMultiDBExtension.DatabaseType;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,26 +28,32 @@ import org.slf4j.LoggerFactory;
  *       path segment in the JDBC URL is replaced.
  *   <li>SQL Server: a dedicated <em>database</em>; the {@code databaseName} property in the
  *       semicolon-delimited JDBC URL is replaced.
- *   <li>Oracle: a per-tenant <em>table prefix</em> in the shared {@code camunda} schema — not a
- *       dedicated schema. Oracle's schema == user, so a schema-per-PT would need {@code CREATE
- *       USER} (DBA-only); more fundamentally, the production secondary-storage isolation check
- *       ({@code SecondaryStorageIsolationValidation}) keys a location on (type, connection url,
- *       table prefix) and deliberately ignores the user, so two Oracle users on the same URL are
- *       treated as the same location and rejected. A distinct table prefix is the validator's
- *       explicitly-allowed "shared connection, distinct prefix" mode and needs no privileges, so
- *       Oracle uses it instead of a per-PT schema.
+ *   <li>Oracle: a dedicated <em>schema</em>, which on Oracle == a dedicated <em>user</em>. Each PT
+ *       gets a {@code CREATE USER <namespace>} (with {@code CONNECT}/{@code RESOURCE} and an
+ *       unlimited tablespace quota) and connects as that user, so its tables live in its own schema
+ *       and no table prefix is needed. The PT's {@code database-vendor-id} is pinned to {@code
+ *       oracle} so the production isolation check ({@code SecondaryStorageIsolationValidation})
+ *       recognizes distinct Oracle users on the same JDBC URL as distinct locations (see <a
+ *       href="https://github.com/camunda/camunda/issues/56402">#56402</a>). This exercises the same
+ *       schema-per-user topology as the other dialects; the {@code CREATE USER}/{@code DROP USER}
+ *       bootstrap requires the base connection to be a privileged (DBA-grade) Oracle user.
  * </ul>
  *
  * <p>The namespace name is {@code <basePrefix>_<tenantId>}, where {@code basePrefix} is the
  * run-unique 10-character random token generated for the current test run (so concurrent CI matrix
  * runs targeting the same server cannot collide). For the schema/database dialects it names the
- * schema/database; for Oracle it is the per-PT table prefix.
+ * schema/database; for Oracle it names the per-PT user/schema.
  */
 @NullMarked
 final class PhysicalTenantSchemaProvisioner {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PhysicalTenantSchemaProvisioner.class);
+
+  /**
+   * Vendor id pinned on Oracle PTs so the production isolation check keys on the connecting user.
+   */
+  private static final String ORACLE_VENDOR_ID = "oracle";
 
   private PhysicalTenantSchemaProvisioner() {}
 
@@ -139,22 +146,25 @@ final class PhysicalTenantSchemaProvisioner {
       case RDBMS_POSTGRES, RDBMS_AURORA -> {
         createPostgresSchema(baseUrl, baseUsername, basePassword, namespace);
         yield new PtStorageConfig(
-            derivePostgresUrl(baseUrl, namespace), baseUsername, basePassword, "");
+            derivePostgresUrl(baseUrl, namespace), baseUsername, basePassword, "", null);
       }
       case RDBMS_MYSQL, RDBMS_MARIADB -> {
         createMysqlDatabase(baseUrl, baseUsername, basePassword, namespace);
         yield new PtStorageConfig(
-            deriveMysqlUrl(baseUrl, namespace), baseUsername, basePassword, "");
+            deriveMysqlUrl(baseUrl, namespace), baseUsername, basePassword, "", null);
       }
       case RDBMS_MSSQL -> {
         createMssqlDatabase(baseUrl, baseUsername, basePassword, namespace);
         yield new PtStorageConfig(
-            deriveMssqlUrl(baseUrl, namespace), baseUsername, basePassword, "");
+            deriveMssqlUrl(baseUrl, namespace), baseUsername, basePassword, "", null);
       }
-      case RDBMS_ORACLE ->
-          // Oracle isolates by table prefix in the shared schema (see class javadoc): no DDL, the
-          // base connection is reused and the namespace becomes the per-PT table prefix.
-          new PtStorageConfig(baseUrl, baseUsername, basePassword, namespace);
+      case RDBMS_ORACLE -> {
+        // Oracle isolates by schema-per-user: create a dedicated user (== schema) and connect as it
+        // (see class javadoc). No table prefix; the vendor id is pinned so the production isolation
+        // check keys the location on the distinct user rather than rejecting the shared URL.
+        createOracleUser(baseUrl, baseUsername, basePassword, namespace, basePassword);
+        yield new PtStorageConfig(baseUrl, namespace, basePassword, "", ORACLE_VENDOR_ID);
+      }
       default ->
           throw new IllegalArgumentException(
               "provisionAndDerive called for unsupported database type: " + databaseType);
@@ -181,17 +191,43 @@ final class PhysicalTenantSchemaProvisioner {
   }
 
   /**
+   * Creates a dedicated Oracle user (== schema) for a physical tenant and grants it the privileges
+   * needed to own its own tables ({@code CONNECT}, {@code RESOURCE}, and an unlimited tablespace
+   * quota). Oracle has no {@code CREATE USER IF NOT EXISTS}, so any leftover user from a prior
+   * same-JVM rerun is dropped first (best-effort) to guarantee a fresh schema per run. Requires the
+   * bootstrap connection to be a privileged (DBA-grade) Oracle user.
+   */
+  private static void createOracleUser(
+      final String url,
+      final String adminUser,
+      final String adminPass,
+      final String namespace,
+      final String userPassword) {
+    try {
+      executeDdl(url, adminUser, adminPass, "DROP USER " + namespace + " CASCADE");
+    } catch (final RuntimeException e) {
+      // Expected when no leftover user exists (ORA-01918); recreate cleanly below.
+      LOGGER.debug("No pre-existing Oracle user '{}' to drop before create", namespace);
+    }
+    executeDdl(
+        url,
+        adminUser,
+        adminPass,
+        "CREATE USER " + namespace + " IDENTIFIED BY \"" + userPassword + "\"",
+        "GRANT CONNECT, RESOURCE TO " + namespace,
+        "GRANT UNLIMITED TABLESPACE TO " + namespace);
+  }
+
+  /**
    * Best-effort drop of a previously provisioned namespace, used for per-run cleanup so persistent
    * shared instances (notably Aurora) don't accumulate orphaned schemas/databases across CI runs.
    *
    * <p>Failures are logged and swallowed: cleanup must never fail a test run, and the {@code IF
    * EXISTS} guards make repeated invocations harmless.
    *
-   * <p>Oracle and H2 have no namespace object to drop and are no-ops: H2 uses a throwaway in-memory
-   * database per PT, and Oracle isolates by table prefix in the shared schema. Oracle's per-run
-   * prefixed tables are therefore <em>not</em> dropped here — the run-unique prefix keeps separate
-   * runs from colliding, and the Oracle matrix runs against a fresh container per run, so they
-   * don't accumulate on a long-lived shared instance the way schema/database namespaces would.
+   * <p>H2 has no namespace object to drop and is a no-op: it uses a throwaway in-memory database
+   * per PT. Oracle drops the per-PT user with {@code DROP USER ... CASCADE} (which removes the
+   * schema and all its objects), matching the schema/database dialects.
    */
   static void dropNamespace(
       final DatabaseType databaseType,
@@ -205,7 +241,8 @@ final class PhysicalTenantSchemaProvisioner {
           case RDBMS_MYSQL, RDBMS_MARIADB -> "DROP DATABASE IF EXISTS `" + namespace + "`";
           case RDBMS_MSSQL ->
               "IF DB_ID('" + namespace + "') IS NOT NULL DROP DATABASE [" + namespace + "]";
-          // Oracle / H2: nothing to drop (table-prefix isolation / per-PT in-memory DB).
+          case RDBMS_ORACLE -> "DROP USER " + namespace + " CASCADE";
+          // H2: nothing to drop (per-PT in-memory DB).
           default -> null;
         };
     if (ddl == null) {
@@ -219,20 +256,29 @@ final class PhysicalTenantSchemaProvisioner {
   }
 
   private static void executeDdl(
-      final String url, final String user, final String pass, final String ddl) {
-    LOGGER.debug("Executing bootstrap DDL: {}", ddl);
+      final String url, final String user, final String pass, final String... ddls) {
     try (final var conn = DriverManager.getConnection(url, user, pass);
         final var stmt = conn.createStatement()) {
-      stmt.execute(ddl);
+      for (final String ddl : ddls) {
+        LOGGER.debug("Executing bootstrap DDL: {}", ddl);
+        stmt.execute(ddl);
+      }
     } catch (final SQLException e) {
-      throw new RuntimeException("Failed to execute bootstrap DDL: " + ddl, e);
+      throw new RuntimeException("Failed to execute bootstrap DDL: " + String.join("; ", ddls), e);
     }
   }
 
   /**
    * Holds the derived per-physical-tenant JDBC connection parameters. {@code prefix} is the table
-   * prefix to apply: empty for the schema/database dialects (isolation is at the schema/database
-   * level), or the namespace for Oracle (isolation is by table prefix in the shared schema).
+   * prefix to apply: empty for every RDBMS dialect (isolation is at the schema/database/user
+   * level). {@code databaseVendorId}, when non-null, pins the PT's {@code database-vendor-id} — set
+   * to {@code oracle} so the production isolation check keys the storage location on the connecting
+   * user.
    */
-  record PtStorageConfig(String url, String username, String password, String prefix) {}
+  record PtStorageConfig(
+      String url,
+      String username,
+      String password,
+      String prefix,
+      @Nullable String databaseVendorId) {}
 }

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisionerTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/PhysicalTenantSchemaProvisionerTest.java
@@ -192,12 +192,12 @@ class PhysicalTenantSchemaProvisionerTest {
   }
 
   @Test
-  void shouldNotAttemptCleanupForOracleAndH2() {
-    // given a URL that would fail if a connection were attempted
+  void shouldNotThrowWhenDroppingOracleUserFails() {
+    // given a URL with no matching driver so the DROP USER bootstrap connection fails fast
     final String unreachableUrl = "jdbc:invalid://does-not-exist";
 
-    // when / then — Oracle (table-prefix isolation) and H2 (per-PT in-memory DB) have no namespace
-    // object to drop, so dropNamespace is a no-op and never touches the connection
+    // when / then — Oracle now isolates by user/schema, so cleanup issues DROP USER; the failure is
+    // best-effort and must be swallowed
     assertThatNoException()
         .isThrownBy(
             () ->
@@ -207,6 +207,16 @@ class PhysicalTenantSchemaProvisionerTest {
                     "user",
                     "pass",
                     "ABCDEFGHIJ_tenanta"));
+  }
+
+  @Test
+  void shouldNotAttemptCleanupForH2() {
+    // given a URL that would fail if a connection were attempted
+    final String unreachableUrl = "jdbc:invalid://does-not-exist";
+
+    // when / then — H2 uses a per-PT in-memory DB with no namespace object to drop, so
+    // dropNamespace
+    // is a no-op and never touches the connection
     assertThatNoException()
         .isThrownBy(
             () ->


### PR DESCRIPTION
Closes #56402

## Problem

On Oracle, schema == user, so two physical tenants isolated by distinct Oracle users on the same JDBC URL (no distinct table prefix, no schema in the URL) are genuinely separate storage locations. But `StorageIdentity` keyed a location on `(type, url, prefix)` and deliberately ignored the DB user, so those tenants collapsed to a single identity and the cross-tenant `SecondaryStorageIsolationValidation` falsely rejected the deployment — the broker refused to start on a legitimate Oracle multi-tenant topology.

Unlike PostgreSQL (which encodes the schema in the JDBC URL via `currentSchema=…`, already handled), the Oracle thin driver does not carry the schema in the URL, so the connecting user is the only static signal of isolation.

## Fix (`configuration/`)

- `StorageIdentity` gains an Oracle-only `schema` component, populated **only** when `database-vendor-id` is explicitly `oracle` (trimmed, upper-case-folded user; blank = no distinction). It stays empty for every other vendor and for ES/OS, so distinct users never falsely isolate tenants on PostgreSQL/MySQL, where the user does not partition storage.
- The collision message gains a hint to set `database-vendor-id: oracle` when an RDBMS group collides.
- Unit tests cover Oracle distinct-users (pass), same/blank-users (reject), case-insensitivity, and a **mandatory regression guard** that distinct users on a non-Oracle/unset vendor are still rejected — guarding against trading the false positive for a silent double-write on MySQL/Postgres.

## Follow-up: MultiDb harness (`qa/util/`, `qa/docs/adr/`)

Now that production supports the schema-per-user topology, the MultiDb harness switches Oracle from the table-prefix workaround (#56153) back to schema-per-user for true end-to-end coverage:

- Each Oracle PT gets a dedicated user (== schema) via `CREATE USER` (with `CONNECT`/`RESOURCE` and an unlimited tablespace quota) and connects as that user with no table prefix, pinning `database-vendor-id: oracle`. Cleanup drops the user with `DROP USER … CASCADE`.
- ADR `0001-multidb-multiple-physical-tenants-per-broker` updated: Oracle is no longer the exception; a historical note records why it was and how #56402 removed the limitation.

> ⚠️ This re-introduces the privileged `CREATE USER`/`DROP USER` bootstrap, so the base Oracle connection must be DBA-grade and the **Oracle CI matrix needs a corresponding grant** to run green.

## Out of scope

The camunda-docs update (documenting the two limitations — quoted case-sensitive identifiers and `currentSchema`-in-URL overriding the user — and the `database-vendor-id: oracle` guidance) lives in a separate repo and is handed off separately.

## Testing

- `configuration`: `SecondaryStorageIsolationValidationTest` — 19/19 pass
- `qa/util`: `PhysicalTenantSchemaProvisionerTest` — 14/14 pass
- Both modules compile and pass spotless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)