### PR TITLE
feat: rolling upgrade tenant aware job streaming

### DIFF
--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
@@ -33,6 +33,7 @@ final class ClientStreamRegistration<M extends BufferWriter> {
 
   private State state = State.INITIAL;
   private @Nullable CompletionStage<byte[]> pendingRequest;
+  private @Nullable CompletionStage<byte[]> legacyPendingRequest;
 
   ClientStreamRegistration(final AggregatedClientStream<M> stream, final MemberId serverId) {
     this.stream = stream;
@@ -65,6 +66,14 @@ final class ClientStreamRegistration<M extends BufferWriter> {
 
   void setPendingRequest(final CompletionStage<byte[]> pendingRequest) {
     this.pendingRequest = pendingRequest;
+  }
+
+  @Nullable CompletionStage<byte[]> legacyPendingRequest() {
+    return legacyPendingRequest;
+  }
+
+  void setLegacyPendingRequest(final CompletionStage<byte[]> legacyPendingRequest) {
+    this.legacyPendingRequest = legacyPendingRequest;
   }
 
   boolean transitionToAdding() {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -32,10 +32,13 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -235,16 +238,22 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     final var request = new RemoveStreamRequest().streamId(registration.streamId());
     final var payload = BufferUtil.bufferAsArray(request);
 
-    final var pendingRequest = registration.pendingRequest();
-    if (pendingRequest == null) {
+    final var previousRequests =
+        Stream.of(registration.pendingRequest(), registration.legacyPendingRequest())
+            .filter(Objects::nonNull)
+            .map(CompletionStage::toCompletableFuture)
+            .toArray(CompletableFuture[]::new);
+    if (previousRequests.length == 0) {
       sendRemoveRequestAndLegacy(registration, payload);
       return;
     }
 
-    // to minimize the likelihood of out-of-order requests on the server side, wait until the
-    // current request is finished before sending the next request, regardless of the result
-    pendingRequest.whenCompleteAsync(
-        (ok, error) -> sendRemoveRequestAndLegacy(registration, payload), executor::run);
+    // to minimize the likelihood of out-of-order requests on the server side, wait until any
+    // current request (primary or legacy) is finished before sending the next one, regardless of
+    // the result
+    CompletableFuture.allOf(previousRequests)
+        .whenCompleteAsync(
+            (ok, error) -> sendRemoveRequestAndLegacy(registration, payload), executor::run);
   }
 
   private void sendRemoveRequestAndLegacy(
@@ -309,6 +318,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       final byte[] request,
       final CompletableFuture<Void> added) {
     if (registration.state() != State.ADDING) {
+      added.complete(null);
       return;
     }
 
@@ -350,6 +360,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       final byte[] request,
       final CompletableFuture<Void> legacyAdded) {
     if (registration.state() != State.ADDING) {
+      legacyAdded.complete(null);
       return;
     }
 
@@ -361,6 +372,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
             Function.identity(),
             registration.serverId(),
             REQUEST_TIMEOUT);
+    registration.setLegacyPendingRequest(pendingRequest);
     pendingRequest.whenCompleteAsync(
         (response, error) ->
             handleAddResponse(
@@ -381,6 +393,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     final var state = registration.state();
     if (state != State.ADDING) {
       LOGGER.trace("Skip handling ADD response since the state is {}", state, error);
+      added.complete(null);
       return;
     }
 
@@ -417,6 +430,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       final byte[] request,
       final CompletableFuture<Void> removed) {
     if (registration.state() != State.REMOVING) {
+      removed.complete(null);
       return;
     }
 
@@ -458,6 +472,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       final byte[] request,
       final CompletableFuture<Void> legacyRemoved) {
     if (registration.state() != State.REMOVING) {
+      legacyRemoved.complete(null);
       return;
     }
 
@@ -469,6 +484,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
             Function.identity(),
             registration.serverId(),
             REQUEST_TIMEOUT);
+    registration.setLegacyPendingRequest(pendingRequest);
     pendingRequest.whenCompleteAsync(
         (response, error) ->
             handleRemoveResponse(
@@ -489,6 +505,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     final var state = registration.state();
     if (state != State.REMOVING) {
       LOGGER.trace("Skip handling REMOVE response since the state is {}", state, error);
+      removed.complete(null);
       return;
     }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -184,7 +185,8 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
                       Function.identity(),
                       serverId,
                       true);
-                  dualSendIfDefaultTenant(physicalTenantId, StreamTopics.REMOVE, payload, serverId);
+                  legacyUnicastIfDefaultTenant(
+                      StreamTopics.REMOVE, physicalTenantId, payload, serverId);
                   purgeRegistration(streamId, serverId);
                 }));
   }
@@ -209,9 +211,14 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     }
 
     final var payload = BufferUtil.bufferAsArray(request);
-    dualSendIfDefaultTenant(
-        registration.physicalTenantId(), StreamTopics.ADD, payload, registration.serverId());
-    sendAddRequest(registration, payload);
+    final var added = new CompletableFuture<Void>();
+    final var legacyAdded = new CompletableFuture<Void>();
+
+    sendAddRequest(registration, payload, added);
+    sendLegacyAddRequestIfDefaultTenant(registration, payload, legacyAdded);
+
+    CompletableFuture.allOf(added, legacyAdded)
+        .whenCompleteAsync((ok, error) -> registration.transitionToAdded(), executor::run);
   }
 
   private void remove(final ClientStreamRegistration<M> registration) {
@@ -227,19 +234,34 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var request = new RemoveStreamRequest().streamId(registration.streamId());
     final var payload = BufferUtil.bufferAsArray(request);
-    dualSendIfDefaultTenant(
-        registration.physicalTenantId(), StreamTopics.REMOVE, payload, registration.serverId());
 
     final var pendingRequest = registration.pendingRequest();
     if (pendingRequest == null) {
-      sendRemoveRequest(registration, payload);
+      sendRemoveRequestAndLegacy(registration, payload);
       return;
     }
 
     // to minimize the likelihood of out-of-order requests on the server side, wait until the
     // current request is finished before sending the next request, regardless of the result
     pendingRequest.whenCompleteAsync(
-        (ok, error) -> sendRemoveRequest(registration, payload), executor::run);
+        (ok, error) -> sendRemoveRequestAndLegacy(registration, payload), executor::run);
+  }
+
+  private void sendRemoveRequestAndLegacy(
+      final ClientStreamRegistration<M> registration, final byte[] payload) {
+    final var removed = new CompletableFuture<Void>();
+    final var legacyRemoved = new CompletableFuture<Void>();
+
+    sendRemoveRequest(registration, payload, removed);
+    sendLegacyRemoveRequestIfDefaultTenant(registration, payload, legacyRemoved);
+
+    CompletableFuture.allOf(removed, legacyRemoved)
+        .whenCompleteAsync(
+            (ok, error) -> {
+              registration.transitionToRemoved();
+              purgeRegistration(registration.streamId(), registration.serverId());
+            },
+            executor::run);
   }
 
   /**
@@ -283,7 +305,9 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   private void sendAddRequest(
-      final ClientStreamRegistration<M> registration, final byte[] request) {
+      final ClientStreamRegistration<M> registration,
+      final byte[] request,
+      final CompletableFuture<Void> added) {
     if (registration.state() != State.ADDING) {
       return;
     }
@@ -298,15 +322,62 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
             REQUEST_TIMEOUT);
     registration.setPendingRequest(pendingRequest);
     pendingRequest.whenCompleteAsync(
-        (response, error) -> handleAddResponse(registration, request, response, error),
+        (response, error) ->
+            handleAddResponse(
+                registration,
+                response,
+                error,
+                () -> sendAddRequest(registration, request, added),
+                added),
+        executor::run);
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void sendLegacyAddRequestIfDefaultTenant(
+      final ClientStreamRegistration<M> registration,
+      final byte[] request,
+      final CompletableFuture<Void> legacyAdded) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(registration.physicalTenantId())) {
+      legacyAdded.complete(null);
+      return;
+    }
+
+    sendLegacyAddRequest(registration, request, legacyAdded);
+  }
+
+  private void sendLegacyAddRequest(
+      final ClientStreamRegistration<M> registration,
+      final byte[] request,
+      final CompletableFuture<Void> legacyAdded) {
+    if (registration.state() != State.ADDING) {
+      return;
+    }
+
+    final var pendingRequest =
+        communicationService.send(
+            StreamTopics.ADD.legacyTopic(),
+            request,
+            Function.identity(),
+            Function.identity(),
+            registration.serverId(),
+            REQUEST_TIMEOUT);
+    pendingRequest.whenCompleteAsync(
+        (response, error) ->
+            handleAddResponse(
+                registration,
+                response,
+                error,
+                () -> sendLegacyAddRequest(registration, request, legacyAdded),
+                legacyAdded),
         executor::run);
   }
 
   private void handleAddResponse(
       final ClientStreamRegistration<M> registration,
-      final byte[] request,
       final byte[] responseBuffer,
-      final @Nullable Throwable error) {
+      final @Nullable Throwable error,
+      final Runnable retry,
+      final CompletableFuture<Void> added) {
     final var state = registration.state();
     if (state != State.ADDING) {
       LOGGER.trace("Skip handling ADD response since the state is {}", state, error);
@@ -318,7 +389,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     if (error == null) {
       response = responseDecoder.decode(responseBuffer, new AddStreamResponse());
       if (response.isRight()) {
-        registration.transitionToAdded();
+        added.complete(null);
         return;
       }
 
@@ -338,11 +409,13 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
         registration.serverId(),
         RETRY_DELAY,
         failure);
-    executor.schedule(RETRY_DELAY, () -> sendAddRequest(registration, request));
+    executor.schedule(RETRY_DELAY, retry);
   }
 
   private void sendRemoveRequest(
-      final ClientStreamRegistration<M> registration, final byte[] request) {
+      final ClientStreamRegistration<M> registration,
+      final byte[] request,
+      final CompletableFuture<Void> removed) {
     if (registration.state() != State.REMOVING) {
       return;
     }
@@ -357,15 +430,62 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
             REQUEST_TIMEOUT);
     registration.setPendingRequest(pendingRequest);
     pendingRequest.whenCompleteAsync(
-        (response, error) -> handleRemoveResponse(registration, request, response, error),
+        (response, error) ->
+            handleRemoveResponse(
+                registration,
+                response,
+                error,
+                () -> sendRemoveRequest(registration, request, removed),
+                removed),
+        executor::run);
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void sendLegacyRemoveRequestIfDefaultTenant(
+      final ClientStreamRegistration<M> registration,
+      final byte[] request,
+      final CompletableFuture<Void> legacyRemoved) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(registration.physicalTenantId())) {
+      legacyRemoved.complete(null);
+      return;
+    }
+
+    sendLegacyRemoveRequest(registration, request, legacyRemoved);
+  }
+
+  private void sendLegacyRemoveRequest(
+      final ClientStreamRegistration<M> registration,
+      final byte[] request,
+      final CompletableFuture<Void> legacyRemoved) {
+    if (registration.state() != State.REMOVING) {
+      return;
+    }
+
+    final var pendingRequest =
+        communicationService.send(
+            StreamTopics.REMOVE.legacyTopic(),
+            request,
+            Function.identity(),
+            Function.identity(),
+            registration.serverId(),
+            REQUEST_TIMEOUT);
+    pendingRequest.whenCompleteAsync(
+        (response, error) ->
+            handleRemoveResponse(
+                registration,
+                response,
+                error,
+                () -> sendLegacyRemoveRequest(registration, request, legacyRemoved),
+                legacyRemoved),
         executor::run);
   }
 
   private void handleRemoveResponse(
       final ClientStreamRegistration<M> registration,
-      final byte[] request,
       final byte[] responseBuffer,
-      final @Nullable Throwable error) {
+      final @Nullable Throwable error,
+      final Runnable retry,
+      final CompletableFuture<Void> removed) {
     final var state = registration.state();
     if (state != State.REMOVING) {
       LOGGER.trace("Skip handling REMOVE response since the state is {}", state, error);
@@ -377,8 +497,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     if (error == null) {
       response = responseDecoder.decode(responseBuffer, new RemoveStreamResponse());
       if (response.isRight()) {
-        registration.transitionToRemoved();
-        purgeRegistration(registration.streamId(), registration.serverId());
+        removed.complete(null);
         return;
       }
 
@@ -394,14 +513,18 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     //   - ErrorResponse.code in [ MALFORMED, INVALID ]
     switch (failure) {
       // all returned errors are currently unnecessary to retry
-      case final UnrecoverableException e -> handleUnrecoverableExceptionOnRemove(registration, e);
+      case final UnrecoverableException e ->
+          handleUnrecoverableExceptionOnRemove(registration, e, removed);
       // no point retrying if the remote handler failed to handle our request
-      case final RemoteHandlerFailure e -> handleUnrecoverableExceptionOnRemove(registration, e);
+      case final RemoteHandlerFailure e ->
+          handleUnrecoverableExceptionOnRemove(registration, e, removed);
       // should not happen, since it means the member was removed from the topology, but keep as a
       // failsafe
-      case final NoSuchMemberException e -> handleUnrecoverableExceptionOnRemove(registration, e);
+      case final NoSuchMemberException e ->
+          handleUnrecoverableExceptionOnRemove(registration, e, removed);
       // essentially happens due to malformed request, no point retrying
-      case final ProtocolException e -> handleUnrecoverableExceptionOnRemove(registration, e);
+      case final ProtocolException e ->
+          handleUnrecoverableExceptionOnRemove(registration, e, removed);
       default -> {
         LOGGER.debug(
             "Failed to remove remote stream {} on {}, will retry in {}",
@@ -409,13 +532,15 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
             registration.serverId(),
             RETRY_DELAY,
             failure);
-        executor.schedule(RETRY_DELAY, () -> sendRemoveRequest(registration, request));
+        executor.schedule(RETRY_DELAY, retry);
       }
     }
   }
 
   private void handleUnrecoverableExceptionOnRemove(
-      final ClientStreamRegistration<M> registration, final Throwable e) {
+      final ClientStreamRegistration<M> registration,
+      final Throwable e,
+      final CompletableFuture<Void> removed) {
     LOGGER.debug(
         """
         Failed to remove stream '{}' for member '{}'; unrecoverable error occurred on recipient
@@ -423,8 +548,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
         registration.streamId(),
         registration.serverId(),
         e);
-    registration.transitionToRemoved();
-    purgeRegistration(registration.streamId(), registration.serverId());
+    removed.complete(null);
   }
 
   private void purgeRegistration(final UUID streamId, final MemberId serverId) {
@@ -449,19 +573,19 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
         Function.identity(),
         brokerId,
         true);
-    dualSendIfDefaultTenant(
-        physicalTenantId, StreamTopics.REMOVE_ALL, REMOVE_ALL_REQUEST, brokerId);
+    legacyUnicastIfDefaultTenant(
+        StreamTopics.REMOVE_ALL, physicalTenantId, REMOVE_ALL_REQUEST, brokerId);
   }
 
   /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  private void dualSendIfDefaultTenant(
-      final String physicalTenantId,
+  private void legacyUnicastIfDefaultTenant(
       final StreamTopics topic,
+      final String physicalTenantId,
       final byte[] payload,
       final MemberId serverId) {
     if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       return;
     }
-    communicationService.unicast(topic.dualTopic(), payload, Function.identity(), serverId, true);
+    communicationService.unicast(topic.legacyTopic(), payload, Function.identity(), serverId, true);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
@@ -215,12 +216,12 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var payload = BufferUtil.bufferAsArray(request);
     final var added = new CompletableFuture<Void>();
-    final var legacyAdded = new CompletableFuture<Void>();
-
     sendAddRequest(registration, payload, added);
-    sendLegacyAddRequestIfDefaultTenant(registration, payload, legacyAdded);
 
-    CompletableFuture.allOf(added, legacyAdded)
+    raceLegacyIfDefaultTenant(
+            added,
+            registration.physicalTenantId(),
+            legacyAdded -> sendLegacyAddRequest(registration, payload, legacyAdded))
         .whenCompleteAsync((ok, error) -> registration.transitionToAdded(), executor::run);
   }
 
@@ -259,18 +260,36 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   private void sendRemoveRequestAndLegacy(
       final ClientStreamRegistration<M> registration, final byte[] payload) {
     final var removed = new CompletableFuture<Void>();
-    final var legacyRemoved = new CompletableFuture<Void>();
-
     sendRemoveRequest(registration, payload, removed);
-    sendLegacyRemoveRequestIfDefaultTenant(registration, payload, legacyRemoved);
 
-    CompletableFuture.allOf(removed, legacyRemoved)
+    raceLegacyIfDefaultTenant(
+            removed,
+            registration.physicalTenantId(),
+            legacyRemoved -> sendLegacyRemoveRequest(registration, payload, legacyRemoved))
         .whenCompleteAsync(
             (ok, error) -> {
               registration.transitionToRemoved();
               purgeRegistration(registration.streamId(), registration.serverId());
             },
             executor::run);
+  }
+
+  /**
+   * Rolling-upgrade compat; to remove alongside the legacy topic in 8.11, delete this method and
+   * replace every {@code raceLegacyIfDefaultTenant(primary, tenantId, sendLegacy)} call with {@code
+   * primary}, then delete the now-unused {@code sendLegacy*} methods it was wired to.
+   */
+  private CompletableFuture<Void> raceLegacyIfDefaultTenant(
+      final CompletableFuture<Void> primary,
+      final String physicalTenantId,
+      final Consumer<CompletableFuture<Void>> sendLegacy) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      return primary;
+    }
+
+    final var legacy = new CompletableFuture<Void>();
+    sendLegacy.accept(legacy);
+    return CompletableFuture.anyOf(primary, legacy).thenApplyAsync(ignored -> null, executor::run);
   }
 
   /**
@@ -343,18 +362,6 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  private void sendLegacyAddRequestIfDefaultTenant(
-      final ClientStreamRegistration<M> registration,
-      final byte[] request,
-      final CompletableFuture<Void> legacyAdded) {
-    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(registration.physicalTenantId())) {
-      legacyAdded.complete(null);
-      return;
-    }
-
-    sendLegacyAddRequest(registration, request, legacyAdded);
-  }
-
   private void sendLegacyAddRequest(
       final ClientStreamRegistration<M> registration,
       final byte[] request,
@@ -455,18 +462,6 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  private void sendLegacyRemoveRequestIfDefaultTenant(
-      final ClientStreamRegistration<M> registration,
-      final byte[] request,
-      final CompletableFuture<Void> legacyRemoved) {
-    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(registration.physicalTenantId())) {
-      legacyRemoved.complete(null);
-      return;
-    }
-
-    sendLegacyRemoveRequest(registration, request, legacyRemoved);
-  }
-
   private void sendLegacyRemoveRequest(
       final ClientStreamRegistration<M> registration,
       final byte[] request,

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
@@ -182,6 +184,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
                       Function.identity(),
                       serverId,
                       true);
+                  dualSendIfDefaultTenant(physicalTenantId, StreamTopics.REMOVE, payload, serverId);
                   purgeRegistration(streamId, serverId);
                 }));
   }
@@ -206,6 +209,8 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     }
 
     final var payload = BufferUtil.bufferAsArray(request);
+    dualSendIfDefaultTenant(
+        registration.physicalTenantId(), StreamTopics.ADD, payload, registration.serverId());
     sendAddRequest(registration, payload);
   }
 
@@ -222,6 +227,8 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var request = new RemoveStreamRequest().streamId(registration.streamId());
     final var payload = BufferUtil.bufferAsArray(request);
+    dualSendIfDefaultTenant(
+        registration.physicalTenantId(), StreamTopics.REMOVE, payload, registration.serverId());
 
     final var pendingRequest = registration.pendingRequest();
     if (pendingRequest == null) {
@@ -442,5 +449,19 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
         Function.identity(),
         brokerId,
         true);
+    dualSendIfDefaultTenant(
+        physicalTenantId, StreamTopics.REMOVE_ALL, REMOVE_ALL_REQUEST, brokerId);
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void dualSendIfDefaultTenant(
+      final String physicalTenantId,
+      final StreamTopics topic,
+      final byte[] payload,
+      final MemberId serverId) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      return;
+    }
+    communicationService.unicast(topic.dualTopic(), payload, Function.identity(), serverId, true);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -77,7 +77,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   @Override
   protected void onActorStarted() {
     communicationService.replyToAsync(
-        StreamTopics.PUSH.topic(DEFAULT_PHYSICAL_TENANT_ID),
+        StreamTopics.PUSH.legacyTopic(),
         MessageUtil::parsePushRequest,
         apiHandler::handlePushRequest,
         BufferUtil::bufferAsArray,
@@ -153,11 +153,14 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
     if (registeredRestartPhysicalTenants.add(physicalTenantId)) {
       registerRestartTopicHandler(
           StreamTopics.RESTART_STREAMS.topic(physicalTenantId), physicalTenantId);
+      registerLegacyRestartHandler(physicalTenantId);
+    }
+  }
 
-      if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
-        // Rolling-upgrade compat; remove alongside the legacy topic in 8.11.
-        registerRestartTopicHandler(StreamTopics.RESTART_STREAMS.dualTopic(), physicalTenantId);
-      }
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void registerLegacyRestartHandler(final String physicalTenantId) {
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      registerRestartTopicHandler(StreamTopics.RESTART_STREAMS.legacyTopic(), physicalTenantId);
     }
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -151,12 +151,22 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
 
   private void registerRestartHandler(final String physicalTenantId) {
     if (registeredRestartPhysicalTenants.add(physicalTenantId)) {
-      communicationService.replyTo(
-          StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
-          Function.identity(),
-          (sender, payload) -> apiHandler.handleRestartRequest(sender, physicalTenantId, payload),
-          Function.identity(),
-          actor::run);
+      registerRestartTopicHandler(
+          StreamTopics.RESTART_STREAMS.topic(physicalTenantId), physicalTenantId);
+
+      if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+        // Rolling-upgrade compat; remove alongside the legacy topic in 8.11.
+        registerRestartTopicHandler(StreamTopics.RESTART_STREAMS.dualTopic(), physicalTenantId);
+      }
     }
+  }
+
+  private void registerRestartTopicHandler(final String topic, final String physicalTenantId) {
+    communicationService.replyTo(
+        topic,
+        Function.identity(),
+        (sender, payload) -> apiHandler.handleRestartRequest(sender, physicalTenantId, payload),
+        Function.identity(),
+        actor::run);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.MessagingException.NoRemoteHandler;
@@ -65,31 +67,33 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   @Override
   protected void onActorStarting() {
-    transport.replyTo(
+    registerTopicHandlers(
         StreamTopics.ADD.topic(physicalTenantId),
-        MessageUtil::parseAddRequest,
-        requestHandler::add,
-        BufferUtil::bufferAsArray,
-        actor::run);
-    transport.replyTo(
         StreamTopics.REMOVE.topic(physicalTenantId),
-        MessageUtil::parseRemoveRequest,
-        requestHandler::remove,
-        BufferUtil::bufferAsArray,
-        actor::run);
-    transport.replyTo(
-        StreamTopics.REMOVE_ALL.topic(physicalTenantId),
-        Function.identity(),
-        this::onRemoveAll,
-        Function.identity(),
-        actor::run);
+        StreamTopics.REMOVE_ALL.topic(physicalTenantId));
+
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      // Rolling-upgrade compat; remove alongside the legacy topic in 8.11.
+      registerTopicHandlers(
+          StreamTopics.ADD.dualTopic(),
+          StreamTopics.REMOVE.dualTopic(),
+          StreamTopics.REMOVE_ALL.dualTopic());
+    }
   }
 
   @Override
   protected void onActorClosing() {
-    transport.unsubscribe(StreamTopics.ADD.topic(physicalTenantId));
-    transport.unsubscribe(StreamTopics.REMOVE.topic(physicalTenantId));
-    transport.unsubscribe(StreamTopics.REMOVE_ALL.topic(physicalTenantId));
+    unsubscribeTopics(
+        StreamTopics.ADD.topic(physicalTenantId),
+        StreamTopics.REMOVE.topic(physicalTenantId),
+        StreamTopics.REMOVE_ALL.topic(physicalTenantId));
+
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      unsubscribeTopics(
+          StreamTopics.ADD.dualTopic(),
+          StreamTopics.REMOVE.dualTopic(),
+          StreamTopics.REMOVE_ALL.dualTopic());
+    }
     requestHandler.close();
   }
 
@@ -105,7 +109,55 @@ public final class RemoteStreamTransport<M> extends Actor {
   public CompletableFuture<Void> restartStreams(final MemberId receiver) {
     final var completed = new CompletableFuture<Void>();
     sendRestartStreamsRequest(receiver, completed, INITIAL_RETRY_DELAY_MS);
+    sendDualRestartStreamsRequest(receiver);
     return completed;
+  }
+
+  private void registerTopicHandlers(
+      final String addTopic, final String removeTopic, final String removeAllTopic) {
+    transport.replyTo(
+        addTopic,
+        MessageUtil::parseAddRequest,
+        requestHandler::add,
+        BufferUtil::bufferAsArray,
+        actor::run);
+    transport.replyTo(
+        removeTopic,
+        MessageUtil::parseRemoveRequest,
+        requestHandler::remove,
+        BufferUtil::bufferAsArray,
+        actor::run);
+    transport.replyTo(
+        removeAllTopic, Function.identity(), this::onRemoveAll, Function.identity(), actor::run);
+  }
+
+  private void unsubscribeTopics(
+      final String addTopic, final String removeTopic, final String removeAllTopic) {
+    transport.unsubscribe(addTopic);
+    transport.unsubscribe(removeTopic);
+    transport.unsubscribe(removeAllTopic);
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void sendDualRestartStreamsRequest(final MemberId receiver) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      return;
+    }
+
+    transport
+        .send(
+            StreamTopics.RESTART_STREAMS.dualTopic(),
+            ArrayUtil.EMPTY_BYTE_ARRAY,
+            Function.identity(),
+            Function.identity(),
+            receiver,
+            REQUEST_TIMEOUT)
+        .exceptionallyAsync(
+            error -> {
+              LOG.trace("Failed to restart streams for dual topic member '{}'", receiver, error);
+              return null;
+            },
+            actor);
   }
 
   private void sendRestartStreamsRequest(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.LongUnaryOperator;
@@ -116,13 +117,27 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   public CompletableFuture<Void> restartStreams(final MemberId receiver) {
     final var completed = new CompletableFuture<Void>();
-    final var legacyCompleted = new CompletableFuture<Void>();
-
     sendRestartStreamsRequest(receiver, completed, INITIAL_RETRY_DELAY_MS);
-    sendLegacyRestartStreamsRequestIfDefaultTenant(
-        receiver, legacyCompleted, INITIAL_RETRY_DELAY_MS);
 
-    return CompletableFuture.allOf(completed, legacyCompleted);
+    return raceLegacyIfDefaultTenant(
+        physicalTenantId,
+        completed,
+        legacyCompleted ->
+            sendLegacyRestartStreamsRequest(receiver, legacyCompleted, INITIAL_RETRY_DELAY_MS));
+  }
+
+  /** Rolling-upgrade compat; to remove alongside the legacy topic in 8.11 */
+  private CompletableFuture<Void> raceLegacyIfDefaultTenant(
+      final String physicalTenantId,
+      final CompletableFuture<Void> primary,
+      final Consumer<CompletableFuture<Void>> sendLegacy) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      return primary;
+    }
+
+    final var legacy = new CompletableFuture<Void>();
+    sendLegacy.accept(legacy);
+    return CompletableFuture.anyOf(primary, legacy).thenApplyAsync(ignored -> null, actor);
   }
 
   private void registerTopicHandlers(
@@ -181,16 +196,6 @@ public final class RemoteStreamTransport<M> extends Actor {
   }
 
   /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  private void sendLegacyRestartStreamsRequestIfDefaultTenant(
-      final MemberId receiver, final CompletableFuture<Void> completed, final long retryDelayMs) {
-    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
-      completed.complete(null);
-      return;
-    }
-
-    sendLegacyRestartStreamsRequest(receiver, completed, retryDelayMs);
-  }
-
   private void sendLegacyRestartStreamsRequest(
       final MemberId receiver, final CompletableFuture<Void> completed, final long retryDelayMs) {
     try {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -71,14 +71,7 @@ public final class RemoteStreamTransport<M> extends Actor {
         StreamTopics.ADD.topic(physicalTenantId),
         StreamTopics.REMOVE.topic(physicalTenantId),
         StreamTopics.REMOVE_ALL.topic(physicalTenantId));
-
-    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
-      // Rolling-upgrade compat; remove alongside the legacy topic in 8.11.
-      registerTopicHandlers(
-          StreamTopics.ADD.dualTopic(),
-          StreamTopics.REMOVE.dualTopic(),
-          StreamTopics.REMOVE_ALL.dualTopic());
-    }
+    registerLegacyTopicHandlers();
   }
 
   @Override
@@ -87,14 +80,28 @@ public final class RemoteStreamTransport<M> extends Actor {
         StreamTopics.ADD.topic(physicalTenantId),
         StreamTopics.REMOVE.topic(physicalTenantId),
         StreamTopics.REMOVE_ALL.topic(physicalTenantId));
+    unsubscribeLegacyTopics();
+    requestHandler.close();
+  }
 
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void registerLegacyTopicHandlers() {
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      registerTopicHandlers(
+          StreamTopics.ADD.legacyTopic(),
+          StreamTopics.REMOVE.legacyTopic(),
+          StreamTopics.REMOVE_ALL.legacyTopic());
+    }
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void unsubscribeLegacyTopics() {
     if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       unsubscribeTopics(
-          StreamTopics.ADD.dualTopic(),
-          StreamTopics.REMOVE.dualTopic(),
-          StreamTopics.REMOVE_ALL.dualTopic());
+          StreamTopics.ADD.legacyTopic(),
+          StreamTopics.REMOVE.legacyTopic(),
+          StreamTopics.REMOVE_ALL.legacyTopic());
     }
-    requestHandler.close();
   }
 
   public void removeAll(final MemberId member) {
@@ -109,7 +116,7 @@ public final class RemoteStreamTransport<M> extends Actor {
   public CompletableFuture<Void> restartStreams(final MemberId receiver) {
     final var completed = new CompletableFuture<Void>();
     sendRestartStreamsRequest(receiver, completed, INITIAL_RETRY_DELAY_MS);
-    sendDualRestartStreamsRequest(receiver);
+    sendLegacyRestartStreamsRequest(receiver);
     return completed;
   }
 
@@ -139,14 +146,14 @@ public final class RemoteStreamTransport<M> extends Actor {
   }
 
   /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  private void sendDualRestartStreamsRequest(final MemberId receiver) {
+  private void sendLegacyRestartStreamsRequest(final MemberId receiver) {
     if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       return;
     }
 
     transport
         .send(
-            StreamTopics.RESTART_STREAMS.dualTopic(),
+            StreamTopics.RESTART_STREAMS.legacyTopic(),
             ArrayUtil.EMPTY_BYTE_ARRAY,
             Function.identity(),
             Function.identity(),
@@ -154,7 +161,7 @@ public final class RemoteStreamTransport<M> extends Actor {
             REQUEST_TIMEOUT)
         .exceptionallyAsync(
             error -> {
-              LOG.trace("Failed to restart streams for dual topic member '{}'", receiver, error);
+              LOG.trace("Failed to restart streams for legacy topic member '{}'", receiver, error);
               return null;
             },
             actor);

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.LongConsumer;
 import java.util.function.LongUnaryOperator;
 import org.agrona.collections.ArrayUtil;
 import org.jspecify.annotations.Nullable;
@@ -115,9 +116,13 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   public CompletableFuture<Void> restartStreams(final MemberId receiver) {
     final var completed = new CompletableFuture<Void>();
+    final var legacyCompleted = new CompletableFuture<Void>();
+
     sendRestartStreamsRequest(receiver, completed, INITIAL_RETRY_DELAY_MS);
-    sendLegacyRestartStreamsRequest(receiver);
-    return completed;
+    sendLegacyRestartStreamsRequestIfDefaultTenant(
+        receiver, legacyCompleted, INITIAL_RETRY_DELAY_MS);
+
+    return CompletableFuture.allOf(completed, legacyCompleted);
   }
 
   private void registerTopicHandlers(
@@ -145,34 +150,18 @@ public final class RemoteStreamTransport<M> extends Actor {
     transport.unsubscribe(removeAllTopic);
   }
 
-  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  private void sendLegacyRestartStreamsRequest(final MemberId receiver) {
-    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
-      return;
-    }
-
-    transport
-        .send(
-            StreamTopics.RESTART_STREAMS.legacyTopic(),
-            ArrayUtil.EMPTY_BYTE_ARRAY,
-            Function.identity(),
-            Function.identity(),
-            receiver,
-            REQUEST_TIMEOUT)
-        .exceptionallyAsync(
-            error -> {
-              LOG.trace("Failed to restart streams for legacy topic member '{}'", receiver, error);
-              return null;
-            },
-            actor);
-  }
-
   private void sendRestartStreamsRequest(
       final MemberId receiver, final CompletableFuture<Void> completed, final long retryDelayMs) {
     try {
       sendRestartStreamsRequest(receiver)
           .whenCompleteAsync(
-              (ok, error) -> onRestartStreamsResponse(receiver, error, completed, retryDelayMs),
+              (ok, error) ->
+                  onRestartStreamsResponse(
+                      receiver,
+                      error,
+                      completed,
+                      retryDelayMs,
+                      nextDelay -> sendRestartStreamsRequest(receiver, completed, nextDelay)),
               actor);
     } catch (final Exception e) {
       LOG.warn("Failed to restart streams for member '{}'", receiver, e);
@@ -191,11 +180,53 @@ public final class RemoteStreamTransport<M> extends Actor {
         .thenApplyAsync(ok -> null, actor);
   }
 
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void sendLegacyRestartStreamsRequestIfDefaultTenant(
+      final MemberId receiver, final CompletableFuture<Void> completed, final long retryDelayMs) {
+    if (!DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      completed.complete(null);
+      return;
+    }
+
+    sendLegacyRestartStreamsRequest(receiver, completed, retryDelayMs);
+  }
+
+  private void sendLegacyRestartStreamsRequest(
+      final MemberId receiver, final CompletableFuture<Void> completed, final long retryDelayMs) {
+    try {
+      sendLegacyRestartStreamsRequest(receiver)
+          .whenCompleteAsync(
+              (ok, error) ->
+                  onRestartStreamsResponse(
+                      receiver,
+                      error,
+                      completed,
+                      retryDelayMs,
+                      nextDelay -> sendLegacyRestartStreamsRequest(receiver, completed, nextDelay)),
+              actor);
+    } catch (final Exception e) {
+      LOG.warn("Failed to restart legacy streams for member '{}'", receiver, e);
+    }
+  }
+
+  private CompletableFuture<Void> sendLegacyRestartStreamsRequest(final MemberId receiver) {
+    return transport
+        .send(
+            StreamTopics.RESTART_STREAMS.legacyTopic(),
+            ArrayUtil.EMPTY_BYTE_ARRAY,
+            Function.identity(),
+            Function.identity(),
+            receiver,
+            REQUEST_TIMEOUT)
+        .thenApplyAsync(ok -> null, actor);
+  }
+
   private void onRestartStreamsResponse(
       final MemberId receiver,
       final @Nullable Throwable error,
       final CompletableFuture<Void> completed,
-      final long retryDelayMs) {
+      final long retryDelayMs,
+      final LongConsumer retry) {
     if (error == null) {
       LOG.debug("Requested streams from client service member '{}'", receiver);
       completed.complete(null);
@@ -244,9 +275,7 @@ public final class RemoteStreamTransport<M> extends Actor {
             retryDelayMs,
             error);
         final var nextRetryDelay = retryDelaySupplier.applyAsLong(retryDelayMs);
-        actor.schedule(
-            Duration.ofMillis(nextRetryDelay),
-            () -> sendRestartStreamsRequest(receiver, completed, nextRetryDelay));
+        actor.schedule(Duration.ofMillis(nextRetryDelay), () -> retry.accept(nextRetryDelay));
       }
     }
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.Actor;
@@ -93,7 +91,7 @@ public final class RemoteStreamerImpl<M, P extends BufferWriter> extends Actor
 
   private CompletableFuture<byte[]> send(final PushStreamRequest request, final MemberId receiver) {
     return transport.send(
-        StreamTopics.PUSH.topic(DEFAULT_PHYSICAL_TENANT_ID),
+        StreamTopics.PUSH.legacyTopic(),
         request,
         BufferUtil::bufferAsArray,
         Function.identity(),

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl.messages;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import java.util.Objects;
 
 public enum StreamTopics {
@@ -24,17 +22,14 @@ public enum StreamTopics {
     this.topic = topic;
   }
 
+  /** The physicalTenantId-scoped topic name, used for every physical tenant, including default. */
   public String topic(final String physicalTenantId) {
     Objects.requireNonNull(physicalTenantId, "physicalTenantId must not be null");
-    // remove this condition that leads to legacy topic in 8.11
-    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
-      return topic;
-    }
     return physicalTenantId + "-" + topic;
   }
 
   /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
-  public String dualTopic() {
-    return DEFAULT_PHYSICAL_TENANT_ID + "-" + topic;
+  public String legacyTopic() {
+    return topic;
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
@@ -26,9 +26,15 @@ public enum StreamTopics {
 
   public String topic(final String physicalTenantId) {
     Objects.requireNonNull(physicalTenantId, "physicalTenantId must not be null");
+    // remove this condition that leads to legacy topic in 8.11
     if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       return topic;
     }
     return physicalTenantId + "-" + topic;
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  public String dualTopic() {
+    return DEFAULT_PHYSICAL_TENANT_ID + "-" + topic;
   }
 }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -721,6 +721,60 @@ final class ClientStreamRequestManagerTest {
     assertThat(otherStream.isConnected(serverId)).isTrue();
   }
 
+  @Test
+  void shouldDualSendAddRemoveAndRemoveAllForDefaultTenant() {
+    // given
+    final var serverId = MemberId.anonymous();
+
+    // when - ADD
+    requestManager.add(clientStream, serverId);
+
+    // then - dual-sent on the default-prefixed topic (rolling-upgrade compatibility)
+    verify(mockTransport)
+        .unicast(eq(StreamTopics.ADD.dualTopic()), any(), any(), eq(serverId), anyBoolean());
+
+    // when - REMOVE
+    requestManager.remove(clientStream, serverId);
+
+    // then
+    verify(mockTransport)
+        .unicast(eq(StreamTopics.REMOVE.dualTopic()), any(), any(), eq(serverId), anyBoolean());
+
+    // when - REMOVE_ALL
+    requestManager.removeAll(Map.of(DEFAULT_PHYSICAL_TENANT_ID, Set.of(serverId)));
+
+    // then
+    verify(mockTransport)
+        .unicast(eq(StreamTopics.REMOVE_ALL.dualTopic()), any(), any(), eq(serverId), anyBoolean());
+  }
+
+  @Test
+  void shouldNotDualSendForNonDefaultTenant() {
+    // given
+    final String physicalTenantId = "tenant1";
+    final var tenantStream =
+        new AggregatedClientStream<>(
+            UUID.randomUUID(),
+            new LogicalId<>(
+                new UnsafeBuffer(BufferUtil.wrapString("tenant-foo")), new TestMetadata()),
+            physicalTenantId);
+    tenantStream.open(requestManager, Collections.emptySet());
+    final var serverId = MemberId.anonymous();
+
+    // when
+    requestManager.add(tenantStream, serverId);
+    requestManager.remove(tenantStream, serverId);
+    requestManager.removeAll(Map.of(physicalTenantId, Set.of(serverId)));
+
+    // then - never sent on any default-prefixed dual topic
+    verify(mockTransport, never())
+        .unicast(eq(StreamTopics.ADD.dualTopic()), any(), any(), any(), anyBoolean());
+    verify(mockTransport, never())
+        .unicast(eq(StreamTopics.REMOVE.dualTopic()), any(), any(), any(), anyBoolean());
+    verify(mockTransport, never())
+        .unicast(eq(StreamTopics.REMOVE_ALL.dualTopic()), any(), any(), any(), anyBoolean());
+  }
+
   private static Stream<MessagingException> provideMessagingFailures() {
     return Stream.of(
         new NoSuchMemberException("failed"),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -463,6 +463,49 @@ final class ClientStreamRequestManagerTest {
   }
 
   @Test
+  void shouldWaitForPendingLegacyAddOnRemove() {
+    // given - the primary ADD succeeds immediately (default stub), but the legacy ADD is left
+    // pending; this leaves the registration in ADDING with only a legacy request in flight
+    final var serverId = MemberId.anonymous();
+    final var legacyPendingRequest = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.ADD.legacyTopic()), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(legacyPendingRequest);
+    requestManager.add(clientStream, serverId);
+
+    // when - remove is requested while the legacy ADD is still in flight
+    requestManager.remove(clientStream, serverId);
+
+    // then - neither REMOVE (primary nor legacy) is sent yet, to avoid racing the legacy ADD
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport, never())
+        .send(eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), eq(serverId), any());
+
+    // when - the legacy ADD finally completes
+    legacyPendingRequest.complete(addStreamSuccess);
+
+    // then - only now is REMOVE sent on both channels
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport)
+        .send(eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    assertThat(clientStream.isConnected(serverId)).isFalse();
+  }
+
+  @Test
   void shouldNotRetryAddIfClosed() {
     // given
     final var pendingRequest = new CompletableFuture<byte[]>();

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -782,9 +782,9 @@ final class ClientStreamRequestManagerTest {
   }
 
   @Test
-  void shouldSendLegacyAddRequestForDefaultTenant() {
-    // given - hold the primary (prefixed) ADD pending so we can observe that legacy alone isn't
-    // enough to mark the stream added; legacy resolves via the default success stub from setup()
+  void shouldAddRegistrationAsSoonAsLegacyAddSucceedsWhilePrimaryIsPending() {
+    // given - hold the primary (prefixed) ADD pending; legacy resolves via the default success
+    // stub from setup(). Whichever responds first should be enough to mark the stream added.
     final var serverId = MemberId.anonymous();
     final var primaryPending = new CompletableFuture<byte[]>();
     when(mockTransport.<byte[], byte[]>send(
@@ -799,12 +799,12 @@ final class ClientStreamRequestManagerTest {
     // when
     requestManager.add(clientStream, serverId);
 
-    // then - legacy ADD was sent, but the stream isn't added until the primary succeeds too
+    // then - legacy ADD was sent and alone is enough to mark the stream added
     verify(mockTransport)
         .send(eq(StreamTopics.ADD.legacyTopic()), any(), any(), any(), eq(serverId), any());
-    assertThat(clientStream.isConnected(serverId)).isFalse();
+    assertThat(clientStream.isConnected(serverId)).isTrue();
 
-    // when - the primary finally succeeds
+    // when - the primary eventually succeeds too; this must be a no-op
     primaryPending.complete(addStreamSuccess);
 
     // then
@@ -812,7 +812,7 @@ final class ClientStreamRequestManagerTest {
   }
 
   @Test
-  void shouldSendLegacyRemoveRequestForDefaultTenant() {
+  void shouldRemoveRegistrationAsSoonAsLegacyRemoveSucceedsWhilePrimaryIsPending() {
     // given
     final var serverId = MemberId.anonymous();
     requestManager.add(clientStream, serverId);
@@ -829,12 +829,12 @@ final class ClientStreamRequestManagerTest {
     // when
     requestManager.remove(clientStream, serverId);
 
-    // then - legacy REMOVE was sent, but the stream stays connected until the primary succeeds too
+    // then - legacy REMOVE was sent and alone is enough to mark the stream removed
     verify(mockTransport)
         .send(eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), eq(serverId), any());
-    assertThat(clientStream.isConnected(serverId)).isTrue();
+    assertThat(clientStream.isConnected(serverId)).isFalse();
 
-    // when - the primary finally succeeds
+    // when - the primary eventually succeeds too; this must be a no-op
     primaryPending.complete(removeStreamSuccess);
 
     // then

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -83,13 +83,18 @@ final class ClientStreamRequestManagerTest {
             any(),
             any()))
         .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
+    when(mockTransport.send(eq(StreamTopics.ADD.legacyTopic()), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
+    when(mockTransport.send(
+            eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
     clientStream.open(requestManager, Collections.emptySet());
   }
 
   @Test
   void shouldNotAddWhenRemoving() {
     // given - adding the stream, then removing it without completing the request, leaving it in
-    // REMOVING indefinitely
+    // REMOVING indefinitely; stub both the primary and legacy REMOVE so neither resolves
     final var serverId = MemberId.anonymous();
     final var pendingRequest = new CompletableFuture<byte[]>();
     when(mockTransport.<byte[], byte[]>send(
@@ -99,6 +104,9 @@ final class ClientStreamRequestManagerTest {
             any(),
             eq(serverId),
             any()))
+        .thenReturn(pendingRequest);
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), eq(serverId), any()))
         .thenReturn(pendingRequest);
     requestManager.add(clientStream, serverId);
     requestManager.remove(clientStream, serverId);
@@ -174,7 +182,8 @@ final class ClientStreamRequestManagerTest {
 
   @Test
   void shouldNotRemoveIfAlreadyRemoving() {
-    // given - we add the stream then remove it, with the remove request pending indefinitely
+    // given - we add the stream then remove it, with the remove request pending indefinitely;
+    // stub both the primary and legacy REMOVE so neither resolves
     final var serverId = MemberId.anonymous();
     final var pendingRequest = new CompletableFuture<byte[]>();
     when(mockTransport.<byte[], byte[]>send(
@@ -184,6 +193,9 @@ final class ClientStreamRequestManagerTest {
             any(),
             eq(serverId),
             any()))
+        .thenReturn(pendingRequest);
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), eq(serverId), any()))
         .thenReturn(pendingRequest);
     requestManager.add(clientStream, serverId);
     requestManager.remove(clientStream, serverId);
@@ -207,9 +219,14 @@ final class ClientStreamRequestManagerTest {
     // given
     final var pendingRequest = new CompletableFuture<byte[]>();
     final var serverId = MemberId.anonymous();
-    when(mockTransport.<byte[], byte[]>send(any(), any(), any(), any(), any(), any()))
-        .thenReturn(pendingRequest)
-        .thenReturn(CompletableFuture.completedFuture(new byte[0]));
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(pendingRequest);
     requestManager.add(clientStream, serverId);
 
     // when
@@ -722,34 +739,81 @@ final class ClientStreamRequestManagerTest {
   }
 
   @Test
-  void shouldDualSendAddRemoveAndRemoveAllForDefaultTenant() {
+  void shouldSendLegacyAddRequestForDefaultTenant() {
+    // given - hold the primary (prefixed) ADD pending so we can observe that legacy alone isn't
+    // enough to mark the stream added; legacy resolves via the default success stub from setup()
+    final var serverId = MemberId.anonymous();
+    final var primaryPending = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(primaryPending);
+
+    // when
+    requestManager.add(clientStream, serverId);
+
+    // then - legacy ADD was sent, but the stream isn't added until the primary succeeds too
+    verify(mockTransport)
+        .send(eq(StreamTopics.ADD.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    assertThat(clientStream.isConnected(serverId)).isFalse();
+
+    // when - the primary finally succeeds
+    primaryPending.complete(addStreamSuccess);
+
+    // then
+    assertThat(clientStream.isConnected(serverId)).isTrue();
+  }
+
+  @Test
+  void shouldSendLegacyRemoveRequestForDefaultTenant() {
+    // given
+    final var serverId = MemberId.anonymous();
+    requestManager.add(clientStream, serverId);
+    final var primaryPending = new CompletableFuture<byte[]>();
+    when(mockTransport.<byte[], byte[]>send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(primaryPending);
+
+    // when
+    requestManager.remove(clientStream, serverId);
+
+    // then - legacy REMOVE was sent, but the stream stays connected until the primary succeeds too
+    verify(mockTransport)
+        .send(eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), eq(serverId), any());
+    assertThat(clientStream.isConnected(serverId)).isTrue();
+
+    // when - the primary finally succeeds
+    primaryPending.complete(removeStreamSuccess);
+
+    // then
+    assertThat(clientStream.isConnected(serverId)).isFalse();
+  }
+
+  @Test
+  void shouldUnicastLegacyRemoveAllForDefaultTenant() {
     // given
     final var serverId = MemberId.anonymous();
 
-    // when - ADD
-    requestManager.add(clientStream, serverId);
-
-    // then - dual-sent on the default-prefixed topic (rolling-upgrade compatibility)
-    verify(mockTransport)
-        .unicast(eq(StreamTopics.ADD.dualTopic()), any(), any(), eq(serverId), anyBoolean());
-
-    // when - REMOVE
-    requestManager.remove(clientStream, serverId);
-
-    // then
-    verify(mockTransport)
-        .unicast(eq(StreamTopics.REMOVE.dualTopic()), any(), any(), eq(serverId), anyBoolean());
-
-    // when - REMOVE_ALL
+    // when
     requestManager.removeAll(Map.of(DEFAULT_PHYSICAL_TENANT_ID, Set.of(serverId)));
 
     // then
     verify(mockTransport)
-        .unicast(eq(StreamTopics.REMOVE_ALL.dualTopic()), any(), any(), eq(serverId), anyBoolean());
+        .unicast(
+            eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), eq(serverId), anyBoolean());
   }
 
   @Test
-  void shouldNotDualSendForNonDefaultTenant() {
+  void shouldNotSendOrUnicastLegacyTopicsForNonDefaultTenant() {
     // given
     final String physicalTenantId = "tenant1";
     final var tenantStream =
@@ -760,19 +824,30 @@ final class ClientStreamRequestManagerTest {
             physicalTenantId);
     tenantStream.open(requestManager, Collections.emptySet());
     final var serverId = MemberId.anonymous();
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(physicalTenantId)), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
+    when(mockTransport.send(
+            eq(StreamTopics.REMOVE.topic(physicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
 
     // when
     requestManager.add(tenantStream, serverId);
     requestManager.remove(tenantStream, serverId);
     requestManager.removeAll(Map.of(physicalTenantId, Set.of(serverId)));
 
-    // then - never sent on any default-prefixed dual topic
+    // then - never sent/unicast on any legacy topic
     verify(mockTransport, never())
-        .unicast(eq(StreamTopics.ADD.dualTopic()), any(), any(), any(), anyBoolean());
+        .send(eq(StreamTopics.ADD.legacyTopic()), any(), any(), any(), any(), any());
     verify(mockTransport, never())
-        .unicast(eq(StreamTopics.REMOVE.dualTopic()), any(), any(), any(), anyBoolean());
+        .send(eq(StreamTopics.REMOVE.legacyTopic()), any(), any(), any(), any(), any());
     verify(mockTransport, never())
-        .unicast(eq(StreamTopics.REMOVE_ALL.dualTopic()), any(), any(), any(), anyBoolean());
+        .unicast(eq(StreamTopics.REMOVE_ALL.legacyTopic()), any(), any(), any(), anyBoolean());
   }
 
   private static Stream<MessagingException> provideMessagingFailures() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
@@ -170,7 +170,7 @@ final class RemoteStreamTransportTest {
   }
 
   @Test
-  void shouldReplyOnDualAddRemoveAndRemoveAllTopicsForDefaultTenant() {
+  void shouldReplyOnLegacyAddRemoveAndRemoveAllTopicsForDefaultTenant() {
     // given
     final var streamId = UUID.randomUUID();
     final var senderMemberId = sender.getMembershipService().getLocalMember().id();
@@ -185,7 +185,7 @@ final class RemoteStreamTransportTest {
         receiver
             .getCommunicationService()
             .send(
-                StreamTopics.ADD.dualTopic(),
+                StreamTopics.ADD.legacyTopic(),
                 BufferUtil.bufferAsArray(addRequest),
                 Function.identity(),
                 Function.identity(),
@@ -199,7 +199,7 @@ final class RemoteStreamTransportTest {
         receiver
             .getCommunicationService()
             .send(
-                StreamTopics.REMOVE.dualTopic(),
+                StreamTopics.REMOVE.legacyTopic(),
                 BufferUtil.bufferAsArray(removeRequest),
                 Function.identity(),
                 Function.identity(),
@@ -212,7 +212,7 @@ final class RemoteStreamTransportTest {
         receiver
             .getCommunicationService()
             .send(
-                StreamTopics.REMOVE_ALL.dualTopic(),
+                StreamTopics.REMOVE_ALL.legacyTopic(),
                 ArrayUtil.EMPTY_BYTE_ARRAY,
                 Function.identity(),
                 Function.identity(),
@@ -222,7 +222,7 @@ final class RemoteStreamTransportTest {
   }
 
   @Test
-  void shouldNotReplyOnDualTopicsForNonDefaultTenant() {
+  void shouldNotReplyOnLegacyTopicsForNonDefaultTenant() {
     // given
     CloseHelper.quietClose(transport);
     final var nonDefaultTransport =
@@ -244,14 +244,14 @@ final class RemoteStreamTransportTest {
           receiver
               .getCommunicationService()
               .send(
-                  StreamTopics.ADD.dualTopic(),
+                  StreamTopics.ADD.legacyTopic(),
                   ArrayUtil.EMPTY_BYTE_ARRAY,
                   Function.identity(),
                   Function.identity(),
                   sender.getMembershipService().getLocalMember().id(),
                   Duration.ofSeconds(5));
 
-      // then - no handler registered on the default-prefixed dual topic for a non-default tenant
+      // then - no handler registered on the legacy topic for a non-default tenant
       assertThat(addResponse).failsWithin(Duration.ofSeconds(5));
     } finally {
       CloseHelper.quietClose(nonDefaultTransport);
@@ -259,16 +259,16 @@ final class RemoteStreamTransportTest {
   }
 
   @Test
-  void shouldDualSendRestartStreamsOnDefaultPrefixedTopicForDefaultTenant() {
+  void shouldSendLegacyRestartStreamsRequestForDefaultTenant() {
     // given
-    final var dualRestartReceived = new AtomicBoolean(false);
+    final var legacyRestartReceived = new AtomicBoolean(false);
     receiver
         .getCommunicationService()
         .replyTo(
-            StreamTopics.RESTART_STREAMS.dualTopic(),
+            StreamTopics.RESTART_STREAMS.legacyTopic(),
             Function.identity(),
             (id, ignored) -> {
-              dualRestartReceived.set(true);
+              legacyRestartReceived.set(true);
               return ArrayUtil.EMPTY_BYTE_ARRAY;
             },
             Function.identity(),
@@ -280,8 +280,8 @@ final class RemoteStreamTransportTest {
 
     // then
     assertThat(completed).succeedsWithin(Duration.ofSeconds(5));
-    Awaitility.await("until the dual RESTART_STREAMS request is received")
-        .untilTrue(dualRestartReceived);
+    Awaitility.await("until the legacy RESTART_STREAMS request is received")
+        .untilTrue(legacyRestartReceived);
   }
 
   private Node createNode(final String id) {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
@@ -19,17 +19,23 @@ import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.messages.AddStreamRequest;
+import io.camunda.zeebe.transport.stream.impl.messages.RemoveStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
 import org.agrona.CloseHelper;
 import org.agrona.collections.ArrayUtil;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
@@ -161,6 +167,121 @@ final class RemoteStreamTransportTest {
         .havingRootCause()
         .isInstanceOf(RemoteHandlerFailure.class);
     assertThat(senderBackoffSupplier.recorded).isEmpty();
+  }
+
+  @Test
+  void shouldReplyOnDualAddRemoveAndRemoveAllTopicsForDefaultTenant() {
+    // given
+    final var streamId = UUID.randomUUID();
+    final var senderMemberId = sender.getMembershipService().getLocalMember().id();
+
+    // when / then - ADD
+    final var addRequest =
+        new AddStreamRequest()
+            .streamId(streamId)
+            .streamType(new UnsafeBuffer(BufferUtil.wrapString("foo")))
+            .metadata(new UnsafeBuffer(new byte[Integer.BYTES]));
+    final var addResponse =
+        receiver
+            .getCommunicationService()
+            .send(
+                StreamTopics.ADD.dualTopic(),
+                BufferUtil.bufferAsArray(addRequest),
+                Function.identity(),
+                Function.identity(),
+                senderMemberId,
+                Duration.ofSeconds(5));
+    assertThat(addResponse).succeedsWithin(Duration.ofSeconds(5));
+
+    // when / then - REMOVE
+    final var removeRequest = new RemoveStreamRequest().streamId(streamId);
+    final var removeResponse =
+        receiver
+            .getCommunicationService()
+            .send(
+                StreamTopics.REMOVE.dualTopic(),
+                BufferUtil.bufferAsArray(removeRequest),
+                Function.identity(),
+                Function.identity(),
+                senderMemberId,
+                Duration.ofSeconds(5));
+    assertThat(removeResponse).succeedsWithin(Duration.ofSeconds(5));
+
+    // when / then - REMOVE_ALL
+    final var removeAllResponse =
+        receiver
+            .getCommunicationService()
+            .send(
+                StreamTopics.REMOVE_ALL.dualTopic(),
+                ArrayUtil.EMPTY_BYTE_ARRAY,
+                Function.identity(),
+                Function.identity(),
+                senderMemberId,
+                Duration.ofSeconds(5));
+    assertThat(removeAllResponse).succeedsWithin(Duration.ofSeconds(5));
+  }
+
+  @Test
+  void shouldNotReplyOnDualTopicsForNonDefaultTenant() {
+    // given
+    CloseHelper.quietClose(transport);
+    final var nonDefaultTransport =
+        new RemoteStreamTransport<>(
+            sender.getCommunicationService(),
+            new RemoteStreamApiHandler<>(
+                new RemoteStreamRegistry<>(RemoteStreamMetrics.noop()),
+                buffer -> {
+                  final var data = new TestSerializableData();
+                  data.wrap(buffer, 0, buffer.capacity());
+                  return data;
+                }),
+            senderBackoffSupplier,
+            "tenant1");
+    scheduler.submitActor(nonDefaultTransport).join();
+    try {
+      // when
+      final var addResponse =
+          receiver
+              .getCommunicationService()
+              .send(
+                  StreamTopics.ADD.dualTopic(),
+                  ArrayUtil.EMPTY_BYTE_ARRAY,
+                  Function.identity(),
+                  Function.identity(),
+                  sender.getMembershipService().getLocalMember().id(),
+                  Duration.ofSeconds(5));
+
+      // then - no handler registered on the default-prefixed dual topic for a non-default tenant
+      assertThat(addResponse).failsWithin(Duration.ofSeconds(5));
+    } finally {
+      CloseHelper.quietClose(nonDefaultTransport);
+    }
+  }
+
+  @Test
+  void shouldDualSendRestartStreamsOnDefaultPrefixedTopicForDefaultTenant() {
+    // given
+    final var dualRestartReceived = new AtomicBoolean(false);
+    receiver
+        .getCommunicationService()
+        .replyTo(
+            StreamTopics.RESTART_STREAMS.dualTopic(),
+            Function.identity(),
+            (id, ignored) -> {
+              dualRestartReceived.set(true);
+              return ArrayUtil.EMPTY_BYTE_ARRAY;
+            },
+            Function.identity(),
+            Runnable::run);
+
+    // when
+    final var completed =
+        transport.restartStreams(receiver.getMembershipService().getLocalMember().id());
+
+    // then
+    assertThat(completed).succeedsWithin(Duration.ofSeconds(5));
+    Awaitility.await("until the dual RESTART_STREAMS request is received")
+        .untilTrue(dualRestartReceived);
   }
 
   private Node createNode(final String id) {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongUnaryOperator;
 import org.agrona.CloseHelper;
@@ -115,7 +116,8 @@ final class RemoteStreamTransportTest {
 
   @Test
   void shouldRetryOnError() throws Exception {
-    // given
+    // given - the primary and legacy channels both retry independently against the stopped
+    // receiver, so backoff entries from both interleave; we only assert that retries happened
     receiver.stop().join();
 
     // when
@@ -127,32 +129,49 @@ final class RemoteStreamTransportTest {
             () -> assertThat(senderBackoffSupplier.recorded).hasSizeGreaterThanOrEqualTo(2));
     try (final var newReceiver = createClusterNode(nodes.get(1), nodes)) {
       newReceiver.start().join();
-      newReceiver
-          .getCommunicationService()
-          .replyTo(
-              StreamTopics.RESTART_STREAMS.topic(DEFAULT_PHYSICAL_TENANT_ID),
-              Function.identity(),
-              (id, ignored) -> ArrayUtil.EMPTY_BYTE_ARRAY,
-              Function.identity(),
-              Runnable::run);
+      final var newCommunicationService = newReceiver.getCommunicationService();
+      newCommunicationService.replyTo(
+          StreamTopics.RESTART_STREAMS.topic(DEFAULT_PHYSICAL_TENANT_ID),
+          Function.identity(),
+          (id, ignored) -> ArrayUtil.EMPTY_BYTE_ARRAY,
+          Function.identity(),
+          Runnable::run);
+      newCommunicationService.replyTo(
+          StreamTopics.RESTART_STREAMS.legacyTopic(),
+          Function.identity(),
+          (id, ignored) -> ArrayUtil.EMPTY_BYTE_ARRAY,
+          Function.identity(),
+          Runnable::run);
 
       // then
       assertThat(completed).succeedsWithin(Duration.ofSeconds(5));
-      assertThat(senderBackoffSupplier.recorded).startsWith(100L, 200L);
+      assertThat(senderBackoffSupplier.recorded).hasSizeGreaterThanOrEqualTo(2).contains(100L);
     }
   }
 
   @Test
   void shouldNotRetryOnRemoteHandlerFailure() {
-    // given
+    // given - both the primary and legacy topics must fail the same way, otherwise the legacy
+    // channel would get NoRemoteHandler (no handler registered) and race completed with a false
+    // success
+    final BiFunction<MemberId, byte[], byte[]> throwingHandler =
+        (id, ignored) -> {
+          throw new RuntimeException("I have become error, destroyer of worlds");
+        };
     receiver
         .getCommunicationService()
         .replyTo(
             StreamTopics.RESTART_STREAMS.topic(DEFAULT_PHYSICAL_TENANT_ID),
             Function.identity(),
-            (id, ignored) -> {
-              throw new RuntimeException("I have become error, destroyer of worlds");
-            },
+            throwingHandler,
+            Function.identity(),
+            Runnable::run);
+    receiver
+        .getCommunicationService()
+        .replyTo(
+            StreamTopics.RESTART_STREAMS.legacyTopic(),
+            Function.identity(),
+            throwingHandler,
             Function.identity(),
             Runnable::run);
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -116,7 +115,7 @@ final class RemoteStreamerTest {
     // then
     Mockito.verify(communicationService, Mockito.timeout(5_000).times(1))
         .send(
-            Mockito.eq(StreamTopics.PUSH.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            Mockito.eq(StreamTopics.PUSH.legacyTopic()),
             Mockito.eq(new PushStreamRequest().streamId(streamId.streamId()).payload(payload)),
             Mockito.any(),
             Mockito.any(),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -426,7 +426,7 @@ final class StreamIntegrationTest {
     }
 
     @Test
-    void shouldAddStreamAgainOnDualRestartRequest() {
+    void shouldAddStreamAgainOnLegacyRestartRequest() {
       // given
       final var streamType = BufferUtil.wrapString("foo");
       final var properties = new TestSerializableData();
@@ -457,7 +457,7 @@ final class StreamIntegrationTest {
             .cluster
             .getCommunicationService()
             .send(
-                StreamTopics.RESTART_STREAMS.dualTopic(),
+                StreamTopics.RESTART_STREAMS.legacyTopic(),
                 ArrayUtil.EMPTY_BYTE_ARRAY,
                 Function.identity(),
                 Function.identity(),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -37,9 +37,11 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -50,8 +52,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import org.agrona.CloseHelper;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.ArrayUtil;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -415,6 +419,51 @@ final class StreamIntegrationTest {
           new TestServer(createClusterNode(clusterNodes.get(0), clusterNodes))) {
         restartedServer.start();
         client.streamService.onServerJoined(restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+
+        // then
+        awaitStreamAdded(streamType, streamId, restartedServer, server2);
+      }
+    }
+
+    @Test
+    void shouldAddStreamAgainOnDualRestartRequest() {
+      // given
+      final var streamType = BufferUtil.wrapString("foo");
+      final var properties = new TestSerializableData();
+      final var streamId =
+          clientStreamer
+              .add(
+                  streamType,
+                  properties,
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+              .join();
+      assertThat(streamId).isNotNull();
+      awaitStreamAdded(streamType, streamId, server1, server2);
+      server1.close();
+      client.streamService.onServerRemoved(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+      awaitStreamOnClient(
+          streamId,
+          stream ->
+              assertThat(stream)
+                  .map(ClientStream::liveConnections)
+                  .hasValue(Set.of(server2.memberId())));
+
+      // when
+      try (final var restartedServer =
+          new TestServer(createClusterNode(clusterNodes.getFirst(), clusterNodes))) {
+        restartedServer.start();
+        restartedServer
+            .cluster
+            .getCommunicationService()
+            .send(
+                StreamTopics.RESTART_STREAMS.dualTopic(),
+                ArrayUtil.EMPTY_BYTE_ARRAY,
+                Function.identity(),
+                Function.identity(),
+                client.cluster.getMembershipService().getLocalMember().id(),
+                Duration.ofSeconds(5))
+            .join();
 
         // then
         awaitStreamAdded(streamType, streamId, restartedServer, server2);

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopicsTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopicsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.transport.stream.impl.messages;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+final class StreamTopicsTest {
+
+  @ParameterizedTest
+  @EnumSource(StreamTopics.class)
+  void shouldUseLegacyUnprefixedTopicForDefaultTenant(final StreamTopics topic) {
+    assertThat(topic.topic(DEFAULT_PHYSICAL_TENANT_ID))
+        .doesNotStartWith(DEFAULT_PHYSICAL_TENANT_ID + "-");
+  }
+
+  @ParameterizedTest
+  @EnumSource(StreamTopics.class)
+  void shouldPrefixTopicForNonDefaultTenant(final StreamTopics topic) {
+    assertThat(topic.topic("tenant1")).startsWith("tenant1-");
+  }
+
+  @ParameterizedTest
+  @EnumSource(StreamTopics.class)
+  void shouldUseDefaultPrefixedTopicForDualTopic(final StreamTopics topic) {
+    assertThat(topic.dualTopic())
+        .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID + "-" + topic.topic(DEFAULT_PHYSICAL_TENANT_ID))
+        .startsWith(DEFAULT_PHYSICAL_TENANT_ID + "-")
+        .isNotEqualTo(topic.topic(DEFAULT_PHYSICAL_TENANT_ID));
+  }
+}

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopicsTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopicsTest.java
@@ -17,9 +17,10 @@ final class StreamTopicsTest {
 
   @ParameterizedTest
   @EnumSource(StreamTopics.class)
-  void shouldUseLegacyUnprefixedTopicForDefaultTenant(final StreamTopics topic) {
+  void shouldPrefixTopicForDefaultTenant(final StreamTopics topic) {
     assertThat(topic.topic(DEFAULT_PHYSICAL_TENANT_ID))
-        .doesNotStartWith(DEFAULT_PHYSICAL_TENANT_ID + "-");
+        .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID + "-" + topic.legacyTopic())
+        .startsWith(DEFAULT_PHYSICAL_TENANT_ID + "-");
   }
 
   @ParameterizedTest
@@ -30,10 +31,9 @@ final class StreamTopicsTest {
 
   @ParameterizedTest
   @EnumSource(StreamTopics.class)
-  void shouldUseDefaultPrefixedTopicForDualTopic(final StreamTopics topic) {
-    assertThat(topic.dualTopic())
-        .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID + "-" + topic.topic(DEFAULT_PHYSICAL_TENANT_ID))
-        .startsWith(DEFAULT_PHYSICAL_TENANT_ID + "-")
+  void shouldUseUnprefixedNameForLegacyTopic(final StreamTopics topic) {
+    assertThat(topic.legacyTopic())
+        .doesNotContain(DEFAULT_PHYSICAL_TENANT_ID + "-")
         .isNotEqualTo(topic.topic(DEFAULT_PHYSICAL_TENANT_ID));
   }
 }


### PR DESCRIPTION
## Description
  
Adds rolling-upgrade compatibility for job streaming `ADD`/`REMOVE`/`REMOVE_ALL`/`RESTART_STREAMS` between brokers/gateways on mixed versions during a cluster upgrade.

  - Stream topics are now physical-tenant-scoped (`<physicalTenantId>-stream-add`, etc.) for every tenant, including the default one. Previously the default tenant used an unprefixed topic name.
  - For the default physical tenant only, every `ADD`/`REMOVE`/`REMOVE_ALL`/`RESTART_STREAMS` request is additionally sent on the old unprefixed "legacy" topic, so brokers/gateways still running a pre-upgrade version keep working during the rolling upgrade. The legacy topic and this dual-send can be removed in
  8.11.
  - `ClientStreamRequestManager` and `RemoteStreamTransport` both retry independently per channel (primary vs. legacy) and only report a stream as added/removed/restarted once both channels agree.

  No change to what gets sent on the wire or when — only to how the two completion futures are tracked and resolved.

## Related issues

closes #56225
