### PR TITLE
test: add job search API coverage for priority filter and sort

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithJobPriority.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithJobPriority.bpmn
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_processWithJobPriority" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="processWithJobPriority" name="Process with job priority" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0f1wqwc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:parallelGateway id="Gateway_1pph9x7">
+      <bpmn:incoming>Flow_0f1wqwc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zy2l70</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ockqzv</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0p4wn83</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0f1wqwc" sourceRef="StartEvent_1" targetRef="Gateway_1pph9x7" />
+    <bpmn:sequenceFlow id="Flow_0zy2l70" sourceRef="Gateway_1pph9x7" targetRef="Activity_PriorityHigh" />
+    <bpmn:serviceTask id="Activity_PriorityHigh" name="high priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="priorityJobType" />
+        <zeebe:jobPriorityDefinition priority="90" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0zy2l70</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vumtxw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1ockqzv" sourceRef="Gateway_1pph9x7" targetRef="Activity_PriorityMid" />
+    <bpmn:serviceTask id="Activity_PriorityMid" name="mid priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="priorityJobType" />
+        <zeebe:jobPriorityDefinition priority="50" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ockqzv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1skkueu</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0p4wn83" sourceRef="Gateway_1pph9x7" targetRef="Activity_PriorityLow" />
+    <bpmn:serviceTask id="Activity_PriorityLow" name="low priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="priorityJobType" />
+        <zeebe:jobPriorityDefinition priority="10" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0p4wn83</bpmn:incoming>
+      <bpmn:outgoing>Flow_11hzfk4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="Gateway_1el4beg">
+      <bpmn:incoming>Flow_1skkueu</bpmn:incoming>
+      <bpmn:incoming>Flow_1vumtxw</bpmn:incoming>
+      <bpmn:incoming>Flow_11hzfk4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1sgfdsy</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1skkueu" sourceRef="Activity_PriorityMid" targetRef="Gateway_1el4beg" />
+    <bpmn:sequenceFlow id="Flow_1vumtxw" sourceRef="Activity_PriorityHigh" targetRef="Gateway_1el4beg" />
+    <bpmn:sequenceFlow id="Flow_11hzfk4" sourceRef="Activity_PriorityLow" targetRef="Gateway_1el4beg" />
+    <bpmn:endEvent id="Event_11eote1">
+      <bpmn:incoming>Flow_1sgfdsy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1sgfdsy" sourceRef="Gateway_1el4beg" targetRef="Event_11eote1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithJobPriority">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1pph9x7_di" bpmnElement="Gateway_1pph9x7">
+        <dc:Bounds x="275" y="155" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_PriorityHigh_di" bpmnElement="Activity_PriorityHigh">
+        <dc:Bounds x="410" y="50" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_PriorityMid_di" bpmnElement="Activity_PriorityMid">
+        <dc:Bounds x="410" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_PriorityLow_di" bpmnElement="Activity_PriorityLow">
+        <dc:Bounds x="410" y="250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1el4beg_di" bpmnElement="Gateway_1el4beg">
+        <dc:Bounds x="595" y="155" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11eote1_di" bpmnElement="Event_11eote1">
+        <dc:Bounds x="732" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0f1wqwc_di" bpmnElement="Flow_0f1wqwc">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="275" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zy2l70_di" bpmnElement="Flow_0zy2l70">
+        <di:waypoint x="300" y="155" />
+        <di:waypoint x="300" y="90" />
+        <di:waypoint x="410" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ockqzv_di" bpmnElement="Flow_1ockqzv">
+        <di:waypoint x="325" y="180" />
+        <di:waypoint x="410" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p4wn83_di" bpmnElement="Flow_0p4wn83">
+        <di:waypoint x="300" y="205" />
+        <di:waypoint x="300" y="290" />
+        <di:waypoint x="410" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1skkueu_di" bpmnElement="Flow_1skkueu">
+        <di:waypoint x="510" y="180" />
+        <di:waypoint x="595" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vumtxw_di" bpmnElement="Flow_1vumtxw">
+        <di:waypoint x="510" y="90" />
+        <di:waypoint x="620" y="90" />
+        <di:waypoint x="620" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11hzfk4_di" bpmnElement="Flow_11hzfk4">
+        <di:waypoint x="510" y="290" />
+        <di:waypoint x="620" y="290" />
+        <di:waypoint x="620" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sgfdsy_di" bpmnElement="Flow_1sgfdsy">
+        <di:waypoint x="645" y="180" />
+        <di:waypoint x="732" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
@@ -247,3 +247,162 @@ test.describe.parallel('Job API Tests', () => {
     });
   });
 });
+
+test.describe.parallel('Job Priority API Tests', () => {
+  const state: Record<string, unknown> = {};
+  const runSuffix = randomUUID().slice(0, 8);
+  const processId = `processWithJobPriority-${runSuffix}`;
+  const priorityJobType = `priorityJobType-${runSuffix}`;
+
+  // Priorities are defined statically per task in resources/processWithJobPriority.bpmn.
+  // All three tasks share one job type so priority is the only thing that can
+  // distinguish the resulting jobs from each other.
+  const priorityByElementId: Record<string, number> = {
+    Activity_PriorityHigh: 90,
+    Activity_PriorityMid: 50,
+    Activity_PriorityLow: 10,
+  };
+
+  test.beforeAll(async () => {
+    await deployWithSubstitutions('./resources/processWithJobPriority.bpmn', {
+      processWithJobPriority: processId,
+      priorityJobType: priorityJobType,
+    });
+    const processInstance = await createInstances(processId, 1, 1);
+    state['processInstanceKey'] = processInstance[0].processInstanceKey;
+  });
+
+  test.afterAll(async () => {
+    await cancelProcessInstance(state['processInstanceKey'] as string);
+  });
+
+  test('Search Jobs - priority field matches the value defined at deploy time', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$eq: state['processInstanceKey']},
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.items).toHaveLength(3);
+      const actualPriorityByElementId = Object.fromEntries(
+        json.items.map((item: {elementId: string; priority: number}) => [
+          item.elementId,
+          item.priority,
+        ]),
+      );
+      expect(actualPriorityByElementId).toEqual(priorityByElementId);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test("Search Jobs - sorted by field 'priority' descending returns the highest priority job first", async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          sort: [
+            {
+              field: 'priority',
+              order: 'DESC',
+            },
+          ],
+          filter: {
+            processInstanceKey: {$eq: state['processInstanceKey']},
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      const actualPriorityList = json.items.map(
+        (item: {priority: number}) => item.priority,
+      );
+      expect(actualPriorityList).toEqual([90, 50, 10]);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Jobs - filter priority $gte 50 returns only the mid and high priority jobs', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$eq: state['processInstanceKey']},
+            priority: {$gte: 50},
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      const actualPriorities = json.items
+        .map((item: {priority: number}) => item.priority)
+        .sort((a: number, b: number) => a - b);
+      expect(actualPriorities).toEqual([50, 90]);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Jobs - filter priority $lt 50 returns only the low priority job', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$eq: state['processInstanceKey']},
+            priority: {$lt: 50},
+          },
+        },
+      });
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/search',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.items).toHaveLength(1);
+      expect(json.items[0].priority).toBe(10);
+    }).toPass(defaultAssertionOptions);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `Job Priority API Tests` suite to `tests/api/v2/job/job-api-tests.spec.ts` covering `POST /jobs/search` filtering and sorting by the new `priority` field (Job & Process Prioritization epic).
- Adds a new fixture `resources/processWithJobPriority.bpmn`: three parallel service tasks of the *same* job type, each with a static `zeebe:jobPriorityDefinition` (10/50/90) — needed because the existing `processWithThreeParallelTasks.bpmn` fixture uses a different job type per task, which can't exercise priority ordering/filtering.
- Tests added:
  - `Search Jobs - priority field matches the value defined at deploy time`
  - `Search Jobs - sorted by field 'priority' descending returns the highest priority job first`
  - `Search Jobs - filter priority $gte 50 returns only the mid and high priority jobs`
  - `Search Jobs - filter priority $lt 50 returns only the low priority job`

Closes camunda/camunda#57921 (sub-issue of camunda/camunda#50567, linked to QA epic https://github.com/camunda/product-hub/issues/3615).

## Verification
- `npx tsc --noEmit`, `eslint`, `prettier --check` all pass clean on the changed files.
- Manually verified sort/filter behavior directly against a locally-built `main` broker via raw REST calls (bypassing Playwright) to confirm expectations match the actual implementation (`SearchQueryResponseMapper`, `JobFilter`/`JobSort`), independent of any test-harness issues.
- **Known pre-existing issue, not caused by this change:** `validateResponse()` (via `assert-json-body`) currently fails on any job search result for a job that hasn't reached a terminal/denied state, because the schema-extraction tool doesn't carry `nullable: true` through from the OpenAPI spec for fields like `deniedReason`/`endTime`/`isDenied`/`businessId`/`deadline`. Confirmed this reproduces identically on the untouched, pre-existing sibling test (`Search Jobs - sorted by field 'type'`) — will file a separate tracking issue for the `assert-json-body` tooling gap.
- On-demand E2E workflow triggered against this branch: https://github.com/camunda/camunda/actions/runs/29492632480 (will update this PR with results once complete, per contributing guidelines).

## Test plan
- [ ][ On-demand workflow run reviewed;](https://github.com/camunda/camunda/actions/runs/29492632480/job/87602457403) any failures confirmed pre-existing (not regressions)
- [ ] TestRail test case suite linked (https://camunda.testrail.com/index.php?/cases/view/13898402)