### PR TITLE
bisect(1b/2): extract per-tenant search engine configurations

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -11,7 +11,6 @@ import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
-import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.TakeBackupRequestDto;
@@ -23,7 +22,6 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeExceptionMapper;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -191,10 +189,5 @@ public class StandaloneBackupManager implements CommandLineRunner {
       return ex -> 1;
     }
 
-    @Bean
-    @ConfigurationProperties(prefix = "camunda.database")
-    public SearchEngineConfiguration searchEngineConfiguration() {
-      return SearchEngineConfiguration.of(b -> b);
-    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantSearchEngineConfigurations.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/PhysicalTenantSearchEngineConfigurations.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
+import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
+import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.configuration.beans.SearchEngineIndexProperties;
+import io.camunda.configuration.beans.SearchEngineRetentionProperties;
+import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
+import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.connect.configuration.DatabaseConfig;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.search.schema.config.SearchEngineConfiguration;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Provides the per-physical-tenant {@link SearchEngineConfiguration} map. Kept separate from {@link
+ * SearchEngineDatabaseConfiguration} so that applications that need the per-tenant configurations
+ * without schema initialization (e.g. the standalone backup manager) can register this class alone.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnSecondaryStorageType({
+  SecondaryStorageType.elasticsearch,
+  SecondaryStorageType.opensearch
+})
+public class PhysicalTenantSearchEngineConfigurations {
+
+  @Bean
+  public Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant(
+      final PhysicalTenantResolver physicalTenantResolver) {
+    final var byTenant = new LinkedHashMap<String, SearchEngineConfiguration>();
+    for (final String tenantId : physicalTenantResolver.known()) {
+      byTenant.put(tenantId, convert(physicalTenantResolver.forPhysicalTenant(tenantId)));
+    }
+    return Collections.unmodifiableMap(byTenant);
+  }
+
+  private static SearchEngineConfiguration convert(final Camunda tenantCamunda) {
+    final var index = new SearchEngineIndexProperties();
+    SearchEngineIndexPropertiesOverride.applyTo(tenantCamunda, index);
+    final var retention = new SearchEngineRetentionProperties();
+    SearchEngineRetentionPropertiesOverride.applyTo(tenantCamunda, retention);
+    final var schemaManager = new SearchEngineSchemaManagerProperties();
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(tenantCamunda, schemaManager);
+    return buildConfiguration(
+        new Converter(tenantCamunda).convert(), index, retention, schemaManager);
+  }
+
+  static SearchEngineConfiguration buildConfiguration(
+      final SearchEngineConnectProperties connect,
+      final SearchEngineIndexProperties index,
+      final SearchEngineRetentionProperties retention,
+      final SearchEngineSchemaManagerProperties schemaManager) {
+
+    // Override schema creation if database type is "none"
+    final DatabaseType databaseType = connect.getTypeEnum();
+    if (DatabaseConfig.NONE.equalsIgnoreCase(databaseType.name())) {
+      schemaManager.setCreateSchema(false);
+    }
+
+    return SearchEngineConfiguration.of(
+        b -> b.connect(connect).index(index).retention(retention).schemaManager(schemaManager));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -8,27 +8,13 @@
 package io.camunda.application.commons.search;
 
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
-import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
-import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
-import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
-import io.camunda.configuration.beans.SearchEngineConnectProperties;
-import io.camunda.configuration.beans.SearchEngineIndexProperties;
-import io.camunda.configuration.beans.SearchEngineRetentionProperties;
-import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
-import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
-import io.camunda.search.connect.configuration.DatabaseConfig;
-import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -42,26 +28,13 @@ import org.springframework.context.annotation.Configuration;
 })
 public class SearchEngineDatabaseConfiguration {
 
+  // Still required as an unqualified bean: io.camunda.operate.management.IndicesCheck autowires
+  // a plain SearchEngineConfiguration for the default physical tenant.
   @Bean
-  public Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant(
-      final PhysicalTenantResolver physicalTenantResolver,
-      final SearchEngineConnectProperties searchEngineConnectProperties,
-      final SearchEngineIndexProperties searchEngineIndexProperties,
-      final SearchEngineRetentionProperties searchEngineRetentionProperties,
-      final SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties) {
-    final var byTenant = new LinkedHashMap<String, SearchEngineConfiguration>();
-    for (final String tenantId : physicalTenantResolver.known()) {
-      byTenant.put(
-          tenantId,
-          PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)
-              ? buildConfiguration(
-                  searchEngineConnectProperties,
-                  searchEngineIndexProperties,
-                  searchEngineRetentionProperties,
-                  searchEngineSchemaManagerProperties)
-              : convert(physicalTenantResolver.forPhysicalTenant(tenantId)));
-    }
-    return Collections.unmodifiableMap(byTenant);
+  public SearchEngineConfiguration searchEngineConfiguration(
+      @Qualifier("searchEngineConfigurationsByTenant")
+          final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant) {
+    return searchEngineConfigurationsByTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Bean
@@ -80,45 +53,5 @@ public class SearchEngineDatabaseConfiguration {
         physicalTenantScopedIndexDescriptors,
         meterRegistry,
         isGatewayEnabled);
-  }
-
-  @Bean
-  public SearchEngineConfiguration searchEngineConfiguration(
-      final SearchEngineConnectProperties searchEngineConnectProperties,
-      final SearchEngineIndexProperties searchEngineIndexProperties,
-      final SearchEngineRetentionProperties searchEngineRetentionProperties,
-      final SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties) {
-    return buildConfiguration(
-        searchEngineConnectProperties,
-        searchEngineIndexProperties,
-        searchEngineRetentionProperties,
-        searchEngineSchemaManagerProperties);
-  }
-
-  private static SearchEngineConfiguration convert(final Camunda tenantCamunda) {
-    final var index = new SearchEngineIndexProperties();
-    SearchEngineIndexPropertiesOverride.applyTo(tenantCamunda, index);
-    final var retention = new SearchEngineRetentionProperties();
-    SearchEngineRetentionPropertiesOverride.applyTo(tenantCamunda, retention);
-    final var schemaManager = new SearchEngineSchemaManagerProperties();
-    SearchEngineSchemaManagerPropertiesOverride.applyTo(tenantCamunda, schemaManager);
-    return buildConfiguration(
-        new Converter(tenantCamunda).convert(), index, retention, schemaManager);
-  }
-
-  private static SearchEngineConfiguration buildConfiguration(
-      final SearchEngineConnectProperties connect,
-      final SearchEngineIndexProperties index,
-      final SearchEngineRetentionProperties retention,
-      final SearchEngineSchemaManagerProperties schemaManager) {
-
-    // Override schema creation if database type is "none"
-    final DatabaseType databaseType = connect.getTypeEnum();
-    if (DatabaseConfig.NONE.equalsIgnoreCase(databaseType.name())) {
-      schemaManager.setCreateSchema(false);
-    }
-
-    return SearchEngineConfiguration.of(
-        b -> b.connect(connect).index(index).retention(retention).schemaManager(schemaManager));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
@@ -12,10 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.UnifiedConfigurationHelper;
-import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
-import io.camunda.configuration.beanoverrides.SearchEngineIndexPropertiesOverride;
-import io.camunda.configuration.beanoverrides.SearchEngineRetentionPropertiesOverride;
-import io.camunda.configuration.beanoverrides.SearchEngineSchemaManagerPropertiesOverride;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.configuration.beans.SearchEngineIndexProperties;
 import io.camunda.configuration.beans.SearchEngineRetentionProperties;
@@ -37,20 +33,9 @@ class SearchEngineDatabaseConfigurationTest {
   }
 
   private static Map<String, SearchEngineConfiguration> configsByTenant(final Camunda camunda) {
-    final var connect = new Converter(camunda).convert();
-    final var index = new SearchEngineIndexProperties();
-    SearchEngineIndexPropertiesOverride.applyTo(camunda, index);
-    final var retention = new SearchEngineRetentionProperties();
-    SearchEngineRetentionPropertiesOverride.applyTo(camunda, retention);
-    final var schemaManager = new SearchEngineSchemaManagerProperties();
-    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, schemaManager);
-    return new SearchEngineDatabaseConfiguration()
+    return new PhysicalTenantSearchEngineConfigurations()
         .searchEngineConfigurationsByTenant(
-            PhysicalTenantResolver.of(new MockEnvironment(), camunda),
-            connect,
-            index,
-            retention,
-            schemaManager);
+            PhysicalTenantResolver.of(new MockEnvironment(), camunda));
   }
 
   @Test
@@ -64,12 +49,11 @@ class SearchEngineDatabaseConfigurationTest {
 
     // when
     final SearchEngineConfiguration config =
-        new SearchEngineDatabaseConfiguration()
-            .searchEngineConfiguration(
-                connect,
-                new SearchEngineIndexProperties(),
-                new SearchEngineRetentionProperties(),
-                schemaManager);
+        PhysicalTenantSearchEngineConfigurations.buildConfiguration(
+            connect,
+            new SearchEngineIndexProperties(),
+            new SearchEngineRetentionProperties(),
+            schemaManager);
 
     // then
     assertThat(config.schemaManager().isCreateSchema()).isFalse();

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -13,6 +13,7 @@ import io.camunda.application.StandaloneBackupManager.BackupManagerConfiguration
 import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
+import io.camunda.application.commons.search.PhysicalTenantSearchEngineConfigurations;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
@@ -34,6 +35,7 @@ public class TestStandaloneBackupManager
         StandaloneBackupManager.class,
         NativeSearchClientsConfiguration.class,
         PhysicalTenantSearchClientReadersConfiguration.class,
+        PhysicalTenantSearchEngineConfigurations.class,
         SearchClientReaderConfiguration.class);
   }
 


### PR DESCRIPTION
Bisection step 1b/2 of PR #57932 (issue #51993). Contains 1a + the SearchEngineDatabaseConfiguration extraction/rewire. Combined diff vs db1ea79286c is empty. Not for merge.