### PR TITLE
feat: display all active agent instances in agent status overlay

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.test.tsx
@@ -32,7 +32,7 @@ const getWrapper = (processInstanceId = PROCESS_INSTANCE_ID) => {
 };
 
 describe('useAgentInstancesStatusPerElement', () => {
-  it('should return an empty results when there are no agent instances', async () => {
+  it('should return an empty result when there are no agent instances', async () => {
     mockSearchAgentInstances().withSuccess(searchResult([]));
 
     const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
@@ -45,7 +45,7 @@ describe('useAgentInstancesStatusPerElement', () => {
     expect(result.current.elementsWithAgent.size).toBe(0);
   });
 
-  it('should map a agent instance to its element', async () => {
+  it('should map an agent instance to its element', async () => {
     mockSearchAgentInstances().withSuccess(
       searchResult([
         mockAgentInstance({

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.test.tsx
@@ -1,0 +1,265 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter, Routes, Route} from 'react-router-dom';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
+import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';
+import {searchResult} from 'modules/testUtils';
+import {Paths} from 'modules/Routes';
+import {useAgentInstancesStatusPerElement} from './agentInstances';
+
+const PROCESS_INSTANCE_ID = '123';
+
+const getWrapper = (processInstanceId = PROCESS_INSTANCE_ID) => {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      <MemoryRouter initialEntries={[Paths.processInstance(processInstanceId)]}>
+        <Routes>
+          <Route path={Paths.processInstance()} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+describe('useAgentInstancesStatusPerElement', () => {
+  it('should return an empty results when there are no agent instances', async () => {
+    mockSearchAgentInstances().withSuccess(searchResult([]));
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(0),
+    );
+    expect(result.current.elementsWithAgent.size).toBe(0);
+  });
+
+  it('should map a agent instance to its element', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_agent',
+          status: 'THINKING',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(1),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_agent'),
+    ).toEqual({
+      agentInstanceKey: 'agent-1',
+      status: 'THINKING',
+      additionalActiveCount: 0,
+    });
+    expect(result.current.elementsWithAgent).toContain('Activity_agent');
+  });
+
+  it('should map agent instances on different elements to separate entries', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_a',
+          status: 'THINKING',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-2',
+          elementId: 'Activity_b',
+          status: 'TOOL_CALLING',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(2),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_a'),
+    ).toMatchObject({agentInstanceKey: 'agent-1', additionalActiveCount: 0});
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_b'),
+    ).toMatchObject({agentInstanceKey: 'agent-2', additionalActiveCount: 0});
+    expect(result.current.elementsWithAgent).toContain('Activity_a');
+    expect(result.current.elementsWithAgent).toContain('Activity_b');
+  });
+
+  it('should count additional active agents sharing an element', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_agent',
+          status: 'THINKING',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-2',
+          elementId: 'Activity_agent',
+          status: 'THINKING',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-3',
+          elementId: 'Activity_agent',
+          status: 'THINKING',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(1),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_agent'),
+    ).toMatchObject({additionalActiveCount: 2});
+  });
+
+  it('should surface the most important status among agents on the same element', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_agent',
+          status: 'TOOL_CALLING',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-2',
+          elementId: 'Activity_agent',
+          status: 'INITIALIZING',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(1),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_agent'),
+    ).toMatchObject({
+      agentInstanceKey: 'agent-2',
+      status: 'INITIALIZING',
+    });
+  });
+
+  it('should prefer TOOL_DISCOVERY over TOOL_CALLING', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_agent',
+          status: 'TOOL_DISCOVERY',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-2',
+          elementId: 'Activity_agent',
+          status: 'TOOL_CALLING',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(1),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_agent'),
+    ).toMatchObject({
+      agentInstanceKey: 'agent-1',
+      status: 'TOOL_DISCOVERY',
+    });
+  });
+
+  it('should prefer THINKING over TOOL_DISCOVERY', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_agent',
+          status: 'THINKING',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-2',
+          elementId: 'Activity_agent',
+          status: 'TOOL_DISCOVERY',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(1),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_agent'),
+    ).toMatchObject({
+      agentInstanceKey: 'agent-1',
+      status: 'THINKING',
+    });
+  });
+
+  it('should prefer INITIALIZING over THINKING', async () => {
+    mockSearchAgentInstances().withSuccess(
+      searchResult([
+        mockAgentInstance({
+          agentInstanceKey: 'agent-1',
+          elementId: 'Activity_agent',
+          status: 'INITIALIZING',
+        }),
+        mockAgentInstance({
+          agentInstanceKey: 'agent-2',
+          elementId: 'Activity_agent',
+          status: 'THINKING',
+        }),
+      ]),
+    );
+
+    const {result} = renderHook(() => useAgentInstancesStatusPerElement(), {
+      wrapper: getWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.agentInstancesStatusMap.size).toBe(1),
+    );
+    expect(
+      result.current.agentInstancesStatusMap.get('Activity_agent'),
+    ).toMatchObject({
+      agentInstanceKey: 'agent-1',
+      status: 'INITIALIZING',
+    });
+  });
+});

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.ts
@@ -11,6 +11,17 @@ import {useProcessInstanceAgentInstances} from 'modules/queries/agentInstances/u
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import type {AgentStatusPayload} from 'modules/bpmn-js/overlayTypes';
 
+/** Assigns each agent-instance status an importance weight. A bigger number implies higher importance. */
+const STATUS_IMPORTANCE: Record<AgentInstance['status'], number> = {
+  INITIALIZING: 4,
+  THINKING: 3,
+  TOOL_DISCOVERY: 2,
+  TOOL_CALLING: 1,
+  COMPLETED: 0,
+  UNKNOWN: 0,
+  IDLE: 0,
+};
+
 type AgentInstancesStatusMap = Map<
   AgentInstance['elementId'],
   AgentStatusPayload
@@ -33,9 +44,16 @@ const useAgentInstancesStatusPerElement = (): {
           status: agentInstance.status,
           additionalActiveCount: 0,
         });
-      } else {
-        // NOTE: Object stored in map. So data in map gets updated as well.
-        statusInfo.additionalActiveCount += 1;
+        continue;
+      }
+      // NOTE: Object stored in map. So data in map gets updated as well.
+      statusInfo.additionalActiveCount += 1;
+      if (
+        STATUS_IMPORTANCE[agentInstance.status] >
+        STATUS_IMPORTANCE[statusInfo.status]
+      ) {
+        statusInfo.agentInstanceKey = agentInstance.agentInstanceKey;
+        statusInfo.status = agentInstance.status;
       }
     }
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentInstances.ts
@@ -9,27 +9,41 @@
 import {useMemo} from 'react';
 import {useProcessInstanceAgentInstances} from 'modules/queries/agentInstances/useProcessInstanceAgentInstances';
 import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {AgentStatusPayload} from 'modules/bpmn-js/overlayTypes';
 
-const useFirstAgentInstancePerElement = (): {
-  agentInstances: AgentInstance[];
+type AgentInstancesStatusMap = Map<
+  AgentInstance['elementId'],
+  AgentStatusPayload
+>;
+
+const useAgentInstancesStatusPerElement = (): {
+  agentInstancesStatusMap: AgentInstancesStatusMap;
   elementsWithAgent: Set<string>;
 } => {
   const {data} = useProcessInstanceAgentInstances();
 
   return useMemo(() => {
-    const elementsWithAgent = new Set<string>();
-    const agentInstances: AgentInstance[] = [];
+    const agentInstancesStatusMap: AgentInstancesStatusMap = new Map();
 
     for (const agentInstance of data?.items ?? []) {
-      if (elementsWithAgent.has(agentInstance.elementId)) {
-        continue;
+      const statusInfo = agentInstancesStatusMap.get(agentInstance.elementId);
+      if (!statusInfo) {
+        agentInstancesStatusMap.set(agentInstance.elementId, {
+          agentInstanceKey: agentInstance.agentInstanceKey,
+          status: agentInstance.status,
+          additionalActiveCount: 0,
+        });
+      } else {
+        // NOTE: Object stored in map. So data in map gets updated as well.
+        statusInfo.additionalActiveCount += 1;
       }
-      elementsWithAgent.add(agentInstance.elementId);
-      agentInstances.push(agentInstance);
     }
 
-    return {agentInstances, elementsWithAgent};
+    return {
+      agentInstancesStatusMap,
+      elementsWithAgent: new Set(agentInstancesStatusMap.keys()),
+    };
   }, [data]);
 };
 
-export {useFirstAgentInstancePerElement};
+export {type AgentInstancesStatusMap, useAgentInstancesStatusPerElement};

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentShineOverlay.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentShineOverlay.tsx
@@ -77,7 +77,8 @@ const useAgentShineOverlaysData = (
 ): OverlayData[] =>
   useMemo(
     () =>
-      Array.from(agentInstancesStatusMap.entries()).map(
+      Array.from(
+        agentInstancesStatusMap.entries(),
         ([elementId, statusInfo]) => ({
           type: AGENT_SHINE_OVERLAY_TYPE,
           elementId,

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentShineOverlay.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentShineOverlay.tsx
@@ -13,12 +13,12 @@ import {createPortal} from 'react-dom';
 import styled, {keyframes} from 'styled-components';
 import {AGENT_SHINE} from 'modules/bpmn-js/badgePositions';
 import {PURPLE_30, PURPLE_40, PURPLE_60} from './agentStatusOverlay';
-import type {AgentInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import type {
   AgentShinePayload,
   OverlayData,
 } from 'modules/bpmn-js/overlayTypes';
 import type {DiagramOverlay} from './types';
+import type {AgentInstancesStatusMap} from './agentInstances';
 
 const AGENT_SHINE_OVERLAY_TYPE = 'agentShine';
 
@@ -73,19 +73,21 @@ type Size = {
 };
 
 const useAgentShineOverlaysData = (
-  agentInstances: AgentInstance[],
+  agentInstancesStatusMap: AgentInstancesStatusMap,
 ): OverlayData[] =>
   useMemo(
     () =>
-      agentInstances.map((agentInstance) => ({
-        type: AGENT_SHINE_OVERLAY_TYPE,
-        elementId: agentInstance.elementId,
-        position: AGENT_SHINE,
-        payload: {
-          agentInstanceKey: agentInstance.agentInstanceKey,
-        } satisfies AgentShinePayload,
-      })),
-    [agentInstances],
+      Array.from(agentInstancesStatusMap.entries()).map(
+        ([elementId, statusInfo]) => ({
+          type: AGENT_SHINE_OVERLAY_TYPE,
+          elementId,
+          position: AGENT_SHINE,
+          payload: {
+            agentInstanceKey: statusInfo.agentInstanceKey,
+          } satisfies AgentShinePayload,
+        }),
+      ),
+    [agentInstancesStatusMap],
   );
 
 const AgentShineOverlay: React.FC<{overlay: DiagramOverlay}> = ({overlay}) => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.test.tsx
@@ -11,11 +11,14 @@ import {AgentStatusOverlay} from './agentStatusOverlay';
 import {render, screen} from 'modules/testing-library';
 import type {DiagramOverlay} from './types';
 
-const createOverlay = (status: AgentInstanceStatus): DiagramOverlay => ({
+const createOverlay = (
+  status: AgentInstanceStatus,
+  additionalActiveCount = 0,
+): DiagramOverlay => ({
   container: document.body,
   elementId: 'Activity_agent',
   type: 'agentStatus',
-  payload: {status, agentInstanceKey: 'agent-1'},
+  payload: {status, agentInstanceKey: 'agent-1', additionalActiveCount},
 });
 
 describe('agentStatusOverlay', () => {
@@ -45,4 +48,20 @@ describe('agentStatusOverlay', () => {
       ).not.toBeInTheDocument();
     },
   );
+
+  it('should append the count of other active agents on the element', () => {
+    render(<AgentStatusOverlay overlay={createOverlay('THINKING', 3)} />);
+
+    expect(
+      screen.getByTestId('agent-status-overlay-THINKING'),
+    ).toHaveTextContent('Thinking... + 3 more active');
+  });
+
+  it('should not append a count when no other agents are active', () => {
+    render(<AgentStatusOverlay overlay={createOverlay('THINKING', 0)} />);
+
+    const overlay = screen.getByTestId('agent-status-overlay-THINKING');
+    expect(overlay).toHaveTextContent('Thinking...');
+    expect(overlay).not.toHaveTextContent('more active');
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.tsx
@@ -85,7 +85,8 @@ const useAgentStatusOverlaysData = (
 ): OverlayData[] =>
   useMemo(
     () =>
-      Array.from(agentInstancesStatusMap.entries()).map(
+      Array.from(
+        agentInstancesStatusMap.entries(),
         ([elementId, statusInfo]) => ({
           type: AGENT_STATUS_OVERLAY_TYPE,
           elementId,

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.tsx
@@ -12,15 +12,13 @@ import {useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import styled, {keyframes} from 'styled-components';
 import {AGENT_STATUS_TAG} from 'modules/bpmn-js/badgePositions';
-import type {
-  AgentInstance,
-  AgentInstanceStatus,
-} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {AgentInstanceStatus} from '@camunda/camunda-api-zod-schemas/8.10';
 import type {
   AgentStatusPayload,
   OverlayData,
 } from 'modules/bpmn-js/overlayTypes';
 import type {DiagramOverlay} from './types';
+import type {AgentInstancesStatusMap} from './agentInstances';
 
 const AGENT_STATUS_OVERLAY_TYPE = 'agentStatus';
 
@@ -83,33 +81,37 @@ const AGENT_STATUS_LABELS: Record<AgentInstanceStatus, string | null> = {
 };
 
 const useAgentStatusOverlaysData = (
-  agentInstances: AgentInstance[],
+  agentInstancesStatusMap: AgentInstancesStatusMap,
 ): OverlayData[] =>
   useMemo(
     () =>
-      agentInstances.map((agentInstance) => ({
-        type: AGENT_STATUS_OVERLAY_TYPE,
-        elementId: agentInstance.elementId,
-        position: AGENT_STATUS_TAG,
-        payload: {
-          status: agentInstance.status,
-          agentInstanceKey: agentInstance.agentInstanceKey,
-        } satisfies AgentStatusPayload,
-      })),
-    [agentInstances],
+      Array.from(agentInstancesStatusMap.entries()).map(
+        ([elementId, statusInfo]) => ({
+          type: AGENT_STATUS_OVERLAY_TYPE,
+          elementId,
+          position: AGENT_STATUS_TAG,
+          payload: statusInfo satisfies AgentStatusPayload,
+        }),
+      ),
+    [agentInstancesStatusMap],
   );
 
 const AgentStatusOverlay: React.FC<{overlay: DiagramOverlay}> = ({overlay}) => {
-  const {status} = overlay.payload as AgentStatusPayload;
+  const {status, additionalActiveCount} = overlay.payload as AgentStatusPayload;
   const label = AGENT_STATUS_LABELS[status];
   if (label === null) {
     return null;
   }
 
+  const fullLabel =
+    additionalActiveCount > 0
+      ? `${label} + ${additionalActiveCount} more active`
+      : label;
+
   return createPortal(
     <AgentStatusContainer>
       <AgentStatus data-testid={`agent-status-overlay-${status}`}>
-        {label}
+        {fullLabel}
       </AgentStatus>
     </AgentStatusContainer>,
     overlay.container,

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/useDiagramOverlaysData.ts
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/useDiagramOverlaysData.ts
@@ -8,7 +8,7 @@
 
 import {useMemo} from 'react';
 import type {OverlayData} from 'modules/bpmn-js/overlayTypes';
-import {useFirstAgentInstancePerElement} from './agentInstances';
+import {useAgentInstancesStatusPerElement} from './agentInstances';
 import {useElementStateOverlaysData} from './elementStateOverlay';
 import {useModificationBadgeOverlaysData} from './modificationBadgeOverlay';
 import {useWaitingStateOverlaysData} from './waitingStateOverlay';
@@ -18,13 +18,14 @@ import {useAgentShineOverlaysData} from './agentShineOverlay';
 const useDiagramOverlaysData = (
   isModificationModeEnabled: boolean,
 ): OverlayData[] => {
-  const {agentInstances, elementsWithAgent} = useFirstAgentInstancePerElement();
+  const {agentInstancesStatusMap, elementsWithAgent} =
+    useAgentInstancesStatusPerElement();
 
   const elementStateData = useElementStateOverlaysData();
   const modificationBadgeData = useModificationBadgeOverlaysData();
   const waitingStateData = useWaitingStateOverlaysData(elementsWithAgent);
-  const agentStatusData = useAgentStatusOverlaysData(agentInstances);
-  const agentShineData = useAgentShineOverlaysData(agentInstances);
+  const agentStatusData = useAgentStatusOverlaysData(agentInstancesStatusMap);
+  const agentShineData = useAgentShineOverlaysData(agentInstancesStatusMap);
 
   return useMemo(() => {
     // While modifying, show the element states and the pending modification

--- a/operate/client/src/modules/bpmn-js/overlayTypes.ts
+++ b/operate/client/src/modules/bpmn-js/overlayTypes.ts
@@ -80,7 +80,8 @@ const isAgentStatusPayload = (
     typeof payload === 'object' &&
     payload !== null &&
     'status' in payload &&
-    'agentInstanceKey' in payload
+    'agentInstanceKey' in payload &&
+    'additionalActiveCount' in payload
   );
 };
 

--- a/operate/client/src/modules/bpmn-js/overlayTypes.ts
+++ b/operate/client/src/modules/bpmn-js/overlayTypes.ts
@@ -39,6 +39,7 @@ type WaitingStatePayload = {
 type AgentStatusPayload = {
   status: AgentInstance['status'];
   agentInstanceKey: string;
+  additionalActiveCount: number;
 };
 
 type AgentShinePayload = {

--- a/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
+++ b/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
@@ -18,6 +18,7 @@ const useProcessInstanceAgentInstances = () => {
     ...agentInstancesSearchOptions({
       loadAllItems: true,
       payload: {
+        sort: [{field: 'lastUpdatedDate', order: 'desc'}],
         filter: {
           processInstanceKey: processInstanceId ?? '',
           status: {$in: ACTIVE_STATUSES_ARRAY},

--- a/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
+++ b/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
@@ -18,7 +18,6 @@ const useProcessInstanceAgentInstances = () => {
     ...agentInstancesSearchOptions({
       loadAllItems: true,
       payload: {
-        sort: [{field: 'lastUpdatedDate', order: 'desc'}],
         filter: {
           processInstanceKey: processInstanceId ?? '',
           status: {$in: ACTIVE_STATUSES_ARRAY},


### PR DESCRIPTION
## Description

This PR enhances the agent status overlay to include a `additionalActiveCount`, which is displayed when multiple agent instances are active for an element. This results in a `Thinking... + 10 more active` status overlay label. As shown, only one status is picked and displayed. When considering the status to display, the status of each agent is weighted by importance, and the most important status is chosen for display.

**Decision Context:** https://camunda.slack.com/archives/C0AH08C7UA2/p1784194496046739

<details>
<summary>Mock handler for easy testing</summary>

```typescript
// operate/client/src/modules/mock-server/handlers.ts
import {http, HttpResponse, type RequestHandler} from 'msw';
import {
  endpoints,
  type QueryAgentInstancesRequestBody,
  type QueryAgentInstancesResponseBody,
} from '@camunda/camunda-api-zod-schemas/8.10';
import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';

// VISUAL TESTING ONLY — remove this handler before committing.
// Returns several active agent instances on a single element so the agent status
// overlay renders the multi-agent label, e.g. "Thinking... + 3 more active".
//
// Set DEMO_ELEMENT_ID to an element ID that actually exists in the diagram of the
// process instance you open, otherwise the overlay has no element to attach to.
const DEMO_ELEMENT_ID = 'ai_agent_task';

const handlers: RequestHandler[] = [
  http.post(endpoints.queryAgentInstances.getUrl(), async ({request}) => {
    const body = (await request.json()) as QueryAgentInstancesRequestBody;
    const processInstanceKey =
      typeof body.filter?.processInstanceKey === 'string'
        ? body.filter.processInstanceKey
        : mockAgentInstance().processInstanceKey;

    const items = [
      mockAgentInstance({
        agentInstanceKey: 'demo-agent-1',
        status: 'THINKING',
        elementId: DEMO_ELEMENT_ID,
        processInstanceKey,
        lastUpdatedDate: '2025-01-15T10:09:00.000Z',
      }),
      mockAgentInstance({
        agentInstanceKey: 'demo-agent-2',
        status: 'TOOL_CALLING',
        elementId: DEMO_ELEMENT_ID,
        processInstanceKey,
        lastUpdatedDate: '2025-01-15T10:08:00.000Z',
      }),
      mockAgentInstance({
        agentInstanceKey: 'demo-agent-3',
        status: 'INITIALIZING',
        elementId: DEMO_ELEMENT_ID,
        processInstanceKey,
        lastUpdatedDate: '2025-01-15T10:07:00.000Z',
      }),
      mockAgentInstance({
        agentInstanceKey: 'demo-agent-4',
        status: 'TOOL_CALLING',
        elementId: DEMO_ELEMENT_ID,
        processInstanceKey,
        lastUpdatedDate: '2025-01-15T10:06:00.000Z',
      }),
    ];

    return HttpResponse.json({
      items,
      page: {
        totalItems: items.length,
        startCursor: null,
        endCursor: null,
        hasMoreTotalItems: false,
      },
    } satisfies QueryAgentInstancesResponseBody);
  }),
];

export {handlers};
```
</details>

## Related issues

closes #57381
