### PR TITLE
feat: dispatch suspend/resume REST requests to the broker

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -41,6 +41,8 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOpe
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceResumeRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceSuspendRequest;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
@@ -107,13 +109,7 @@ public class ProcessInstanceController {
         .toSuspendProcessInstance(processInstanceKey, suspendRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
-            // TODO(#57518): dispatch to suspendProcessInstance(physicalTenantId, mapped) — see
-            // ProcessInstanceServices.suspendProcessInstance — once the zeebe/engine SUSPEND
-            // processor exists. Until then, a real dispatch would time out at 504 with no
-            // SUSPEND_PROCESS_INSTANCE check (that check lives in the not-yet-existing processor).
-            ignored ->
-                CompletableFuture.completedFuture(
-                    ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()));
+            mapped -> suspendProcessInstance(physicalTenantId, mapped));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/resumption")
@@ -125,15 +121,7 @@ public class ProcessInstanceController {
         .toResumeProcessInstance(processInstanceKey, resumeRequest)
         .fold(
             RestErrorMapper::mapProblemToCompletedResponse,
-            // TODO(#57518): dispatch to resumeProcessInstance(physicalTenantId, mapped) — see
-            // ProcessInstanceServices.resumeProcessInstance — once the zeebe/engine RESUME
-            // processor exists. Until then, a real dispatch would time out at 504 with no
-            // SUSPEND_PROCESS_INSTANCE check (resume shares that same permission type — there is
-            // no separate RESUME_PROCESS_INSTANCE — that check lives in the not-yet-existing
-            // processor).
-            ignored ->
-                CompletableFuture.completedFuture(
-                    ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build()));
+            mapped -> resumeProcessInstance(physicalTenantId, mapped));
   }
 
   @CamundaPostMapping(path = "/{processInstanceKey}/migration")
@@ -482,6 +470,24 @@ public class ProcessInstanceController {
     return RequestExecutor.executeServiceMethodWithNoContentResult(
         () ->
             processInstanceServices.cancelProcessInstance(
+                request, authenticationProvider.getCamundaAuthentication()));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> suspendProcessInstance(
+      final String physicalTenantId, final ProcessInstanceSuspendRequest request) {
+    final var processInstanceServices = serviceRegistry.processInstanceServices(physicalTenantId);
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            processInstanceServices.suspendProcessInstance(
+                request, authenticationProvider.getCamundaAuthentication()));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> resumeProcessInstance(
+      final String physicalTenantId, final ProcessInstanceResumeRequest request) {
+    final var processInstanceServices = serviceRegistry.processInstanceServices(physicalTenantId);
+    return RequestExecutor.executeServiceMethodWithNoContentResult(
+        () ->
+            processInstanceServices.resumeProcessInstance(
                 request, authenticationProvider.getCamundaAuthentication()));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -33,6 +33,8 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateBatchOpe
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyBatchOperationRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceResumeRequest;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceSuspendRequest;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.registry.ServiceRegistry;
@@ -104,6 +106,8 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   @Captor ArgumentCaptor<ProcessInstanceMigrateRequest> migrateRequestCaptor;
   @Captor ArgumentCaptor<AssignProcessInstanceBusinessIdRequest> assignBusinessIdRequestCaptor;
   @Captor ArgumentCaptor<ProcessInstanceModifyRequest> modifyRequestCaptor;
+  @Captor ArgumentCaptor<ProcessInstanceSuspendRequest> suspendRequestCaptor;
+  @Captor ArgumentCaptor<ProcessInstanceResumeRequest> resumeRequestCaptor;
   @MockitoBean ProcessInstanceServices processInstanceServices;
   @MockitoBean ServiceRegistry serviceRegistry;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
@@ -1103,15 +1107,19 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnNotImplementedForSuspendProcessInstance() {
+  void shouldSuspendProcessInstance() {
     // given
+    when(processInstanceServices.suspendProcessInstance(
+            any(ProcessInstanceSuspendRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
+
     final var request =
         """
             {
               "operationReference": 123
             }""";
 
-    // when/then — 501: the engine processor for SUSPEND doesn't exist yet (TODO #57518)
+    // when/then
     webClient
         .post()
         .uri(SUSPEND_PROCESS_URL.formatted("1"))
@@ -1120,14 +1128,23 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        .isNoContent();
 
-    Mockito.verifyNoInteractions(processInstanceServices);
+    Mockito.verify(processInstanceServices)
+        .suspendProcessInstance(suspendRequestCaptor.capture(), any());
+    final var capturedRequest = suspendRequestCaptor.getValue();
+    assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
+    assertThat(capturedRequest.operationReference()).isEqualTo(123L);
   }
 
   @Test
-  void shouldReturnNotImplementedForSuspendProcessInstanceWithNoBody() {
-    // when/then — 501: the engine processor for SUSPEND doesn't exist yet (TODO #57518)
+  void shouldSuspendProcessInstanceWithNoBody() {
+    // given
+    when(processInstanceServices.suspendProcessInstance(
+            any(ProcessInstanceSuspendRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
+
+    // when/then
     webClient
         .post()
         .uri(SUSPEND_PROCESS_URL.formatted("1"))
@@ -1135,9 +1152,13 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        .isNoContent();
 
-    Mockito.verifyNoInteractions(processInstanceServices);
+    Mockito.verify(processInstanceServices)
+        .suspendProcessInstance(suspendRequestCaptor.capture(), any());
+    final var capturedRequest = suspendRequestCaptor.getValue();
+    assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
+    assertThat(capturedRequest.operationReference()).isNull();
   }
 
   @Test
@@ -1176,15 +1197,19 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnNotImplementedForResumeProcessInstance() {
+  void shouldResumeProcessInstance() {
     // given
+    when(processInstanceServices.resumeProcessInstance(
+            any(ProcessInstanceResumeRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
+
     final var request =
         """
             {
               "operationReference": 123
             }""";
 
-    // when/then — 501: the engine processor for RESUME doesn't exist yet (TODO #57518)
+    // when/then
     webClient
         .post()
         .uri(RESUME_PROCESS_URL.formatted("1"))
@@ -1193,14 +1218,23 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .bodyValue(request)
         .exchange()
         .expectStatus()
-        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        .isNoContent();
 
-    Mockito.verifyNoInteractions(processInstanceServices);
+    Mockito.verify(processInstanceServices)
+        .resumeProcessInstance(resumeRequestCaptor.capture(), any());
+    final var capturedRequest = resumeRequestCaptor.getValue();
+    assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
+    assertThat(capturedRequest.operationReference()).isEqualTo(123L);
   }
 
   @Test
-  void shouldReturnNotImplementedForResumeProcessInstanceWithNoBody() {
-    // when/then — 501: the engine processor for RESUME doesn't exist yet (TODO #57518)
+  void shouldResumeProcessInstanceWithNoBody() {
+    // given
+    when(processInstanceServices.resumeProcessInstance(
+            any(ProcessInstanceResumeRequest.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(new ProcessInstanceRecord()));
+
+    // when/then
     webClient
         .post()
         .uri(RESUME_PROCESS_URL.formatted("1"))
@@ -1208,9 +1242,13 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
-        .isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+        .isNoContent();
 
-    Mockito.verifyNoInteractions(processInstanceServices);
+    Mockito.verify(processInstanceServices)
+        .resumeProcessInstance(resumeRequestCaptor.capture(), any());
+    final var capturedRequest = resumeRequestCaptor.getValue();
+    assertThat(capturedRequest.processInstanceKey()).isEqualTo(1);
+    assertThat(capturedRequest.operationReference()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

Closes out the gateway→broker wiring for single-instance suspend/resume by removing the `501 NOT_IMPLEMENTED` guard added in #57870, now that the engine-side processors exist (#57882, #57883) and all three have merged into `main`.

`ProcessInstanceController.suspendProcessInstance`/`resumeProcessInstance` now dispatch to the already-implemented `ProcessInstanceServices.suspendProcessInstance`/`resumeProcessInstance`, mirroring the existing `cancelProcessInstance`/`migrateProcessInstance`/`modifyProcessInstance` pattern in the same controller exactly (private 2-arg helper + `RequestExecutor.executeServiceMethodWithNoContentResult`, `204` on success).

The 4 tests that previously asserted `501` now assert `204` + the captured broker request fields.

## Checklist

- [ ] Enable backports when necessary — not applicable, this is a new feature addition, not a bug fix.
- [ ] Not applicable — this PR does not touch the C8 Orchestration Cluster E2E Test Suite.

## Related issues

Closes #57532