### PR TITLE
test: sequentialize tests against shared OpenSearch AWS cluster

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -116,7 +116,7 @@ jobs:
             name: "Camunda QA Module Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
             maven-build-threads: 2
-            maven-test-fork-count: 2
+            maven-test-fork-count: 1
             maven-test-profiles: multi-db-test-client
             runs-on: aws-core-8-default
             owner: '@camunda/monorepo-devops-team'
@@ -124,7 +124,7 @@ jobs:
             name: "Camunda QA Module Non-Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
             maven-build-threads: 2
-            maven-test-fork-count: 2
+            maven-test-fork-count: 1
             maven-test-profiles: multi-db-test-non-client
             runs-on: aws-core-8-default
             owner: '@camunda/monorepo-devops-team'
@@ -132,7 +132,7 @@ jobs:
             name: "Search Client OpenSearch ITs"
             maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
             maven-build-threads: 2
-            maven-test-fork-count: 2
+            maven-test-fork-count: 1
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
             owner: '@camunda/core-features'
@@ -140,7 +140,7 @@ jobs:
             name: "Camunda Exporter ITs"
             maven-modules: "'io.camunda:camunda-exporter'"
             maven-build-threads: 2
-            maven-test-fork-count: 2
+            maven-test-fork-count: 1
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
             owner: '@camunda/data-layer'
@@ -148,7 +148,7 @@ jobs:
             name: "Zeebe OpenSearch Exporter ITs"
             maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
             maven-build-threads: 2
-            maven-test-fork-count: 2
+            maven-test-fork-count: 1
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
             owner: '@camunda/data-layer'


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Last run:
https://github.com/camunda/camunda/actions/runs/29493439103

* Even though the client and non-client test jobs failed (they were expected to fail), there are no shards failure errors in the logs.
* The overall workflow run lasted less than 4 hours, even if sequential, which is acceptable for the nightly run

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
