### PR TITLE
bisect(2a/2): rewire default-tenant SearchEngineConfiguration to derive from the tenant map

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -11,7 +11,6 @@ import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
 import io.camunda.application.commons.search.NativeSearchClientsConfiguration;
 import io.camunda.application.commons.search.PhysicalTenantSearchClientReadersConfiguration;
 import io.camunda.application.commons.search.SearchClientReaderConfiguration;
-import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.TakeBackupRequestDto;
@@ -23,7 +22,6 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.ExitCodeExceptionMapper;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -191,10 +189,5 @@ public class StandaloneBackupManager implements CommandLineRunner {
       return ex -> 1;
     }
 
-    @Bean
-    @ConfigurationProperties(prefix = "camunda.database")
-    public SearchEngineConfiguration searchEngineConfiguration() {
-      return SearchEngineConfiguration.of(b -> b);
-    }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -82,17 +82,13 @@ public class SearchEngineDatabaseConfiguration {
         isGatewayEnabled);
   }
 
+  // Still required as an unqualified bean: io.camunda.operate.management.IndicesCheck autowires
+  // a plain SearchEngineConfiguration for the default physical tenant.
   @Bean
   public SearchEngineConfiguration searchEngineConfiguration(
-      final SearchEngineConnectProperties searchEngineConnectProperties,
-      final SearchEngineIndexProperties searchEngineIndexProperties,
-      final SearchEngineRetentionProperties searchEngineRetentionProperties,
-      final SearchEngineSchemaManagerProperties searchEngineSchemaManagerProperties) {
-    return buildConfiguration(
-        searchEngineConnectProperties,
-        searchEngineIndexProperties,
-        searchEngineRetentionProperties,
-        searchEngineSchemaManagerProperties);
+      @Qualifier("searchEngineConfigurationsByTenant")
+          final Map<String, SearchEngineConfiguration> searchEngineConfigurationsByTenant) {
+    return searchEngineConfigurationsByTenant.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   private static SearchEngineConfiguration convert(final Camunda tenantCamunda) {

--- a/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/SearchEngineDatabaseConfigurationTest.java
@@ -61,15 +61,20 @@ class SearchEngineDatabaseConfigurationTest {
     final SearchEngineSchemaManagerProperties schemaManager =
         new SearchEngineSchemaManagerProperties();
     schemaManager.setCreateSchema(true);
-
-    // when
-    final SearchEngineConfiguration config =
+    final Camunda camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.elasticsearch);
+    final Map<String, SearchEngineConfiguration> configsByTenant =
         new SearchEngineDatabaseConfiguration()
-            .searchEngineConfiguration(
+            .searchEngineConfigurationsByTenant(
+                PhysicalTenantResolver.of(new MockEnvironment(), camunda),
                 connect,
                 new SearchEngineIndexProperties(),
                 new SearchEngineRetentionProperties(),
                 schemaManager);
+
+    // when
+    final SearchEngineConfiguration config =
+        new SearchEngineDatabaseConfiguration().searchEngineConfiguration(configsByTenant);
 
     // then
     assertThat(config.schemaManager().isCreateSchema()).isFalse();


### PR DESCRIPTION
Bisection step 2a/2 of #57942 (issue #51993). On top of #57941 (1a).

Isolates the actual dependency-graph change from db1ea79286c: the default-tenant `searchEngineConfiguration` bean previously built its config directly from properties beans (no dependency on `PhysicalTenantResolver`); this step alone changes it to depend on the `searchEngineConfigurationsByTenant` map (which itself depends on `PhysicalTenantResolver`), without yet moving the map to its own class.

This is my primary suspect for the LongPollingIT/smoke-test cluster-startup timeout seen on #57932 — it introduces a new transitive dependency chain for a bean used during early startup (`io.camunda.operate.management.IndicesCheck`). Not for merge.