### PR TITLE
test: add Operate UI coverage for the Job Priority details-tab row

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -39,6 +39,7 @@ class OperateProcessInstancePage {
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
   readonly detailsTabButton: Locator;
+  readonly jobPriorityValue: Locator;
   readonly variablesTabButton: Locator;
   readonly operationsLogTabButton: Locator;
   readonly operationsLogTable: Locator;
@@ -180,6 +181,7 @@ class OperateProcessInstancePage {
     this.detailsTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Details$/i});
+    this.jobPriorityValue = page.getByTestId('job-priority');
     this.variablesTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Variables$/i});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleServiceTaskWithPriorityProcess.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/simpleServiceTaskWithPriorityProcess.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_simpleServiceTaskWithPriorityProcess" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+  <bpmn:process id="simpleServiceTaskWithPriorityProcess" name="simple service task with priority process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="task" />
+    <bpmn:serviceTask id="task" name="priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="task" />
+        <zeebe:jobPriorityDefinition priority="42" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="task" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simpleServiceTaskWithPriorityProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-224" y="266" width="74" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="task">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceJobPriority.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceJobPriority.spec.ts
@@ -48,7 +48,6 @@ test.describe('Process Instance Job Priority', () => {
   });
 
   test('Job Priority row shows the value defined in the process model', async ({
-    page,
     operateProcessInstancePage,
   }) => {
     await operateProcessInstancePage.gotoProcessInstancePage({
@@ -58,11 +57,10 @@ test.describe('Process Instance Job Priority', () => {
     await operateProcessInstancePage.clickTreeItem(/priority task/i);
     await operateProcessInstancePage.clickDetailsTab();
 
-    await expect(page.getByTestId('job-priority')).toHaveText('42');
+    await expect(operateProcessInstancePage.jobPriorityValue).toHaveText('42');
   });
 
   test('Job Priority row shows the default priority when none is defined', async ({
-    page,
     operateProcessInstancePage,
   }) => {
     await operateProcessInstancePage.gotoProcessInstancePage({
@@ -72,6 +70,6 @@ test.describe('Process Instance Job Priority', () => {
     await operateProcessInstancePage.clickTreeItem('task', true);
     await operateProcessInstancePage.clickDetailsTab();
 
-    await expect(page.getByTestId('job-priority')).toHaveText('0');
+    await expect(operateProcessInstancePage.jobPriorityValue).toHaveText('0');
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceJobPriority.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceJobPriority.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+import {sleep} from 'utils/sleep';
+
+type ProcessInstance = {
+  processInstanceKey: string;
+};
+
+let instanceWithExplicitPriority: ProcessInstance;
+let instanceWithDefaultPriority: ProcessInstance;
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/simpleServiceTaskWithPriorityProcess.bpmn',
+    './resources/simpleServiceTaskProcess.bpmn',
+  ]);
+
+  instanceWithExplicitPriority = await createSingleInstance(
+    'simpleServiceTaskWithPriorityProcess',
+    1,
+  );
+
+  instanceWithDefaultPriority = await createSingleInstance(
+    'simpleServiceTaskProcess',
+    1,
+  );
+});
+
+test.describe('Process Instance Job Priority', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Job Priority row shows the value defined in the process model', async ({
+    page,
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instanceWithExplicitPriority.processInstanceKey,
+    });
+    await sleep(1000);
+
+    await operateProcessInstancePage.clickTreeItem(/priority task/i);
+    await operateProcessInstancePage.clickDetailsTab();
+
+    await expect(page.getByTestId('job-priority')).toHaveText('42');
+  });
+
+  test('Job Priority row shows the default priority when none is defined', async ({
+    page,
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instanceWithDefaultPriority.processInstanceKey,
+    });
+    await sleep(1000);
+
+    await operateProcessInstancePage.clickTreeItem('task', true);
+    await operateProcessInstancePage.clickDetailsTab();
+
+    await expect(page.getByTestId('job-priority')).toHaveText('0');
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceJobPriority.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceJobPriority.spec.ts
@@ -11,7 +11,6 @@ import {expect} from '@playwright/test';
 import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToAppHome} from '@pages/UtilitiesPage';
-import {sleep} from 'utils/sleep';
 
 type ProcessInstance = {
   processInstanceKey: string;
@@ -55,7 +54,6 @@ test.describe('Process Instance Job Priority', () => {
     await operateProcessInstancePage.gotoProcessInstancePage({
       id: instanceWithExplicitPriority.processInstanceKey,
     });
-    await sleep(1000);
 
     await operateProcessInstancePage.clickTreeItem(/priority task/i);
     await operateProcessInstancePage.clickDetailsTab();
@@ -70,7 +68,6 @@ test.describe('Process Instance Job Priority', () => {
     await operateProcessInstancePage.gotoProcessInstancePage({
       id: instanceWithDefaultPriority.processInstanceKey,
     });
-    await sleep(1000);
 
     await operateProcessInstancePage.clickTreeItem('task', true);
     await operateProcessInstancePage.clickDetailsTab();


### PR DESCRIPTION
## Summary
- Adds `tests/operate/processInstanceJobPriority.spec.ts` covering the "Job Priority" row in the Process Instance Details tab (`operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx`), which previously had only component-test coverage, not E2E.
- Adds a new fixture `resources/simpleServiceTaskWithPriorityProcess.bpmn`: a single service task with a static `zeebe:jobPriorityDefinition priority="42"`.
- Tests added:
  - `Job Priority row shows the value defined in the process model` (uses the new fixture, priority=42)
  - `Job Priority row shows the default priority when none is defined` (reuses the existing `simpleServiceTaskProcess.bpmn` fixture, which has no `zeebe:jobPriorityDefinition` — confirms the API/UI default of `0`, and that the row is present rather than absent)

Closes camunda/camunda#57925 (sub-issue of camunda/camunda#50567, linked to QA epic https://github.com/camunda/product-hub/issues/3615).

## Verification
- `npx tsc --noEmit`, `eslint`, `prettier --check` all pass clean on the changed files.
- Ran both tests locally against a freshly-built `main` broker + Elasticsearch (`--project=chromium`) — both pass (found and fixed a locator strict-mode collision along the way: `clickTreeItem('task')` matched both the process-root node, whose accessible label "simple service task process" contains the substring "task", and the actual leaf node — fixed with `exact: true`).
- **On-demand E2E workflow run**: https://github.com/camunda/camunda/actions/runs/29496113983 — **both new tests passed in every job** (`Mode all-in-one, Tasklist v2` and `Mode profiles, Tasklist v2`). The overall run reported failures, but all in files this PR does not touch: `batchOperations.spec.ts`, `processInstanceVariables.spec.ts`, `multiInstanceSelection.spec.ts`, `callActivities.spec.ts`, `dashboard.spec.ts`, `processes.spec.ts`, `processInstancesFilters.spec.ts`, `tasklist/task-history.spec.ts` — pre-existing, not caused by this change.

## Test plan
- [x][ On-demand workflow run reviewed](https://github.com/camunda/camunda/actions/runs/29496113983); failures confirmed pre-existing (not regressions) 

[Here](https://github.com/camunda/camunda/actions/runs/29502224940) is the second time run after fixing the Copilot comment, in case it is needed 
