### PR TITLE
feat: add brokerId to BrokerInfo in /v2/topology

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -895,6 +895,7 @@ public final class ResponseMapper {
     final var partitions = buildPartitions(broker.partitions());
     return BrokerInfo.Builder.create()
         .nodeId(broker.nodeIdx())
+        .brokerId(broker.brokerIdStr())
         .host(broker.host())
         .port(broker.port())
         .partitions(partitions)

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -118,6 +118,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                   List.of(
                       BrokerInfo.Builder.create()
                           .nodeId(0)
+                          .brokerId("0")
                           .host("localhost")
                           .port(26501)
                           .partitions(
@@ -132,6 +133,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                           .build(),
                       BrokerInfo.Builder.create()
                           .nodeId(1)
+                          .brokerId("1")
                           .host("localhost")
                           .port(26502)
                           .partitions(
@@ -146,6 +148,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                           .build(),
                       BrokerInfo.Builder.create()
                           .nodeId(2)
+                          .brokerId("2")
                           .host("localhost")
                           .port(26503)
                           .partitions(

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -206,16 +206,35 @@ components:
       type: object
       required:
         - nodeId
+        - brokerId
         - host
         - port
         - partitions
         - version
       properties:
         nodeId:
-          description: The unique (within a cluster) node ID for the broker.
+          description: >
+            The node ID for the broker. The uniqueness of this identifier depends
+            if the cluster is zone-aware or not.
+            - non zone-aware: (default) nodeId is unique across the cluster
+            - zone-aware:  (opt-in) nodeId is unique only within its zone.
+            If you are migrating to a zone aware cluster, you must use `brokerId` instead.
+            This property is deprecated, as it's been replaced by `brokerId`.
+
           type: integer
           format: int32
+          deprecated: true
           example: 0
+
+        brokerId:
+          description: >
+            The unique (within a cluster) broker identifier. When the cluster
+            is not zoned, then it's a string that represents the nodeId (an integer).
+            When the cluster is zoned, instead, it's of the form "$zoneName_$nodeId",
+            providing uniqueness even across zones.
+          type: string
+          example: "eu-west-1_0"
+
         host:
           description: The hostname for reaching the broker.
           type: string
@@ -234,6 +253,10 @@ components:
           description: The broker version.
           type: string
           example: 8.8.0
+      x-properties-added-in-version:
+        - propertyName: "brokerId"
+          addedInVersion: "8.10"
+
 
     Partition:
       description: Provides information on a partition within a broker node.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -59,6 +59,7 @@ public class TopologyControllerTest extends RestControllerTest {
           "brokers": [
             {
               "nodeId": 0,
+              "brokerId": "0",
               "host": "localhost",
               "port": 26501,
               "version": "%s",
@@ -73,6 +74,7 @@ public class TopologyControllerTest extends RestControllerTest {
             },
             {
               "nodeId": 1,
+              "brokerId": "1",
               "host": "localhost",
               "port": 26502,
               "version": "%s",
@@ -87,6 +89,7 @@ public class TopologyControllerTest extends RestControllerTest {
             },
             {
               "nodeId": 2,
+              "brokerId": "2",
               "host": "localhost",
               "port": 26503,
               "version": "%s",
@@ -165,6 +168,7 @@ public class TopologyControllerTest extends RestControllerTest {
           "brokers": [
             {
               "nodeId": 0,
+              "brokerId": "0",
               "host": "localhost",
               "port": 26501,
               "version": "%s",

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/topology/TopologyClusterTest.java
@@ -63,6 +63,9 @@ public final class TopologyClusterTest {
 
       assertThat(brokers.size()).isEqualTo(3);
       assertThat(brokers).extracting(BrokerInfo::getNodeId).containsExactlyInAnyOrder(0, 1, 2);
+      assertThat(brokers)
+          .extracting(BrokerInfo::getMemberId)
+          .containsExactlyInAnyOrder("0", "1", "2");
     }
   }
 


### PR DESCRIPTION
## Description
The new field is required as it's introduced in 8.10. The field nodeId is also deprecated, but will remain forever.

The different semantics of uniqueness for nodeId is not a problem as it changes only for zone-aware clusters, which is not the default and the user must opt-in explicitly.

This matches what was already done in the gRPC api. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57589 
