### PR TITLE
feat: add batch suspend/resume process instances to CamundaClient

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -40,6 +40,13 @@ public interface CreateBatchOperationCommandStep1 {
   CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceSuspend();
 
   /**
+   * Defines the type of the batch operation to resume process instances.
+   *
+   * @return the builder for this command
+   */
+  CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceResume();
+
+  /**
    * Defines the type of the batch operation to delete process instances.
    *
    * @return the builder for this command

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateBatchOperationCommandStep1.java
@@ -33,6 +33,13 @@ public interface CreateBatchOperationCommandStep1 {
   CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceCancel();
 
   /**
+   * Defines the type of the batch operation to suspend process instances.
+   *
+   * @return the builder for this command
+   */
+  CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceSuspend();
+
+  /**
    * Defines the type of the batch operation to delete process instances.
    *
    * @return the builder for this command

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -49,6 +49,7 @@ import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPla
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationMoveBatchOperationInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceSuspensionBatchOperationRequest;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -140,6 +141,8 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
     switch (type) {
       case CANCEL_PROCESS_INSTANCE:
         return "/process-instances/cancellation";
+      case SUSPEND_PROCESS_INSTANCE:
+        return "/process-instances/suspension";
       case DELETE_PROCESS_INSTANCE:
         return "/process-instances/deletion";
       case DELETE_DECISION_INSTANCE:
@@ -169,6 +172,9 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
             .moveInstructions(moveInstructions);
       case CANCEL_PROCESS_INSTANCE:
         return new ProcessInstanceCancellationBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter));
+      case SUSPEND_PROCESS_INSTANCE:
+        return new ProcessInstanceSuspensionBatchOperationRequest()
             .filter(provideSearchRequestProperty(filter));
       case DELETE_PROCESS_INSTANCE:
         return new ProcessInstanceDeletionBatchOperationRequest()
@@ -267,6 +273,15 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
           httpClient,
           jsonMapper,
           BatchOperationTypeEnum.CANCEL_PROCESS_INSTANCE,
+          SearchRequestBuilders::processInstanceFilter);
+    }
+
+    @Override
+    public CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceSuspend() {
+      return new CreateBatchOperationCommandImpl<>(
+          httpClient,
+          jsonMapper,
+          BatchOperationTypeEnum.SUSPEND_PROCESS_INSTANCE,
           SearchRequestBuilders::processInstanceFilter);
     }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateBatchOperationCommandImpl.java
@@ -49,6 +49,7 @@ import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPla
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationMoveBatchOperationInstruction;
+import io.camunda.client.protocol.rest.ProcessInstanceResumptionBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceSuspensionBatchOperationRequest;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -143,6 +144,8 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
         return "/process-instances/cancellation";
       case SUSPEND_PROCESS_INSTANCE:
         return "/process-instances/suspension";
+      case RESUME_PROCESS_INSTANCE:
+        return "/process-instances/resumption";
       case DELETE_PROCESS_INSTANCE:
         return "/process-instances/deletion";
       case DELETE_DECISION_INSTANCE:
@@ -175,6 +178,9 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
             .filter(provideSearchRequestProperty(filter));
       case SUSPEND_PROCESS_INSTANCE:
         return new ProcessInstanceSuspensionBatchOperationRequest()
+            .filter(provideSearchRequestProperty(filter));
+      case RESUME_PROCESS_INSTANCE:
+        return new ProcessInstanceResumptionBatchOperationRequest()
             .filter(provideSearchRequestProperty(filter));
       case DELETE_PROCESS_INSTANCE:
         return new ProcessInstanceDeletionBatchOperationRequest()
@@ -282,6 +288,15 @@ public class CreateBatchOperationCommandImpl<E extends SearchRequestFilter>
           httpClient,
           jsonMapper,
           BatchOperationTypeEnum.SUSPEND_PROCESS_INSTANCE,
+          SearchRequestBuilders::processInstanceFilter);
+    }
+
+    @Override
+    public CreateBatchOperationCommandStep2<ProcessInstanceFilter> processInstanceResume() {
+      return new CreateBatchOperationCommandImpl<>(
+          httpClient,
+          jsonMapper,
+          BatchOperationTypeEnum.RESUME_PROCESS_INSTANCE,
           SearchRequestBuilders::processInstanceFilter);
     }
 

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -28,6 +28,7 @@ import io.camunda.client.protocol.rest.ProcessInstanceIncidentResolutionBatchOpe
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
+import io.camunda.client.protocol.rest.ProcessInstanceResumptionBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceSuspensionBatchOperationRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
@@ -130,6 +131,54 @@ public final class CreateBatchOperationTest extends ClientRestTest {
 
     final ProcessInstanceSuspensionBatchOperationRequest lastRequest =
         gatewayService.getLastRequest(ProcessInstanceSuspensionBatchOperationRequest.class);
+    assertThat(lastRequest.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
+  }
+
+  @Test
+  public void shouldSendProcessInstanceResumeCommandEmptyFilter() {
+    // given
+    gatewayService.onResumeProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .processInstanceResume()
+        .filter(filter -> {})
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/resumption");
+
+    final ProcessInstanceResumptionBatchOperationRequest lastRequest =
+        gatewayService.getLastRequest(ProcessInstanceResumptionBatchOperationRequest.class);
+    assertThat(lastRequest.getFilter()).isNotNull();
+  }
+
+  @Test
+  public void shouldSendProcessInstanceResumeCommandWithFilter() {
+    // given
+    gatewayService.onResumeProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .processInstanceResume()
+        .filter(filter -> filter.processDefinitionId("test-01"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/resumption");
+
+    final ProcessInstanceResumptionBatchOperationRequest lastRequest =
+        gatewayService.getLastRequest(ProcessInstanceResumptionBatchOperationRequest.class);
     assertThat(lastRequest.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
   }
 

--- a/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/batchoperation/CreateBatchOperationTest.java
@@ -28,6 +28,7 @@ import io.camunda.client.protocol.rest.ProcessInstanceIncidentResolutionBatchOpe
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationPlan;
 import io.camunda.client.protocol.rest.ProcessInstanceMigrationBatchOperationRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceModificationBatchOperationRequest;
+import io.camunda.client.protocol.rest.ProcessInstanceSuspensionBatchOperationRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.util.List;
@@ -81,6 +82,54 @@ public final class CreateBatchOperationTest extends ClientRestTest {
 
     final ProcessInstanceCancellationBatchOperationRequest lastRequest =
         gatewayService.getLastRequest(ProcessInstanceCancellationBatchOperationRequest.class);
+    assertThat(lastRequest.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
+  }
+
+  @Test
+  public void shouldSendProcessInstanceSuspendCommandEmptyFilter() {
+    // given
+    gatewayService.onSuspendProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .processInstanceSuspend()
+        .filter(filter -> {})
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/suspension");
+
+    final ProcessInstanceSuspensionBatchOperationRequest lastRequest =
+        gatewayService.getLastRequest(ProcessInstanceSuspensionBatchOperationRequest.class);
+    assertThat(lastRequest.getFilter()).isNotNull();
+  }
+
+  @Test
+  public void shouldSendProcessInstanceSuspendCommandWithFilter() {
+    // given
+    gatewayService.onSuspendProcessInstancesRequest(
+        Instancio.create(BatchOperationCreatedResult.class).batchOperationKey("2"));
+
+    // when
+    client
+        .newCreateBatchOperationCommand()
+        .processInstanceSuspend()
+        .filter(filter -> filter.processDefinitionId("test-01"))
+        .send()
+        .join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.POST);
+    assertThat(request.getUrl()).isEqualTo("/v2/process-instances/suspension");
+
+    final ProcessInstanceSuspensionBatchOperationRequest lastRequest =
+        gatewayService.getLastRequest(ProcessInstanceSuspensionBatchOperationRequest.class);
     assertThat(lastRequest.getFilter().getProcessDefinitionId().get$Eq()).isEqualTo("test-01");
   }
 

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -93,6 +93,8 @@ public class RestGatewayPaths {
   private static final String URL_PROCESS_INSTANCES = REST_API_PATH + "/process-instances";
   private static final String URL_PROCESS_INSTANCES_CANCELLATION =
       REST_API_PATH + "/process-instances/cancellation";
+  private static final String URL_PROCESS_INSTANCES_SUSPENSION =
+      REST_API_PATH + "/process-instances/suspension";
   private static final String URL_PROCESS_INSTANCES_DELETION =
       REST_API_PATH + "/process-instances/deletion";
   private static final String URL_PROCESS_INSTANCES_INCIDENT_RESOLUTION =
@@ -337,6 +339,10 @@ public class RestGatewayPaths {
 
   public static String getProcessInstancesCancelUrl() {
     return URL_PROCESS_INSTANCES_CANCELLATION;
+  }
+
+  public static String getProcessInstancesSuspendUrl() {
+    return URL_PROCESS_INSTANCES_SUSPENSION;
   }
 
   public static String getProcessInstancesDeletionUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -95,6 +95,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/process-instances/cancellation";
   private static final String URL_PROCESS_INSTANCES_SUSPENSION =
       REST_API_PATH + "/process-instances/suspension";
+  private static final String URL_PROCESS_INSTANCES_RESUMPTION =
+      REST_API_PATH + "/process-instances/resumption";
   private static final String URL_PROCESS_INSTANCES_DELETION =
       REST_API_PATH + "/process-instances/deletion";
   private static final String URL_PROCESS_INSTANCES_INCIDENT_RESOLUTION =
@@ -343,6 +345,10 @@ public class RestGatewayPaths {
 
   public static String getProcessInstancesSuspendUrl() {
     return URL_PROCESS_INSTANCES_SUSPENSION;
+  }
+
+  public static String getProcessInstancesResumeUrl() {
+    return URL_PROCESS_INSTANCES_RESUMPTION;
   }
 
   public static String getProcessInstancesDeletionUrl() {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -291,6 +291,10 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getProcessInstancesCancelUrl(), response);
   }
 
+  public void onSuspendProcessInstancesRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesSuspendUrl(), response);
+  }
+
   public void onDeleteProcessInstanceRequest(
       final long processInstanceKey, final BatchOperationCreatedResult response) {
     registerPost(RestGatewayPaths.getDeleteProcessInstanceUrl(processInstanceKey), response);

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -295,6 +295,10 @@ public class RestGatewayService {
     registerPost(RestGatewayPaths.getProcessInstancesSuspendUrl(), response);
   }
 
+  public void onResumeProcessInstancesRequest(final BatchOperationCreatedResult response) {
+    registerPost(RestGatewayPaths.getProcessInstancesResumeUrl(), response);
+  }
+
   public void onDeleteProcessInstanceRequest(
       final long processInstanceKey, final BatchOperationCreatedResult response) {
     registerPost(RestGatewayPaths.getDeleteProcessInstanceUrl(processInstanceKey), response);


### PR DESCRIPTION
## Description

Adds `processInstanceSuspend()` and `processInstanceResume()` batch-operation methods to the Java `CamundaClient`'s fluent `newCreateBatchOperationCommand()` API, for Java client parity with the existing batch suspend/resume REST endpoints (`POST /process-instances/suspension`, `POST /process-instances/resumption`).

Both are new cases wired into the existing generic `CreateBatchOperationCommandImpl` mechanism, mirroring the existing `processInstanceCancel()` case exactly (same fluent-API shape, same `getUrl()`/`getBody()` switch pattern). The OpenAPI contract and generated Java request/response models for these two endpoints already existed (#57648); this PR only adds the client SDK wiring, per the issue's scope.

Not in scope: server-side REST controller wiring for the batch suspension/resumption endpoints (not yet implemented) and exposing `operationReference` (no sibling batch command exposes it either).

## Checklist

- [x] Enable backports when necessary — not applicable, this is a new feature, not a bug fix.
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR. — not applicable, this PR does not touch that suite.

## Related issues

closes #57542