### PR TITLE
AgentInstance CREATE: surface 409 conflict response and document idempotency contract

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -240,23 +240,31 @@ class AgentInstanceAuthorizationIT {
   }
 
   @Test
-  void createShouldReturnExistingKeyWhenAlreadyExistsForAuthorizedUser(
+  void createShouldReturn409WhenAlreadyExistsForAuthorizedUser(
       @Authenticated(USER3) final CamundaClient camundaClient) {
     // given — user3 has UPDATE_PROCESS_INSTANCE on PROCESS_ID_3, and an agent instance was
     // already created for elementInstanceKey3 by admin in setUp
 
-    // when
-    final var response =
-        camundaClient
-            .newCreateAgentInstanceCommand()
-            .elementInstanceKey(elementInstanceKey3)
-            .model("gpt-4o")
-            .provider("openai")
-            .systemPrompt("You are a helpful assistant.")
-            .execute();
+    // when — duplicate CREATE for the same element instance
+    final var exception =
+        assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    camundaClient
+                        .newCreateAgentInstanceCommand()
+                        .elementInstanceKey(elementInstanceKey3)
+                        .model("gpt-4o")
+                        .provider("openai")
+                        .systemPrompt("You are a helpful assistant.")
+                        .execute())
+            .actual();
 
-    // then — idempotent CREATE returns the existing key
-    assertThat(response.getAgentInstanceKey()).isEqualTo(agentInstanceKey3);
+    // then — 409 Conflict with ALREADY_EXISTS regardless of payload
+    assertThat(exception.details().getStatus()).isEqualTo(409);
+    assertThat(exception.details().getTitle()).isEqualTo("ALREADY_EXISTS");
+    assertThat(exception.details().getDetail())
+        .contains(String.valueOf(elementInstanceKey3))
+        .contains(String.valueOf(agentInstanceKey3));
   }
 
   // ── update ────────────────────────────────────────────────────────────────

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -50,7 +49,6 @@ public final class AgentInstanceCreateProcessor
   private final TypedRejectionWriter rejectionWriter;
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
-  private final AgentInstanceState agentInstanceState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
 
@@ -64,7 +62,6 @@ public final class AgentInstanceCreateProcessor
     rejectionWriter = writers.rejection();
     elementInstanceState = processingState.getElementInstanceState();
     processState = processingState.getProcessState();
-    agentInstanceState = processingState.getAgentInstanceState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
   }
@@ -99,28 +96,18 @@ public final class AgentInstanceCreateProcessor
       return;
     }
 
-    // Idempotent CREATE: if an agent instance already exists, return the existing one to the
-    // client (the public API has no 409). Reject on the stream to suppress a duplicate CREATED
-    // event, but respond with the existing record so the client sees the same result as the
-    // original CREATE. This check runs before the active-state and element-type guards so that a
-    // late retry against an element instance that has since left ACTIVE (e.g. parked in
-    // COMPLETING behind an incident) still returns the existing record rather than INVALID_STATE.
+    // Reject CREATE when an agent instance already exists for this element instance. The existence
+    // check runs before the active-state and element-type guards so that a late retry against an
+    // element instance that has since left ACTIVE (e.g. parked in COMPLETING behind an incident)
+    // gets ALREADY_EXISTS rather than INVALID_STATE. Both the stream rejection and the HTTP
+    // response are consistent: no success event is emitted.
     final var existingAgentInstanceKey = elementInstance.getAgentInstanceKey();
     if (existingAgentInstanceKey != -1L) {
-      final var existingRecord = agentInstanceState.getRecord(existingAgentInstanceKey);
-      // The stored record carries the changedAttributes from the last UPDATE that touched it. On
-      // CREATED that field is contractually empty (see
-      // AgentInstanceRecordValue#getChangedAttributes),
-      // so strip it before responding. getRecord returns a fresh deserialization, so this mutation
-      // does not leak back into state.
-      existingRecord.setChangedAttributes(List.of());
-      rejectionWriter.appendRejection(
+      writeRejection(
           command,
           RejectionType.ALREADY_EXISTS,
           ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS.formatted(
               elementInstanceKey, existingAgentInstanceKey));
-      responseWriter.writeAcceptedResponseOnCommand(
-          existingAgentInstanceKey, AgentInstanceIntent.CREATED, existingRecord, command);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -31,6 +31,9 @@ import java.util.List;
 public final class AgentInstanceCreateProcessor
     implements TypedRecordProcessor<AgentInstanceRecord> {
 
+  // CAUTION: callers may parse this message to extract the existing agentInstanceKey from the
+  // second '%d'. Wording changes that alter the position of the numeric values are a breaking
+  // contract change — update connector-side parsing logic in sync.
   private static final String ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS =
       "Expected to associate element instance with key '%d' with an agent instance, but it is already associated with agent instance with key '%d'.";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateTest.java
@@ -402,10 +402,9 @@ public class AgentInstanceCreateTest {
   }
 
   @Test
-  public void shouldTreatSecondCreateForSameElementInstanceAsIdempotentSuccess() {
-    // given -- only one agent instance can exist per element instance; the public API has no 409.
-    // The engine short-circuits a second CREATE: a rejection lands on the stream (suppressing a
-    // second CREATED event), and the client response carries the existing record.
+  public void shouldRejectDuplicateCreateWithAlreadyExistsOnStream() {
+    // given -- only one agent instance can exist per element instance. A second CREATE is always
+    // rejected with ALREADY_EXISTS on the stream.
     ENGINE
         .deployment()
         .withXmlResource(
@@ -495,7 +494,7 @@ public class AgentInstanceCreateTest {
   }
 
   @Test
-  public void shouldReturnExistingRecordForRetryAfterElementInstanceLeftActive() {
+  public void shouldRejectDuplicateCreateWithAlreadyExistsEvenWhenElementInstanceLeftActive() {
     // given -- an element instance that successfully got an agent created, then transitioned out
     // of ACTIVE (parked in COMPLETING behind an incident from a faulty output expression). The
     // element instance still exists in state and carries the back-link to the agent instance.
@@ -529,9 +528,8 @@ public class AgentInstanceCreateTest {
             .expectRejection()
             .create();
 
-    // then -- the retry is short-circuited as an idempotent success against the existing record,
-    // not rejected as INVALID_STATE. The stream still carries ALREADY_EXISTS to suppress a
-    // duplicate CREATED event.
+    // then -- the stream rejection is ALREADY_EXISTS, not INVALID_STATE: the existence check
+    // precedes the active-state guard, so a late retry is not misidentified as an invalid state.
     assertThat(retryRejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
     assertThat(retryRejection.getRejectionType()).isEqualTo(RejectionType.ALREADY_EXISTS);
     assertThat(retryRejection.getRejectionReason())

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -43,6 +43,12 @@ paths:
             application/problem+json:
               schema:
                 $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
+        "409":
+          description: An agent instance already exists for the given element instance.
+          content:
+            application/problem+json:
+              schema:
+                $ref: 'problem-detail.yaml#/components/schemas/ProblemDetail'
         "500":
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
         "503":

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -18,10 +18,14 @@ import static org.mockito.Mockito.when;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.AgentHistoryServices;
 import io.camunda.service.AgentInstanceServices;
+import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -33,6 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -160,6 +165,65 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getLimits().getMaxToolCalls()).isEqualTo(50);
                 }),
             any());
+  }
+
+  @Test
+  void shouldReturn409WhenAgentInstanceAlreadyExistsForElementInstance() {
+    // given -- service layer signals ALREADY_EXISTS (e.g. duplicate CREATE from the engine).
+    final var rejectionReason =
+        "Expected to associate element instance with key '%d' with an agent instance,"
+            + " but it is already associated with agent instance with key '%d'."
+                .formatted(ELEMENT_INSTANCE_KEY, AGENT_INSTANCE_KEY);
+    final var expectedDetail =
+        "Command 'CREATE' rejected with code 'ALREADY_EXISTS': " + rejectionReason;
+    when(agentInstanceServices.createAgentInstance(any(AgentInstanceRecord.class), any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                ErrorMapper.mapBrokerRejection(
+                    new BrokerRejection(
+                        AgentInstanceIntent.CREATE,
+                        ELEMENT_INSTANCE_KEY,
+                        RejectionType.ALREADY_EXISTS,
+                        rejectionReason))));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "definition": {
+            "model": "gpt-4o",
+            "provider": "openai",
+            "systemPrompt": "You are a helpful assistant."
+          }
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "ALREADY_EXISTS",
+              "status": 409,
+              "detail": "%s",
+              "instance": "/v2/agent-instances"
+            }
+            """
+                .formatted(expectedDetail),
+            JsonCompareMode.STRICT);
   }
 
   @ParameterizedTest(name = "[{index}] {0}")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.it.engine.client.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
@@ -50,22 +49,24 @@ public final class CreateAgentInstanceTest {
     // yields 503 UNAVAILABLE (PartitionNotFoundException).
     final long elementInstanceKey = Protocol.encodePartitionId(999, 1);
 
-    // when
-    final var responseFuture =
-        client
-            .newCreateAgentInstanceCommand()
-            .elementInstanceKey(elementInstanceKey)
-            .model("test-model")
-            .provider("test-provider")
-            .systemPrompt("You are a helpful assistant.")
-            .send();
+    // when / then
+    final var exception =
+        AssertionsForClassTypes.assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    client
+                        .newCreateAgentInstanceCommand()
+                        .elementInstanceKey(elementInstanceKey)
+                        .model("test-model")
+                        .provider("test-provider")
+                        .systemPrompt("You are a helpful assistant.")
+                        .execute())
+            .actual();
 
-    // then
-    assertThatThrownBy(responseFuture::join)
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("title: UNAVAILABLE")
-        .hasMessageContaining("status: 503")
-        .hasMessageContaining("Expected to handle request, but request could not be delivered");
+    assertThat(exception.details().getStatus()).isEqualTo(HttpStatus.SC_SERVICE_UNAVAILABLE);
+    assertThat(exception.details().getTitle()).isEqualTo("UNAVAILABLE");
+    assertThat(exception.details().getDetail())
+        .contains("Expected to handle request, but request could not be delivered");
   }
 
   @Test
@@ -74,22 +75,24 @@ public final class CreateAgentInstanceTest {
     final int partition = resourcesHelper.getPartitions().getFirst();
     final long nonExistingKey = Protocol.encodePartitionId(partition, 2);
 
-    // when
-    final var responseFuture =
-        client
-            .newCreateAgentInstanceCommand()
-            .elementInstanceKey(nonExistingKey)
-            .model("test-model")
-            .provider("test-provider")
-            .systemPrompt("You are a helpful assistant.")
-            .send();
+    // when / then
+    final var exception =
+        AssertionsForClassTypes.assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    client
+                        .newCreateAgentInstanceCommand()
+                        .elementInstanceKey(nonExistingKey)
+                        .model("test-model")
+                        .provider("test-provider")
+                        .systemPrompt("You are a helpful assistant.")
+                        .execute())
+            .actual();
 
-    // then
-    assertThatThrownBy(responseFuture::join)
-        .isInstanceOf(ProblemException.class)
-        .hasMessageContaining("title: NOT_FOUND")
-        .hasMessageContaining("status: 404")
-        .hasMessageContaining(
+    assertThat(exception.details().getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+    assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
+    assertThat(exception.details().getDetail())
+        .contains(
             "Expected to create agent instance for element instance with key '%d', but no such element instance was found."
                 .formatted(nonExistingKey));
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CreateAgentInstanceTest.java
@@ -7,16 +7,22 @@
  */
 package io.camunda.zeebe.it.engine.client.command;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import org.apache.hc.core5.http.HttpStatus;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,5 +92,60 @@ public final class CreateAgentInstanceTest {
         .hasMessageContaining(
             "Expected to create agent instance for element instance with key '%d', but no such element instance was found."
                 .formatted(nonExistingKey));
+  }
+
+  @Test
+  public void shouldReturn409ConflictWhenAgentInstanceAlreadyExistsForElementInstance() {
+    // given - a service task that stays active until a job is completed, giving us a stable
+    // elementInstanceKey to use for both CREATE attempts.
+    final long processDefinitionKey =
+        resourcesHelper.deployProcess(
+            Bpmn.createExecutableProcess("conflict-test-process")
+                .startEvent()
+                .serviceTask("service-task", t -> t.zeebeJobType("agent-conflict-job"))
+                .endEvent()
+                .done());
+    resourcesHelper.createProcessInstance(processDefinitionKey);
+    final long elementInstanceKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withType("agent-conflict-job")
+            .getFirst()
+            .getValue()
+            .getElementInstanceKey();
+
+    // first CREATE — must succeed and return the new agentInstanceKey.
+    final var firstResult =
+        client
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("test-model")
+            .provider("test-provider")
+            .systemPrompt("You are a helpful assistant.")
+            .execute();
+
+    // when - second CREATE for the same element instance (different payload to rule out
+    // accidental pass-through).
+    final var exception =
+        AssertionsForClassTypes.assertThatExceptionOfType(ProblemException.class)
+            .isThrownBy(
+                () ->
+                    client
+                        .newCreateAgentInstanceCommand()
+                        .elementInstanceKey(elementInstanceKey)
+                        .model("different-model")
+                        .provider("test-provider")
+                        .systemPrompt("A different system prompt.")
+                        .execute())
+            .actual();
+
+    // then - 409 Conflict with ALREADY_EXISTS and the full detail message embedding the
+    // existing agentInstanceKey.
+    assertThat(exception.details().getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+    assertThat(exception.details().getTitle()).isEqualTo("ALREADY_EXISTS");
+    assertThat(exception.details().getDetail())
+        .startsWith("Command 'CREATE' rejected with code 'ALREADY_EXISTS':")
+        .endsWith(
+            "Expected to associate element instance with key '%d' with an agent instance, but it is already associated with agent instance with key '%d'."
+                .formatted(elementInstanceKey, firstResult.getAgentInstanceKey()));
   }
 }


### PR DESCRIPTION
## Description

`AgentInstance.CREATE` is now **strict**: a second `CREATE` for the same `elementInstanceKey` always returns `409 Conflict` (rejection type `ALREADY_EXISTS`), regardless of the payload.

### Why

Previously, `AgentInstanceCreateProcessor` wrote `ALREADY_EXISTS` to the stream but simultaneously called `responseWriter.writeEventOnCommand(CREATED, existingRecord)`, so the HTTP client received `200 OK` with the original record — silently discarding the new payload. A caller that sent a different `systemPrompt` or model saw a successful response, but the engine had kept the original record unchanged. Surfacing the conflict as `409` gives callers an unambiguous signal that their request was not applied.

Decision: Option B from the [#53421](https://github.com/camunda/camunda/issues/53421#issuecomment-4958066971) sync (always reject on existence, regardless of payload).

### Client recovery

On `409`, callers have two options to retrieve the existing `agentInstanceKey`:

1. **Parse the `detail` string directly** (zero extra roundtrips).
The rejection detail has the format:
```
Command 'CREATE' rejected with code 'ALREADY_EXISTS': Expected to associate element
instance with key '<elementInstanceKey>' with an agent instance, but it is already
associated with agent instance with key '<existingAgentInstanceKey>'.
```
Extract `<existingAgentInstanceKey>` from the embedded message and proceed.

2. **Search via the [Search agent instances](https://docs.camunda.io/docs/next/apis-tools/orchestration-cluster-api-rest/specifications/search-agent-instances/) endpoint** using the `elementInstanceKeys` filter. Note: due to eventual consistency, the result may not immediately reflect the latest state — retry the search with backoff if the result is empty.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57575
