### PR TITLE
feat: store secret references on job record during creation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -443,7 +443,7 @@ public final class BpmnJobBehavior {
         JobKind.AD_HOC_SUB_PROCESS,
         JobListenerEventType.UNSPECIFIED,
         element.getJobWorkerProperties().getTaskHeaders(),
-        Map.of());
+        element.getSecretReferences());
   }
 
   private Either<Failure, JobProperties> evaluateTaskListenerJobExpressions(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJob
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.deployment.model.element.JobWorkerProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.element.LinkedResource;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -109,6 +110,7 @@ public final class BpmnJobBehavior {
   private static final Set<State> CANCELABLE_STATES =
       EnumSet.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
   private final JobRecord jobRecord = new JobRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
   private final HeaderEncoder headerEncoder = new HeaderEncoder(LOGGER);
   private final KeyGenerator keyGenerator;
@@ -392,7 +394,8 @@ public final class BpmnJobBehavior {
         jobProperties,
         JobKind.BPMN_ELEMENT,
         JobListenerEventType.UNSPECIFIED,
-        element.getJobWorkerProperties().getTaskHeaders());
+        element.getJobWorkerProperties().getTaskHeaders(),
+        element.getSecretReferences());
   }
 
   public void createNewExecutionListenerJob(
@@ -407,7 +410,8 @@ public final class BpmnJobBehavior {
         jobProperties,
         JobKind.EXECUTION_LISTENER,
         jobListenerEventType,
-        executionListener.getJobWorkerProperties().getTaskHeaders());
+        executionListener.getJobWorkerProperties().getTaskHeaders(),
+        Map.of());
   }
 
   public void createNewTaskListenerJob(
@@ -424,7 +428,8 @@ public final class BpmnJobBehavior {
                     JobKind.TASK_LISTENER,
                     fromTaskListenerEventType(listener.getEventType()),
                     extractUserTaskHeaders(
-                        taskRecordValue, changedAttributes, listener.getJobWorkerProperties())))
+                        taskRecordValue, changedAttributes, listener.getJobWorkerProperties()),
+                    Map.of()))
         .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
   }
 
@@ -437,7 +442,8 @@ public final class BpmnJobBehavior {
         jobProperties,
         JobKind.AD_HOC_SUB_PROCESS,
         JobListenerEventType.UNSPECIFIED,
-        element.getJobWorkerProperties().getTaskHeaders());
+        element.getJobWorkerProperties().getTaskHeaders(),
+        Map.of());
   }
 
   private Either<Failure, JobProperties> evaluateTaskListenerJobExpressions(
@@ -596,7 +602,8 @@ public final class BpmnJobBehavior {
       final JobProperties props,
       final JobKind jobKind,
       final JobListenerEventType jobListenerEventType,
-      final Map<String, String> taskHeaders) {
+      final Map<String, String> taskHeaders,
+      final Map<String, Set<SecretReference>> secretReferences) {
 
     final var encodedHeaders = encodeHeaders(taskHeaders, props);
 
@@ -618,11 +625,21 @@ public final class BpmnJobBehavior {
         .setPriority(props.getPriority())
         .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
         .setBusinessId(getBusinessIdFromProcessInstance(context));
+    setJobSecretReferences(secretReferences);
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
     jobActivationBehavior.publishWork(jobKey, jobRecord);
     jobMetrics.countJobEvent(JobAction.CREATED, jobKind, props.getType());
+  }
+
+  private void setJobSecretReferences(final Map<String, Set<SecretReference>> secretReferences) {
+    // the shared jobRecord is reused across job creations, so reset before populating
+    jobRecord.resetSecretReferences();
+    secretReferences.forEach(
+        (path, secrets) ->
+            secrets.forEach(
+                secret -> jobRecord.addSecretReference(secret.storeId(), secret.name(), path)));
   }
 
   private BpmnElementType getBpmnElementTypeForLogging(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableJobWorkerElement.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableJobWorkerElement.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
+import java.util.Map;
+import java.util.Set;
+
 /**
  * A representation of an element that is based on a job and should be processed by a job worker.
  * For example, a service task.
@@ -16,4 +19,12 @@ public interface ExecutableJobWorkerElement extends ExecutableFlowElement {
   JobWorkerProperties getJobWorkerProperties();
 
   void setJobWorkerProperties(JobWorkerProperties jobWorkerProperties);
+
+  /**
+   * Returns the input-mapping secret references detected at deploy time, keyed by the JSON pointer
+   * (RFC 6901) where each secret is injected. Every job-worker element is a flow node, so this
+   * mirrors {@link ExecutableFlowNode#getSecretReferences()}. Empty when no input mapping
+   * references a secret.
+   */
+  Map<String, Set<SecretReference>> getSecretReferences();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -42,13 +42,21 @@ import scala.jdk.javaapi.CollectionConverters;
  * camunda.secrets.token} else null}) is reported at the enclosing path, not the inner {@code x}.
  */
 @NullMarked
-public record SecretReference(String name) {
+public record SecretReference(String storeId, String name) {
 
   private static final String ROOT = "camunda";
   private static final String NAMESPACE = "secrets";
 
   /** Segments a {@code camunda.secrets.<name>} reference has: root, namespace and name. */
   private static final int REFERENCE_SEGMENT_COUNT = 3;
+
+  /**
+   * Creates a reference with no store id. The {@code camunda.secrets.<name>} syntax carries no
+   * store dimension, so the store is left empty until store selection is wired to the engine.
+   */
+  public SecretReference(final String name) {
+    this("", name);
+  }
 
   /**
    * Parses the secret references used as expressions in a mapping source, each with the FEEL

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -52,7 +52,9 @@ public record SecretReference(String storeId, String name) {
 
   /**
    * Creates a reference with no store id. The {@code camunda.secrets.<name>} syntax carries no
-   * store dimension, so the store is left empty until store selection is wired to the engine.
+   * store dimension, so the store is left empty until store selection is wired to the engine
+   * (tracked under the Secret Resolution epic, <a
+   * href="https://github.com/camunda/camunda/issues/56563">#56563</a>).
    */
   public SecretReference(final String name) {
     this("", name);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobSecretReferenceValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JobSecretReferenceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldStoreSecretReferenceOnJobCreation() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithServiceTask(
+                t ->
+                    t.zeebeInputExpression(
+                        "\"Bearer \" + camunda.secrets.token", "tokens.externalSystemToken")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getSecretReferences())
+        .extracting(
+            JobSecretReferenceValue::getStoreId,
+            JobSecretReferenceValue::getSecretReference,
+            JobSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", "/tokens/externalSystemToken"));
+  }
+
+  @Test
+  public void shouldStoreMultipleSecretReferencesForSingleInputMapping() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithServiceTask(
+                t ->
+                    t.zeebeInputExpression(
+                        "\"Bearer \" + camunda.secrets.token + camunda.secrets.postfix",
+                        "tokens.externalSystemToken")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getSecretReferences())
+        .extracting(
+            JobSecretReferenceValue::getStoreId,
+            JobSecretReferenceValue::getSecretReference,
+            JobSecretReferenceValue::getPath)
+        .containsExactlyInAnyOrder(
+            tuple("", "token", "/tokens/externalSystemToken"),
+            tuple("", "postfix", "/tokens/externalSystemToken"));
+  }
+
+  @Test
+  public void shouldStoreSecretReferencesFromMultipleInputMappings() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithServiceTask(
+                t ->
+                    t.zeebeInputExpression("camunda.secrets.token", "auth.token")
+                        .zeebeInputExpression("camunda.secrets.apiKey", "auth.key")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getSecretReferences())
+        .extracting(
+            JobSecretReferenceValue::getStoreId,
+            JobSecretReferenceValue::getSecretReference,
+            JobSecretReferenceValue::getPath)
+        .containsExactlyInAnyOrder(
+            tuple("", "token", "/auth/token"), tuple("", "apiKey", "/auth/key"));
+  }
+
+  @Test
+  public void shouldHaveNoSecretReferencesWhenTaskReferencesNone() {
+    // given
+    ENGINE.deployment().withXmlResource(processWithServiceTask(t -> {})).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getSecretReferences()).isEmpty();
+  }
+
+  @Test
+  public void shouldCarrySecretReferencesOnJobActivation() {
+    // given unique ids so only this test's job is activatable on the shared engine
+    final String processId = "process-activation";
+    final String jobType = "task-type-activation";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    TASK_ID,
+                    t ->
+                        t.zeebeJobType(jobType)
+                            .zeebeInputExpression("camunda.secrets.token", "auth.token"))
+                .endEvent()
+                .done())
+        .deploy();
+    ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    final var activatedJobs = ENGINE.jobs().withType(jobType).activate().getValue().getJobs();
+
+    // then
+    assertThat(activatedJobs).hasSize(1);
+    assertThat(activatedJobs.getFirst().getSecretReferences())
+        .extracting(
+            JobSecretReferenceValue::getStoreId,
+            JobSecretReferenceValue::getSecretReference,
+            JobSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", "/auth/token"));
+  }
+
+  @Test
+  public void shouldNotStoreSecretReferencesOnExecutionListenerJob() {
+    // given the service task references a secret and has a start execution listener
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithServiceTask(
+                t ->
+                    t.zeebeInputExpression("camunda.secrets.token", "auth.token")
+                        .zeebeExecutionListener(el -> el.start().type("start-listener"))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then the execution listener job does not inherit the element's secret references
+    final Record<JobRecordValue> listenerJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withJobKind(JobKind.EXECUTION_LISTENER)
+            .getFirst();
+
+    assertThat(listenerJob.getValue().getSecretReferences()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotStoreSecretReferencesOnTaskListenerJob() {
+    // given the user task references a secret and has a creating task listener
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithUserTask(
+                t ->
+                    t.zeebeUserTask()
+                        .zeebeInputExpression("camunda.secrets.token", "auth.token")
+                        .zeebeTaskListener(l -> l.creating().type("creating-listener"))))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then the task listener job does not inherit the element's secret references
+    final Record<JobRecordValue> listenerJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withJobKind(JobKind.TASK_LISTENER)
+            .getFirst();
+
+    assertThat(listenerJob.getValue().getSecretReferences()).isEmpty();
+  }
+
+  private static BpmnModelInstance processWithServiceTask(
+      final Consumer<io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask(
+            TASK_ID,
+            t -> {
+              t.zeebeJobType(JOB_TYPE);
+              modifier.accept(t);
+            })
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance processWithUserTask(
+      final Consumer<io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .userTask(TASK_ID, modifier)
+        .endEvent()
+        .done();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
@@ -229,6 +229,45 @@ public final class JobSecretReferenceTest {
     assertThat(listenerJob.getValue().getSecretReferences()).isEmpty();
   }
 
+  @Test
+  public void shouldStoreSecretReferenceOnAdHocSubProcessJob() {
+    // given a job-based ad-hoc sub-process that references a secret in its input mapping
+    final String processId = "process-ahsp";
+    final String jobType = "ahsp-type";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .adHocSubProcess(
+                    TASK_ID,
+                    ahsp -> {
+                      ahsp.task("inner");
+                      ahsp.zeebeInputExpression("camunda.secrets.token", "auth.token");
+                    })
+                .zeebeJobType(jobType)
+                .endEvent()
+                .done())
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withJobKind(JobKind.AD_HOC_SUB_PROCESS)
+            .getFirst();
+
+    assertThat(jobCreated.getValue().getSecretReferences())
+        .extracting(
+            JobSecretReferenceValue::getStoreId,
+            JobSecretReferenceValue::getSecretReference,
+            JobSecretReferenceValue::getPath)
+        .containsExactly(tuple("", "token", "/auth/token"));
+  }
+
   private static BpmnModelInstance processWithServiceTask(
       final Consumer<io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder> modifier) {
     return Bpmn.createExecutableProcess(PROCESS_ID)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -63,6 +63,7 @@ final class BulkIndexRequest {
   private static final String ELEMENT_TYPE_PROPERTY = "elementType";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
+  private static final String SECRET_REFERENCES_PROPERTY = "secretReferences";
   private static final String WITH_LEASE_PROPERTY = "withLease";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
@@ -187,7 +188,8 @@ final class BulkIndexRequest {
     PRIORITY_PROPERTY,
     ELEMENT_TYPE_PROPERTY,
     BUSINESS_ID_PROPERTY,
-    LEASE_TOKEN_PROPERTY
+    LEASE_TOKEN_PROPERTY,
+    SECRET_REFERENCES_PROPERTY
   })
   private static final class JobMixin {}
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
@@ -175,6 +175,19 @@
                 },
                 "leaseToken": {
                   "type": "keyword"
+                },
+                "secretReferences": {
+                  "properties": {
+                    "storeId": {
+                      "type": "keyword"
+                    },
+                    "secretReference": {
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
@@ -156,6 +156,19 @@
             },
             "leaseToken": {
               "type": "keyword"
+            },
+            "secretReferences": {
+              "properties": {
+                "storeId": {
+                  "type": "keyword"
+                },
+                "secretReference": {
+                  "type": "keyword"
+                },
+                "path": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -555,6 +555,64 @@ final class BulkIndexRequestTest {
     }
 
     @Test
+    void shouldIndexJobRecordWithoutSecretReferencesOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobRecord().addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that job records are NOT serialized with secretReferences on previous version")
+          .allSatisfy(
+              value ->
+                  assertThat((Map<String, Object>) value).doesNotContainKey("secretReferences"));
+    }
+
+    @Test
+    void shouldIndexJobRecordWithSecretReferencesOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord().addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("secretReferences"))
+          .describedAs(
+              "Expect that job records are serialized with secretReferences on current version")
+          .containsExactly(
+              List.of(
+                  Map.of(
+                      "storeId", "store", "secretReference", "secret", "path", "/customHeaders")));
+    }
+
+    @Test
     void shouldIndexJobBatchRecordWithoutWithLeaseOnPreviousVersion() {
       // given
       final var record =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -63,6 +63,7 @@ final class BulkIndexRequest {
   private static final String ELEMENT_TYPE_PROPERTY = "elementType";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
+  private static final String SECRET_REFERENCES_PROPERTY = "secretReferences";
   private static final String WITH_LEASE_PROPERTY = "withLease";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
@@ -187,7 +188,8 @@ final class BulkIndexRequest {
     PRIORITY_PROPERTY,
     ELEMENT_TYPE_PROPERTY,
     BUSINESS_ID_PROPERTY,
-    LEASE_TOKEN_PROPERTY
+    LEASE_TOKEN_PROPERTY,
+    SECRET_REFERENCES_PROPERTY
   })
   private static final class JobMixin {}
 

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
@@ -181,6 +181,19 @@
                 },
                 "leaseToken": {
                   "type": "keyword"
+                },
+                "secretReferences": {
+                  "properties": {
+                    "storeId": {
+                      "type": "keyword"
+                    },
+                    "secretReference": {
+                      "type": "keyword"
+                    },
+                    "path": {
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
@@ -162,6 +162,19 @@
             },
             "leaseToken": {
               "type": "keyword"
+            },
+            "secretReferences": {
+              "properties": {
+                "storeId": {
+                  "type": "keyword"
+                },
+                "secretReference": {
+                  "type": "keyword"
+                },
+                "path": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -568,6 +568,64 @@ final class BulkIndexRequestTest {
     }
 
     @Test
+    void shouldIndexJobRecordWithoutSecretReferencesOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(
+                          new JobRecord().addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that job records are NOT serialized with secretReferences on previous version")
+          .allSatisfy(
+              value ->
+                  assertThat((Map<String, Object>) value).doesNotContainKey("secretReferences"));
+    }
+
+    @Test
+    void shouldIndexJobRecordWithSecretReferencesOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(
+                          new JobRecord().addSecretReference("store", "secret", "/customHeaders")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("secretReferences"))
+          .describedAs(
+              "Expect that job records are serialized with secretReferences on current version")
+          .containsExactly(
+              List.of(
+                  Map.of(
+                      "storeId", "store", "secretReference", "secret", "path", "/customHeaders")));
+    }
+
+    @Test
     void shouldIndexJobBatchRecordWithoutWithLeaseOnPreviousVersion() throws IOException {
       // given
       final var record =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -421,7 +421,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .toList();
   }
 
-  public JobRecord setSecretReferences(final List<JobSecretReferenceValue> secretReferences) {
+  public JobRecord setSecretReferences(
+      final List<? extends JobSecretReferenceValue> secretReferences) {
     secretReferencesProp.reset();
     if (secretReferences != null) {
       secretReferences.forEach(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -29,8 +29,10 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobSecretReferenceValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -100,6 +102,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private static final StringValue LEASE_TOKEN_KEY = new StringValue("leaseToken");
+  private static final StringValue SECRET_REFERENCES_KEY = new StringValue("secretReferences");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -148,9 +151,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
   private final StringProperty leaseTokenProp = new StringProperty(LEASE_TOKEN_KEY, EMPTY_STRING);
+  private final ArrayProperty<JobSecretReference> secretReferencesProp =
+      new ArrayProperty<>(SECRET_REFERENCES_KEY, JobSecretReference::new);
 
   public JobRecord() {
-    super(28);
+    super(30);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -179,7 +184,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(priorityProp)
         .declareProperty(businessIdProp)
-        .declareProperty(leaseTokenProp);
+        .declareProperty(leaseTokenProp)
+        .declareProperty(secretReferencesProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -213,6 +219,15 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     priorityProp.setValue(record.getPriority());
     businessIdProp.setValue(record.getBusinessIdBuffer());
     leaseTokenProp.setValue(record.getLeaseTokenBuffer());
+    copySecretReferencesFrom(record);
+  }
+
+  private void copySecretReferencesFrom(final JobRecord record) {
+    // same-class buffer copy avoids the String round-trip of
+    // setSecretReferences(getSecretReferences())
+    secretReferencesProp.reset();
+    record.secretReferencesProp.forEach(
+        reference -> secretReferencesProp.add().copyFrom(reference));
   }
 
   public void wrap(final JobRecord record) {
@@ -390,6 +405,45 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     if (tags != null) {
       tags.forEach(tag -> tagsProp.add().wrap(BufferUtil.wrapString(tag)));
     }
+    return this;
+  }
+
+  @Override
+  public List<JobSecretReferenceValue> getSecretReferences() {
+    // copy each element while iterating the ArrayProperty because the inner values are reused
+    return secretReferencesProp.stream()
+        .map(
+            element -> {
+              final var copy = new JobSecretReference();
+              copy.copy(element);
+              return (JobSecretReferenceValue) copy;
+            })
+        .toList();
+  }
+
+  public JobRecord setSecretReferences(final List<JobSecretReferenceValue> secretReferences) {
+    secretReferencesProp.reset();
+    if (secretReferences != null) {
+      secretReferences.forEach(
+          reference ->
+              addSecretReference(
+                  reference.getStoreId(), reference.getSecretReference(), reference.getPath()));
+    }
+    return this;
+  }
+
+  public JobRecord addSecretReference(
+      final String storeId, final String secretReference, final String path) {
+    secretReferencesProp
+        .add()
+        .setStoreId(storeId)
+        .setSecretReference(secretReference)
+        .setPath(path);
+    return this;
+  }
+
+  public JobRecord resetSecretReferences() {
+    secretReferencesProp.reset();
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobSecretReference.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobSecretReferenceValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; they have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
+})
+public final class JobSecretReference extends ObjectValue implements JobSecretReferenceValue {
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue STORE_ID_KEY = new StringValue("storeId");
+  private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
+  private static final StringValue PATH_KEY = new StringValue("path");
+
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+  private final StringProperty pathProp = new StringProperty(PATH_KEY, "");
+
+  public JobSecretReference() {
+    super(3);
+    declareProperty(storeIdProp).declareProperty(secretReferenceProp).declareProperty(pathProp);
+  }
+
+  @Override
+  public String getStoreId() {
+    return BufferUtil.bufferAsString(storeIdProp.getValue());
+  }
+
+  public JobSecretReference setStoreId(final String storeId) {
+    storeIdProp.setValue(storeId);
+    return this;
+  }
+
+  @Override
+  public String getSecretReference() {
+    return BufferUtil.bufferAsString(secretReferenceProp.getValue());
+  }
+
+  public JobSecretReference setSecretReference(final String secretReference) {
+    secretReferenceProp.setValue(secretReference);
+    return this;
+  }
+
+  @Override
+  public String getPath() {
+    return BufferUtil.bufferAsString(pathProp.getValue());
+  }
+
+  public JobSecretReference setPath(final String path) {
+    pathProp.setValue(path);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getStoreIdBuffer() {
+    return storeIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSecretReferenceBuffer() {
+    return secretReferenceProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getPathBuffer() {
+    return pathProp.getValue();
+  }
+
+  public void copy(final JobSecretReferenceValue secretReference) {
+    setStoreId(secretReference.getStoreId());
+    setSecretReference(secretReference.getSecretReference());
+    setPath(secretReference.getPath());
+  }
+
+  /** Copies the values buffer-to-buffer, avoiding the String round-trip of {@link #copy}. */
+  public JobSecretReference copyFrom(final JobSecretReference other) {
+    storeIdProp.setValue(other.getStoreIdBuffer());
+    secretReferenceProp.setValue(other.getSecretReferenceBuffer());
+    pathProp.setValue(other.getPathBuffer());
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobSecretReference.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobSecretReference.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
-  /* These fields are inherited from ObjectValue; they have no purpose in exported JSON records*/
+  /* Inherited from ObjectValue. They have no purpose in exported JSON records. */
   "encodedLength",
   "empty"
 })
@@ -30,6 +30,8 @@ public final class JobSecretReference extends ObjectValue implements JobSecretRe
 
   private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
   private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+  // RFC 6901 JSON pointer where the resolved secret is injected into the job variables on
+  // activation
   private final StringProperty pathProp = new StringProperty(PATH_KEY, "");
 
   public JobSecretReference() {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -946,7 +946,8 @@ final class JsonSerializableToJsonTest {
                         ],
                         "completionConditionFulfilled": true,
                         "cancelRemainingInstances": true
-                      }
+                      },
+                      "secretReferences": []
                     }
                   ],
                   "timeout": 2,
@@ -1067,7 +1068,8 @@ final class JsonSerializableToJsonTest {
                       .setIsJobToUserTaskMigration(true)
                       .setPriority(42)
                       .setBusinessId("biz-42")
-                      .setLeaseToken("lease-abc-123");
+                      .setLeaseToken("lease-abc-123")
+                      .addSecretReference("store-1", "token", "/tokens/token");
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -1142,7 +1144,14 @@ final class JsonSerializableToJsonTest {
                     ],
                     "completionConditionFulfilled": true,
                     "cancelRemainingInstances": true
-                  }
+                  },
+                  "secretReferences": [
+                    {
+                      "storeId": "store-1",
+                      "secretReference": "token",
+                      "path": "/tokens/token"
+                    }
+                  ]
                 }
                 """
       },
@@ -1201,7 +1210,8 @@ final class JsonSerializableToJsonTest {
                     "activateElements": [],
                     "completionConditionFulfilled": false,
                     "cancelRemainingInstances": false
-                  }
+                  },
+                  "secretReferences": []
                 }
                 """
       },
@@ -1265,7 +1275,8 @@ final class JsonSerializableToJsonTest {
                     "activateElements": [],
                     "completionConditionFulfilled": false,
                     "cancelRemainingInstances": false
-                  }
+                  },
+                  "secretReferences": []
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -29,8 +29,10 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobSecretReferenceValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,6 +41,25 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class JobRecord extends UnifiedRecordValue implements JobRecordValue {
+
+  /**
+   * The worker type prefix for Camunda Agentic AI jobs that are set in Camunda Connectors.
+   *
+   * <p>For 8.9 this is accepted as limitation that all agentic jobs must have this prefix in order
+   * to be categorized as agentic jobs.
+   *
+   * <p>In the future, we might want to introduce a more robust way of identifying agentic jobs
+   */
+  public static final String IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX =
+      "io.camunda.agenticai:aiagent";
+
+  /**
+   * Sentinel lease token that does not scope to a specific job activation, meaning "apply to every
+   * activation of this job". Used to signal "the whole job is gone" — e.g. when discarding agent
+   * history for a destroyed job, an empty lease discards all items for the job regardless of which
+   * activation produced them.
+   */
+  public static final String EMPTY_LEASE = "";
 
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
   public static final String RETRIES = "retries";
@@ -81,6 +102,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private static final StringValue LEASE_TOKEN_KEY = new StringValue("leaseToken");
+  private static final StringValue SECRET_REFERENCES_KEY = new StringValue("secretReferences");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -129,9 +151,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
   private final StringProperty leaseTokenProp = new StringProperty(LEASE_TOKEN_KEY, EMPTY_STRING);
+  private final ArrayProperty<JobSecretReference> secretReferencesProp =
+      new ArrayProperty<>(SECRET_REFERENCES_KEY, JobSecretReference::new);
 
   public JobRecord() {
-    super(26);
+    super(30);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -158,7 +182,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(priorityProp);
+        .declareProperty(priorityProp)
+        .declareProperty(businessIdProp)
+        .declareProperty(leaseTokenProp)
+        .declareProperty(secretReferencesProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -190,6 +217,17 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
     priorityProp.setValue(record.getPriority());
+    businessIdProp.setValue(record.getBusinessIdBuffer());
+    leaseTokenProp.setValue(record.getLeaseTokenBuffer());
+    copySecretReferencesFrom(record);
+  }
+
+  private void copySecretReferencesFrom(final JobRecord record) {
+    // same-class buffer copy avoids the String round-trip of
+    // setSecretReferences(getSecretReferences())
+    secretReferencesProp.reset();
+    record.secretReferencesProp.forEach(
+        reference -> secretReferencesProp.add().copyFrom(reference));
   }
 
   public void wrap(final JobRecord record) {
@@ -288,6 +326,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProp.getValue();
+  }
+
+  @Override
   public String getBpmnProcessId() {
     return bufferAsString(bpmnProcessIdProp.getValue());
   }
@@ -366,18 +409,47 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   @Override
-  public boolean isJobToUserTaskMigration() {
-    return isJobToUserTaskMigrationProp.getValue();
+  public List<JobSecretReferenceValue> getSecretReferences() {
+    // copy each element while iterating the ArrayProperty because the inner values are reused
+    return secretReferencesProp.stream()
+        .map(
+            element -> {
+              final var copy = new JobSecretReference();
+              copy.copy(element);
+              return (JobSecretReferenceValue) copy;
+            })
+        .toList();
+  }
+
+  public JobRecord setSecretReferences(final List<JobSecretReferenceValue> secretReferences) {
+    secretReferencesProp.reset();
+    if (secretReferences != null) {
+      secretReferences.forEach(
+          reference ->
+              addSecretReference(
+                  reference.getStoreId(), reference.getSecretReference(), reference.getPath()));
+    }
+    return this;
+  }
+
+  public JobRecord addSecretReference(
+      final String storeId, final String secretReference, final String path) {
+    secretReferencesProp
+        .add()
+        .setStoreId(storeId)
+        .setSecretReference(secretReference)
+        .setPath(path);
+    return this;
+  }
+
+  public JobRecord resetSecretReferences() {
+    secretReferencesProp.reset();
+    return this;
   }
 
   @Override
-  public long getRootProcessInstanceKey() {
-    return rootProcessInstanceKeyProp.getValue();
-  }
-
-  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
-    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
-    return this;
+  public boolean isJobToUserTaskMigration() {
+    return isJobToUserTaskMigrationProp.getValue();
   }
 
   public JobRecord setProcessDefinitionVersion(final int version) {
@@ -393,6 +465,46 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public JobRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
     return this;
+  }
+
+  public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public JobRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public JobRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
+  }
+
+  @Override
+  public String getLeaseToken() {
+    return bufferAsString(leaseTokenProp.getValue());
+  }
+
+  public JobRecord setLeaseToken(final String leaseToken) {
+    leaseTokenProp.setValue(leaseToken);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getLeaseTokenBuffer() {
+    return leaseTokenProp.getValue();
   }
 
   public JobRecord setElementInstanceKey(final long elementInstanceKey) {
@@ -448,13 +560,13 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
-  public JobRecord setRetries(final int retries) {
-    retriesProp.setValue(retries);
+  public JobRecord setPriority(final int priority) {
+    priorityProp.setValue(priority);
     return this;
   }
 
-  public JobRecord setPriority(final int priority) {
-    priorityProp.setValue(priority);
+  public JobRecord setRetries(final int retries) {
+    retriesProp.setValue(retries);
     return this;
   }
 
@@ -569,5 +681,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public JobRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  @JsonIgnore
+  public boolean isAgentic() {
+    return getType().startsWith(IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX);
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobSecretReference.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobSecretReference.golden
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobSecretReferenceValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; they have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
+})
+public final class JobSecretReference extends ObjectValue implements JobSecretReferenceValue {
+
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue STORE_ID_KEY = new StringValue("storeId");
+  private static final StringValue SECRET_REFERENCE_KEY = new StringValue("secretReference");
+  private static final StringValue PATH_KEY = new StringValue("path");
+
+  private final StringProperty storeIdProp = new StringProperty(STORE_ID_KEY, "");
+  private final StringProperty secretReferenceProp = new StringProperty(SECRET_REFERENCE_KEY, "");
+  private final StringProperty pathProp = new StringProperty(PATH_KEY, "");
+
+  public JobSecretReference() {
+    super(3);
+    declareProperty(storeIdProp).declareProperty(secretReferenceProp).declareProperty(pathProp);
+  }
+
+  @Override
+  public String getStoreId() {
+    return BufferUtil.bufferAsString(storeIdProp.getValue());
+  }
+
+  public JobSecretReference setStoreId(final String storeId) {
+    storeIdProp.setValue(storeId);
+    return this;
+  }
+
+  @Override
+  public String getSecretReference() {
+    return BufferUtil.bufferAsString(secretReferenceProp.getValue());
+  }
+
+  public JobSecretReference setSecretReference(final String secretReference) {
+    secretReferenceProp.setValue(secretReference);
+    return this;
+  }
+
+  @Override
+  public String getPath() {
+    return BufferUtil.bufferAsString(pathProp.getValue());
+  }
+
+  public JobSecretReference setPath(final String path) {
+    pathProp.setValue(path);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getStoreIdBuffer() {
+    return storeIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getSecretReferenceBuffer() {
+    return secretReferenceProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getPathBuffer() {
+    return pathProp.getValue();
+  }
+
+  public void copy(final JobSecretReferenceValue secretReference) {
+    setStoreId(secretReference.getStoreId());
+    setSecretReference(secretReference.getSecretReference());
+    setPath(secretReference.getPath());
+  }
+
+  /** Copies the values buffer-to-buffer, avoiding the String round-trip of {@link #copy}. */
+  public JobSecretReference copyFrom(final JobSecretReference other) {
+    storeIdProp.setValue(other.getStoreIdBuffer());
+    secretReferenceProp.setValue(other.getSecretReferenceBuffer());
+    pathProp.setValue(other.getPathBuffer());
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -196,6 +196,15 @@ public interface JobRecordValue
    */
   boolean isJobToUserTaskMigration();
 
+  /**
+   * Returns the secret references declared in this job's input mappings, each paired with the JSON
+   * path where the resolved secret value is injected when the job is activated. Empty when the job
+   * references no secrets. The resolved secret values are never part of this record.
+   *
+   * @return the secret references of this job
+   */
+  List<JobSecretReferenceValue> getSecretReferences();
+
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableJobResultValue.Builder.class)
   interface JobResultValue {
@@ -307,5 +316,31 @@ public interface JobRecordValue
      * @return the variables that need to be set on the element when it is activated
      */
     Map<String, Object> getVariables();
+  }
+
+  /**
+   * A secret reference declared in a job's input mapping. Carries the reference identifier and the
+   * JSON path where the resolved value is injected, never the resolved secret value itself.
+   */
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableJobSecretReferenceValue.Builder.class)
+  interface JobSecretReferenceValue {
+
+    /**
+     * @return the identifier of the secret store that holds the referenced secret
+     */
+    String getStoreId();
+
+    /**
+     * @return the name that identifies the secret within the store (e.g. {@code token} for {@code
+     *     camunda.secrets.token}); not the resolved secret value
+     */
+    String getSecretReference();
+
+    /**
+     * @return the RFC 6901 JSON pointer at which the resolved secret is injected into the job
+     *     variables on activation
+     */
+    String getPath();
   }
 }


### PR DESCRIPTION
## Description

Stores the input-mapping secret references of a job-worker element on the `JobRecord` when the job is created, so the job-activation path can later resolve them without re-parsing the process model.

At job creation, the secret references detected at deploy time (`ExecutableFlowNode.getSecretReferences()`) are read from the element and written onto the `JobRecord`. Each entry carries:

- `storeId` — the secret store identifier (left empty for now; see below),
- `secretReference` — the bare secret name (e.g. `token` for `camunda.secrets.token`),
- `path` — the RFC 6901 JSON pointer where the resolved value is injected on activation.

Only the references are persisted; resolved secret values are never stored, logged, or exported.

### Notes

- **Stacked on #57844** — the base branch is `rw/57844-secretref-record-and-intents`. It will be retargeted to `main` once that PR merges.
- `storeId` is a placeholder (empty) until the secret store configuration is wired to the engine; a `TODO` marks the spot.
- Scoped to job-worker (`BPMN_ELEMENT`) jobs; execution/task listener and ad-hoc jobs are unaffected.
- The new field is added to the Elasticsearch and OpenSearch job / job-batch templates.

Closes #57849