### PR TITLE
fix: pass flaky-test collector inputs via env instead of run-block interpolation

### DIFF
--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -71,27 +71,46 @@ runs:
     - name: Collect flaky test results
       id: collect-results
       shell: bash
+      env:
+        GENERAL_UNIT_TESTS_RESULT: ${{ inputs.general-unit-tests-result }}
+        GENERAL_UNIT_TESTS_FLAKY: ${{ inputs.general-unit-tests-flaky }}
+        RDBMS_TESTS_RESULT: ${{ inputs.rdbms-tests-result }}
+        RDBMS_TESTS_FLAKY: ${{ inputs.rdbms-tests-flaky }}
+        DOCKER_CHECKS_RESULT: ${{ inputs.docker-checks-result }}
+        DOCKER_CHECKS_FLAKY: ${{ inputs.docker-checks-flaky }}
+        HISTORY_TESTS_RESULT: ${{ inputs.history-tests-result }}
+        HISTORY_MATRIX_OUTPUT_RESULT: ${{ inputs.history-matrix-output-result }}
+        DATABASE_INTEGRATION_TESTS_RESULT: ${{ inputs.database-integration-tests-result }}
+        DATABASE_MATRIX_OUTPUT_RESULT: ${{ inputs.database-matrix-output-result }}
+        IDENTITY_TESTS_RESULT: ${{ inputs.identity-tests-result }}
+        IDENTITY_MATRIX_OUTPUT_RESULT: ${{ inputs.identity-matrix-output-result }}
+        ZEEBE_TESTS_RESULT: ${{ inputs.zeebe-tests-result }}
+        ZEEBE_MATRIX_OUTPUT_RESULT: ${{ inputs.zeebe-matrix-output-result }}
+        INTEGRATION_TESTS_RESULT: ${{ inputs.integration-tests-result }}
+        INTEGRATION_MATRIX_OUTPUT_RESULT: ${{ inputs.integration-matrix-output-result }}
+        PHYSICAL_TENANT_ACCEPTANCE_TESTS_RESULT: ${{ inputs.physical-tenant-acceptance-tests-result }}
+        PHYSICAL_TENANT_ACCEPTANCE_MATRIX_OUTPUT_RESULT: ${{ inputs.physical-tenant-acceptance-matrix-output-result }}
       run: |
         set -euo pipefail
 
         # Source helper functions
-        source ${{ github.action_path }}/scripts/collect-flaky-tests.sh
+        source "${{ github.action_path }}/scripts/collect-flaky-tests.sh"
 
         # Initialize flaky data array
         flaky_data='[]'
 
         # Collect from single jobs
-        collect_from_single_job "general-unit-tests" "${{ inputs.general-unit-tests-result }}" "${{ inputs.general-unit-tests-flaky }}"
-        collect_from_single_job "rdbms-integration-tests" "${{ inputs.rdbms-tests-result }}" "${{ inputs.rdbms-tests-flaky }}"
-        collect_from_single_job "docker-checks" "${{ inputs.docker-checks-result }}" "${{ inputs.docker-checks-flaky }}"
+        collect_from_single_job "general-unit-tests" "$GENERAL_UNIT_TESTS_RESULT" "$GENERAL_UNIT_TESTS_FLAKY"
+        collect_from_single_job "rdbms-integration-tests" "$RDBMS_TESTS_RESULT" "$RDBMS_TESTS_FLAKY"
+        collect_from_single_job "docker-checks" "$DOCKER_CHECKS_RESULT" "$DOCKER_CHECKS_FLAKY"
 
         # Collect from matrix jobs
-        collect_from_matrix_job "history-tests" "${{ inputs.history-tests-result }}" '${{ inputs.history-matrix-output-result }}'
-        collect_from_matrix_job "database-integration-tests" "${{ inputs.database-integration-tests-result }}" '${{ inputs.database-matrix-output-result }}'
-        collect_from_matrix_job "identity-tests" "${{ inputs.identity-tests-result }}" '${{ inputs.identity-matrix-output-result }}'
-        collect_from_matrix_job "zeebe-unit-tests" "${{ inputs.zeebe-tests-result }}" '${{ inputs.zeebe-matrix-output-result }}'
-        collect_from_matrix_job "integration-tests" "${{ inputs.integration-tests-result }}" '${{ inputs.integration-matrix-output-result }}'
-        collect_from_matrix_job "physical-tenant-acceptance-tests" "${{ inputs.physical-tenant-acceptance-tests-result }}" '${{ inputs.physical-tenant-acceptance-matrix-output-result }}'
+        collect_from_matrix_job "history-tests" "$HISTORY_TESTS_RESULT" "$HISTORY_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "database-integration-tests" "$DATABASE_INTEGRATION_TESTS_RESULT" "$DATABASE_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "identity-tests" "$IDENTITY_TESTS_RESULT" "$IDENTITY_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "zeebe-unit-tests" "$ZEEBE_TESTS_RESULT" "$ZEEBE_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "integration-tests" "$INTEGRATION_TESTS_RESULT" "$INTEGRATION_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "physical-tenant-acceptance-tests" "$PHYSICAL_TENANT_ACCEPTANCE_TESTS_RESULT" "$PHYSICAL_TENANT_ACCEPTANCE_MATRIX_OUTPUT_RESULT"
 
         # Output the collected data
         {

--- a/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
+++ b/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
@@ -9,7 +9,7 @@ flaky_data='[]'
 add_job_data() {
   local job_name="$1"
   local flaky_tests="$2"
-  flaky_tests=$(echo "$flaky_tests" | xargs)
+  flaky_tests=$(echo "$flaky_tests" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
   if [[ -n "$flaky_tests" ]]; then
     echo "Adding job: $job_name with flaky test: $flaky_tests"
 


### PR DESCRIPTION
## Summary
- The "Collect flaky test results" step spliced `${{ inputs.* }}` values directly into the `run:` bash script text, which means any flaky test name containing a shell metacharacter gets re-parsed by bash instead of treated as a literal string.
- Observed failure: https://github.com/camunda/camunda/actions/runs/29497960314/job/87627661471 — a flaky test name `io.camunda.authentication.SessionAuthenticationRefreshTest$BasicAuthTest.shouldOnlyRefreshOnceWhenMultipleConcurrentRequests` (nested Java class) rendered into the script as literal `$BasicAuthTest`, which `set -u` then rejected as an unbound variable, failing the whole flaky-test detection job:
  ```
  line 10: BasicAuthTest: unbound variable
  ```
- Fix: pass every `inputs.*` value through the step's `env:` block and reference it as a quoted `"$VAR"` in the script, so values are never re-interpreted as shell syntax. This is also the standard mitigation for GitHub Actions script-injection via untrusted `${{ }}` expansion in `run:` blocks.
- Follow-up fix in the same script: `add_job_data`'s `xargs`-based whitespace trim re-parses quote characters in its input, so a flaky test name with an odd number of `'`/`"` (plausible for a Java assertion-literal display name) throws `xargs: unterminated quote` and aborts the step under `set -euo pipefail`. Switched the trim to `sed`, which treats the value as an opaque string.

## Test plan
- [ ] Confirm the flaky-test-detection job succeeds on a run that includes a flaky test with `$`, `` ` ``, unmatched quotes, or other shell-special characters in its name