### PR TITLE
test: widen TestWebappClient login timeout to cover async user provisioning

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestWebappClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestWebappClient.java
@@ -27,7 +27,12 @@ import org.awaitility.core.ConditionTimeoutException;
 
 public class TestWebappClient {
 
-  private static final Duration LOGIN_TIMEOUT = Duration.ofSeconds(3);
+  // Generous upper bound, not the expected wait. On ES/OS the default user only becomes
+  // searchable once it is exported and the index refreshes (gated behind schema init and the
+  // exporter's backoff), which can lag startup by several seconds under CI load. The retry is
+  // condition-based and returns as soon as login is accepted, so this only bites when something
+  // is genuinely wrong.
+  private static final Duration LOGIN_TIMEOUT = Duration.ofSeconds(60);
 
   private final URI endpoint;
 
@@ -42,10 +47,9 @@ public class TestWebappClient {
     final var loginRequest = buildLoginRequest(username, password);
     final var lastResponse = new AtomicReference<HttpResponse<String>>();
 
-    // The default user is provisioned asynchronously; on Elasticsearch/OpenSearch it only becomes
-    // searchable after an index refresh. Until then the username lookup misses and login is
-    // rejected, so retry until it is accepted rather than handing back an unauthenticated client
-    // whose failure only surfaces later as a confusing 401 on the first authenticated request.
+    // Retry until the login is accepted (see LOGIN_TIMEOUT): until the user is searchable the
+    // username lookup misses and login is rejected, and handing back an unauthenticated client here
+    // would only surface later as a confusing 401 on the first authenticated request.
     try {
       Awaitility.await("login of user '%s'".formatted(username))
           .atMost(LOGIN_TIMEOUT)


### PR DESCRIPTION
## Description

The basic-auth webapp-login ITs — most visibly `BasicAuthUnprotectedApiSessionIT#shouldRecognizeAndInvalidateSessionOnUnprotectedApiChain` — still flake occasionally on Elasticsearch/OpenSearch with a `401` on `/login`, despite the bounded 3s per-login retry added in #57745.

### Root cause

The default `demo` user is only searchable — and therefore only able to authenticate via basic auth — once the `CamundaExporter` has flushed it to secondary storage and the index has refreshed. From a failing run's logs, that export is gated behind:

1. **Schema initialization** — `~15s` on a loaded CI ES (`30.4s → 45.9s` in the failing run).
2. **The exporter's exponential-backoff open cycle** — while the schema isn't ready the exporter keeps failing to open (`Schema is not ready for use`) on a growing backoff, so even after schema-ready it stays asleep for several more seconds before it opens and exports the user.

So the user can become searchable several seconds *after* the application reports `Started`. The 3s per-login retry window in `TestWebappClient` starts at that point and can expire before the user exists → persistent 401.

### Fix

`TestWebappClient.logIn` already retries on the correct, universal condition — login accepted (2xx) — so this just widens its ceiling from **3s to 60s** to cover worst-case provisioning under CI load, aligned with the multi-db harness's readiness awaits. Because the wait is condition-based it still returns as soon as login succeeds, so the larger ceiling only applies when something is genuinely wrong.

### Why not gate readiness once in `CamundaMultiDBExtension`?

That was the initial approach here, but it was reverted: the extension cannot tell, up front, which of the many `@MultiDbTest` app shapes exposes a reachable, login-relevant default user. It broke in several distinct ways —

- MCP variant with `camunda.rest.enabled=false` → `/v2/users/search` returns `404`;
- `@MultiDbTestApplication(managedLifecycle = false)` apps aren't started at `beforeAll` → `Connection refused` (seen across all ES/OS CI jobs on the interim version);

and connection-refused is ambiguous between "still starting" (retry) and "absent" (skip), so it can't be handled correctly at that layer. The login helper, by contrast, runs only for tests that actually log in, against an app that by definition has `/login` and is running.

### Verifying

Run under the `multi-db-test` profile (LOCAL mode spins up the same ES codepath that flakes):

- `BasicAuthUnprotectedApiSessionIT`, `BasicAuthLogoutIT`, `CsrfTokenIT` — green

Follow-up to #57745 / #57744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)