### PR TITLE
feat: add kind property to ClusterVariable

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
@@ -50,4 +50,13 @@ public interface GloballyScopedClusterVariableCreationCommandStep1
    * @return this builder for method chaining
    */
   GloballyScopedClusterVariableCreationCommandStep1 create(String name, Object value);
+
+  /**
+   * Sets the kind of the cluster variable (optional, defaults to JSON).
+   *
+   * @param kind the kind (JSON or SECRET_REFERENCE)
+   * @return this builder for method chaining
+   */
+  GloballyScopedClusterVariableCreationCommandStep1 kind(
+      io.camunda.client.api.search.enums.ClusterVariableKind kind);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
@@ -50,4 +50,13 @@ public interface TenantScopedClusterVariableCreationCommandStep1
    * @return this builder for method chaining
    */
   TenantScopedClusterVariableCreationCommandStep1 create(String name, Object value);
+
+  /**
+   * Sets the kind of the cluster variable (optional, defaults to JSON).
+   *
+   * @param kind the kind (JSON or SECRET_REFERENCE)
+   * @return this builder for method chaining
+   */
+  TenantScopedClusterVariableCreationCommandStep1 kind(
+      io.camunda.client.api.search.enums.ClusterVariableKind kind);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableKind.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableKind.java
@@ -13,19 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.response;
+package io.camunda.client.api.search.enums;
 
-import io.camunda.client.api.search.enums.ClusterVariableScope;
-
-public interface CreateClusterVariableResponse {
-
-  String getName();
-
-  Object getValue();
-
-  ClusterVariableScope getScope();
-
-  String getTenantId();
-
-  io.camunda.client.api.search.enums.ClusterVariableKind getKind();
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.client.api.search.filter;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
 import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
@@ -86,6 +88,22 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ClusterVariableFilter scope(final Consumer<ClusterVariableScopeProperty> fn);
+
+  /**
+   * Filters cluster variables by kind.
+   *
+   * @param kind the kind (JSON or SECRET_REFERENCE)
+   * @return the updated filter
+   */
+  ClusterVariableFilter kind(final ClusterVariableKind kind);
+
+  /**
+   * Filters cluster variables by kind using advanced filter operations.
+   *
+   * @param fn the kind property consumer
+   * @return the updated filter
+   */
+  ClusterVariableFilter kind(final Consumer<ClusterVariableKindProperty> fn);
 
   /**
    * Filters cluster variables by truncation status in storage. When true, returns only variables

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableKindProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableKindProperty.java
@@ -13,19 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.client.api.response;
+package io.camunda.client.api.search.filter.builder;
 
-import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 
-public interface CreateClusterVariableResponse {
-
-  String getName();
-
-  Object getValue();
-
-  ClusterVariableScope getScope();
-
-  String getTenantId();
-
-  io.camunda.client.api.search.enums.ClusterVariableKind getKind();
-}
+public interface ClusterVariableKindProperty
+    extends LikeProperty<ClusterVariableKind, String, ClusterVariableKindProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
@@ -54,6 +54,15 @@ public class GloballyScopedCreateClusterVariableImpl
   }
 
   @Override
+  public GloballyScopedClusterVariableCreationCommandStep1 kind(
+      final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+    createVariableRequest.setKind(
+        io.camunda.client.impl.util.EnumUtil.convert(
+            kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
   public GloballyScopedClusterVariableCreationCommandStep1 requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
@@ -57,6 +57,15 @@ public class TenantScopedCreateClusterVariableImpl
   }
 
   @Override
+  public TenantScopedClusterVariableCreationCommandStep1 kind(
+      final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+    createVariableRequest.setKind(
+        io.camunda.client.impl.util.EnumUtil.convert(
+            kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
   public TenantScopedClusterVariableCreationCommandStep1 requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
@@ -26,6 +26,7 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
   private String value;
   private ClusterVariableScope scope;
   private String tenantId;
+  private io.camunda.client.api.search.enums.ClusterVariableKind kind;
 
   public CreateClusterVariableResponse setResponse(
       final ClusterVariableResult clusterVariableResult) {
@@ -33,6 +34,10 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
     value = clusterVariableResult.getValue();
     tenantId = clusterVariableResult.getTenantId();
     scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
+    kind =
+        EnumUtil.convert(
+            clusterVariableResult.getKind(),
+            io.camunda.client.api.search.enums.ClusterVariableKind.class);
     return this;
   }
 
@@ -54,5 +59,10 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public io.camunda.client.api.search.enums.ClusterVariableKind getKind() {
+    return kind;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
@@ -15,10 +15,13 @@
  */
 package io.camunda.client.impl.search.filter;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.filter.ClusterVariableFilter;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
 import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.ClusterVariableKindPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ClusterVariableScopePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
@@ -88,6 +91,20 @@ public class ClusterVariableFilterImpl
     final ClusterVariableScopeProperty property = new ClusterVariableScopePropertyImpl();
     fn.accept(property);
     filter.setScope(provideSearchRequestProperty(property));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter kind(final ClusterVariableKind kind) {
+    kind(b -> b.eq(kind));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter kind(final Consumer<ClusterVariableKindProperty> fn) {
+    final ClusterVariableKindProperty property = new ClusterVariableKindPropertyImpl();
+    fn.accept(property);
+    filter.setKind(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableKindPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableKindPropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
+import io.camunda.client.protocol.rest.ClusterVariableKindFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClusterVariableKindPropertyImpl
+    extends TypedSearchRequestPropertyProvider<ClusterVariableKindFilterProperty>
+    implements ClusterVariableKindProperty {
+
+  private final ClusterVariableKindFilterProperty filterProperty =
+      new ClusterVariableKindFilterProperty();
+
+  @Override
+  public ClusterVariableKindProperty eq(final ClusterVariableKind value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty neq(final ClusterVariableKind value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty in(final List<ClusterVariableKind> value) {
+    filterProperty.set$In(
+        value.stream()
+            .map(source -> EnumUtil.convert(source, ClusterVariableKindEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty in(final ClusterVariableKind... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected ClusterVariableKindFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public ClusterVariableKindProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.client.protocol.rest.ProblemDetail;
@@ -40,7 +41,9 @@ public class CreateClusterVariableTest extends ClientRestTest {
   void shouldCreateGlobalScopedClusterVariable() {
     // given
     gatewayService.onCreateGlobalClusterVariableRequest(
-        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
+        Instancio.create(ClusterVariableResult.class)
+            .scope(ClusterVariableScopeEnum.GLOBAL)
+            .kind(ClusterVariableKindEnum.JSON));
 
     // when
     client
@@ -60,7 +63,9 @@ public class CreateClusterVariableTest extends ClientRestTest {
     // given
     gatewayService.onCreateTenantClusterVariableRequest(
         TENANT_ID,
-        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
+        Instancio.create(ClusterVariableResult.class)
+            .scope(ClusterVariableScopeEnum.TENANT)
+            .kind(ClusterVariableKindEnum.JSON));
 
     // when
     client
@@ -112,6 +117,34 @@ public class CreateClusterVariableTest extends ClientRestTest {
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldCreateGlobalClusterVariableWithKind() {
+    // given
+    final ClusterVariableResult responseProto =
+        Instancio.create(ClusterVariableResult.class)
+            .scope(ClusterVariableScopeEnum.GLOBAL)
+            .kind(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
+    gatewayService.onCreateGlobalClusterVariableRequest(responseProto);
+
+    // when
+    final io.camunda.client.api.response.CreateClusterVariableResponse response =
+        client
+            .newGloballyScopedClusterVariableCreateRequest()
+            .create(VARIABLE_NAME, VARIABLE_VALUE)
+            .kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getKind())
+        .isEqualTo(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE);
+    final io.camunda.client.protocol.rest.CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(
+            io.camunda.client.protocol.rest.CreateClusterVariableRequest.class);
+    assertThat(sentRequest.getKind())
+        .isEqualTo(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -201,7 +201,8 @@ public class SearchClusterVariableTest extends ClientRestTest {
     final io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest request =
         gatewayService.getLastRequest(
             io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest.class);
-    assertThat(request.getFilter().getKind()).isNotNull();
+    assertThat(request.getFilter().getKind().get$Eq())
+        .isEqualTo(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -188,6 +188,23 @@ public class SearchClusterVariableTest extends ClientRestTest {
   }
 
   @Test
+  void shouldFilterClusterVariablesByKind() {
+    // when
+    client
+        .newClusterVariableSearchRequest()
+        .filter(
+            f -> f.kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE))
+        .send()
+        .join();
+
+    // then
+    final io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest request =
+        gatewayService.getLastRequest(
+            io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getKind()).isNotNull();
+  }
+
+  @Test
   void shouldChainWithFullValuesMethodCall() {
     // when
     client

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -603,7 +603,7 @@
     </addColumn>
   </changeSet>
 
-  <changeSet id="create_cluster_variable_kind_index" author="camunda">
+  <changeSet id="create_cluster_variable_kind_index" author="camunda" runInTransaction="false">
     <preConditions onFail="MARK_RAN">
       <not>
         <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND"

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -592,4 +592,42 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_kind_to_cluster_variable" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}CLUSTER_VARIABLE" columnName="KIND"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}CLUSTER_VARIABLE">
+      <column name="KIND" type="VARCHAR(255)" defaultValue="JSON"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_kind_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND"
+          tableName="${prefix}CLUSTER_VARIABLE"/>
+      </not>
+    </preConditions>
+    <!-- Use async index creation to avoid locking the table during rolling upgrade -->
+    <sql dbms="postgresql">
+      CREATE INDEX CONCURRENTLY ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+    </sql>
+    <sql dbms="mysql,h2,oracle">
+      CREATE INDEX ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+    </sql>
+    <sql dbms="mariadb">
+      CREATE INDEX ONLINE ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+    </sql>
+    <sql dbms="mssql">
+      CREATE INDEX ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+      WITH (ONLINE = ON)
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -12,11 +12,13 @@ import static io.camunda.util.ValueTypeUtil.mapDouble;
 import static io.camunda.util.ValueTypeUtil.mapLong;
 
 import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.util.ValueTypeUtil;
+import java.util.Objects;
 import java.util.function.Function;
 
 public record ClusterVariableDbModel(
@@ -29,7 +31,8 @@ public record ClusterVariableDbModel(
     String fullValue,
     boolean isPreview,
     String tenantId,
-    ClusterVariableScope scope)
+    ClusterVariableScope scope,
+    ClusterVariableKind kind)
     implements Copyable<ClusterVariableDbModel> {
 
   @Override
@@ -42,7 +45,8 @@ public record ClusterVariableDbModel(
                 .name(name)
                 .value(value)
                 .tenantId(tenantId)
-                .scope(scope))
+                .scope(scope)
+                .kind(kind))
         .build();
   }
 
@@ -70,7 +74,8 @@ public record ClusterVariableDbModel(
         fullValue,
         isPreview,
         tenantId,
-        scope);
+        scope,
+        kind);
   }
 
   public static class ClusterVariableDbModelBuilder
@@ -79,6 +84,7 @@ public record ClusterVariableDbModel(
     private String value;
     private String tenantId;
     private ClusterVariableScope scope;
+    private ClusterVariableKind kind = ClusterVariableKind.JSON;
 
     public ClusterVariableDbModelBuilder name(final String name) {
       this.name = name;
@@ -97,6 +103,11 @@ public record ClusterVariableDbModel(
 
     public ClusterVariableDbModelBuilder tenantId(final String tenantId) {
       this.tenantId = tenantId;
+      return this;
+    }
+
+    public ClusterVariableDbModelBuilder kind(final ClusterVariableKind kind) {
+      this.kind = Objects.requireNonNullElse(kind, ClusterVariableKind.JSON);
       return this;
     }
 
@@ -122,7 +133,8 @@ public record ClusterVariableDbModel(
           null,
           false,
           tenantId,
-          scope);
+          scope,
+          kind);
     }
 
     private String getCompositeId() {
@@ -131,7 +143,17 @@ public record ClusterVariableDbModel(
 
     private ClusterVariableDbModel getModel(final ValueTypeEnum valueTypeEnum, final String value) {
       return new ClusterVariableDbModel(
-          getCompositeId(), name, valueTypeEnum, null, null, value, null, false, tenantId, scope);
+          getCompositeId(),
+          name,
+          valueTypeEnum,
+          null,
+          null,
+          value,
+          null,
+          false,
+          tenantId,
+          scope,
+          kind);
     }
 
     private ClusterVariableDbModel getDoubleModel() {
@@ -145,7 +167,8 @@ public record ClusterVariableDbModel(
           null,
           false,
           tenantId,
-          scope);
+          scope,
+          kind);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -25,6 +25,7 @@
        empty list. We use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
       <arg column="METADATA" javaType="java.util.List"
         typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+      <arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>
     </constructor>
   </resultMap>
 
@@ -48,7 +49,8 @@
     TENANT_ID,
     SCOPE,
     IS_PREVIEW,
-    NULL AS METADATA
+    NULL AS METADATA,
+    KIND
     FROM ${prefix}CLUSTER_VARIABLE
     <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
     ) t
@@ -68,7 +70,8 @@
     TENANT_ID,
     SCOPE,
     IS_PREVIEW,
-    NULL AS METADATA
+    NULL AS METADATA,
+    KIND
     FROM ${prefix}CLUSTER_VARIABLE
     WHERE CLUSTER_VARIABLE_ID = #{id}
   </select>
@@ -76,12 +79,11 @@
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
     INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
                                            LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
-                                           TENANT_ID,
-                                           SCOPE)
+                                           TENANT_ID, SCOPE, KIND)
     VALUES (#{id}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
             #{longValue, jdbcType=NUMERIC},
             #{value},
-            #{fullValue}, #{isPreview}, #{tenantId}, #{scope})
+            #{fullValue}, #{isPreview}, #{tenantId}, #{scope}, #{kind})
   </insert>
 
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
@@ -137,6 +139,13 @@
       <if test="filter.scopeOperations != null and !filter.scopeOperations.isEmpty()">
         <foreach collection="filter.scopeOperations" item="operation">
           AND SCOPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <if test="filter.kindOperations != null and !filter.kindOperations.isEmpty()">
+        <foreach collection="filter.kindOperations" item="operation">
+          AND KIND
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>

--- a/docs/superpowers/plans/2026-07-16-clustervar-kind.md
+++ b/docs/superpowers/plans/2026-07-16-clustervar-kind.md
@@ -1,0 +1,1495 @@
+# ClusterVariable `kind` Property Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `kind` enum property (`JSON` | `SECRET_REFERENCE`, default `JSON`) to ClusterVariable across the full stack: engine protocol, exporters, secondary storage (ES/OS + RDBMS), search filters, REST API, and CamundaClient.
+
+**Architecture:** `kind` is set at creation time and immutable thereafter, flowing through the same pipeline as `scope`: engine record → exporter → secondary storage → search domain → REST gateway → Java client. Old records without `kind` deserialize as `JSON` at every layer via defaults.
+
+**Tech Stack:** Java 21, Immutables, MyBatis, Liquibase, OpenAPI/Swagger codegen, JUnit 5, AssertJ, Mockito, WireMock.
+
+## Global Constraints
+
+- All Java files need the Camunda License header (copy from an adjacent file in the same package).
+- Apache License header for files under `zeebe/protocol` and `clients/java`.
+- Run `./mvnw license:format spotless:apply -T1C` before every commit that touches Java or XML.
+- Use `@Nullable` (jspecify) on nullable fields/parameters; add `@NullMarked` to classes where the annotation is new.
+- Test method names start with `should`.
+- Tests structured with `// given`, `// when`, `// then` comments.
+- Use AssertJ (`assertThat`), not JUnit assertions.
+- `kind` is **immutable after creation** — never add it to update paths.
+- Never touch golden Liquibase files (`db/rdbms-schema/src/test/resources/db/changelog/rdbms-exporter/changesets/golden/`).
+
+---
+
+### Task 1: Protocol — `ClusterVariableKind` enum + record field
+
+**Files:**
+- Create: `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java`
+- Modify: `zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java`
+- Modify: `zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java`
+- Modify: `zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java`
+- Test: `zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java`
+
+**Interfaces:**
+- Produces: `ClusterVariableKind` enum at `io.camunda.zeebe.protocol.record.value.ClusterVariableKind`; `ClusterVariableRecordValue.getKind()` returning `ClusterVariableKind`; `ClusterVariableRecord.getKind()` / `setKind(ClusterVariableKind)`; `BrokerCreateClusterVariableRequest.setKind(ClusterVariableKind)`
+
+- [ ] **Step 1: Create `ClusterVariableKind` enum**
+
+```java
+// zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}
+```
+
+- [ ] **Step 2: Add `getKind()` to `ClusterVariableRecordValue`**
+
+Add after `getMetadata()`:
+
+```java
+/**
+ * Returns the kind of this cluster variable.
+ *
+ * <p>Determines how the value is interpreted at job activation.
+ * {@code SECRET_REFERENCE} values contain {@code camunda.secrets.X} references
+ * resolved only at activation time. Defaults to {@code JSON}.
+ *
+ * @return the variable kind (never {@code null})
+ */
+ClusterVariableKind getKind();
+```
+
+- [ ] **Step 3: Write the failing test for `ClusterVariableRecord.getKind()`**
+
+Add to `ClusterVariableRecordTest`:
+
+```java
+@Test
+void shouldRoundTripKindViaMsgPack() {
+  // given
+  final var original =
+      new ClusterVariableRecord()
+          .setName("myVar")
+          .setScope(ClusterVariableScope.GLOBAL)
+          .setTenantId("<default>")
+          .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")))
+          .setKind(ClusterVariableKind.SECRET_REFERENCE);
+
+  // when
+  final var copy = new ClusterVariableRecord();
+  copy.copyFrom(original);
+
+  // then
+  assertThat(copy.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+}
+
+@Test
+void shouldDefaultKindToJsonWhenNotSet() {
+  // given / when
+  final var record = new ClusterVariableRecord();
+
+  // then
+  assertThat(record.getKind()).isEqualTo(ClusterVariableKind.JSON);
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+```bash
+./mvnw verify -pl zeebe/protocol-impl -Dtest=ClusterVariableRecordTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: compilation failure — `getKind()` / `setKind()` not yet defined.
+
+- [ ] **Step 5: Implement `kind` in `ClusterVariableRecord`**
+
+Add a `KIND_KEY` constant and `kindProp` field. Change the constructor from `super(5)` to `super(6)` and declare the new property.
+
+```java
+// New constants (add with existing StringValue constants):
+private static final StringValue KIND_KEY = new StringValue("kind");
+
+// New field (add after metadataProp):
+private final EnumProperty<ClusterVariableKind> kindProp =
+    new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
+
+// Updated constructor:
+public ClusterVariableRecord() {
+  super(6);
+  declareProperty(nameProp)
+      .declareProperty(valueProp)
+      .declareProperty(scopeProp)
+      .declareProperty(tenantIdProp)
+      .declareProperty(metadataProp)
+      .declareProperty(kindProp);
+}
+
+// New getter:
+@Override
+public ClusterVariableKind getKind() {
+  return kindProp.getValue();
+}
+
+// New setter:
+public ClusterVariableRecord setKind(final ClusterVariableKind kind) {
+  kindProp.setValue(kind);
+  return this;
+}
+```
+
+Required import: `io.camunda.zeebe.msgpack.property.EnumProperty`
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+./mvnw verify -pl zeebe/protocol-impl -Dtest=ClusterVariableRecordTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`, all tests pass.
+
+- [ ] **Step 7: Add `setKind()` to `BrokerCreateClusterVariableRequest`**
+
+Add after `setValue()`:
+
+```java
+public BrokerCreateClusterVariableRequest setKind(
+    final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+  if (kind != null) {
+    requestDto.setKind(kind);
+  }
+  return this;
+}
+```
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git add zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java \
+        zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java \
+        zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java \
+        zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java \
+        zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
+git commit -m "feat: add ClusterVariableKind to protocol record"
+```
+
+---
+
+### Task 2: Webapps schema — entity + index constant + ES/OS index mappings
+
+**Files:**
+- Create: `webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java`
+- Modify: `webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java`
+- Modify: `webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java`
+- Modify: `webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json`
+- Modify: `webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json`
+
+**Interfaces:**
+- Consumes: `ClusterVariableKind` from Task 1 (protocol layer — for `fromProtocol()` helper)
+- Produces: `ClusterVariableKind` at `io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind` with `fromProtocol()`; `ClusterVariableEntity.getKind()` / `setKind()`; `ClusterVariableIndex.KIND = "kind"`
+
+- [ ] **Step 1: Create `ClusterVariableKind` in webapps-schema**
+
+```java
+// webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.clustervariable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableKind.class);
+
+  public static ClusterVariableKind fromProtocol(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    if (kind == null) {
+      return JSON;
+    }
+    return switch (kind) {
+      case JSON -> JSON;
+      case SECRET_REFERENCE -> SECRET_REFERENCE;
+    };
+  }
+}
+```
+
+- [ ] **Step 2: Add `kind` field to `ClusterVariableEntity`**
+
+Add after the `metadata` field:
+
+```java
+@SinceVersion(value = "8.10.0", requireDefault = false)
+private ClusterVariableKind kind;
+```
+
+Add getter and setter (following the existing style — setter returns `this`):
+
+```java
+public ClusterVariableKind getKind() {
+  return kind;
+}
+
+public ClusterVariableEntity setKind(final ClusterVariableKind kind) {
+  this.kind = kind;
+  return this;
+}
+```
+
+Also update `hashCode()`, `equals()`, and `toString()` to include `kind`. In `hashCode`:
+
+```java
+return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata, kind);
+```
+
+In `equals` — add `&& kind == that.kind` in the return expression. In `toString` — append `", kind=" + kind`.
+
+- [ ] **Step 3: Add `KIND` constant to `ClusterVariableIndex`**
+
+Add after the existing constants:
+
+```java
+public static final String KIND = "kind";
+```
+
+- [ ] **Step 4: Add `kind` to ES index mapping**
+
+In `webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json`, add after the `isPreview` entry:
+
+```json
+"kind": {
+  "type": "keyword"
+},
+```
+
+- [ ] **Step 5: Add `kind` to OS index mapping**
+
+Same change in `webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json`.
+
+- [ ] **Step 6: Build webapps-schema to verify**
+
+```bash
+./mvnw verify -pl webapps-schema -Dquickly -DskipTests=false -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git add webapps-schema/
+git commit -m "feat: add ClusterVariableKind to webapps schema entity and ES/OS index mapping"
+```
+
+---
+
+### Task 3: ES/OS exporter handler — set `kind` on entity
+
+**Files:**
+- Modify: `zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java`
+- Test: `zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java`
+
+**Interfaces:**
+- Consumes: `ClusterVariableKind.fromProtocol()` from Task 2; `ClusterVariableRecordValue.getKind()` from Task 1
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `ClusterVariableCreatedUpdatedHandlerTest`:
+
+```java
+@ParameterizedTest
+@EnumSource(
+    value = ClusterVariableIntent.class,
+    names = {"CREATED", "UPDATED"},
+    mode = Mode.INCLUDE)
+void shouldSetKindOnEntity(final ClusterVariableIntent intent) {
+  // given
+  final ClusterVariableRecordValue recordValue =
+      ImmutableClusterVariableRecordValue.builder()
+          .from(factory.generateObject(ClusterVariableRecordValue.class))
+          .withScope(ClusterVariableScope.GLOBAL)
+          .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
+          .build();
+
+  final Record<ClusterVariableRecordValue> record =
+      factory.generateRecord(
+          ValueType.CLUSTER_VARIABLE,
+          r -> r.withIntent(intent).withValue(recordValue));
+
+  // when
+  final ClusterVariableEntity entity = new ClusterVariableEntity();
+  underTest.updateEntity(record, entity);
+
+  // then
+  assertThat(entity.getKind())
+      .isEqualTo(
+          io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind.SECRET_REFERENCE);
+}
+
+@ParameterizedTest
+@EnumSource(
+    value = ClusterVariableIntent.class,
+    names = {"CREATED", "UPDATED"},
+    mode = Mode.INCLUDE)
+void shouldDefaultKindToJsonWhenNotInRecord(final ClusterVariableIntent intent) {
+  // given
+  final ClusterVariableRecordValue recordValue =
+      ImmutableClusterVariableRecordValue.builder()
+          .from(factory.generateObject(ClusterVariableRecordValue.class))
+          .withScope(ClusterVariableScope.GLOBAL)
+          .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+          .build();
+
+  final Record<ClusterVariableRecordValue> record =
+      factory.generateRecord(
+          ValueType.CLUSTER_VARIABLE,
+          r -> r.withIntent(intent).withValue(recordValue));
+
+  // when
+  final ClusterVariableEntity entity = new ClusterVariableEntity();
+  underTest.updateEntity(record, entity);
+
+  // then
+  assertThat(entity.getKind())
+      .isEqualTo(
+          io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind.JSON);
+}
+```
+
+- [ ] **Step 2: Run test to confirm failure**
+
+```bash
+./mvnw verify -pl zeebe/exporters/camunda-exporter -Dtest=ClusterVariableCreatedUpdatedHandlerTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: FAIL — `entity.getKind()` is null.
+
+- [ ] **Step 3: Set kind in `updateEntity()`**
+
+In `ClusterVariableCreatedUpdatedHandler.updateEntity()`, add after `.setName(recordValue.getName())`:
+
+```java
+entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
+```
+
+Add import: `import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;`
+
+- [ ] **Step 4: Run test to verify passing**
+
+```bash
+./mvnw verify -pl zeebe/exporters/camunda-exporter -Dtest=ClusterVariableCreatedUpdatedHandlerTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git add zeebe/exporters/camunda-exporter/
+git commit -m "feat: export ClusterVariable kind in ES/OS exporter handler"
+```
+
+---
+
+### Task 4: Search domain — `ClusterVariableKind` enum, entity record field, filter operations, transformers
+
+**Files:**
+- Create: `search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java`
+- Modify: `search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java`
+- Modify: `search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java`
+- Modify: `search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java`
+- Modify: `search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java`
+- Test: `search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterMetadataTransformerTest.java`
+
+**Interfaces:**
+- Consumes: `ClusterVariableKind` (webapps-schema) from Task 2; `ClusterVariableIndex.KIND` from Task 2
+- Produces: `ClusterVariableKind` at `io.camunda.search.entities.ClusterVariableKind`; `ClusterVariableEntity` record gains `@Nullable ClusterVariableKind kind`; `ClusterVariableFilter.Builder.kinds()` / `kindOperations()` methods
+
+- [ ] **Step 1: Create `ClusterVariableKind` in search-domain**
+
+```java
+// search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}
+```
+
+- [ ] **Step 2: Add `kind` to `ClusterVariableEntity` record**
+
+`ClusterVariableEntity` is a Java record. Add `@Nullable ClusterVariableKind kind` as a new component after `metadata`:
+
+```java
+public record ClusterVariableEntity(
+    String id,
+    String name,
+    String value,
+    @Nullable String fullValue,
+    @Nullable Boolean isPreview,
+    ClusterVariableScope scope,
+    @Nullable String tenantId,
+    @Nullable List<MetadataEntry> metadata,
+    @Nullable ClusterVariableKind kind)
+    implements TenantOwnedEntity {
+
+  public ClusterVariableEntity {
+    Objects.requireNonNull(id, "id");
+    Objects.requireNonNull(name, "name");
+    Objects.requireNonNull(value, "value");
+    Objects.requireNonNull(scope, "scope");
+    metadata = metadata != null ? new ArrayList<>(metadata) : new ArrayList<>();
+  }
+  // ... rest unchanged
+}
+```
+
+Add import: `import io.camunda.search.entities.ClusterVariableKind;`
+
+- [ ] **Step 3: Add `kindOperations` to `ClusterVariableFilter`**
+
+The filter is also a Java record. Add `List<Operation<String>> kindOperations` as a new component after `metadataOperations`, before `isTruncated`.
+
+In the `Builder` class add:
+
+```java
+List<Operation<String>> kindOperations;
+
+public Builder kindOperations(final List<Operation<String>> operations) {
+  kindOperations = addValuesToList(kindOperations, operations);
+  return this;
+}
+
+public Builder kinds(final String value, final String... values) {
+  return kindOperations(FilterUtil.mapDefaultToOperation(value, values));
+}
+
+public Builder kinds(final List<String> values) {
+  return kindOperations(FilterUtil.mapDefaultToOperation(values));
+}
+
+@SafeVarargs
+public final Builder kindOperations(
+    final Operation<String> operation, final Operation<String>... operations) {
+  return kindOperations(collectValues(operation, operations));
+}
+```
+
+Update `build()` to pass `kindOperations` to the record constructor, defaulting to empty list:
+
+```java
+Objects.requireNonNullElseGet(kindOperations, Collections::emptyList),
+```
+
+- [ ] **Step 4: Write a failing test for the kind filter transformer**
+
+Add to `ClusterVariableFilterMetadataTransformerTest`:
+
+```java
+@Test
+void shouldTransformKindFilter() {
+  // given
+  final var filter =
+      FilterBuilders.clusterVariable()
+          .kinds("JSON")
+          .build();
+
+  // when
+  final SearchQuery query = new ClusterVariableFilterTransformer(
+      new ClusterVariableIndex("", true)).toSearchQuery(filter);
+
+  // then
+  assertThat(query)
+      .isInstanceOf(SearchBoolQuery.class);
+  final var bool = (SearchBoolQuery) query;
+  assertThat(bool.must()).hasSize(1);
+  final var kindQuery = bool.must().get(0);
+  assertThat(kindQuery).isInstanceOf(SearchTermsQuery.class);
+  final var terms = (SearchTermsQuery) kindQuery;
+  assertThat(terms.field()).isEqualTo(ClusterVariableIndex.KIND);
+  assertThat(terms.values()).containsExactly("JSON");
+}
+```
+
+- [ ] **Step 5: Run test to confirm failure**
+
+```bash
+./mvnw verify -pl search/search-client-query-transformer -Dtest=ClusterVariableFilterMetadataTransformerTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: FAIL — compilation error or null result.
+
+- [ ] **Step 6: Update `ClusterVariableEntityTransformer`**
+
+Replace the `apply` method body to map `kind`:
+
+```java
+@Override
+public ClusterVariableEntity apply(
+    final io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity value) {
+  final var webappsKind = value.getKind();
+  final ClusterVariableKind kind =
+      webappsKind != null ? ClusterVariableKind.valueOf(webappsKind.name()) : ClusterVariableKind.JSON;
+  return new ClusterVariableEntity(
+      value.getId(),
+      value.getName(),
+      value.getValue(),
+      value.getFullValue(),
+      value.getIsPreview(),
+      ClusterVariableScope.valueOf(value.getScope().name()),
+      value.getTenantId(),
+      toMetadata(value.getMetadata()),
+      kind);
+}
+```
+
+Add import: `import io.camunda.search.entities.ClusterVariableKind;`
+
+- [ ] **Step 7: Update `ClusterVariableFilterTransformer.toSearchQuery()`**
+
+Add kind query generation. In `toSearchQuery()`:
+
+```java
+queries.addAll(getKindQuery(filter.kindOperations()));
+```
+
+Add the private method:
+
+```java
+private Collection<SearchQuery> getKindQuery(final List<Operation<String>> operations) {
+  return stringOperations(ClusterVariableIndex.KIND, operations);
+}
+```
+
+- [ ] **Step 8: Run tests**
+
+```bash
+./mvnw verify -pl search/search-client-query-transformer -Dtest=ClusterVariableFilterMetadataTransformerTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 9: Format and commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git add search/
+git commit -m "feat: add kind to search domain ClusterVariable entity and filter"
+```
+
+---
+
+### Task 5: RDBMS — db model, mapper XML, Liquibase migration, RDBMS exporter
+
+**Files:**
+- Modify: `db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java`
+- Modify: `db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml`
+- Modify: `db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml`
+- Modify: `zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java`
+- Test: `qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java`
+
+**Interfaces:**
+- Consumes: `ClusterVariableKind` from Task 4 (search-domain); `ClusterVariableRecordValue.getKind()` from Task 1
+- Produces: `ClusterVariableDbModel.kind()` component; KIND column in RDBMS; RDBMS exporter maps kind
+
+- [ ] **Step 1: Add `kind` to `ClusterVariableDbModel`**
+
+The record currently has components: `id, name, type, doubleValue, longValue, value, fullValue, isPreview, tenantId, scope`. Add `ClusterVariableKind kind` at the end:
+
+```java
+public record ClusterVariableDbModel(
+    String id,
+    String name,
+    ValueTypeEnum type,
+    Double doubleValue,
+    Long longValue,
+    String value,
+    String fullValue,
+    boolean isPreview,
+    String tenantId,
+    ClusterVariableScope scope,
+    ClusterVariableKind kind)
+    implements Copyable<ClusterVariableDbModel> {
+```
+
+Update `copy()` to pass `kind` through:
+
+```java
+@Override
+public ClusterVariableDbModel copy(
+    final Function<ObjectBuilder<ClusterVariableDbModel>, ObjectBuilder<ClusterVariableDbModel>>
+        builderFunction) {
+  return builderFunction
+      .apply(
+          new ClusterVariableDbModelBuilder()
+              .name(name)
+              .value(value)
+              .tenantId(tenantId)
+              .scope(scope)
+              .kind(kind))
+      .build();
+}
+```
+
+Update `truncateValue()` to pass `kind` in the `new ClusterVariableDbModel(...)` call (add `kind` as last argument after `scope`).
+
+Add `ClusterVariableKind kind` field to `ClusterVariableDbModelBuilder`, with builder method:
+
+```java
+private ClusterVariableKind kind = ClusterVariableKind.JSON;
+
+public ClusterVariableDbModelBuilder kind(final ClusterVariableKind kind) {
+  this.kind = Objects.requireNonNullElse(kind, ClusterVariableKind.JSON);
+  return this;
+}
+```
+
+Update all `new ClusterVariableDbModel(...)` calls inside the builder's `getLongModel()`, `getModel()`, and `getDoubleModel()` to pass `kind` as the final argument.
+
+- [ ] **Step 2: Update `ClusterVariableMapper.xml`**
+
+**resultMap** — add after the `METADATA` arg:
+
+```xml
+<arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>
+```
+
+Also update the `ClusterVariableEntity` record constructor call to match the new component count (the resultMap args must match the record canonical constructor order: id, name, value, fullValue, isPreview, scope, tenantId, metadata, kind).
+
+**`get` select** — add `KIND` to the column list:
+
+```sql
+CLUSTER_VARIABLE_ID,
+VAR_NAME,
+VAR_VALUE,
+VAR_FULL_VALUE,
+TENANT_ID,
+SCOPE,
+IS_PREVIEW,
+NULL AS METADATA,
+KIND
+```
+
+**`search` inner select** — add `KIND` to the column list same way.
+
+**`insert` statement** — add `KIND` to the column list and `#{kind}` to the values:
+
+```xml
+INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
+                                       LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
+                                       TENANT_ID, SCOPE, KIND)
+VALUES (#{id}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
+        #{longValue, jdbcType=NUMERIC},
+        #{value},
+        #{fullValue}, #{isPreview}, #{tenantId}, #{scope}, #{kind})
+```
+
+**`update` statement** — do NOT add KIND (kind is immutable).
+
+**`searchFilter` SQL** — add kind filter support after the `scopeOperations` block:
+
+```xml
+<if test="filter.kindOperations != null and !filter.kindOperations.isEmpty()">
+  <foreach collection="filter.kindOperations" item="operation">
+    AND KIND
+    <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+  </foreach>
+</if>
+```
+
+- [ ] **Step 3: Add Liquibase changeset to `8.10.0.xml`**
+
+Add at the end of the file, before `</databaseChangeLog>`:
+
+```xml
+<changeSet id="add_kind_to_cluster_variable" author="camunda">
+  <preConditions onFail="MARK_RAN">
+    <not>
+      <columnExists tableName="${prefix}CLUSTER_VARIABLE" columnName="KIND"/>
+    </not>
+  </preConditions>
+  <addColumn tableName="${prefix}CLUSTER_VARIABLE">
+    <column name="KIND" type="VARCHAR(255)" defaultValue="JSON">
+      <constraints nullable="false"/>
+    </column>
+  </addColumn>
+</changeSet>
+
+<changeSet id="create_cluster_variable_kind_index" author="camunda">
+  <preConditions onFail="MARK_RAN">
+    <not>
+      <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND"
+        tableName="${prefix}CLUSTER_VARIABLE"/>
+    </not>
+  </preConditions>
+  <createIndex tableName="${prefix}CLUSTER_VARIABLE"
+    indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND">
+    <column name="KIND"/>
+  </createIndex>
+</changeSet>
+```
+
+- [ ] **Step 4: Update RDBMS exporter handler to map `kind`**
+
+In `ClusterVariableExportHandler.map()`, add `.kind(...)` to the builder:
+
+```java
+private ClusterVariableDbModel map(final Record<ClusterVariableRecordValue> record) {
+  final var value = record.getValue();
+  final var builder =
+      new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+          .name(value.getName())
+          .value(value.getValue())
+          .kind(ClusterVariableKind.valueOf(value.getKind().name()));
+  if (value.getScope() == GLOBAL) {
+    builder.scope(ClusterVariableScope.GLOBAL).tenantId(null);
+  } else {
+    builder.scope(ClusterVariableScope.TENANT).tenantId(value.getTenantId());
+  }
+  return builder.build();
+}
+```
+
+Add import: `import io.camunda.search.entities.ClusterVariableKind;`
+
+- [ ] **Step 5: Write a failing test for kind persistence**
+
+Add to `ClusterVariableIT`:
+
+```java
+@TestTemplate
+public void shouldSaveAndFindClusterVariableWithKind(
+    final CamundaRdbmsTestApplication testApplication) {
+  // given
+  final var dbModel =
+      new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+          .name(generateRandomString())
+          .value("\"secret\"")
+          .scope(ClusterVariableScope.GLOBAL)
+          .tenantId(null)
+          .kind(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE)
+          .build();
+  createAndSaveVariables(testApplication.getRdbmsService(), dbModel);
+
+  // when
+  final var found =
+      testApplication
+          .getRdbmsService()
+          .getClusterVariableReader()
+          .getGloballyScopedClusterVariable(
+              dbModel.name(),
+              CommonFixtures.resourceAccessChecksFromResourceIds(
+                  AuthorizationResourceType.CLUSTER_VARIABLE, dbModel.name()));
+
+  // then
+  assertThat(found).isNotNull();
+  assertThat(found.kind())
+      .isEqualTo(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE);
+}
+```
+
+- [ ] **Step 6: Run RDBMS test**
+
+```bash
+./mvnw verify -pl qa/acceptance-tests -Dit.test=ClusterVariableIT -DskipTests=false -DskipUTs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: test passes.
+
+- [ ] **Step 7: Also run RDBMS schema tests**
+
+```bash
+./mvnw verify -pl db/rdbms-schema -DskipTests=false -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git add db/rdbms/ \
+        db/rdbms-schema/ \
+        zeebe/exporters/rdbms-exporter/ \
+        qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+git commit -m "feat: add kind to RDBMS cluster variable storage and exporter"
+```
+
+---
+
+### Task 6: OpenAPI spec + service layer + HTTP gateway mappers
+
+**Files:**
+- Modify: `zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml`
+- Modify: `service/src/main/java/io/camunda/service/ClusterVariableServices.java`
+- Modify: `gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java`
+- Modify: `gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java`
+- Modify: `gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java`
+- Modify: `gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java`
+- Test: `zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java`
+
+**Interfaces:**
+- Consumes: `ClusterVariableKind` (protocol) from Task 1; `ClusterVariableKind` (search-domain) from Task 4
+- Produces: `CreateClusterVariableRequest.getKind()` in generated model; `ClusterVariableResultBase.getKind()` in generated model; `ClusterVariableSearchQueryFilterRequest.getKind()` in generated model; `ClusterVariableServices.ClusterVariableRequest.kind`
+
+- [ ] **Step 1: Update `cluster-variables.yaml`**
+
+Add `ClusterVariableKindEnum` schema to `components.schemas` (before `ClusterVariableScopeEnum`):
+
+```yaml
+ClusterVariableKindEnum:
+  type: string
+  enum: [JSON, SECRET_REFERENCE]
+  description: The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
+```
+
+Add `ClusterVariableKindFilterProperty` and `AdvancedClusterVariableKindFilter` (following the scope filter pattern, after `AdvancedClusterVariableScopeFilter`):
+
+```yaml
+ClusterVariableKindFilterProperty:
+  description: ClusterVariableKindEnum property with full advanced search capabilities.
+  oneOf:
+    - type: string
+      title: Exact match
+      description: Matches the value exactly.
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableKindEnum'
+    - $ref: '#/components/schemas/AdvancedClusterVariableKindFilter'
+AdvancedClusterVariableKindFilter:
+  title: Advanced filter
+  description: Advanced ClusterVariableKindEnum filter.
+  type: object
+  properties:
+    $eq:
+      description: Checks for equality with the provided value.
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableKindEnum'
+    $neq:
+      description: Checks for inequality with the provided value.
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableKindEnum'
+    $exists:
+      description: Checks if the current property exists.
+      type: boolean
+    $in:
+      description: Checks if the property matches any of the provided values.
+      type: array
+      items:
+        $ref: '#/components/schemas/ClusterVariableKindEnum'
+    $like:
+      $ref: "filters.yaml#/components/schemas/LikeFilter"
+```
+
+Add `kind` as an **optional** property to `CreateClusterVariableRequest`:
+
+```yaml
+CreateClusterVariableRequest:
+  type: object
+  required:
+    - name
+    - value
+  properties:
+    name:
+      # ... existing
+    value:
+      # ... existing
+    kind:
+      description: The kind of the cluster variable. Defaults to JSON if not specified.
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableKindEnum'
+```
+
+Add `kind` as a **required** property to `ClusterVariableResultBase`:
+
+```yaml
+ClusterVariableResultBase:
+  type: object
+  required:
+    - name
+    - scope
+    - tenantId
+    - kind
+  properties:
+    name:
+      # ... existing
+    scope:
+      # ... existing
+    tenantId:
+      # ... existing
+    kind:
+      $ref: '#/components/schemas/ClusterVariableKindEnum'
+```
+
+Add `kind` filter to `ClusterVariableSearchQueryFilterRequest`:
+
+```yaml
+ClusterVariableSearchQueryFilterRequest:
+  # ...
+  properties:
+    # ... existing properties
+    kind:
+      description: The kind filter for cluster variables.
+      allOf:
+        - $ref: '#/components/schemas/ClusterVariableKindFilterProperty'
+```
+
+- [ ] **Step 2: Regenerate server model and client model**
+
+```bash
+./mvnw install -pl gateways/gateway-model,clients/java -am -Dquickly -T2 2>&1 | grep -E "BUILD|ERROR|FAIL"
+```
+
+Expected: `BUILD SUCCESS`. This generates `ClusterVariableKindEnum`, `ClusterVariableKindFilterProperty`, `AdvancedClusterVariableKindFilter` in both `gateways/gateway-model` and `clients/java`.
+
+- [ ] **Step 3: Update `ClusterVariableServices.ClusterVariableRequest`**
+
+Add `kind` to the record:
+
+```java
+public record ClusterVariableRequest(String name, Object value, String tenantId,
+    io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {}
+```
+
+Update all four methods that construct `ClusterVariableRequest` to pass `kind` — for create methods use `request.getKind()` (mapped from the gateway model), and for delete/get methods (where value is null) pass `null` for kind.
+
+Also update the create methods to pass kind to the broker request:
+
+```java
+// in createGloballyScopedClusterVariable:
+new BrokerCreateClusterVariableRequest()
+    .setName(request.name())
+    .setValue(toDirectBufferValue(request.value()))
+    .setKind(request.kind())
+    .setGlobalScope(),
+
+// in createTenantScopedClusterVariable:
+new BrokerCreateClusterVariableRequest()
+    .setName(request.name())
+    .setValue(toDirectBufferValue(request.value()))
+    .setKind(request.kind())
+    .setTenantScope(request.tenantId()),
+```
+
+- [ ] **Step 4: Update `ClusterVariableMapper` (gateway mapper)**
+
+The `ClusterVariableMapper` builds `ClusterVariableRequest` objects from REST requests. Update the four `toXxx` methods that produce create requests to map `request.getKind()`:
+
+```java
+// Helper to convert gateway model kind to protocol kind
+private static io.camunda.zeebe.protocol.record.value.ClusterVariableKind toProtocolKind(
+    final io.camunda.gateway.protocol.model.ClusterVariableKindEnum kind) {
+  if (kind == null) {
+    return io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON;
+  }
+  return switch (kind) {
+    case JSON -> io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON;
+    case SECRET_REFERENCE ->
+        io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE;
+  };
+}
+```
+
+In `toGlobalClusterVariableCreateRequest`:
+
+```java
+() -> new ClusterVariableRequest(request.getName(), request.getValue(), null,
+    toProtocolKind(request.getKind()))
+```
+
+In `toTenantClusterVariableCreateRequest`:
+
+```java
+() -> new ClusterVariableRequest(request.getName(), request.getValue(), tenantId,
+    toProtocolKind(request.getKind()))
+```
+
+For delete/get `ClusterVariableRequest` constructors (where `value` is null), pass `null` for kind.
+
+- [ ] **Step 5: Update `ResponseMapper.toClusterVariableResponse()`**
+
+Map `kind` from `ClusterVariableRecord` to `ClusterVariableKindEnum`:
+
+```java
+public static ClusterVariableResult toClusterVariableResponse(
+    final ClusterVariableRecord clusterVariableRecord) {
+  final ClusterVariableScopeEnum scope =
+      clusterVariableRecord.isTenantScoped()
+          ? ClusterVariableScopeEnum.TENANT
+          : ClusterVariableScopeEnum.GLOBAL;
+  final @Nullable String tenantId =
+      clusterVariableRecord.isTenantScoped() ? clusterVariableRecord.getTenantId() : null;
+  final ClusterVariableKindEnum kind =
+      switch (clusterVariableRecord.getKind()) {
+        case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+        default -> ClusterVariableKindEnum.JSON;
+      };
+  return ClusterVariableResult.Builder.create()
+      .name(clusterVariableRecord.getName())
+      .scope(scope)
+      .tenantId(tenantId)
+      .kind(kind)
+      .value(clusterVariableRecord.getValue())
+      .build();
+}
+```
+
+Add import: `import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;`
+
+- [ ] **Step 6: Update `SearchQueryResponseMapper`**
+
+In both `toClusterVariableSearchResult()` and `toClusterVariableResult()`, add kind mapping before the builder call:
+
+```java
+private static ClusterVariableKindEnum toKindEnum(
+    final io.camunda.search.entities.ClusterVariableKind kind) {
+  if (kind == null) {
+    return ClusterVariableKindEnum.JSON;
+  }
+  return switch (kind) {
+    case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+    default -> ClusterVariableKindEnum.JSON;
+  };
+}
+```
+
+Then add `.kind(toKindEnum(clusterVariableEntity.kind()))` to both builder calls.
+
+- [ ] **Step 7: Update `SearchQueryFilterMapper.toClusterVariableFilter()`**
+
+Add kind mapping inside the filter builder block:
+
+```java
+ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
+```
+
+- [ ] **Step 8: Write failing controller test**
+
+Add to `ClusterVariableControllerTest`:
+
+```java
+@Test
+void shouldCreateGlobalClusterVariableWithSecretReferenceKind() throws Exception {
+  // given
+  final var record = new ClusterVariableRecord()
+      .setName("myVar")
+      .setScope(io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL)
+      .setKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+  when(clusterVariableServices.createGloballyScopedClusterVariable(
+          createRequestCaptor.capture(), any()))
+      .thenReturn(CompletableFuture.completedFuture(record));
+
+  // when / then
+  mockMvc
+      .perform(
+          post(GLOBAL_URL)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content("{\"name\":\"myVar\",\"value\":\"camunda.secrets.MY_SECRET\",\"kind\":\"SECRET_REFERENCE\"}"))
+      .andExpect(status().isOk())
+      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(
+          content().json("{\"kind\":\"SECRET_REFERENCE\"}", JsonCompareMode.LENIENT));
+
+  assertThat(createRequestCaptor.getValue().kind())
+      .isEqualTo(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+}
+```
+
+- [ ] **Step 9: Run controller test**
+
+```bash
+./mvnw verify -pl zeebe/gateway-rest -Dtest=ClusterVariableControllerTest -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 10: Format and commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git add zeebe/gateway-protocol/ \
+        service/src/main/java/io/camunda/service/ClusterVariableServices.java \
+        gateways/gateway-mapping-http/ \
+        zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+git commit -m "feat: add kind to REST API, gateway mappers and service layer"
+```
+
+---
+
+### Task 7: CamundaClient — kind enum, filter property, create commands, response
+
+**Files:**
+- Create: `clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableKind.java`
+- Create: `clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableKindProperty.java`
+- Create: `clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableKindPropertyImpl.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java`
+- Modify: `clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java`
+- Test: `clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java`
+- Test: `clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java`
+
+**Interfaces:**
+- Consumes: Generated `ClusterVariableKindEnum` and `ClusterVariableKindFilterProperty` from `io.camunda.client.protocol.rest` (from Task 6 regeneration)
+
+- [ ] **Step 1: Create `ClusterVariableKind` client enum**
+
+```java
+// clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableKind.java
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ * ... Apache License 2.0 header ...
+ */
+package io.camunda.client.api.search.enums;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}
+```
+
+- [ ] **Step 2: Create `ClusterVariableKindProperty` interface**
+
+```java
+// clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableKindProperty.java
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ * ... Apache License 2.0 header ...
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+
+public interface ClusterVariableKindProperty
+    extends LikeProperty<ClusterVariableKind, String, ClusterVariableKindProperty> {}
+```
+
+- [ ] **Step 3: Create `ClusterVariableKindPropertyImpl`**
+
+```java
+// clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableKindPropertyImpl.java
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ * ... Apache License 2.0 header ...
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
+import io.camunda.client.protocol.rest.ClusterVariableKindFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClusterVariableKindPropertyImpl
+    extends TypedSearchRequestPropertyProvider<ClusterVariableKindFilterProperty>
+    implements ClusterVariableKindProperty {
+
+  private final ClusterVariableKindFilterProperty filterProperty =
+      new ClusterVariableKindFilterProperty();
+
+  @Override
+  public ClusterVariableKindProperty eq(final ClusterVariableKind value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty neq(final ClusterVariableKind value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty in(final List<ClusterVariableKind> value) {
+    filterProperty.set$In(
+        value.stream()
+            .map(source -> EnumUtil.convert(source, ClusterVariableKindEnum.class))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty in(final ClusterVariableKind... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected ClusterVariableKindFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public ClusterVariableKindProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}
+```
+
+- [ ] **Step 4: Add `kind()` to `ClusterVariableFilter` interface**
+
+Add after `scope(Consumer<ClusterVariableScopeProperty> fn)`:
+
+```java
+/**
+ * Filters cluster variables by kind.
+ *
+ * @param kind the kind (JSON or SECRET_REFERENCE)
+ * @return the updated filter
+ */
+ClusterVariableFilter kind(final ClusterVariableKind kind);
+
+/**
+ * Filters cluster variables by kind using advanced filter operations.
+ *
+ * @param fn the kind property consumer
+ * @return the updated filter
+ */
+ClusterVariableFilter kind(final Consumer<ClusterVariableKindProperty> fn);
+```
+
+Add imports:
+
+```java
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
+```
+
+- [ ] **Step 5: Implement `kind()` in `ClusterVariableFilterImpl`**
+
+```java
+@Override
+public ClusterVariableFilter kind(final ClusterVariableKind kind) {
+  kind(b -> b.eq(kind));
+  return this;
+}
+
+@Override
+public ClusterVariableFilter kind(final Consumer<ClusterVariableKindProperty> fn) {
+  final ClusterVariableKindProperty property = new ClusterVariableKindPropertyImpl();
+  fn.accept(property);
+  filter.setKind(provideSearchRequestProperty(property));
+  return this;
+}
+```
+
+Add imports for `ClusterVariableKind`, `ClusterVariableKindProperty`, `ClusterVariableKindPropertyImpl`.
+
+- [ ] **Step 6: Add `kind()` to create command interfaces**
+
+In `GloballyScopedClusterVariableCreationCommandStep1`, add:
+
+```java
+/**
+ * Sets the kind of the cluster variable (optional, defaults to JSON).
+ *
+ * @param kind the kind (JSON or SECRET_REFERENCE)
+ * @return this builder for method chaining
+ */
+GloballyScopedClusterVariableCreationCommandStep1 kind(
+    io.camunda.client.api.search.enums.ClusterVariableKind kind);
+```
+
+Same method in `TenantScopedClusterVariableCreationCommandStep1`, returning `TenantScopedClusterVariableCreationCommandStep1`.
+
+- [ ] **Step 7: Implement `kind()` in create command impls**
+
+In `GloballyScopedCreateClusterVariableImpl`:
+
+```java
+@Override
+public GloballyScopedClusterVariableCreationCommandStep1 kind(
+    final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+  createVariableRequest.setKind(
+      io.camunda.client.impl.util.EnumUtil.convert(
+          kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+  return this;
+}
+```
+
+Same pattern in `TenantScopedCreateClusterVariableImpl`.
+
+- [ ] **Step 8: Add `getKind()` to `CreateClusterVariableResponse`**
+
+```java
+io.camunda.client.api.search.enums.ClusterVariableKind getKind();
+```
+
+- [ ] **Step 9: Implement `getKind()` in `CreateClusterVariableResponseImpl`**
+
+Add field:
+
+```java
+private io.camunda.client.api.search.enums.ClusterVariableKind kind;
+```
+
+In `setResponse()`, add:
+
+```java
+kind = EnumUtil.convert(
+    clusterVariableResult.getKind(),
+    io.camunda.client.api.search.enums.ClusterVariableKind.class);
+```
+
+Add getter:
+
+```java
+@Override
+public io.camunda.client.api.search.enums.ClusterVariableKind getKind() {
+  return kind;
+}
+```
+
+- [ ] **Step 10: Write failing client tests**
+
+In `CreateClusterVariableTest`, add:
+
+```java
+@Test
+void shouldCreateGlobalClusterVariableWithKind() {
+  // given
+  final var responseProto =
+      Instancio.create(ClusterVariableResult.class)
+          .scope(ClusterVariableScopeEnum.GLOBAL)
+          .kind(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
+  gatewayService.onCreateGlobalClusterVariableRequest(responseProto);
+
+  // when
+  final var response =
+      client
+          .newGloballyScopedClusterVariableCreateRequest()
+          .create(VARIABLE_NAME, VARIABLE_VALUE)
+          .kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE)
+          .send()
+          .join();
+
+  // then
+  assertThat(response.getKind())
+      .isEqualTo(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE);
+  final var sentRequest =
+      gatewayService.getLastRequest(
+          io.camunda.client.protocol.rest.CreateClusterVariableRequest.class);
+  assertThat(sentRequest.getKind())
+      .isEqualTo(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
+}
+```
+
+In `SearchClusterVariableTest`, add:
+
+```java
+@Test
+void shouldFilterClusterVariablesByKind() {
+  // when
+  client
+      .newClusterVariableSearchRequest()
+      .filter(f -> f.kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE))
+      .send()
+      .join();
+
+  // then
+  final var request =
+      gatewayService.getLastRequest(
+          io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest.class);
+  assertThat(request.getFilter().getKind()).isNotNull();
+}
+```
+
+- [ ] **Step 11: Run client tests**
+
+```bash
+./mvnw verify -pl clients/java -Dtest="CreateClusterVariableTest,SearchClusterVariableTest" -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 12: Full module build + format + commit**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+./mvnw verify -pl clients/java -DskipTests=false -DskipITs -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+git add clients/java/
+git commit -m "feat: add ClusterVariable kind to CamundaClient filter and create command"
+```
+
+---
+
+### Task 8: Final build verification
+
+- [ ] **Step 1: Full repo compile check**
+
+```bash
+./mvnw install -Dquickly -T1C 2>&1 | grep -E "BUILD|ERROR|FAIL"
+```
+
+Expected: `BUILD SUCCESS`.
+
+- [ ] **Step 2: Run all ClusterVariable-related tests in key modules**
+
+```bash
+./mvnw verify \
+  -pl zeebe/protocol-impl,zeebe/exporters/camunda-exporter,search/search-client-query-transformer,clients/java,zeebe/gateway-rest \
+  -Dtest="ClusterVariableRecordTest,ClusterVariableCreatedUpdatedHandlerTest,ClusterVariableFilterMetadataTransformerTest,CreateClusterVariableTest,SearchClusterVariableTest,ClusterVariableControllerTest" \
+  -DskipTests=false -DskipITs -Dquickly -T2 2>&1 | grep -E "BUILD|ERROR|FAIL|Tests run"
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit if any formatting drifted**
+
+```bash
+./mvnw license:format spotless:apply -T1C
+git diff --stat
+# commit only if there are changes
+```
+

--- a/docs/superpowers/specs/2026-07-16-clustervar-kind-design.md
+++ b/docs/superpowers/specs/2026-07-16-clustervar-kind-design.md
@@ -35,6 +35,7 @@ Protocol record (msgpack / engine state)
 ### 1. Protocol layer (`zeebe/protocol` + `zeebe/protocol-impl`)
 
 **New enum** `ClusterVariableKind` at `io.camunda.zeebe.protocol.record.value.ClusterVariableKind`:
+
 ```java
 public enum ClusterVariableKind {
   JSON,
@@ -45,11 +46,13 @@ public enum ClusterVariableKind {
 No `UNSPECIFIED` sentinel — the protocol record's default is `JSON`, so old records without a `kind` field deserialize as `JSON` automatically.
 
 `ClusterVariableRecordValue` gains:
+
 ```java
 ClusterVariableKind getKind();
 ```
 
 `ClusterVariableRecord` (protocol-impl) gains a new `EnumProperty`:
+
 ```java
 private final EnumProperty<ClusterVariableKind> kindProp =
     new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
@@ -74,6 +77,7 @@ No changes. `ClusterVariableInstance` wraps the full `ClusterVariableRecord` as 
 ### 4. Secondary storage — ES/OS
 
 **`ClusterVariableKind`** enum added to `webapps-schema` at `io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind`:
+
 ```java
 public enum ClusterVariableKind {
   JSON, SECRET_REFERENCE;
@@ -89,15 +93,18 @@ public enum ClusterVariableKind {
 ```
 
 **`ClusterVariableEntity`** (webapps-schema) gains:
+
 ```java
 @SinceVersion(value = "8.10.0", requireDefault = false)
 private ClusterVariableKind kind;
 ```
+
 With getter + setter.
 
 **`ClusterVariableIndex`** gains `public static final String KIND = "kind"`.
 
 **ES/OS index mappings** (`camunda-cluster-variable.json` for both ES and OS) gain:
+
 ```json
 "kind": { "type": "keyword" }
 ```
@@ -114,6 +121,7 @@ With getter + setter.
 - `update` statement is NOT changed (kind is immutable)
 
 **Liquibase changeset** (added to `8.10.0.xml`):
+
 ```xml
 <changeSet id="add_kind_to_cluster_variable" author="camunda">
   <addColumn tableName="${prefix}CLUSTER_VARIABLE">
@@ -129,6 +137,7 @@ Also add an index on KIND for filter performance.
 ### 6. Search domain
 
 **`ClusterVariableKind`** enum added at `io.camunda.search.entities.ClusterVariableKind`:
+
 ```java
 public enum ClusterVariableKind { JSON, SECRET_REFERENCE; }
 ```
@@ -138,6 +147,7 @@ public enum ClusterVariableKind { JSON, SECRET_REFERENCE; }
 **`ClusterVariableFilter`** gains `List<Operation<String>> kindOperations` (parallel to `scopeOperations`). Builder gains `kinds()` and `kindOperations()` methods.
 
 **`ClusterVariableEntityTransformer`**: maps `value.getKind()` with null-default fallback:
+
 ```java
 final var kind = value.getKind() != null
     ? ClusterVariableKind.valueOf(value.getKind().name())
@@ -151,6 +161,7 @@ final var kind = value.getKind() != null
 ### 7. REST API — OpenAPI spec (`cluster-variables.yaml`)
 
 New schema components:
+
 ```yaml
 ClusterVariableKindEnum:
   type: string
@@ -199,6 +210,7 @@ AdvancedClusterVariableKindFilter:
 - `ClusterVariableKindPropertyImpl` implementation
 
 **`ClusterVariableFilter`** API interface gains:
+
 ```java
 ClusterVariableFilter kind(ClusterVariableKind kind);
 ClusterVariableFilter kind(Consumer<ClusterVariableKindProperty> fn);
@@ -207,6 +219,7 @@ ClusterVariableFilter kind(Consumer<ClusterVariableKindProperty> fn);
 **`ClusterVariableFilterImpl`** implements both.
 
 **`GloballyScopedClusterVariableCreationCommandStep1`** gains:
+
 ```java
 GloballyScopedClusterVariableCreationCommandStep1 kind(ClusterVariableKind kind);
 ```
@@ -221,29 +234,30 @@ Both create impls pass `kind` to the REST request body.
 
 ## Backwards compatibility
 
-| Layer | Old state | Migration |
-|-------|-----------|-----------|
-| Engine (msgpack) | Old records have no `kind` field | `EnumProperty` default `JSON` — reads as `JSON` automatically |
-| ES/OS documents | Old documents have no `kind` field | `@JsonIgnoreProperties(ignoreUnknown=true)` + null→JSON fallback in transformer |
-| RDBMS rows | Old rows have no `KIND` column | Liquibase `addColumn` with `defaultValue="JSON"` |
+|      Layer       |             Old state              |                                    Migration                                    |
+|------------------|------------------------------------|---------------------------------------------------------------------------------|
+| Engine (msgpack) | Old records have no `kind` field   | `EnumProperty` default `JSON` — reads as `JSON` automatically                   |
+| ES/OS documents  | Old documents have no `kind` field | `@JsonIgnoreProperties(ignoreUnknown=true)` + null→JSON fallback in transformer |
+| RDBMS rows       | Old rows have no `KIND` column     | Liquibase `addColumn` with `defaultValue="JSON"`                                |
 
 ## Files changed (summary)
 
 ~33 files across 11 modules:
 
-| Module | Files |
-|--------|-------|
-| `zeebe/protocol` | `ClusterVariableKind.java` (new), `ClusterVariableRecordValue.java` |
-| `zeebe/protocol-impl` | `ClusterVariableRecord.java` |
-| `zeebe/gateway` (broker requests) | `BrokerCreateClusterVariableRequest.java` |
-| `zeebe/exporters/camunda-exporter` | `ClusterVariableCreatedUpdatedHandler.java` |
-| `zeebe/exporters/rdbms-exporter` | `ClusterVariableExportHandler.java` |
-| `webapps-schema` | `ClusterVariableKind.java` (new), `ClusterVariableEntity.java`, `ClusterVariableIndex.java`, 2× JSON mappings |
-| `search/search-domain` | `ClusterVariableKind.java` (new), `ClusterVariableEntity.java`, `ClusterVariableFilter.java` |
-| `search/search-client-query-transformer` | `ClusterVariableEntityTransformer.java`, `ClusterVariableFilterTransformer.java` |
-| `db/rdbms` | `ClusterVariableDbModel.java`, `ClusterVariableMapper.xml` |
-| `db/rdbms-schema` | `8.10.0.xml` (add changeset) |
-| `zeebe/gateway-protocol` (OpenAPI) | `cluster-variables.yaml` |
-| `gateways/gateway-mapping-http` | `ClusterVariableMapper.java`, `ResponseMapper.java`, `SearchQueryResponseMapper.java`, `SearchQueryFilterMapper.java` |
-| `service` | `ClusterVariableServices.java` |
-| `clients/java` | `ClusterVariableKind.java` (new), `ClusterVariableKindProperty.java` (new), `ClusterVariableKindPropertyImpl.java` (new), `ClusterVariableFilter.java`, `ClusterVariableFilterImpl.java`, `GloballyScopedClusterVariableCreationCommandStep1.java`, `GloballyScopedCreateClusterVariableImpl.java`, `TenantScopedClusterVariableCreationCommandStep1.java`, `TenantScopedCreateClusterVariableImpl.java`, `CreateClusterVariableResponse.java`, `CreateClusterVariableResponseImpl.java` |
+|                  Module                  |                                                                                                                                                                                                                                          Files                                                                                                                                                                                                                                           |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `zeebe/protocol`                         | `ClusterVariableKind.java` (new), `ClusterVariableRecordValue.java`                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `zeebe/protocol-impl`                    | `ClusterVariableRecord.java`                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `zeebe/gateway` (broker requests)        | `BrokerCreateClusterVariableRequest.java`                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `zeebe/exporters/camunda-exporter`       | `ClusterVariableCreatedUpdatedHandler.java`                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `zeebe/exporters/rdbms-exporter`         | `ClusterVariableExportHandler.java`                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `webapps-schema`                         | `ClusterVariableKind.java` (new), `ClusterVariableEntity.java`, `ClusterVariableIndex.java`, 2× JSON mappings                                                                                                                                                                                                                                                                                                                                                                            |
+| `search/search-domain`                   | `ClusterVariableKind.java` (new), `ClusterVariableEntity.java`, `ClusterVariableFilter.java`                                                                                                                                                                                                                                                                                                                                                                                             |
+| `search/search-client-query-transformer` | `ClusterVariableEntityTransformer.java`, `ClusterVariableFilterTransformer.java`                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `db/rdbms`                               | `ClusterVariableDbModel.java`, `ClusterVariableMapper.xml`                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `db/rdbms-schema`                        | `8.10.0.xml` (add changeset)                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `zeebe/gateway-protocol` (OpenAPI)       | `cluster-variables.yaml`                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `gateways/gateway-mapping-http`          | `ClusterVariableMapper.java`, `ResponseMapper.java`, `SearchQueryResponseMapper.java`, `SearchQueryFilterMapper.java`                                                                                                                                                                                                                                                                                                                                                                    |
+| `service`                                | `ClusterVariableServices.java`                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `clients/java`                           | `ClusterVariableKind.java` (new), `ClusterVariableKindProperty.java` (new), `ClusterVariableKindPropertyImpl.java` (new), `ClusterVariableFilter.java`, `ClusterVariableFilterImpl.java`, `GloballyScopedClusterVariableCreationCommandStep1.java`, `GloballyScopedCreateClusterVariableImpl.java`, `TenantScopedClusterVariableCreationCommandStep1.java`, `TenantScopedCreateClusterVariableImpl.java`, `CreateClusterVariableResponse.java`, `CreateClusterVariableResponseImpl.java` |
+

--- a/docs/superpowers/specs/2026-07-16-clustervar-kind-design.md
+++ b/docs/superpowers/specs/2026-07-16-clustervar-kind-design.md
@@ -1,0 +1,249 @@
+# Design: Add `kind` property to ClusterVariable
+
+**Issue:** #57920  
+**Date:** 2026-07-16  
+**Status:** Approved
+
+## Summary
+
+Add a `kind` enum property to ClusterVariable with values `JSON` (default) and `SECRET_REFERENCE`. The kind determines how the variable value is interpreted at job activation — `SECRET_REFERENCE` values contain `camunda.secrets.X` references that get resolved only when a job is activated.
+
+## Acceptance criteria
+
+- ClusterVariables have a `kind` property (JSON | SECRET_REFERENCE)
+- `kind` is stored in secondary storage (ES/OS and RDBMS)
+- ClusterVariables can be filtered by `kind` via the search API
+- `kind` can be set on create; defaults to `JSON` when not specified
+- `kind` is **immutable** after creation (not present on the update endpoint)
+- `kind` is supported in the CamundaClient (create command + search filter)
+
+## Architecture
+
+`kind` flows through the same stack as `scope`:
+
+```
+Protocol record (msgpack / engine state)
+  → Exporter (ES/OS handler + RDBMS handler)
+  → Secondary storage (ES/OS index + RDBMS table)
+  → Search filter + response mapper
+  → HTTP gateway REST API (OpenAPI spec + mappers)
+  → CamundaClient (create command + search filter)
+```
+
+## Layer-by-layer design
+
+### 1. Protocol layer (`zeebe/protocol` + `zeebe/protocol-impl`)
+
+**New enum** `ClusterVariableKind` at `io.camunda.zeebe.protocol.record.value.ClusterVariableKind`:
+```java
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}
+```
+
+No `UNSPECIFIED` sentinel — the protocol record's default is `JSON`, so old records without a `kind` field deserialize as `JSON` automatically.
+
+`ClusterVariableRecordValue` gains:
+```java
+ClusterVariableKind getKind();
+```
+
+`ClusterVariableRecord` (protocol-impl) gains a new `EnumProperty`:
+```java
+private final EnumProperty<ClusterVariableKind> kindProp =
+    new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
+```
+
+The property is declared in the constructor (`super(6)` instead of 5). Getter and setter added.
+
+**Backwards compatibility:** The msgpack `EnumProperty` default of `JSON` means any existing record without a `kind` field deserializes as `JSON`. No migration needed at the protocol level.
+
+`BrokerCreateClusterVariableRequest` gains `setKind(ClusterVariableKind)`.
+
+### 2. Engine state
+
+No changes. `ClusterVariableInstance` wraps the full `ClusterVariableRecord` as a msgpack `ObjectProperty`. Adding a new property to `ClusterVariableRecord` is automatically persisted.
+
+### 3. Exporters
+
+**ES/OS exporter** (`ClusterVariableCreatedUpdatedHandler`): call `entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()))` in `updateEntity()`.
+
+**RDBMS exporter** (`ClusterVariableExportHandler`): pass `kind` to `ClusterVariableDbModel.ClusterVariableDbModelBuilder`.
+
+### 4. Secondary storage — ES/OS
+
+**`ClusterVariableKind`** enum added to `webapps-schema` at `io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind`:
+```java
+public enum ClusterVariableKind {
+  JSON, SECRET_REFERENCE;
+
+  public static ClusterVariableKind fromProtocol(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    return switch (kind) {
+      case JSON -> JSON;
+      case SECRET_REFERENCE -> SECRET_REFERENCE;
+    };
+  }
+}
+```
+
+**`ClusterVariableEntity`** (webapps-schema) gains:
+```java
+@SinceVersion(value = "8.10.0", requireDefault = false)
+private ClusterVariableKind kind;
+```
+With getter + setter.
+
+**`ClusterVariableIndex`** gains `public static final String KIND = "kind"`.
+
+**ES/OS index mappings** (`camunda-cluster-variable.json` for both ES and OS) gain:
+```json
+"kind": { "type": "keyword" }
+```
+
+### 5. Secondary storage — RDBMS
+
+**`ClusterVariableDbModel`** gains `ClusterVariableKind kind` as a record component.
+
+**`ClusterVariableMapper.xml`**:
+- `resultMap`: add `<arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>`
+- `select` (get and search): include `KIND` column
+- `insert`: include `#{kind}` in INSERT statement
+- `searchFilter`: add `AND KIND = #{filter.kindOperations...}` for kind filter operations
+- `update` statement is NOT changed (kind is immutable)
+
+**Liquibase changeset** (added to `8.10.0.xml`):
+```xml
+<changeSet id="add_kind_to_cluster_variable" author="camunda">
+  <addColumn tableName="${prefix}CLUSTER_VARIABLE">
+    <column name="KIND" type="VARCHAR(255)" defaultValue="JSON">
+      <constraints nullable="false"/>
+    </column>
+  </addColumn>
+</changeSet>
+```
+
+Also add an index on KIND for filter performance.
+
+### 6. Search domain
+
+**`ClusterVariableKind`** enum added at `io.camunda.search.entities.ClusterVariableKind`:
+```java
+public enum ClusterVariableKind { JSON, SECRET_REFERENCE; }
+```
+
+**`ClusterVariableEntity`** record gains `@Nullable ClusterVariableKind kind` component.
+
+**`ClusterVariableFilter`** gains `List<Operation<String>> kindOperations` (parallel to `scopeOperations`). Builder gains `kinds()` and `kindOperations()` methods.
+
+**`ClusterVariableEntityTransformer`**: maps `value.getKind()` with null-default fallback:
+```java
+final var kind = value.getKind() != null
+    ? ClusterVariableKind.valueOf(value.getKind().name())
+    : ClusterVariableKind.JSON;
+```
+
+**`ClusterVariableFilterTransformer`**: adds `getKindQuery(filter.kindOperations())` using `stringOperations(ClusterVariableIndex.KIND, operations)`.
+
+**RDBMS filter** (`ClusterVariableMapper.xml` `searchFilter`): adds kind operations using the same `operationCondition` pattern as scope.
+
+### 7. REST API — OpenAPI spec (`cluster-variables.yaml`)
+
+New schema components:
+```yaml
+ClusterVariableKindEnum:
+  type: string
+  enum: [JSON, SECRET_REFERENCE]
+  description: The kind of a cluster variable.
+
+ClusterVariableKindFilterProperty:
+  oneOf:
+    - type: string
+      allOf: [$ref: ClusterVariableKindEnum]
+    - $ref: AdvancedClusterVariableKindFilter
+
+AdvancedClusterVariableKindFilter:
+  type: object
+  properties:
+    $eq: { allOf: [$ref: ClusterVariableKindEnum] }
+    $neq: { allOf: [$ref: ClusterVariableKindEnum] }
+    $exists: { type: boolean }
+    $in: { type: array, items: { $ref: ClusterVariableKindEnum } }
+```
+
+`CreateClusterVariableRequest` gains optional `kind` (type: `$ref: ClusterVariableKindEnum`).
+
+`ClusterVariableResultBase` gains required `kind` (type: `$ref: ClusterVariableKindEnum`).
+
+`ClusterVariableSearchQueryFilterRequest` gains `kind` (type: `$ref: ClusterVariableKindFilterProperty`).
+
+### 8. HTTP gateway mappers
+
+`ClusterVariableMapper.java`: `toTenantClusterVariableCreateRequest` and `toGlobalClusterVariableCreateRequest` pass `request.getKind()` into `ClusterVariableRequest`.
+
+`ResponseMapper.toClusterVariableResponse()`: maps `clusterVariableRecord.getKind()` → `ClusterVariableKindEnum`.
+
+`SearchQueryResponseMapper.toClusterVariableSearchResult()` and `toClusterVariableResult()`: map `clusterVariableEntity.kind()` → `ClusterVariableKindEnum`.
+
+`SearchQueryFilterMapper.toClusterVariableFilter()`: maps `filter.getKind()` → `kindOperations`.
+
+`ClusterVariableServices.ClusterVariableRequest` gains `ClusterVariableKind kind` field.
+
+### 9. CamundaClient (`clients/java`)
+
+**New enum** `io.camunda.client.api.search.enums.ClusterVariableKind`: `JSON`, `SECRET_REFERENCE`.
+
+**New filter builder types**:
+- `ClusterVariableKindProperty` interface (analogous to `ClusterVariableScopeProperty`)
+- `ClusterVariableKindPropertyImpl` implementation
+
+**`ClusterVariableFilter`** API interface gains:
+```java
+ClusterVariableFilter kind(ClusterVariableKind kind);
+ClusterVariableFilter kind(Consumer<ClusterVariableKindProperty> fn);
+```
+
+**`ClusterVariableFilterImpl`** implements both.
+
+**`GloballyScopedClusterVariableCreationCommandStep1`** gains:
+```java
+GloballyScopedClusterVariableCreationCommandStep1 kind(ClusterVariableKind kind);
+```
+
+**`TenantScopedClusterVariableCreationCommandStep1`** gains the same.
+
+Both create impls pass `kind` to the REST request body.
+
+**`CreateClusterVariableResponse`** gains `ClusterVariableKind getKind()`.
+
+**`CreateClusterVariableResponseImpl`** maps kind from `ClusterVariableResult.getKind()`.
+
+## Backwards compatibility
+
+| Layer | Old state | Migration |
+|-------|-----------|-----------|
+| Engine (msgpack) | Old records have no `kind` field | `EnumProperty` default `JSON` — reads as `JSON` automatically |
+| ES/OS documents | Old documents have no `kind` field | `@JsonIgnoreProperties(ignoreUnknown=true)` + null→JSON fallback in transformer |
+| RDBMS rows | Old rows have no `KIND` column | Liquibase `addColumn` with `defaultValue="JSON"` |
+
+## Files changed (summary)
+
+~33 files across 11 modules:
+
+| Module | Files |
+|--------|-------|
+| `zeebe/protocol` | `ClusterVariableKind.java` (new), `ClusterVariableRecordValue.java` |
+| `zeebe/protocol-impl` | `ClusterVariableRecord.java` |
+| `zeebe/gateway` (broker requests) | `BrokerCreateClusterVariableRequest.java` |
+| `zeebe/exporters/camunda-exporter` | `ClusterVariableCreatedUpdatedHandler.java` |
+| `zeebe/exporters/rdbms-exporter` | `ClusterVariableExportHandler.java` |
+| `webapps-schema` | `ClusterVariableKind.java` (new), `ClusterVariableEntity.java`, `ClusterVariableIndex.java`, 2× JSON mappings |
+| `search/search-domain` | `ClusterVariableKind.java` (new), `ClusterVariableEntity.java`, `ClusterVariableFilter.java` |
+| `search/search-client-query-transformer` | `ClusterVariableEntityTransformer.java`, `ClusterVariableFilterTransformer.java` |
+| `db/rdbms` | `ClusterVariableDbModel.java`, `ClusterVariableMapper.xml` |
+| `db/rdbms-schema` | `8.10.0.xml` (add changeset) |
+| `zeebe/gateway-protocol` (OpenAPI) | `cluster-variables.yaml` |
+| `gateways/gateway-mapping-http` | `ClusterVariableMapper.java`, `ResponseMapper.java`, `SearchQueryResponseMapper.java`, `SearchQueryFilterMapper.java` |
+| `service` | `ClusterVariableServices.java` |
+| `clients/java` | `ClusterVariableKind.java` (new), `ClusterVariableKindProperty.java` (new), `ClusterVariableKindPropertyImpl.java` (new), `ClusterVariableFilter.java`, `ClusterVariableFilterImpl.java`, `GloballyScopedClusterVariableCreationCommandStep1.java`, `GloballyScopedCreateClusterVariableImpl.java`, `TenantScopedClusterVariableCreationCommandStep1.java`, `TenantScopedCreateClusterVariableImpl.java`, `CreateClusterVariableResponse.java`, `CreateClusterVariableResponseImpl.java` |

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -26,6 +26,7 @@ import io.camunda.gateway.protocol.model.AuthorizationCreateResult;
 import io.camunda.gateway.protocol.model.BatchOperationCreatedResult;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.BrokerInfo;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.CreateProcessInstanceResult;
@@ -847,10 +848,16 @@ public final class ResponseMapper {
             : ClusterVariableScopeEnum.GLOBAL;
     final @Nullable String tenantId =
         clusterVariableRecord.isTenantScoped() ? clusterVariableRecord.getTenantId() : null;
+    final ClusterVariableKindEnum kind =
+        switch (clusterVariableRecord.getKind()) {
+          case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+          default -> ClusterVariableKindEnum.JSON;
+        };
     return ClusterVariableResult.Builder.create()
         .name(clusterVariableRecord.getName())
         .scope(scope)
         .tenantId(tenantId)
+        .kind(kind)
         .value(clusterVariableRecord.getValue())
         .build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
@@ -9,10 +9,13 @@ package io.camunda.gateway.mapping.http.mapper;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.validator.ClusterVariableRequestValidator;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.CreateClusterVariableRequest;
 import io.camunda.gateway.protocol.model.UpdateClusterVariableRequest;
 import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.util.Either;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.ProblemDetail;
 
 public class ClusterVariableMapper {
@@ -29,14 +32,19 @@ public class ClusterVariableMapper {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableCreateRequest(
             request, tenantId),
-        () -> new ClusterVariableRequest(request.getName(), request.getValue(), tenantId));
+        () ->
+            new ClusterVariableRequest(
+                request.getName(),
+                request.getValue(),
+                tenantId,
+                toProtocolKind(request.getKind())));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableUpdateRequest(
       final String name, final UpdateClusterVariableRequest request) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableUpdateRequest(name, request),
-        () -> new ClusterVariableRequest(name, request.getValue(), null));
+        () -> new ClusterVariableRequest(name, request.getValue(), null, null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableUpdateRequest(
@@ -44,27 +52,39 @@ public class ClusterVariableMapper {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableUpdateRequest(
             name, request, tenantId),
-        () -> new ClusterVariableRequest(name, request.getValue(), tenantId));
+        () -> new ClusterVariableRequest(name, request.getValue(), tenantId, null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableRequest(
       final String name, final String tenantId) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableRequest(name, tenantId),
-        () -> new ClusterVariableRequest(name, null, tenantId));
+        () -> new ClusterVariableRequest(name, null, tenantId, null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableCreateRequest(
       final CreateClusterVariableRequest request) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableCreateRequest(request),
-        () -> new ClusterVariableRequest(request.getName(), request.getValue(), null));
+        () ->
+            new ClusterVariableRequest(
+                request.getName(), request.getValue(), null, toProtocolKind(request.getKind())));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableRequest(
       final String name) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableRequest(name),
-        () -> new ClusterVariableRequest(name, null, null));
+        () -> new ClusterVariableRequest(name, null, null, null));
+  }
+
+  private static ClusterVariableKind toProtocolKind(final @Nullable ClusterVariableKindEnum kind) {
+    if (kind == null) {
+      return ClusterVariableKind.JSON;
+    }
+    return switch (kind) {
+      case JSON -> ClusterVariableKind.JSON;
+      case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
+    };
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -387,6 +387,7 @@ public class SearchQueryFilterMapper {
         .map(mapToStringOperations())
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
+    ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
 
     return builder.build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -52,6 +52,7 @@ import io.camunda.gateway.protocol.model.BatchOperationSearchQueryResult;
 import io.camunda.gateway.protocol.model.BatchOperationStateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.CamundaUserResult;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryResult;
@@ -186,6 +187,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
@@ -1655,6 +1657,7 @@ public final class SearchQueryResponseMapper {
         .name(clusterVariableEntity.name())
         .scope(scope)
         .tenantId(tenantId)
+        .kind(toKindEnum(clusterVariableEntity.kind()))
         .value(
             requireNonNull(
                 !truncateValues
@@ -1681,8 +1684,19 @@ public final class SearchQueryResponseMapper {
         .name(clusterVariableEntity.name())
         .scope(scope)
         .tenantId(tenantId)
+        .kind(toKindEnum(clusterVariableEntity.kind()))
         .value(requireNonNull(getFullValueIfPresent(clusterVariableEntity), "value"))
         .build();
+  }
+
+  private static ClusterVariableKindEnum toKindEnum(final ClusterVariableKind kind) {
+    if (kind == null) {
+      return ClusterVariableKindEnum.JSON;
+    }
+    return switch (kind) {
+      case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+      default -> ClusterVariableKindEnum.JSON;
+    };
   }
 
   private static @Nullable String getFullValueIfPresent(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -441,6 +441,36 @@ public class ClusterVariableIT {
     assertThat(deletedInstance).isNull();
   }
 
+  @TestTemplate
+  public void shouldSaveAndFindClusterVariableWithKind(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var dbModel =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+            .name(generateRandomString(10))
+            .value("\"secret\"")
+            .scope(ClusterVariableScope.GLOBAL)
+            .tenantId(null)
+            .kind(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+    createAndSaveVariables(testApplication.getRdbmsService(), dbModel);
+
+    // when
+    final var found =
+        testApplication
+            .getRdbmsService()
+            .getClusterVariableReader()
+            .getGloballyScopedClusterVariable(
+                dbModel.name(),
+                CommonFixtures.resourceAccessChecksFromResourceIds(
+                    AuthorizationResourceType.CLUSTER_VARIABLE, dbModel.name()));
+
+    // then
+    assertThat(found).isNotNull();
+    assertThat(found.kind())
+        .isEqualTo(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE);
+  }
+
   private void assertVariableDbModelEqualToEntity(
       final ClusterVariableDbModel dbModel, final ClusterVariableEntity entity) {
     // metadata is not yet persisted in ClusterVariableDbModel, so it has no equivalent to compare

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.entity;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import java.util.List;
 
@@ -21,6 +22,11 @@ public class ClusterVariableEntityTransformer
   @Override
   public ClusterVariableEntity apply(
       final io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity value) {
+    final var webappsKind = value.getKind();
+    final ClusterVariableKind kind =
+        webappsKind != null
+            ? ClusterVariableKind.valueOf(webappsKind.name())
+            : ClusterVariableKind.JSON;
     return new ClusterVariableEntity(
         value.getId(),
         value.getName(),
@@ -29,7 +35,8 @@ public class ClusterVariableEntityTransformer
         value.getIsPreview(),
         ClusterVariableScope.valueOf(value.getScope().name()),
         value.getTenantId(),
-        toMetadata(value.getMetadata()));
+        toMetadata(value.getMetadata()),
+        kind);
   }
 
   private List<MetadataEntry> toMetadata(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -50,6 +50,7 @@ public final class ClusterVariableFilterTransformer
     queries.addAll(getScopeQuery(filter.scopeOperations()));
     queries.addAll(getTenantQuery(filter.tenantIdOperations()));
     queries.addAll(getMetadataQuery(filter.metadataOperations()));
+    queries.addAll(getKindQuery(filter.kindOperations()));
     ofNullable(getIsTruncatedQuery(filter.isTruncated())).ifPresent(queries::add);
     return and(queries);
   }
@@ -74,6 +75,10 @@ public final class ClusterVariableFilterTransformer
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
     return stringTerms(ClusterVariableIndex.NAME, authorization.resourceIds());
+  }
+
+  private Collection<SearchQuery> getKindQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.KIND, operations);
   }
 
   private Collection<SearchQuery> getNamesQuery(final List<Operation<String>> operations) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterMetadataTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterMetadataTransformerTest.java
@@ -28,7 +28,9 @@ import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.query.SearchWildcardQuery;
+import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.MetadataValueFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UntypedOperation;
@@ -256,6 +258,39 @@ public final class ClusterVariableFilterMetadataTransformerTest extends Abstract
     final var nestedQueries =
         bool.must().stream().filter(q -> q.queryOption() instanceof SearchNestedQuery).toList();
     assertThat(nestedQueries).hasSize(2);
+  }
+
+  @Test
+  void shouldTransformKindFilter() {
+    // given
+    final var filter = FilterBuilders.clusterVariable().kinds("JSON").build();
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // single-value kinds() maps to EQ → SearchTermQuery, returned directly (no bool wrapper)
+    assertThat(query.queryOption()).isInstanceOf(SearchTermQuery.class);
+    final var termQuery = (SearchTermQuery) query.queryOption();
+    assertThat(termQuery.field()).isEqualTo(ClusterVariableIndex.KIND);
+    assertThat(termQuery.value().stringValue()).isEqualTo("JSON");
+  }
+
+  @Test
+  void shouldTransformMultipleKindFilter() {
+    // given
+    final var filter = FilterBuilders.clusterVariable().kinds("JSON", "SECRET_REFERENCE").build();
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // multiple values → IN → SearchTermsQuery, returned directly (no bool wrapper)
+    assertThat(query.queryOption()).isInstanceOf(SearchTermsQuery.class);
+    final var terms = (SearchTermsQuery) query.queryOption();
+    assertThat(terms.field()).isEqualTo(ClusterVariableIndex.KIND);
+    assertThat(terms.values().stream().map(TypedValue::stringValue).toList())
+        .containsExactly("JSON", "SECRET_REFERENCE");
   }
 
   private SearchQuery transformMetadataQuery(final String key, final Operation<?>... operations) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -22,7 +22,8 @@ public record ClusterVariableEntity(
     @Nullable Boolean isPreview,
     ClusterVariableScope scope,
     @Nullable String tenantId,
-    @Nullable List<MetadataEntry> metadata)
+    @Nullable List<MetadataEntry> metadata,
+    @Nullable ClusterVariableKind kind)
     implements TenantOwnedEntity {
 
   public ClusterVariableEntity {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -22,6 +22,7 @@ public record ClusterVariableFilter(
     List<Operation<String>> scopeOperations,
     List<Operation<String>> tenantIdOperations,
     List<MetadataValueFilter> metadataOperations,
+    List<Operation<String>> kindOperations,
     Boolean isTruncated)
     implements FilterBase {
 
@@ -31,6 +32,7 @@ public record ClusterVariableFilter(
     List<Operation<String>> scopeOperations;
     List<Operation<String>> tenantIdOperations;
     List<MetadataValueFilter> metadataOperations;
+    List<Operation<String>> kindOperations;
     Boolean isTruncated;
 
     public Builder nameOperations(final List<Operation<String>> operations) {
@@ -132,6 +134,25 @@ public record ClusterVariableFilter(
       return metadataOperations(collectValues(operation, operations));
     }
 
+    public Builder kindOperations(final List<Operation<String>> operations) {
+      kindOperations = addValuesToList(kindOperations, operations);
+      return this;
+    }
+
+    public Builder kinds(final String value, final String... values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder kinds(final List<String> values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder kindOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return kindOperations(collectValues(operation, operations));
+    }
+
     public Builder isTruncated(final Boolean value) {
       isTruncated = value;
       return this;
@@ -145,6 +166,7 @@ public record ClusterVariableFilter(
           Objects.requireNonNullElseGet(scopeOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(tenantIdOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(metadataOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(kindOperations, Collections::emptyList),
           isTruncated);
     }
   }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -56,6 +56,7 @@ public final class ClusterVariableServices
         new BrokerCreateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
+            .setKind(request.kind())
             .setGlobalScope(),
         authentication);
   }
@@ -66,6 +67,7 @@ public final class ClusterVariableServices
         new BrokerCreateClusterVariableRequest()
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
+            .setKind(request.kind())
             .setTenantScope(request.tenantId()),
         authentication);
   }
@@ -148,5 +150,9 @@ public final class ClusterVariableServices
     return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(value));
   }
 
-  public record ClusterVariableRequest(String name, Object value, String tenantId) {}
+  public record ClusterVariableRequest(
+      String name,
+      Object value,
+      String tenantId,
+      io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {}
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -29,6 +29,7 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   public static final String METADATA_KEY = "metadata.key";
   public static final String METADATA_VALUE = "metadata.value";
   public static final String METADATA_VALUE_NUMBER = "metadata.valueNumber";
+  public static final String KIND = "kind";
 
   public ClusterVariableIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -38,6 +38,9 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<MetadataEntry> metadata;
 
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private ClusterVariableKind kind;
+
   public boolean getIsPreview() {
     return isPreview;
   }
@@ -112,9 +115,18 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
     return this;
   }
 
+  public ClusterVariableKind getKind() {
+    return kind;
+  }
+
+  public ClusterVariableEntity setKind(final ClusterVariableKind kind) {
+    this.kind = kind;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata);
+    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata, kind);
   }
 
   @Override
@@ -130,7 +142,8 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         && Objects.equals(fullValue, that.fullValue)
         && scope == that.scope
         && Objects.equals(tenantId, that.tenantId)
-        && Objects.equals(metadata, that.metadata);
+        && Objects.equals(metadata, that.metadata)
+        && kind == that.kind;
   }
 
   @Override
@@ -157,6 +170,8 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         + '\''
         + ", metadata="
         + metadata
+        + ", kind="
+        + kind
         + '}';
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.clustervariable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableKind.class);
+
+  public static ClusterVariableKind fromProtocol(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    if (kind == null) {
+      return JSON;
+    }
+    return switch (kind) {
+      case JSON -> JSON;
+      case SECRET_REFERENCE -> SECRET_REFERENCE;
+    };
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
@@ -25,6 +25,9 @@
       "isPreview": {
         "type": "boolean"
       },
+      "kind": {
+        "type": "keyword"
+      },
       "metadata": {
         "type": "nested",
         "properties": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
@@ -25,6 +25,9 @@
       "isPreview": {
         "type": "boolean"
       },
+      "kind": {
+        "type": "keyword"
+      },
       "metadata": {
         "type": "nested",
         "properties": {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -74,7 +75,8 @@ public class ClusterVariableCreatedUpdatedHandler
     final var recordValue = record.getValue();
     entity
         .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope()))
-        .setName(recordValue.getName());
+        .setName(recordValue.getName())
+        .setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
 
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
       entity.setTenantId(recordValue.getTenantId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -7,6 +7,14 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.FULL_VALUE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.IS_PREVIEW;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.METADATA;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.SCOPE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.VALUE;
+
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
@@ -19,6 +27,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,8 +84,13 @@ public class ClusterVariableCreatedUpdatedHandler
     final var recordValue = record.getValue();
     entity
         .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope()))
-        .setName(recordValue.getName())
-        .setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
+        .setName(recordValue.getName());
+
+    // kind is immutable after creation — the UPDATED engine record carries the EnumProperty
+    // default (JSON) and does NOT reflect the stored kind. Only set it on CREATED.
+    if (record.getIntent() == ClusterVariableIntent.CREATED) {
+      entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
+    }
 
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
       entity.setTenantId(recordValue.getTenantId());
@@ -107,7 +121,18 @@ public class ClusterVariableCreatedUpdatedHandler
   @Override
   public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    // Use upsert with only mutable fields as updateFields, so UPDATED records never overwrite the
+    // immutable kind field in an existing ES/OS document. On CREATED (document absent) the full
+    // entity is indexed. This is consistent with how the RDBMS exporter excludes KIND from UPDATE.
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(NAME, entity.getName());
+    updateFields.put(VALUE, entity.getValue());
+    updateFields.put(FULL_VALUE, entity.getFullValue());
+    updateFields.put(IS_PREVIEW, entity.getIsPreview());
+    updateFields.put(SCOPE, entity.getScope());
+    updateFields.put(TENANT_ID, entity.getTenantId());
+    updateFields.put(METADATA, entity.getMetadata());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -271,6 +271,62 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
       value = ClusterVariableIntent.class,
       names = {"CREATED", "UPDATED"},
       mode = Mode.INCLUDE)
+  void shouldSetKindOnEntity(final ClusterVariableIntent intent) {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getKind())
+        .isEqualTo(
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind
+                .SECRET_REFERENCE);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
+  void shouldDefaultKindToJsonWhenNotInRecord(final ClusterVariableIntent intent) {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getKind())
+        .isEqualTo(io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind.JSON);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
   void shouldMapMetadataWithNumericAndStringValues(final ClusterVariableIntent intent) {
     // given
     final ClusterVariableRecordValue clusterVariableRecordValue =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -8,13 +8,19 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -140,7 +146,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlush() {
+  void shouldUpsertEntityOnFlushWithMutableFieldsOnly() {
     // given
     final ClusterVariableEntity inputEntity =
         new ClusterVariableEntity()
@@ -149,14 +155,19 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             .setValue("value")
             .setTenantId("tenantId")
             .setScope(
-                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT);
+                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT)
+            .setKind(ClusterVariableKind.SECRET_REFERENCE);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    // upsert is used so that the immutable "kind" field is never overwritten on UPDATED records
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("id"), eq(inputEntity), anyMap());
+    // batchRequest.add() must not be called — it does a full document replace that would
+    // overwrite the stored kind with null on UPDATED records
+    verify(mockRequest, never()).add(anyString(), any());
   }
 
   @ParameterizedTest
@@ -266,12 +277,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
         .containsExactly(new MetadataEntry("kind", "CREDENTIALS", null));
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = ClusterVariableIntent.class,
-      names = {"CREATED", "UPDATED"},
-      mode = Mode.INCLUDE)
-  void shouldSetKindOnEntity(final ClusterVariableIntent intent) {
+  @Test
+  void shouldSetKindOnEntityForCreatedRecord() {
     // given
     final ClusterVariableRecordValue recordValue =
         ImmutableClusterVariableRecordValue.builder()
@@ -282,7 +289,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
 
     final Record<ClusterVariableRecordValue> record =
         factory.generateRecord(
-            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
 
     // when
     final ClusterVariableEntity entity = new ClusterVariableEntity();
@@ -295,12 +303,34 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
                 .SECRET_REFERENCE);
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = ClusterVariableIntent.class,
-      names = {"CREATED", "UPDATED"},
-      mode = Mode.INCLUDE)
-  void shouldDefaultKindToJsonWhenNotInRecord(final ClusterVariableIntent intent) {
+  @Test
+  void shouldNotOverwriteKindOnUpdatedRecord() {
+    // given — UPDATED records carry the EnumProperty default (JSON), not the stored kind
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.UPDATED).withValue(recordValue));
+
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    // entity.kind is null here — the upsert partial-update path preserves whatever is in the doc
+    assertThat(entity.getKind()).isNull();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then — kind must not be set on UPDATED so the stored value survives the upsert
+    assertThat(entity.getKind()).isNull();
+  }
+
+  @Test
+  void shouldDefaultKindToJsonOnCreatedWhenRecordKindIsJson() {
     // given
     final ClusterVariableRecordValue recordValue =
         ImmutableClusterVariableRecordValue.builder()
@@ -311,7 +341,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
 
     final Record<ClusterVariableRecordValue> record =
         factory.generateRecord(
-            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
 
     // when
     final ClusterVariableEntity entity = new ClusterVariableEntity();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -51,7 +52,8 @@ public class ClusterVariableExportHandler
     final var builder =
         new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
             .name(value.getName())
-            .value(value.getValue());
+            .value(value.getValue())
+            .kind(ClusterVariableKind.valueOf(value.getKind().name()));
     if (value.getScope() == GLOBAL) {
       builder.scope(ClusterVariableScope.GLOBAL).tenantId(null);
     } else {

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
+import io.camunda.search.entities.ClusterVariableKind;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterVariableExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private ClusterVariableWriter clusterVariableWriter;
+
+  @Captor private ArgumentCaptor<ClusterVariableDbModel> dbModelCaptor;
+
+  private ClusterVariableExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new ClusterVariableExportHandler(clusterVariableWriter);
+  }
+
+  @Test
+  void shouldMapKindFromCreatedRecord() {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(clusterVariableWriter).create(dbModelCaptor.capture());
+    assertThat(dbModelCaptor.getValue().kind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldDefaultKindToJsonWhenRecordKindIsJson() {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(clusterVariableWriter).create(dbModelCaptor.capture());
+    assertThat(dbModelCaptor.getValue().kind()).isEqualTo(ClusterVariableKind.JSON);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -455,6 +455,10 @@ paths:
 
 components:
   schemas:
+    ClusterVariableKindEnum:
+      type: string
+      enum: [JSON, SECRET_REFERENCE]
+      description: The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
     ClusterVariableScopeEnum:
       type: string
       enum: [ GLOBAL, TENANT ]
@@ -472,6 +476,10 @@ components:
         value:
           type: object
           description: The value of the cluster variable. Can be any JSON object or primitive value. Will be serialized as a JSON string in responses.
+        kind:
+          description: The kind of the cluster variable. Defaults to JSON if not specified.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
     UpdateClusterVariableRequest:
       type: object
       required:
@@ -512,6 +520,7 @@ components:
         - name
         - scope
         - tenantId
+        - kind
       properties:
         name:
           description: The name of the cluster variable. Unique within its scope (global or tenant-specific).
@@ -523,6 +532,8 @@ components:
           type: string
           nullable: true
           description: Only provided if the cluster variable scope is TENANT. Null for global scope variables.
+        kind:
+          $ref: '#/components/schemas/ClusterVariableKindEnum'
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
       additionalProperties: false
@@ -578,6 +589,10 @@ components:
           description: |
             Filter cluster variables by truncation status of their stored values. When true, returns only variables whose stored values are truncated (i.e., the value exceeds the storage size limit and is truncated in storage). When false, returns only variables with non-truncated stored values. This filter is based on the underlying storage characteristic, not the response format.
           type: boolean
+        kind:
+          description: The kind filter for cluster variables.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindFilterProperty'
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.
       oneOf:
@@ -608,6 +623,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"
+    ClusterVariableKindFilterProperty:
+      description: ClusterVariableKindEnum property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        - $ref: '#/components/schemas/AdvancedClusterVariableKindFilter'
+    AdvancedClusterVariableKindFilter:
+      title: Advanced filter
+      description: Advanced ClusterVariableKindEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterVariableKindEnum'
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
     ClusterVariableSearchQueryResult:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -897,4 +897,36 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
   }
+
+  @Test
+  void shouldCreateGlobalClusterVariableWithSecretReferenceKind() {
+    // given
+    final var record =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL)
+            .setKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+    when(clusterVariableServices.createGloballyScopedClusterVariable(
+            createRequestCaptor.capture(), any()))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            "{\"name\":\"myVar\",\"value\":\"camunda.secrets.MY_SECRET\",\"kind\":\"SECRET_REFERENCE\"}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json("{\"kind\":\"SECRET_REFERENCE\"}", JsonCompareMode.LENIENT);
+
+    assertThat(createRequestCaptor.getValue().kind())
+        .isEqualTo(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
@@ -44,6 +44,14 @@ public class BrokerCreateClusterVariableRequest
     return this;
   }
 
+  public BrokerCreateClusterVariableRequest setKind(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    if (kind != null) {
+      requestDto.setKind(kind);
+    }
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +31,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue SCOPE_KEY = new StringValue("scope");
   private static final StringValue METADATA_KEY = new StringValue("metadata");
+  private static final StringValue KIND_KEY = new StringValue("kind");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -38,14 +40,17 @@ public class ClusterVariableRecord extends UnifiedRecordValue
       new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
   private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
+  private final EnumProperty<ClusterVariableKind> kindProp =
+      new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
 
   public ClusterVariableRecord() {
-    super(5);
+    super(6);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(metadataProp);
+        .declareProperty(metadataProp)
+        .declareProperty(kindProp);
   }
 
   @Override
@@ -119,6 +124,16 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getMetadataBuffer() {
     return metadataProp.getValue();
+  }
+
+  @Override
+  public ClusterVariableKind getKind() {
+    return kindProp.getValue();
+  }
+
+  public ClusterVariableRecord setKind(final ClusterVariableKind kind) {
+    kindProp.setValue(kind);
+    return this;
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3384,7 +3384,8 @@ final class JsonSerializableToJsonTest {
                   "value": "42",
                   "scope": "GLOBAL",
                   "tenantId": "<default>",
-                  "metadata": { "credentialType": "OAUTH2" }
+                  "metadata": { "credentialType": "OAUTH2" },
+                  "kind": "JSON"
                 }
                 """
       },
@@ -3403,7 +3404,8 @@ final class JsonSerializableToJsonTest {
                   "value": "42",
                   "scope": "TENANT",
                   "tenantId": "tenant-1",
-                  "metadata": {}
+                  "metadata": {},
+                  "kind": "JSON"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -39,6 +40,34 @@ final class ClusterVariableRecordTest {
     assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
     assertThat(copy.getValue()).isEqualTo(original.getValue());
     assertThat(copy.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldRoundTripKindViaMsgPack() {
+    // given
+    final var original =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(ClusterVariableScope.GLOBAL)
+            .setTenantId("<default>")
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")))
+            .setKind(ClusterVariableKind.SECRET_REFERENCE);
+
+    // when
+    final var copy = new ClusterVariableRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldDefaultKindToJsonWhenNotSet() {
+    // given / when
+    final var record = new ClusterVariableRecord();
+
+    // then
+    assertThat(record.getKind()).isEqualTo(ClusterVariableKind.JSON);
   }
 
   @Test

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +31,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue SCOPE_KEY = new StringValue("scope");
   private static final StringValue METADATA_KEY = new StringValue("metadata");
+  private static final StringValue KIND_KEY = new StringValue("kind");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -38,14 +40,17 @@ public class ClusterVariableRecord extends UnifiedRecordValue
       new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
   private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
+  private final EnumProperty<ClusterVariableKind> kindProp =
+      new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
 
   public ClusterVariableRecord() {
-    super(5);
+    super(6);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(metadataProp);
+        .declareProperty(metadataProp)
+        .declareProperty(kindProp);
   }
 
   @Override
@@ -119,6 +124,16 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getMetadataBuffer() {
     return metadataProp.getValue();
+  }
+
+  @Override
+  public ClusterVariableKind getKind() {
+    return kindProp.getValue();
+  }
+
+  public ClusterVariableRecord setKind(final ClusterVariableKind kind) {
+    kindProp.setValue(kind);
+    return this;
   }
 
   @JsonIgnore

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -33,6 +33,7 @@ import org.immutables.value.Value;
  *   <li>{@link #getValue()} – the current value of the cluster variable, as a deserialized object.
  *   <li>{@link #getScope()} – the current scope of the cluster variable.
  *   <li>{@link #getMetadata()} – the metadata attached to this cluster variable.
+ *   <li>{@link #getKind()} – the kind of value stored in this cluster variable.
  * </ul>
  *
  * @see RecordValue;
@@ -75,4 +76,18 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
    * @return the metadata map
    */
   Map<String, Object> getMetadata();
+
+  /**
+   * Returns the kind of this cluster variable.
+   *
+   * <p>Determines how the value is interpreted at job activation. {@code SECRET_REFERENCE} values
+   * contain {@code camunda.secrets.X} references resolved only at activation time. Defaults to
+   * {@code JSON}.
+   *
+   * @return the variable kind (never {@code null})
+   */
+  @Value.Default
+  default ClusterVariableKind getKind() {
+    return ClusterVariableKind.JSON;
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds a `kind` enum (`JSON` | `SECRET_REFERENCE`) to `ClusterVariable` across the full stack. The kind determines how the variable value is interpreted at job activation — `SECRET_REFERENCE` values contain `camunda.secrets.X` references that get resolved only when a job is activated. `kind` is settable on create (defaults to `JSON`), immutable after that, stored in both ES/OS and RDBMS, filterable via the search API, and exposed in `CamundaClient`.

The implementation follows the existing `scope` pattern exactly: new `EnumProperty` in the protocol record, `@SinceVersion(8.10.0)` entity field, nullable `KIND` column with `defaultValue="JSON"` in a Liquibase changeset, `ClusterVariableKindFilterProperty` in the CamundaClient, and matching OpenAPI schema components.

One thing that turned out to be a bit more interesting than I'd expected: the ES/OS exporter handler (`ClusterVariableCreatedUpdatedHandler`) runs for both `CREATED` and `UPDATED` intents. On `UPDATED`, the engine record carries `kind=JSON` (the `EnumProperty` default), not the stored value — so naively setting `entity.setKind(...)` on every intent would silently reset any `SECRET_REFERENCE` variable to `JSON` in ES/OS after the first update. Fixed this two ways: 1. Guard `setKind()` to `CREATED` intent only, so the same-batch `CREATED+UPDATED` case doesn't overwrite the kind the `CREATED` record already set. 2. Switch the `UPDATED` path from a full document replace (`batchRequest.add`) to a partial upsert (`batchRequest.upsert`) that excludes `kind`, so cross-batch updates never touch the field in ES/OS. This mirrors what the RDBMS exporter already does by excluding `KIND` from its `UPDATE` SQL.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57920