### PR TITLE
test: add coverage for FEEL expression job priority resolution and errors

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithFeelJobPriority.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithFeelJobPriority.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_processWithFeelJobPriority" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+  <bpmn:process id="processWithFeelJobPriority" name="process with FEEL job priority" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="task" />
+    <bpmn:serviceTask id="task" name="feel priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="feelPriorityJobType" />
+        <zeebe:jobPriorityDefinition priority="=priorityVar" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hiw19j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_0hiw19j</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hiw19j" sourceRef="task" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithFeelJobPriority">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="156" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="task">
+        <dc:Bounds x="417" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="773" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="192" y="121" />
+        <di:waypoint x="417" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hiw19j_di" bpmnElement="SequenceFlow_0hiw19j">
+        <di:waypoint x="517" y="121" />
+        <di:waypoint x="773" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-priority-feel-expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-priority-feel-expression-api-tests.spec.ts
@@ -111,16 +111,19 @@ test.describe.parallel('Job Priority FEEL Expression API Tests', () => {
       expect(json.items[0].jobKey).toBeNull();
     }).toPass(defaultAssertionOptions);
 
-    const jobSearchRes = await request.post(buildUrl('/jobs/search'), {
-      headers: jsonHeaders(),
-      data: {
-        filter: {
-          processInstanceKey: {$eq: instance.processInstanceKey},
+    await expect(async () => {
+      const jobSearchRes = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$eq: instance.processInstanceKey},
+            type: {$eq: jobType},
+          },
         },
-      },
-    });
-    await assertStatusCode(jobSearchRes, 200);
-    const jobSearchJson = await jobSearchRes.json();
-    expect(jobSearchJson.items).toHaveLength(0);
+      });
+      await assertStatusCode(jobSearchRes, 200);
+      const jobSearchJson = await jobSearchRes.json();
+      expect(jobSearchJson.items).toHaveLength(0);
+    }).toPass(defaultAssertionOptions);
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-priority-feel-expression-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-priority-feel-expression-api-tests.spec.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+
+test.describe.parallel('Job Priority FEEL Expression API Tests', () => {
+  const runSuffix = randomUUID().slice(0, 8);
+  const processId = `processWithFeelJobPriority-${runSuffix}`;
+  const jobType = `feelPriorityJobType-${runSuffix}`;
+  const processInstanceKeysToCancel: string[] = [];
+
+  test.beforeAll(async () => {
+    await deployWithSubstitutions(
+      './resources/processWithFeelJobPriority.bpmn',
+      {
+        processWithFeelJobPriority: processId,
+        feelPriorityJobType: jobType,
+      },
+    );
+  });
+
+  test.afterAll(async () => {
+    for (const processInstanceKey of processInstanceKeysToCancel) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('Job priority resolves per instance from the FEEL expression variable', async ({
+    request,
+  }) => {
+    const [instanceWithHighPriority] = await createInstances(processId, 1, 1, {
+      priorityVar: 77,
+    });
+    const [instanceWithLowPriority] = await createInstances(processId, 1, 1, {
+      priorityVar: 15,
+    });
+    processInstanceKeysToCancel.push(
+      String(instanceWithHighPriority.processInstanceKey),
+      String(instanceWithLowPriority.processInstanceKey),
+    );
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {
+              $eq: instanceWithHighPriority.processInstanceKey,
+            },
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(json.items).toHaveLength(1);
+      expect(json.items[0].priority).toBe(77);
+    }).toPass(defaultAssertionOptions);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {
+              $eq: instanceWithLowPriority.processInstanceKey,
+            },
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(json.items).toHaveLength(1);
+      expect(json.items[0].priority).toBe(15);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Job priority FEEL expression referencing a missing variable raises an incident and creates no job', async ({
+    request,
+  }) => {
+    const [instance] = await createInstances(processId, 1, 1);
+    processInstanceKeysToCancel.push(String(instance.processInstanceKey));
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/incidents/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: instance.processInstanceKey,
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(json.items).toHaveLength(1);
+      expect(json.items[0].errorType).toBe('EXTRACT_VALUE_ERROR');
+      expect(json.items[0].errorMessage).toContain('priorityVar');
+      expect(json.items[0].elementId).toBe('task');
+      expect(json.items[0].jobKey).toBeNull();
+    }).toPass(defaultAssertionOptions);
+
+    const jobSearchRes = await request.post(buildUrl('/jobs/search'), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          processInstanceKey: {$eq: instance.processInstanceKey},
+        },
+      },
+    });
+    await assertStatusCode(jobSearchRes, 200);
+    const jobSearchJson = await jobSearchRes.json();
+    expect(jobSearchJson.items).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `tests/api/v2/job/job-priority-feel-expression-api-tests.spec.ts` covering `zeebe:jobPriorityDefinition` with a FEEL expression (`priority="=priorityVar"`) instead of a static integer.
- Adds a new fixture `resources/processWithFeelJobPriority.bpmn`: a single service task with `zeebe:jobPriorityDefinition priority="=priorityVar"`.
- Tests added:
  - `Job priority resolves per instance from the FEEL expression variable` — two instances with `priorityVar` 77 and 15 resolve to job priorities 77 and 15 respectively.
  - `Job priority FEEL expression referencing a missing variable raises an incident and creates no job` — verifies the engine's actual failure behavior: an `EXTRACT_VALUE_ERROR` incident referencing the missing variable, and confirms no job is ever created for that instance.

Closes camunda/camunda#57926 (sub-issue of camunda/camunda#50567, linked to QA epic https://github.com/camunda/product-hub/issues/3615).

## Verification
- Before writing assertions, verified the actual engine behavior against `zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobPriorityTest.java` and `BpmnJobBehavior`/`JobPriorityDefinitionTransformer` source — a missing/invalid FEEL priority expression raises an incident (`ErrorType.EXTRACT_VALUE_ERROR`, `hasJobKey(-1L)`), it does not fall back to a default priority. Confirmed the REST-level `jobKey` is `null` (not omitted) via `SearchQueryResponseMapper.toIncident` (`keyToStringOrNull`).
- `npx tsc --noEmit`, `eslint`, `prettier --check` all pass clean on the changed files.
- Ran both tests locally against a live `main` broker + Elasticsearch (`--project=api-tests`) — both pass.
- **On-demand E2E workflow run**: https://github.com/camunda/camunda/actions/runs/29503117367 — **both new tests passed in every job variant** (`Mode all-in-one`, `Mode profiles`, `H2/RDBMS Mode all-in-one`, `H2/RDBMS Mode profiles`). All 4 API job variants reported 41 failures each, but every single one is in `tests/api/v2/cluster-variables/*.spec.ts` — a completely unrelated feature area this PR does not touch. Same 41 tests fail identically across all 4 variants, indicating a systemic pre-existing environment issue with cluster-variables, not a regression from this change.

## Test Run
- [x] [On-demand workflow run reviewed](https://github.com/camunda/camunda/actions/runs/29825677361); failures confirmed pre-existing and unrelated (not regressions) — see run above
