### PR TITLE
fix: ProcessingStateMachine does not access previousRecord after hasNext()

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -1,18 +1,9 @@
 /*
- * Copyright 2017-present Open Networking Foundation
- * Copyright © 2020 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.zeebe.journal.file;
 

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
@@ -77,6 +77,10 @@ public final class JournalRecordReaderUtil {
               expectedIndex, record.index()));
     }
     buffer.position(startPosition + metadataLength + recordLength);
+
+    // NOTE: the UnsafeBuffer wraps the ByteBuffer via its memory address (unsafe)
+    //       if the underlying buffer is unmapped, any access to serializedRecord will crash the JVM
+    //       link: https://github.com/camunda/camunda/issues/57609
     return new PersistedJournalRecord(
         metadata, record, new UnsafeBuffer(buffer, startPosition + metadataLength, recordLength));
   }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -1,26 +1,20 @@
 /*
- * Copyright © 2017 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.journal.JournalReader;
+import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
 import io.camunda.zeebe.journal.util.MockJournalMetastore;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -34,6 +28,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -173,6 +168,26 @@ class SegmentedJournalReaderTest {
     assertThat(journal.getJournalIndex().lookup(journal.getLastIndex()))
         .describedAs("Index must be built during seek")
         .isNotNull();
+  }
+
+  @Test
+  @Disabled(
+      "The test is crashing the JVM w/ SIGSEV as the record is referencing a pointer that has been unmapped.")
+  void shouldResetBufferWhenClosing() {
+    // given
+    for (int i = 1; i <= ENTRIES_PER_SEGMENT + 1; i++) {
+      assertThat(journal.append(i, recordDataWriter).index()).isEqualTo(i);
+    }
+    final JournalRecord record;
+    record = reader.next();
+    assertThat(record).isNotNull().returns("test", r -> BufferUtil.bufferAsString(r.data()));
+    journal.getFirstSegment().delete();
+
+    // when - reader is closed
+    reader.close();
+
+    // then
+    assertThat(BufferUtil.bufferAsString(record.data())).isEqualTo("");
   }
 
   private int getSerializedSize(final DirectBuffer data) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -141,6 +141,7 @@ public final class ProcessingStateMachine {
   private final RecordValues recordValues;
   private final TypedRecordImpl typedCommand;
   private final StreamProcessorListener streamProcessorListener;
+  private final PreviousRecord previousRecord = new PreviousRecord();
   // current iteration
   private LoggedEvent currentRecord;
   private ZeebeDbTransaction zeebeDbTransaction;
@@ -217,11 +218,11 @@ public final class ProcessingStateMachine {
   }
 
   void markProcessingCompleted() {
+    final var position = currentRecord.getPosition();
     currentStateDescription.set(
-        "finished processing",
-        currentRecord.getPosition(),
-        metadata.getIntent(),
-        metadata.getValueType());
+        "finished processing", position, metadata.getIntent(), metadata.getValueType());
+    previousRecord.set(position, isEventOrRejection.applies(currentRecord));
+    currentRecord = null;
     inProcessing = false;
     if (onErrorRetries > 0) {
       onErrorRetries = 0;
@@ -230,33 +231,29 @@ public final class ProcessingStateMachine {
   }
 
   void tryToReadNextRecord() {
-    final boolean hasNext;
-    if (currentRecord != null) {
-      final var previousRecord = currentRecord;
-      final var previousPosition = previousRecord.getPosition();
-      final var isAnEventOrARejection = isEventOrRejection.applies(previousRecord);
+    if (inProcessing) {
+      return;
+    }
 
-      // NOTE: hasNext() may advance the underlying storage reader and can switch/close segment
-      // readers
-      // when crossing a segment boundary. If the previous segment is marked for deletion and has
-      // no remaining readers, it may be unmapped, so avoid dereferencing `previousRecord` after
-      // calling hasNext().
-      hasNext = logStreamReader.hasNext();
+    // NOTE: hasNext() may advance the underlying storage reader and can switch/close segment
+    // readers. When crossing a segment boundary, the previous segment may be unmapped.
+    // currentRecord cannot be dereferenced until `.next()` is called
+    final var hasNext = logStreamReader.hasNext();
 
+    if (previousRecord.present) {
       // All commands cause a follow-up event or rejection, which means the processor
       // reached the end of the log if:
       //  * the last record was an event or rejection
       //  * and there is no next record on the log
       //  * and this was the last record written (records that have been written to the dispatcher
       //    might not be written to the log yet, which means they will appear shortly after this)
-      reachedEnd = isAnEventOrARejection && !hasNext && lastWrittenPosition <= previousPosition;
-    } else {
-      hasNext = logStreamReader.hasNext();
+      reachedEnd =
+          previousRecord.eventOrRejection
+              && !hasNext
+              && lastWrittenPosition <= previousRecord.position;
     }
-    // currentRecord cannot be accessed anymore until we replace with the next one by calling
-    // `next()`
 
-    if (shouldProcessNext.getAsBoolean() && hasNext && !inProcessing) {
+    if (shouldProcessNext.getAsBoolean() && hasNext) {
       currentRecord = logStreamReader.next();
 
       if (processingFilter.applies(currentRecord)) {
@@ -842,6 +839,19 @@ public final class ProcessingStateMachine {
 
   private record BatchProcessingStepResult(
       List<TypedRecord<?>> toProcess, List<LogAppendEntry> toWrite) {}
+
+  private static final class PreviousRecord {
+
+    private long position;
+    private boolean eventOrRejection;
+    private boolean present;
+
+    private void set(final long position, final boolean eventOrRejection) {
+      this.position = position;
+      this.eventOrRejection = eventOrRejection;
+      present = true;
+    }
+  }
 
   @FunctionalInterface
   private interface NextProcessingStep {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -230,21 +230,31 @@ public final class ProcessingStateMachine {
   }
 
   void tryToReadNextRecord() {
-    final var hasNext = logStreamReader.hasNext();
-
+    final boolean hasNext;
     if (currentRecord != null) {
       final var previousRecord = currentRecord;
+      final var previousPosition = previousRecord.getPosition();
+      final var isAnEventOrARejection = isEventOrRejection.applies(previousRecord);
+
+      // NOTE: hasNext() may advance the underlying storage reader and can switch/close segment
+      // readers
+      // when crossing a segment boundary. If the previous segment is marked for deletion and has
+      // no remaining readers, it may be unmapped, so avoid dereferencing `previousRecord` after
+      // calling hasNext().
+      hasNext = logStreamReader.hasNext();
+
       // All commands cause a follow-up event or rejection, which means the processor
       // reached the end of the log if:
       //  * the last record was an event or rejection
       //  * and there is no next record on the log
       //  * and this was the last record written (records that have been written to the dispatcher
       //    might not be written to the log yet, which means they will appear shortly after this)
-      reachedEnd =
-          isEventOrRejection.applies(previousRecord)
-              && !hasNext
-              && lastWrittenPosition <= previousRecord.getPosition();
+      reachedEnd = isAnEventOrARejection && !hasNext && lastWrittenPosition <= previousPosition;
+    } else {
+      hasNext = logStreamReader.hasNext();
     }
+    // currentRecord cannot be accessed anymore until we replace with the next one by calling
+    // `next()`
 
     if (shouldProcessNext.getAsBoolean() && hasNext && !inProcessing) {
       currentRecord = logStreamReader.next();

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -1718,7 +1718,7 @@ public final class StreamProcessorTest {
           Files.deleteIfExists(tempFile);
         }
       } catch (final IOException e) {
-        // best effort
+        throw new RuntimeException(e);
       } finally {
         lastMapped = null;
         tempFile = null;

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -68,7 +68,9 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.agrona.IoUtil;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
@@ -77,6 +79,8 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
@@ -1577,50 +1581,75 @@ public final class StreamProcessorTest {
    * unmapped buffer and the JVM crashes; with the fix all reads happen before {@code hasNext()} and
    * the processor drains the log normally.
    */
-  @RegressionTest("https://github.com/camunda/camunda/issues/57609")
-  public void shouldNotAccessPreviousRecordAfterHasNext() {
-    // given -- a reader that unmaps the previously returned record when it crosses to the next one
+  @ParameterizedTest(name = "write in separate batches: {0}")
+  @ValueSource(booleans = {false, true})
+  public void shouldNotAccessPreviousRecordAfterHasNext(final boolean writeInSeparateBatches)
+      throws InterruptedException {
+    // given -- a reader that unmaps a returned record when checking for another record
     final var realStream = streamPlatform.getLogStream();
     final var spyStream = spy(realStream);
-    doAnswer(invocation -> new UnmapOnCrossReader((LogStreamReader) invocation.callRealMethod()))
+    final var recordUnmapped = new CountDownLatch(1);
+    doAnswer(
+            invocation ->
+                new UnmapOnCrossReader(
+                    (LogStreamReader) invocation.callRealMethod(), recordUnmapped))
         .when(spyStream)
         .newLogStreamReader();
 
     final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
     streamPlatform.buildStreamProcessor(spyStream, true);
 
-    // when - two commands ensure hasNext() returns true while the first record is still held
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+    final var key = new AtomicInteger(1);
+    final var events =
+        Stream.generate(
+                () ->
+                    RecordToWrite.command()
+                        .processInstance(
+                            ACTIVATE_ELEMENT, Records.processInstance(key.getAndIncrement())))
+            .limit(2)
+            .toArray(RecordToWrite[]::new);
+    // when
+    if (writeInSeparateBatches) {
+      streamPlatform.writeBatch(events[0]);
+      assertThat(recordUnmapped.await(10, TimeUnit.SECONDS)).isTrue();
+      streamPlatform.writeBatch(events[1]);
+    } else {
+      streamPlatform.writeBatch(events);
+    }
 
-    // then -- the processor keeps processing across the crossing instead of crashing the JVM
+    // then -- the processor does not access the invalid previous record
     verify(defaultRecordProcessor, TIMEOUT.times(2)).process(any(), any());
   }
 
   /**
    * Wraps a {@link LogStreamReader}, copying every returned record into its own mmap'd buffer and
-   * unmapping the previously returned record's buffer whenever {@code hasNext()} advances to a new
-   * record. This emulates a journal segment being unmapped as the reader crosses a segment
-   * boundary, see {@link #shouldNotAccessPreviousRecordAfterHasNext()}.
+   * unmapping the previously returned record's buffer whenever {@code hasNext()} checks the
+   * underlying reader. This emulates a journal segment being unmapped when the reader crosses a
+   * segment boundary, including when no next record is available yet.
    */
   private static final class UnmapOnCrossReader implements LogStreamReader {
 
     private final LogStreamReader delegate;
+    private final CountDownLatch unavailableNextRecord;
     private MappedByteBuffer lastMapped;
     private Path tempFile;
 
-    private UnmapOnCrossReader(final LogStreamReader delegate) {
+    private UnmapOnCrossReader(
+        final LogStreamReader delegate, final CountDownLatch unavailableNextRecord) {
       this.delegate = delegate;
+      this.unavailableNextRecord = unavailableNextRecord;
     }
 
     @Override
     public boolean hasNext() {
       final boolean hasNext = delegate.hasNext();
-      // advancing to the next record releases (unmaps) the previously returned record's segment;
-      // only happens when we actually cross to a new record.
-      if (hasNext && lastMapped != null) {
+      // Checking for the next record may release the previously returned record's segment, even
+      // when no next record is available yet.
+      if (lastMapped != null) {
         unmapLast();
+        if (!hasNext) {
+          unavailableNextRecord.countDown();
+        }
       }
       return hasNext;
     }
@@ -1686,12 +1715,14 @@ public final class StreamProcessorTest {
           IoUtil.unmap(lastMapped);
         }
         if (tempFile != null) {
-          Files.delete(tempFile);
+          Files.deleteIfExists(tempFile);
         }
       } catch (final IOException e) {
         // best effort
+      } finally {
+        lastMapped = null;
+        tempFile = null;
       }
-      lastMapped = null;
     }
 
     @Override

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDbTransaction;
+import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
+import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -55,11 +57,20 @@ import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import org.agrona.IoUtil;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.awaitility.Awaitility;
@@ -1548,6 +1559,146 @@ public final class StreamProcessorTest {
                         && healthReport.getIssue().throwable()
                             instanceof final UncommittedStateException uncommittedStateException
                         && uncommittedStateException.getCause().equals(unexpectedException)));
+  }
+
+  /**
+   * Reproduces the use-after-unmap crash described in
+   * https://github.com/camunda/camunda/issues/57609.
+   *
+   * <p>The {@link ProcessingStateMachine} kept the last-read record as a zero-copy flyweight into a
+   * journal segment's mmap buffer, and used to dereference it <em>after</em> calling {@code
+   * hasNext()}. {@code hasNext()} can cross a segment boundary and unmap the previous segment, so
+   * reading the flyweight afterwards accessed freed memory and crashed the JVM (SIGSEGV).
+   *
+   * <p>This test emulates that by wrapping the real reader: every returned record is copied into a
+   * freshly mmap'd buffer, and crossing to the next record (a {@code hasNext()} that advances)
+   * unmaps the previously returned record's buffer — exactly the window in which the previous
+   * record must no longer be touched. With the buggy ordering the processor thread reads the
+   * unmapped buffer and the JVM crashes; with the fix all reads happen before {@code hasNext()} and
+   * the processor drains the log normally.
+   */
+  @RegressionTest("https://github.com/camunda/camunda/issues/57609")
+  public void shouldNotAccessPreviousRecordAfterHasNext() {
+    // given -- a reader that unmaps the previously returned record when it crosses to the next one
+    final var realStream = streamPlatform.getLogStream();
+    final var spyStream = spy(realStream);
+    doAnswer(invocation -> new UnmapOnCrossReader((LogStreamReader) invocation.callRealMethod()))
+        .when(spyStream)
+        .newLogStreamReader();
+
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    streamPlatform.buildStreamProcessor(spyStream, true);
+
+    // when - two commands ensure hasNext() returns true while the first record is still held
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(2)));
+
+    // then -- the processor keeps processing across the crossing instead of crashing the JVM
+    verify(defaultRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+  }
+
+  /**
+   * Wraps a {@link LogStreamReader}, copying every returned record into its own mmap'd buffer and
+   * unmapping the previously returned record's buffer whenever {@code hasNext()} advances to a new
+   * record. This emulates a journal segment being unmapped as the reader crosses a segment
+   * boundary, see {@link #shouldNotAccessPreviousRecordAfterHasNext()}.
+   */
+  private static final class UnmapOnCrossReader implements LogStreamReader {
+
+    private final LogStreamReader delegate;
+    private MappedByteBuffer lastMapped;
+    private Path tempFile;
+
+    private UnmapOnCrossReader(final LogStreamReader delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+      final boolean hasNext = delegate.hasNext();
+      // advancing to the next record releases (unmaps) the previously returned record's segment;
+      // only happens when we actually cross to a new record.
+      if (hasNext && lastMapped != null) {
+        unmapLast();
+      }
+      return hasNext;
+    }
+
+    @Override
+    public LoggedEvent next() {
+      final var event = delegate.next();
+      unmapLast();
+      lastMapped = mapToNativeMemory(event);
+      final var copy = new LoggedEventImpl();
+      copy.wrap(new UnsafeBuffer(lastMapped), 0);
+      return copy;
+    }
+
+    private MappedByteBuffer mapToNativeMemory(final LoggedEvent event) {
+      final int length = event.getLength();
+      try {
+        tempFile = Files.createTempFile("uae-repro-57609", ".seg");
+        try (final var channel =
+            FileChannel.open(tempFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+          final var mapped = channel.map(MapMode.READ_WRITE, 0, length);
+          event.write(new UnsafeBuffer(mapped), 0);
+          return mapped;
+        }
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    @Override
+    public boolean seekToNextEvent(final long position) {
+      return delegate.seekToNextEvent(position);
+    }
+
+    @Override
+    public boolean seek(final long position) {
+      return delegate.seek(position);
+    }
+
+    @Override
+    public void seekToFirstEvent() {
+      delegate.seekToFirstEvent();
+    }
+
+    @Override
+    public long seekToEnd() {
+      return delegate.seekToEnd();
+    }
+
+    @Override
+    public long getPosition() {
+      return delegate.getPosition();
+    }
+
+    @Override
+    public LoggedEvent peekNext() {
+      return delegate.peekNext();
+    }
+
+    private void unmapLast() {
+      try {
+        if (lastMapped != null) {
+          IoUtil.unmap(lastMapped);
+        }
+        if (tempFile != null) {
+          Files.delete(tempFile);
+        }
+      } catch (final IOException e) {
+        // best effort
+      }
+      lastMapped = null;
+    }
+
+    @Override
+    public void close() {
+      unmapLast();
+      delegate.close();
+    }
   }
 
   private static final class TestProcessor implements RecordProcessor {


### PR DESCRIPTION
## Description
Accessing previousRecord after hasNext() has been called might crash the JVM if the segment is unmapped before `next()` has been called.

All access of previousRecord now happen before `hasNext()` has been called.

Added a test that is crashing the JVM with the ProcessingStateMachine code from main:
```
just utOnly StreamProcessorTest -pl zeebe/stream-platform/
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.2:test (default-test) on project zeebe-stream-platform:
[ERROR]
[ERROR] See /home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform/target/surefire-reports for the individual test results.
[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd '/home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform' && '/usr/lib/jvm/java-25-openjdk/bin/java' '--add-opens=java.base/java.io=ALL-UNNAMED' '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED' '--enable-native-access=ALL-UNNAMED' '-jar' '/home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform/target/surefire/surefirebooter-20260716200256978_3.jar' '/home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform/target/surefire' '2026-07-16T20-02-56_904-jvmRun1' 'surefire-20260716200256978_1tmp' 'surefire_0-20260716200256978_2tmp'
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 134
[ERROR] Crashed tests:
[ERROR] io.camunda.zeebe.stream.impl.StreamProcessorTest
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd '/home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform' && '/usr/lib/jvm/java-25-openjdk/bin/java' '--add-opens=java.base/java.io=ALL-UNNAMED' '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED' '--enable-native-access=ALL-UNNAMED' '-jar' '/home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform/target/surefire/surefirebooter-20260716200256978_3.jar' '/home/carlosana/workspace/camunda/monorepo/zeebe/stream-platform/target/surefire' '2026-07-16T20-02-56_904-jvmRun1' 'surefire-20260716200256978_1tmp' 'surefire_0-20260716200256978_2tmp'
[ERROR] Error occurred in starting fork, check output in log
[ERROR] Process Exit Code: 134
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57609
