### PR TITLE
feat: add ClusterVariableKind to protocol record

### DIFF
--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-cluster-variable.json
@@ -25,6 +25,9 @@
       "isPreview": {
         "type": "boolean"
       },
+      "kind": {
+        "type": "keyword"
+      },
       "metadata": {
         "type": "nested",
         "properties": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-cluster-variable.json
@@ -25,6 +25,9 @@
       "isPreview": {
         "type": "boolean"
       },
+      "kind": {
+        "type": "keyword"
+      },
       "metadata": {
         "type": "nested",
         "properties": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
@@ -34,6 +34,9 @@
             "tenantId": {
               "type": "keyword"
             },
+            "kind": {
+              "type": "keyword"
+            },
             "metadata": {
               "enabled": false
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
@@ -40,6 +40,9 @@
             "tenantId": {
               "type": "keyword"
             },
+            "kind": {
+              "type": "keyword"
+            },
             "metadata": {
               "enabled": false
             }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateClusterVariableRequest.java
@@ -49,6 +49,14 @@ public class BrokerCreateClusterVariableRequest
     return this;
   }
 
+  public BrokerCreateClusterVariableRequest setKind(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    if (kind != null) {
+      requestDto.setKind(kind);
+    }
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +31,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue SCOPE_KEY = new StringValue("scope");
   private static final StringValue METADATA_KEY = new StringValue("metadata");
+  private static final StringValue KIND_KEY = new StringValue("kind");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -38,14 +40,17 @@ public class ClusterVariableRecord extends UnifiedRecordValue
       new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
   private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
+  private final EnumProperty<ClusterVariableKind> kindProp =
+      new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
 
   public ClusterVariableRecord() {
-    super(5);
+    super(6);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(metadataProp);
+        .declareProperty(metadataProp)
+        .declareProperty(kindProp);
   }
 
   @Override
@@ -119,6 +124,16 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getMetadataBuffer() {
     return metadataProp.getValue();
+  }
+
+  @Override
+  public ClusterVariableKind getKind() {
+    return kindProp.getValue();
+  }
+
+  public ClusterVariableRecord setKind(final ClusterVariableKind kind) {
+    kindProp.setValue(kind);
+    return this;
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -117,6 +117,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
@@ -3379,7 +3380,8 @@ final class JsonSerializableToJsonTest {
                     .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("42")))
                     .setMetadata(
                         new UnsafeBuffer(
-                            MsgPackConverter.convertToMsgPack(Map.of("credentialType", "OAUTH2")))),
+                            MsgPackConverter.convertToMsgPack(Map.of("credentialType", "OAUTH2"))))
+                    .setKind(ClusterVariableKind.SECRET_REFERENCE),
         """
                 {
                   "name": "myVar",
@@ -3387,7 +3389,7 @@ final class JsonSerializableToJsonTest {
                   "scope": "GLOBAL",
                   "tenantId": "<default>",
                   "metadata": { "credentialType": "OAUTH2" },
-                  "kind": "JSON"
+                  "kind": "SECRET_REFERENCE"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3386,7 +3386,8 @@ final class JsonSerializableToJsonTest {
                   "value": "42",
                   "scope": "GLOBAL",
                   "tenantId": "<default>",
-                  "metadata": { "credentialType": "OAUTH2" }
+                  "metadata": { "credentialType": "OAUTH2" },
+                  "kind": "JSON"
                 }
                 """
       },
@@ -3405,7 +3406,8 @@ final class JsonSerializableToJsonTest {
                   "value": "42",
                   "scope": "TENANT",
                   "tenantId": "tenant-1",
-                  "metadata": {}
+                  "metadata": {},
+                  "kind": "JSON"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/clustervariable/ClusterVariableRecordTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.clustervariable;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -39,6 +40,34 @@ final class ClusterVariableRecordTest {
     assertThat(copy.getTenantId()).isEqualTo(original.getTenantId());
     assertThat(copy.getValue()).isEqualTo(original.getValue());
     assertThat(copy.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldRoundTripKindViaMsgPack() {
+    // given
+    final var original =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(ClusterVariableScope.GLOBAL)
+            .setTenantId("<default>")
+            .setValue(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("\"value\"")))
+            .setKind(ClusterVariableKind.SECRET_REFERENCE);
+
+    // when
+    final var copy = new ClusterVariableRecord();
+    copy.copyFrom(original);
+
+    // then
+    assertThat(copy.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldDefaultKindToJsonWhenNotSet() {
+    // given / when
+    final var record = new ClusterVariableRecord();
+
+    // then
+    assertThat(record.getKind()).isEqualTo(ClusterVariableKind.JSON);
   }
 
   @Test

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ClusterVariableRecord.golden
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -30,6 +31,7 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue SCOPE_KEY = new StringValue("scope");
   private static final StringValue METADATA_KEY = new StringValue("metadata");
+  private static final StringValue KIND_KEY = new StringValue("kind");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp =
@@ -38,14 +40,17 @@ public class ClusterVariableRecord extends UnifiedRecordValue
       new EnumProperty<>(SCOPE_KEY, ClusterVariableScope.class, ClusterVariableScope.UNSPECIFIED);
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
   private final DocumentProperty metadataProp = new DocumentProperty(METADATA_KEY);
+  private final EnumProperty<ClusterVariableKind> kindProp =
+      new EnumProperty<>(KIND_KEY, ClusterVariableKind.class, ClusterVariableKind.JSON);
 
   public ClusterVariableRecord() {
-    super(5);
+    super(6);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(metadataProp);
+        .declareProperty(metadataProp)
+        .declareProperty(kindProp);
   }
 
   @Override
@@ -119,6 +124,16 @@ public class ClusterVariableRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getMetadataBuffer() {
     return metadataProp.getValue();
+  }
+
+  @Override
+  public ClusterVariableKind getKind() {
+    return kindProp.getValue();
+  }
+
+  public ClusterVariableRecord setKind(final ClusterVariableKind kind) {
+    kindProp.setValue(kind);
+    return this;
   }
 
   @JsonIgnore

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableKind.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClusterVariableRecordValue.java
@@ -33,6 +33,7 @@ import org.immutables.value.Value;
  *   <li>{@link #getValue()} – the current value of the cluster variable, as a deserialized object.
  *   <li>{@link #getScope()} – the current scope of the cluster variable.
  *   <li>{@link #getMetadata()} – the metadata attached to this cluster variable.
+ *   <li>{@link #getKind()} – the kind of value stored in this cluster variable.
  * </ul>
  *
  * @see RecordValue;
@@ -75,4 +76,18 @@ public interface ClusterVariableRecordValue extends RecordValue, TenantOwned {
    * @return the metadata map
    */
   Map<String, Object> getMetadata();
+
+  /**
+   * Returns the kind of this cluster variable.
+   *
+   * <p>Determines how the value is interpreted at job activation. {@code SECRET_REFERENCE} values
+   * contain {@code camunda.secrets.X} references resolved only at activation time. Defaults to
+   * {@code JSON}.
+   *
+   * @return the variable kind (never {@code null})
+   */
+  @Value.Default
+  default ClusterVariableKind getKind() {
+    return ClusterVariableKind.JSON;
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds `ClusterVariableKind` (enum: `JSON` | `SECRET_REFERENCE`) to the protocol record layer. This is the first in a series of PRs implementing #57920.

1. New `ClusterVariableKind` enum in `zeebe/protocol`.
2. `ClusterVariableRecordValue.getKind()` with `@Value.Default` returning `JSON` for backwards compatibility — old records without a `kind` field deserialize as `JSON` automatically via the `EnumProperty` default.
3. `ClusterVariableRecord` gains a new `EnumProperty<ClusterVariableKind>` (`super(6)` instead of 5).
4. `BrokerCreateClusterVariableRequest.setKind()` for the gateway request path.

No migration needed at the protocol level — the msgpack `EnumProperty` default handles old records transparently.

**Stack** (merge in order):
- 👉 **This PR** — engine/protocol
- ES/OS exporter (webapps-schema + handler)
- API (search domain + REST layer)
- RDBMS exporter
- CamundaClient

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #57920