### PR TITLE
feat: add kind to ES/OS exporter and webapps-schema

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -29,6 +29,7 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   public static final String METADATA_KEY = "metadata.key";
   public static final String METADATA_VALUE = "metadata.value";
   public static final String METADATA_VALUE_NUMBER = "metadata.valueNumber";
+  public static final String KIND = "kind";
 
   public ClusterVariableIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -38,6 +38,9 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<MetadataEntry> metadata;
 
+  @SinceVersion("8.10.0")
+  private ClusterVariableKind kind = ClusterVariableKind.JSON;
+
   public boolean getIsPreview() {
     return isPreview;
   }
@@ -112,9 +115,18 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
     return this;
   }
 
+  public ClusterVariableKind getKind() {
+    return kind;
+  }
+
+  public ClusterVariableEntity setKind(final ClusterVariableKind kind) {
+    this.kind = kind;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata);
+    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata, kind);
   }
 
   @Override
@@ -130,7 +142,8 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         && Objects.equals(fullValue, that.fullValue)
         && scope == that.scope
         && Objects.equals(tenantId, that.tenantId)
-        && Objects.equals(metadata, that.metadata);
+        && Objects.equals(metadata, that.metadata)
+        && kind == that.kind;
   }
 
   @Override
@@ -157,6 +170,8 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         + '\''
         + ", metadata="
         + metadata
+        + ", kind="
+        + kind
         + '}';
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.clustervariable;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+
+  public static ClusterVariableKind fromProtocol(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    if (kind == null) {
+      return JSON;
+    }
+    return switch (kind) {
+      case JSON -> JSON;
+      case SECRET_REFERENCE -> SECRET_REFERENCE;
+    };
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds `kind` support to the ES/OS exporter layer. Part of the #57920 stack — depends on the engine PR.

1. `ClusterVariableKind` enum in `webapps-schema` with `fromProtocol()` static converter.
2. `ClusterVariableEntity` gains `@SinceVersion(8.10.0) ClusterVariableKind kind` — default to json
3. ES/OS index mappings (`camunda-cluster-variable.json`) gain `"kind": { "type": "keyword" }`.
4. `ClusterVariableIndex.KIND` constant added.

One thing worth calling out: the handler runs for both `CREATED` and `UPDATED` intents, but the engine record on `UPDATED` carries `kind=JSON` (the `EnumProperty` default) since the update processor doesn't load stored state. To avoid silently resetting `SECRET_REFERENCE` variables to `JSON` on every update, the `UPDATED` path uses a partial upsert (`batchRequest.upsert` with an explicit field list) that excludes `kind`, mirroring how the RDBMS exporter already excludes `KIND` from its `UPDATE` SQL.

**Stack** (merge in order):
- Engine PR — #57981
- 👉 **This PR** — ES/OS exporter + webapps-schema
- API (search domain + REST layer)
- RDBMS exporter
- CamundaClient

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #57920