### PR TITLE
feat: add kind to ClusterVariable REST API and search layer

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableKind.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/enums/ClusterVariableKind.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.enums;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE,
+  UNKNOWN_ENUM_VALUE;
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ClusterVariableFilter.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.client.api.search.filter;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
 import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.request.TypedFilterableRequest.SearchRequestFilter;
@@ -97,4 +99,21 @@ public interface ClusterVariableFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   ClusterVariableFilter isTruncated(final Boolean isTruncated);
+
+  /**
+   * Filters cluster variables by the specified kind.
+   *
+   * @param kind the kind of the cluster variable (JSON or SECRET_REFERENCE)
+   * @return the updated filter
+   */
+  ClusterVariableFilter kind(final ClusterVariableKind kind);
+
+  /**
+   * Filters cluster variables by the specified kind using {@link ClusterVariableKindProperty}
+   * consumer.
+   *
+   * @param fn the kind {@link ClusterVariableKindProperty} consumer of the variable
+   * @return the updated filter
+   */
+  ClusterVariableFilter kind(final Consumer<ClusterVariableKindProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableKindProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/ClusterVariableKindProperty.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+
+public interface ClusterVariableKindProperty
+    extends LikeProperty<ClusterVariableKind, String, ClusterVariableKindProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ClusterVariable.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.response;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 
 public interface ClusterVariable {
@@ -40,4 +41,7 @@ public interface ClusterVariable {
    * false} for get-by-name operations, which always return full values.
    */
   Boolean isTruncated();
+
+  /* The kind of the cluster variable */
+  ClusterVariableKind getKind();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ClusterVariableFilterImpl.java
@@ -15,10 +15,13 @@
  */
 package io.camunda.client.impl.search.filter;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.filter.ClusterVariableFilter;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
 import io.camunda.client.api.search.filter.builder.ClusterVariableScopeProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.filter.builder.ClusterVariableKindPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ClusterVariableScopePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
@@ -94,6 +97,20 @@ public class ClusterVariableFilterImpl
   @Override
   public ClusterVariableFilter isTruncated(final Boolean isTruncated) {
     filter.setIsTruncated(isTruncated);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter kind(final ClusterVariableKind kind) {
+    kind(b -> b.eq(kind));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableFilter kind(final Consumer<ClusterVariableKindProperty> fn) {
+    final ClusterVariableKindProperty property = new ClusterVariableKindPropertyImpl();
+    fn.accept(property);
+    filter.setKind(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableKindPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/ClusterVariableKindPropertyImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter.builder;
+
+import io.camunda.client.api.search.enums.ClusterVariableKind;
+import io.camunda.client.api.search.filter.builder.ClusterVariableKindProperty;
+import io.camunda.client.impl.search.request.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.util.CollectionUtil;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
+import io.camunda.client.protocol.rest.ClusterVariableKindFilterProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClusterVariableKindPropertyImpl
+    extends TypedSearchRequestPropertyProvider<ClusterVariableKindFilterProperty>
+    implements ClusterVariableKindProperty {
+
+  private final ClusterVariableKindFilterProperty filterProperty =
+      new ClusterVariableKindFilterProperty();
+
+  @Override
+  public ClusterVariableKindProperty eq(final ClusterVariableKind value) {
+    filterProperty.set$Eq(EnumUtil.convert(value, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty neq(final ClusterVariableKind value) {
+    filterProperty.set$Neq(EnumUtil.convert(value, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty exists(final boolean value) {
+    filterProperty.set$Exists(value);
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty in(final List<ClusterVariableKind> value) {
+    filterProperty.set$In(
+        value.stream()
+            .map(source -> (EnumUtil.convert(source, ClusterVariableKindEnum.class)))
+            .collect(Collectors.toList()));
+    return this;
+  }
+
+  @Override
+  public ClusterVariableKindProperty in(final ClusterVariableKind... values) {
+    return in(CollectionUtil.toList(values));
+  }
+
+  @Override
+  protected ClusterVariableKindFilterProperty getSearchRequestProperty() {
+    return filterProperty;
+  }
+
+  @Override
+  public ClusterVariableKindProperty like(final String value) {
+    filterProperty.set$Like(value);
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ClusterVariableImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.impl.search.response;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.client.impl.util.EnumUtil;
@@ -28,6 +29,7 @@ public class ClusterVariableImpl implements ClusterVariable {
   private final String tenantId;
   private final ClusterVariableScope scope;
   private final Boolean isTruncated;
+  private final ClusterVariableKind kind;
 
   public ClusterVariableImpl(final ClusterVariableResult clusterVariableResult) {
     name = clusterVariableResult.getName();
@@ -35,6 +37,7 @@ public class ClusterVariableImpl implements ClusterVariable {
     tenantId = clusterVariableResult.getTenantId();
     scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
     isTruncated = false;
+    kind = EnumUtil.convert(clusterVariableResult.getKind(), ClusterVariableKind.class);
   }
 
   public ClusterVariableImpl(final ClusterVariableSearchResult clusterVariableSearchResult) {
@@ -43,6 +46,7 @@ public class ClusterVariableImpl implements ClusterVariable {
     tenantId = clusterVariableSearchResult.getTenantId();
     scope = EnumUtil.convert(clusterVariableSearchResult.getScope(), ClusterVariableScope.class);
     isTruncated = clusterVariableSearchResult.getIsTruncated();
+    kind = EnumUtil.convert(clusterVariableSearchResult.getKind(), ClusterVariableKind.class);
   }
 
   @Override
@@ -68,5 +72,10 @@ public class ClusterVariableImpl implements ClusterVariable {
   @Override
   public Boolean isTruncated() {
     return isTruncated;
+  }
+
+  @Override
+  public ClusterVariableKind getKind() {
+    return kind;
   }
 }

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -649,4 +649,15 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="add_cluster_variable_kind_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}CLUSTER_VARIABLE" columnName="KIND"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}CLUSTER_VARIABLE">
+      <column name="KIND" type="VARCHAR(255)" defaultValue="JSON"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ClusterVariableSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ClusterVariableSearchColumn.java
@@ -16,7 +16,8 @@ public enum ClusterVariableSearchColumn implements SearchColumn<ClusterVariableE
   VAR_FULL_VALUE("fullValue"),
   TENANT_ID("tenantId"),
   SCOPE("scope"),
-  IS_PREVIEW("isPreview");
+  IS_PREVIEW("isPreview"),
+  KIND("kind");
   private final String property;
 
   ClusterVariableSearchColumn(final String property) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -13,6 +13,7 @@ import static io.camunda.util.ValueTypeUtil.mapLong;
 
 import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.util.ClusterVariableUtil;
@@ -32,7 +33,8 @@ public record ClusterVariableDbModel(
     boolean isPreview,
     String tenantId,
     ClusterVariableScope scope,
-    List<MetadataEntry> metadata)
+    List<MetadataEntry> metadata,
+    ClusterVariableKind kind)
     implements Copyable<ClusterVariableDbModel> {
 
   @Override
@@ -46,7 +48,8 @@ public record ClusterVariableDbModel(
                 .value(value)
                 .tenantId(tenantId)
                 .scope(scope)
-                .metadata(metadata))
+                .metadata(metadata)
+                .kind(kind))
         .build();
   }
 
@@ -75,7 +78,8 @@ public record ClusterVariableDbModel(
         isPreview,
         tenantId,
         scope,
-        truncateMetadata(sizeLimit, byteLimit));
+        truncateMetadata(sizeLimit, byteLimit),
+        kind);
   }
 
   // Metadata values have no full-value fallback column, so oversized values are truncated to fit
@@ -103,6 +107,7 @@ public record ClusterVariableDbModel(
     private String tenantId;
     private ClusterVariableScope scope;
     private List<MetadataEntry> metadata = List.of();
+    private ClusterVariableKind kind;
 
     public ClusterVariableDbModelBuilder name(final String name) {
       this.name = name;
@@ -129,6 +134,11 @@ public record ClusterVariableDbModel(
       return this;
     }
 
+    public ClusterVariableDbModelBuilder kind(final ClusterVariableKind kind) {
+      this.kind = kind;
+      return this;
+    }
+
     @Override
     public ClusterVariableDbModel build() {
       return switch (ValueTypeUtil.getValueType(value)) {
@@ -152,7 +162,8 @@ public record ClusterVariableDbModel(
           false,
           tenantId,
           scope,
-          metadata);
+          metadata,
+          kind);
     }
 
     private String getCompositeId() {
@@ -171,7 +182,8 @@ public record ClusterVariableDbModel(
           false,
           tenantId,
           scope,
-          metadata);
+          metadata,
+          kind);
     }
 
     private ClusterVariableDbModel getDoubleModel() {
@@ -186,7 +198,8 @@ public record ClusterVariableDbModel(
           false,
           tenantId,
           scope,
-          metadata);
+          metadata,
+          kind);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -21,10 +21,6 @@
       <arg column="IS_PREVIEW" javaType="boolean"/>
       <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
-      <!-- no METADATA column yet; queries select a literal NULL and the entity defaults it to an
-       empty list. We use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
-      <arg column="METADATA" javaType="java.util.List"
-        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
       <arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>
     </constructor>
   </resultMap>
@@ -59,7 +55,6 @@
     TENANT_ID,
     SCOPE,
     IS_PREVIEW,
-    NULL AS METADATA,
     KIND
     FROM ${prefix}CLUSTER_VARIABLE cv
     <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
@@ -79,7 +74,6 @@
     TENANT_ID,
     SCOPE,
     IS_PREVIEW,
-    NULL AS METADATA,
     KIND
     FROM ${prefix}CLUSTER_VARIABLE cv
     WHERE cv.CLUSTER_VARIABLE_ID = #{id}

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -21,6 +21,11 @@
       <arg column="IS_PREVIEW" javaType="boolean"/>
       <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <!-- no METADATA column yet; queries select a literal NULL and the entity defaults it to an
+       empty list. We use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
+      <arg column="METADATA" javaType="java.util.List"
+        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+      <arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>
     </constructor>
   </resultMap>
 
@@ -53,7 +58,9 @@
     VAR_FULL_VALUE,
     TENANT_ID,
     SCOPE,
-    IS_PREVIEW
+    IS_PREVIEW,
+    NULL AS METADATA,
+    KIND
     FROM ${prefix}CLUSTER_VARIABLE cv
     <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
     ) filtered
@@ -71,7 +78,9 @@
     VAR_FULL_VALUE,
     TENANT_ID,
     SCOPE,
-    IS_PREVIEW
+    IS_PREVIEW,
+    NULL AS METADATA,
+    KIND
     FROM ${prefix}CLUSTER_VARIABLE cv
     WHERE cv.CLUSTER_VARIABLE_ID = #{id}
   </select>
@@ -94,11 +103,11 @@
     INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
                                            LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
                                            TENANT_ID,
-                                           SCOPE)
+                                           SCOPE, KIND)
     VALUES (#{id}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
             #{longValue, jdbcType=NUMERIC},
             #{value},
-            #{fullValue}, #{isPreview}, #{tenantId}, #{scope})
+            #{fullValue}, #{isPreview}, #{tenantId}, #{scope}, #{kind})
   </insert>
 
   <insert id="insertMetadata" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
@@ -231,6 +240,13 @@
               )
             </otherwise>
           </choose>
+        </foreach>
+      </if>
+
+      <if test="filter.kindOperations != null and !filter.kindOperations.isEmpty()">
+        <foreach collection="filter.kindOperations" item="operation">
+          AND KIND
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>
     </where>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/columns/SearchColumnTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.AuditLogEntity.AuditLogTenantScope;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationState;
 import io.camunda.search.entities.BatchOperationType;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
@@ -149,6 +150,11 @@ public class SearchColumnTest {
               List.of(
                   Tuple.of(ClusterVariableScope.GLOBAL, ClusterVariableScope.GLOBAL),
                   Tuple.of(ClusterVariableScope.GLOBAL, "GLOBAL"))),
+          Map.entry(
+              ClusterVariableKind.class,
+              List.of(
+                  Tuple.of(ClusterVariableKind.JSON, ClusterVariableKind.JSON),
+                  Tuple.of(ClusterVariableKind.JSON, "JSON"))),
           Map.entry(
               AuditLogActorType.class,
               List.of(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -26,6 +26,7 @@ import io.camunda.gateway.protocol.model.AuthorizationCreateResult;
 import io.camunda.gateway.protocol.model.BatchOperationCreatedResult;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.BrokerInfo;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.CreateProcessInstanceResult;
@@ -847,11 +848,17 @@ public final class ResponseMapper {
             : ClusterVariableScopeEnum.GLOBAL;
     final @Nullable String tenantId =
         clusterVariableRecord.isTenantScoped() ? clusterVariableRecord.getTenantId() : null;
+    final ClusterVariableKindEnum kind =
+        switch (clusterVariableRecord.getKind()) {
+          case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+          case JSON -> ClusterVariableKindEnum.JSON;
+        };
     return ClusterVariableResult.Builder.create()
         .name(clusterVariableRecord.getName())
         .scope(scope)
         .tenantId(tenantId)
         .metadata(clusterVariableRecord.getMetadata())
+        .kind(kind)
         .value(clusterVariableRecord.getValue())
         .build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
@@ -9,10 +9,13 @@ package io.camunda.gateway.mapping.http.mapper;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.validator.ClusterVariableRequestValidator;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.CreateClusterVariableRequest;
 import io.camunda.gateway.protocol.model.UpdateClusterVariableRequest;
 import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.util.Either;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.ProblemDetail;
 
 public class ClusterVariableMapper {
@@ -31,14 +34,20 @@ public class ClusterVariableMapper {
             request, tenantId),
         () ->
             new ClusterVariableRequest(
-                request.getName(), request.getValue(), tenantId, request.getMetadata()));
+                request.getName(),
+                request.getValue(),
+                tenantId,
+                request.getMetadata(),
+                toProtocolKind(request.getKind())));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableUpdateRequest(
       final String name, final UpdateClusterVariableRequest request) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableUpdateRequest(name, request),
-        () -> new ClusterVariableRequest(name, request.getValue(), null, request.getMetadata()));
+        () ->
+            new ClusterVariableRequest(
+                name, request.getValue(), null, request.getMetadata(), null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableUpdateRequest(
@@ -47,14 +56,15 @@ public class ClusterVariableMapper {
         clusterVariableRequestValidator.validateTenantClusterVariableUpdateRequest(
             name, request, tenantId),
         () ->
-            new ClusterVariableRequest(name, request.getValue(), tenantId, request.getMetadata()));
+            new ClusterVariableRequest(
+                name, request.getValue(), tenantId, request.getMetadata(), null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableRequest(
       final String name, final String tenantId) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableRequest(name, tenantId),
-        () -> new ClusterVariableRequest(name, null, tenantId, null));
+        () -> new ClusterVariableRequest(name, null, tenantId, null, null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableCreateRequest(
@@ -63,13 +73,28 @@ public class ClusterVariableMapper {
         clusterVariableRequestValidator.validateGlobalClusterVariableCreateRequest(request),
         () ->
             new ClusterVariableRequest(
-                request.getName(), request.getValue(), null, request.getMetadata()));
+                request.getName(),
+                request.getValue(),
+                null,
+                request.getMetadata(),
+                toProtocolKind(request.getKind())));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableRequest(
       final String name) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableRequest(name),
-        () -> new ClusterVariableRequest(name, null, null, null));
+        () -> new ClusterVariableRequest(name, null, null, null, null));
+  }
+
+  private static @Nullable ClusterVariableKind toProtocolKind(
+      final @Nullable ClusterVariableKindEnum kind) {
+    if (kind == null) {
+      return null;
+    }
+    return switch (kind) {
+      case JSON -> ClusterVariableKind.JSON;
+      case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
+    };
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -387,6 +387,7 @@ public class SearchQueryFilterMapper {
         .map(mapToStringOperations())
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
+    ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
 
     return builder.build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -52,6 +52,7 @@ import io.camunda.gateway.protocol.model.BatchOperationSearchQueryResult;
 import io.camunda.gateway.protocol.model.BatchOperationStateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.CamundaUserResult;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryResult;
@@ -186,6 +187,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
@@ -1657,6 +1659,7 @@ public final class SearchQueryResponseMapper {
         .scope(scope)
         .tenantId(tenantId)
         .metadata(toMetadataMap(clusterVariableEntity))
+        .kind(toKindEnum(clusterVariableEntity.kind()))
         .value(
             requireNonNull(
                 !truncateValues
@@ -1684,6 +1687,7 @@ public final class SearchQueryResponseMapper {
         .scope(scope)
         .tenantId(tenantId)
         .metadata(toMetadataMap(clusterVariableEntity))
+        .kind(toKindEnum(clusterVariableEntity.kind()))
         .value(requireNonNull(getFullValueIfPresent(clusterVariableEntity), "value"))
         .build();
   }
@@ -1700,6 +1704,16 @@ public final class SearchQueryResponseMapper {
             result.put(
                 entry.key(), entry.valueNumber() != null ? entry.valueNumber() : entry.value()));
     return result;
+  }
+
+  private static ClusterVariableKindEnum toKindEnum(final @Nullable ClusterVariableKind kind) {
+    if (kind == null) {
+      return ClusterVariableKindEnum.JSON;
+    }
+    return switch (kind) {
+      case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+      case JSON -> ClusterVariableKindEnum.JSON;
+    };
   }
 
   private static @Nullable String getFullValueIfPresent(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ConditionWaitStateDetails;
 import io.camunda.gateway.protocol.model.IncidentErrorTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
@@ -41,6 +42,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemState;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -1231,7 +1233,8 @@ class SearchQueryResponseMapperTest {
             null,
             List.of(
                 new MetadataEntry("kind", "CREDENTIAL", null),
-                new MetadataEntry("schemaVersion", null, 2.0)));
+                new MetadataEntry("schemaVersion", null, 2.0)),
+            null);
 
     // when
     final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
@@ -1239,6 +1242,7 @@ class SearchQueryResponseMapperTest {
     // then
     assertThat(result.getMetadata())
         .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL", "schemaVersion", 2.0));
+    assertThat(result.getKind()).isEqualTo(ClusterVariableKindEnum.JSON);
   }
 
   @Test
@@ -1246,13 +1250,14 @@ class SearchQueryResponseMapperTest {
     // given
     final var entity =
         new ClusterVariableEntity(
-            "id", "name", "value", null, false, ClusterVariableScope.GLOBAL, null, List.of());
+            "id", "name", "value", null, false, ClusterVariableScope.GLOBAL, null, List.of(), null);
 
     // when
     final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
 
     // then
     assertThat(result.getMetadata()).isEmpty();
+    assertThat(result.getKind()).isEqualTo(ClusterVariableKindEnum.JSON);
   }
 
   @Test
@@ -1267,7 +1272,8 @@ class SearchQueryResponseMapperTest {
             false,
             ClusterVariableScope.GLOBAL,
             null,
-            List.of(new MetadataEntry("kind", "CREDENTIAL", null)));
+            List.of(new MetadataEntry("kind", "CREDENTIAL", null)),
+            null);
 
     // when
     final var result = SearchQueryResponseMapper.toClusterVariableSearchResult(entity, true);
@@ -1275,6 +1281,29 @@ class SearchQueryResponseMapperTest {
     // then
     assertThat(result.getMetadata())
         .containsExactlyInAnyOrderEntriesOf(Map.of("kind", "CREDENTIAL"));
+    assertThat(result.getKind()).isEqualTo(ClusterVariableKindEnum.JSON);
+  }
+
+  @Test
+  void shouldMapClusterVariableGetResultWithExplicitKind() {
+    // given
+    final var entity =
+        new ClusterVariableEntity(
+            "id",
+            "name",
+            "value",
+            null,
+            false,
+            ClusterVariableScope.GLOBAL,
+            null,
+            List.of(),
+            ClusterVariableKind.SECRET_REFERENCE);
+
+    // when
+    final var result = SearchQueryResponseMapper.toClusterVariableResult(entity);
+
+    // then
+    assertThat(result.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 
   @Nested

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ClusterVariableSearchIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.client;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.api.search.response.ClusterVariable;
 import io.camunda.it.util.TestHelper;
@@ -192,6 +193,7 @@ public class ClusterVariableSearchIT {
     assertThat(result.getTenantId()).isNull();
     assertThat(result.getScope()).isEqualTo(ClusterVariableScope.GLOBAL);
     assertThat(result.isTruncated()).isFalse();
+    assertThat(result.getKind()).isEqualTo(ClusterVariableKind.JSON);
   }
 
   @Test
@@ -210,6 +212,7 @@ public class ClusterVariableSearchIT {
     assertThat(result.getTenantId()).isEqualTo(tenantId);
     assertThat(result.getScope()).isEqualTo(ClusterVariableScope.TENANT);
     assertThat(result.isTruncated()).isFalse();
+    assertThat(result.getKind()).isEqualTo(ClusterVariableKind.JSON);
   }
 
   // ============ SEARCH TESTS ============
@@ -966,5 +969,36 @@ public class ClusterVariableSearchIT {
 
     // Verify the full value contains the original repeated characters
     assertThat(fullVar.getValue()).contains("xxx");
+  }
+
+  @Test
+  void shouldSearchReturnKindInResults() {
+    // when
+    final var results =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.name(globalVarName1))
+            .send()
+            .join();
+
+    // then
+    assertThat(results.items()).hasSize(1);
+    assertThat(results.items().getFirst().getKind()).isEqualTo(ClusterVariableKind.JSON);
+  }
+
+  @Test
+  void shouldSearchFilterByKind() {
+    // when — all test variables are JSON kind
+    final var results =
+        camundaClient
+            .newClusterVariableSearchRequest()
+            .filter(f -> f.kind(ClusterVariableKind.JSON).scope(ClusterVariableScope.GLOBAL))
+            .send()
+            .join();
+
+    // then — global JSON variables should be returned
+    assertThat(results.items()).isNotEmpty();
+    assertThat(results.items())
+        .allSatisfy(v -> assertThat(v.getKind()).isEqualTo(ClusterVariableKind.JSON));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.entity;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import java.util.List;
 
@@ -21,6 +22,11 @@ public class ClusterVariableEntityTransformer
   @Override
   public ClusterVariableEntity apply(
       final io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity value) {
+    final var webappsKind = value.getKind();
+    final ClusterVariableKind kind =
+        webappsKind != null
+            ? ClusterVariableKind.valueOf(webappsKind.name())
+            : ClusterVariableKind.JSON;
     return new ClusterVariableEntity(
         value.getId(),
         value.getName(),
@@ -29,7 +35,8 @@ public class ClusterVariableEntityTransformer
         value.getIsPreview(),
         ClusterVariableScope.valueOf(value.getScope().name()),
         value.getTenantId(),
-        toMetadata(value.getMetadata()));
+        toMetadata(value.getMetadata()),
+        kind);
   }
 
   private List<MetadataEntry> toMetadata(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -50,6 +50,7 @@ public final class ClusterVariableFilterTransformer
     queries.addAll(getScopeQuery(filter.scopeOperations()));
     queries.addAll(getTenantQuery(filter.tenantIdOperations()));
     queries.addAll(getMetadataQuery(filter.metadataOperations()));
+    queries.addAll(getKindQuery(filter.kindOperations()));
     ofNullable(getIsTruncatedQuery(filter.isTruncated())).ifPresent(queries::add);
     return and(queries);
   }
@@ -74,6 +75,10 @@ public final class ClusterVariableFilterTransformer
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
     return stringTerms(ClusterVariableIndex.NAME, authorization.resourceIds());
+  }
+
+  private Collection<SearchQuery> getKindQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.KIND, operations);
   }
 
   private Collection<SearchQuery> getNamesQuery(final List<Operation<String>> operations) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformerTest.java
@@ -28,14 +28,16 @@ import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.query.SearchWildcardQuery;
+import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.MetadataValueFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UntypedOperation;
 import io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex;
 import org.junit.jupiter.api.Test;
 
-public final class ClusterVariableFilterMetadataTransformerTest extends AbstractTransformerTest {
+public final class ClusterVariableFilterTransformerTest extends AbstractTransformerTest {
 
   @Test
   public void shouldQueryMetadataByExactKeyValue() {
@@ -256,6 +258,39 @@ public final class ClusterVariableFilterMetadataTransformerTest extends Abstract
     final var nestedQueries =
         bool.must().stream().filter(q -> q.queryOption() instanceof SearchNestedQuery).toList();
     assertThat(nestedQueries).hasSize(2);
+  }
+
+  @Test
+  void shouldTransformKindFilter() {
+    // given
+    final var filter = FilterBuilders.clusterVariable().kinds("JSON").build();
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // single-value kinds() maps to EQ → SearchTermQuery, returned directly (no bool wrapper)
+    assertThat(query.queryOption()).isInstanceOf(SearchTermQuery.class);
+    final var termQuery = (SearchTermQuery) query.queryOption();
+    assertThat(termQuery.field()).isEqualTo(ClusterVariableIndex.KIND);
+    assertThat(termQuery.value().stringValue()).isEqualTo("JSON");
+  }
+
+  @Test
+  void shouldTransformMultipleKindFilter() {
+    // given
+    final var filter = FilterBuilders.clusterVariable().kinds("JSON", "SECRET_REFERENCE").build();
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // multiple values → IN → SearchTermsQuery, returned directly (no bool wrapper)
+    assertThat(query.queryOption()).isInstanceOf(SearchTermsQuery.class);
+    final var terms = (SearchTermsQuery) query.queryOption();
+    assertThat(terms.field()).isEqualTo(ClusterVariableIndex.KIND);
+    assertThat(terms.values().stream().map(TypedValue::stringValue).toList())
+        .containsExactly("JSON", "SECRET_REFERENCE");
   }
 
   private SearchQuery transformMetadataQuery(final String key, final Operation<?>... operations) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -22,7 +22,8 @@ public record ClusterVariableEntity(
     @Nullable Boolean isPreview,
     ClusterVariableScope scope,
     @Nullable String tenantId,
-    @Nullable List<MetadataEntry> metadata)
+    @Nullable List<MetadataEntry> metadata,
+    @Nullable ClusterVariableKind kind)
     implements TenantOwnedEntity {
 
   public ClusterVariableEntity {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -43,8 +43,9 @@ public record ClusterVariableEntity(
       final String fullValue,
       final Boolean isPreview,
       final ClusterVariableScope scope,
-      final String tenantId) {
-    this(id, name, value, fullValue, isPreview, scope, tenantId, new ArrayList<>(), null);
+      final String tenantId,
+      final @Nullable ClusterVariableKind kind) {
+    this(id, name, value, fullValue, isPreview, scope, tenantId, new ArrayList<>(), kind);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -44,7 +44,7 @@ public record ClusterVariableEntity(
       final Boolean isPreview,
       final ClusterVariableScope scope,
       final String tenantId) {
-    this(id, name, value, fullValue, isPreview, scope, tenantId, new ArrayList<>());
+    this(id, name, value, fullValue, isPreview, scope, tenantId, new ArrayList<>(), null);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -22,6 +22,7 @@ public record ClusterVariableFilter(
     List<Operation<String>> scopeOperations,
     List<Operation<String>> tenantIdOperations,
     List<MetadataValueFilter> metadataOperations,
+    List<Operation<String>> kindOperations,
     Boolean isTruncated)
     implements FilterBase {
 
@@ -31,6 +32,7 @@ public record ClusterVariableFilter(
     List<Operation<String>> scopeOperations;
     List<Operation<String>> tenantIdOperations;
     List<MetadataValueFilter> metadataOperations;
+    List<Operation<String>> kindOperations;
     Boolean isTruncated;
 
     public Builder nameOperations(final List<Operation<String>> operations) {
@@ -132,6 +134,25 @@ public record ClusterVariableFilter(
       return metadataOperations(collectValues(operation, operations));
     }
 
+    public Builder kindOperations(final List<Operation<String>> operations) {
+      kindOperations = addValuesToList(kindOperations, operations);
+      return this;
+    }
+
+    public Builder kinds(final String value, final String... values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder kinds(final List<String> values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder kindOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return kindOperations(collectValues(operation, operations));
+    }
+
     public Builder isTruncated(final Boolean value) {
       isTruncated = value;
       return this;
@@ -145,6 +166,7 @@ public record ClusterVariableFilter(
           Objects.requireNonNullElseGet(scopeOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(tenantIdOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(metadataOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(kindOperations, Collections::emptyList),
           isTruncated);
     }
   }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.Nullable;
 
 public final class ClusterVariableServices
     extends SearchQueryService<
@@ -58,6 +59,7 @@ public final class ClusterVariableServices
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
             .setMetadata(toDirectBufferMetadata(request.metadata()))
+            .setKind(request.kind())
             .setGlobalScope(),
         authentication);
   }
@@ -69,6 +71,7 @@ public final class ClusterVariableServices
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
             .setMetadata(toDirectBufferMetadata(request.metadata()))
+            .setKind(request.kind())
             .setTenantScope(request.tenantId()),
         authentication);
   }
@@ -158,5 +161,9 @@ public final class ClusterVariableServices
   }
 
   public record ClusterVariableRequest(
-      String name, Object value, String tenantId, Map<String, Object> metadata) {}
+      String name,
+      Object value,
+      String tenantId,
+      Map<String, Object> metadata,
+      io.camunda.zeebe.protocol.record.value.@Nullable ClusterVariableKind kind) {}
 }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteClusterVariableR
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateClusterVariableRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.agrona.DirectBuffer;
@@ -165,5 +166,5 @@ public final class ClusterVariableServices
       Object value,
       String tenantId,
       Map<String, Object> metadata,
-      io.camunda.zeebe.protocol.record.value.@Nullable ClusterVariableKind kind) {}
+      @Nullable ClusterVariableKind kind) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -7,14 +7,6 @@
  */
 package io.camunda.exporter.handlers;
 
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.FULL_VALUE;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.IS_PREVIEW;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.METADATA;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.SCOPE;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.TENANT_ID;
-import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.VALUE;
-
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
@@ -27,7 +19,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,11 +77,7 @@ public class ClusterVariableCreatedUpdatedHandler
         .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope()))
         .setName(recordValue.getName());
 
-    // kind is immutable after creation — the UPDATED engine record carries the EnumProperty
-    // default (JSON) and does NOT reflect the stored kind. Only set it on CREATED.
-    if (record.getIntent() == ClusterVariableIntent.CREATED) {
-      entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
-    }
+    entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
 
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
       entity.setTenantId(recordValue.getTenantId());
@@ -122,18 +109,7 @@ public class ClusterVariableCreatedUpdatedHandler
   @Override
   public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    // Use upsert with only mutable fields as updateFields, so UPDATED records never overwrite the
-    // immutable kind field in an existing ES/OS document. On CREATED (document absent) the full
-    // entity is indexed. This is consistent with how the RDBMS exporter excludes KIND from UPDATE.
-    final Map<String, Object> updateFields = new HashMap<>();
-    updateFields.put(NAME, entity.getName());
-    updateFields.put(VALUE, entity.getValue());
-    updateFields.put(FULL_VALUE, entity.getFullValue());
-    updateFields.put(IS_PREVIEW, entity.getIsPreview());
-    updateFields.put(SCOPE, entity.getScope());
-    updateFields.put(TENANT_ID, entity.getTenantId());
-    updateFields.put(METADATA, entity.getMetadata());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.add(indexName, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -7,17 +7,27 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.FULL_VALUE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.IS_PREVIEW;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.METADATA;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.SCOPE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.VALUE;
+
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,6 +86,12 @@ public class ClusterVariableCreatedUpdatedHandler
         .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope()))
         .setName(recordValue.getName());
 
+    // kind is immutable after creation — the UPDATED engine record carries the EnumProperty
+    // default (JSON) and does NOT reflect the stored kind. Only set it on CREATED.
+    if (record.getIntent() == ClusterVariableIntent.CREATED) {
+      entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
+    }
+
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
       entity.setTenantId(recordValue.getTenantId());
     }
@@ -106,7 +122,18 @@ public class ClusterVariableCreatedUpdatedHandler
   @Override
   public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    // Use upsert with only mutable fields as updateFields, so UPDATED records never overwrite the
+    // immutable kind field in an existing ES/OS document. On CREATED (document absent) the full
+    // entity is indexed. This is consistent with how the RDBMS exporter excludes KIND from UPDATE.
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(NAME, entity.getName());
+    updateFields.put(VALUE, entity.getValue());
+    updateFields.put(FULL_VALUE, entity.getFullValue());
+    updateFields.put(IS_PREVIEW, entity.getIsPreview());
+    updateFields.put(SCOPE, entity.getScope());
+    updateFields.put(TENANT_ID, entity.getTenantId());
+    updateFields.put(METADATA, entity.getMetadata());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -146,7 +146,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
   }
 
   @Test
-  void shouldUpsertEntityOnFlushWithMutableFieldsOnly() {
+  void shouldAddEntityOnFlush() {
     // given
     final ClusterVariableEntity inputEntity =
         new ClusterVariableEntity()
@@ -163,11 +163,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    // upsert is used so that the immutable "kind" field is never overwritten on UPDATED records
-    verify(mockRequest, times(1)).upsert(eq(indexName), eq("id"), eq(inputEntity), anyMap());
-    // batchRequest.add() must not be called — it does a full document replace that would
-    // overwrite the stored kind with null on UPDATED records
-    verify(mockRequest, never()).add(anyString(), any());
+    verify(mockRequest, times(1)).add(eq(indexName), eq(inputEntity));
+    verify(mockRequest, never()).upsert(anyString(), anyString(), any(), anyMap());
   }
 
   @ParameterizedTest
@@ -304,13 +301,13 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
   }
 
   @Test
-  void shouldNotOverwriteKindOnUpdatedRecord() {
-    // given — UPDATED records carry the EnumProperty default (JSON), not the stored kind
+  void shouldSetKindFromRecordOnUpdatedRecord() {
+    // given — UPDATED records carry the authoritative kind from the engine
     final ClusterVariableRecordValue recordValue =
         ImmutableClusterVariableRecordValue.builder()
             .from(factory.generateObject(ClusterVariableRecordValue.class))
             .withScope(ClusterVariableScope.GLOBAL)
-            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
             .build();
 
     final Record<ClusterVariableRecordValue> record =
@@ -318,14 +315,15 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             ValueType.CLUSTER_VARIABLE,
             r -> r.withIntent(ClusterVariableIntent.UPDATED).withValue(recordValue));
 
-    final ClusterVariableEntity entity = new ClusterVariableEntity();
-    entity.setKind(ClusterVariableKind.SECRET_REFERENCE);
-
     // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
     underTest.updateEntity(record, entity);
 
-    // then — kind must not be overwritten on UPDATED so the stored value survives the upsert
-    assertThat(entity.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+    // then — kind is always set from the record, engine enforces immutability upstream
+    assertThat(entity.getKind())
+        .isEqualTo(
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind
+                .SECRET_REFERENCE);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -8,13 +8,19 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -140,7 +146,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlush() {
+  void shouldUpsertEntityOnFlushWithMutableFieldsOnly() {
     // given
     final ClusterVariableEntity inputEntity =
         new ClusterVariableEntity()
@@ -149,14 +155,19 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             .setValue("value")
             .setTenantId("tenantId")
             .setScope(
-                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT);
+                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT)
+            .setKind(ClusterVariableKind.SECRET_REFERENCE);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    // upsert is used so that the immutable "kind" field is never overwritten on UPDATED records
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("id"), eq(inputEntity), anyMap());
+    // batchRequest.add() must not be called — it does a full document replace that would
+    // overwrite the stored kind with null on UPDATED records
+    verify(mockRequest, never()).add(anyString(), any());
   }
 
   @ParameterizedTest
@@ -264,6 +275,81 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
     assertThat(clusterVariableEntity.getIsPreview()).isTrue();
     assertThat(clusterVariableEntity.getMetadata())
         .containsExactly(new MetadataEntry("kind", "CREDENTIALS", null));
+  }
+
+  @Test
+  void shouldSetKindOnEntityForCreatedRecord() {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getKind())
+        .isEqualTo(
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind
+                .SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldNotOverwriteKindOnUpdatedRecord() {
+    // given — UPDATED records carry the EnumProperty default (JSON), not the stored kind
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.UPDATED).withValue(recordValue));
+
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    entity.setKind(ClusterVariableKind.SECRET_REFERENCE);
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then — kind must not be overwritten on UPDATED so the stored value survives the upsert
+    assertThat(entity.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldDefaultKindToJsonOnCreatedWhenRecordKindIsJson() {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getKind())
+        .isEqualTo(io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind.JSON);
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -60,6 +61,13 @@ public class ClusterVariableExportHandler
       builder.scope(ClusterVariableScope.GLOBAL).tenantId(null);
     } else {
       builder.scope(ClusterVariableScope.TENANT).tenantId(value.getTenantId());
+    }
+    if (record.getIntent() == ClusterVariableIntent.CREATED) {
+      builder.kind(
+          switch (value.getKind()) {
+            case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
+            case JSON -> ClusterVariableKind.JSON;
+          });
     }
     return builder.build();
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -62,13 +62,11 @@ public class ClusterVariableExportHandler
     } else {
       builder.scope(ClusterVariableScope.TENANT).tenantId(value.getTenantId());
     }
-    if (record.getIntent() == ClusterVariableIntent.CREATED) {
-      builder.kind(
-          switch (value.getKind()) {
-            case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
-            case JSON -> ClusterVariableKind.JSON;
-          });
-    }
+    builder.kind(
+        switch (value.getKind()) {
+          case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
+          case JSON -> ClusterVariableKind.JSON;
+        });
     return builder.build();
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -455,6 +455,10 @@ paths:
 
 components:
   schemas:
+    ClusterVariableKindEnum:
+      type: string
+      enum: [JSON, SECRET_REFERENCE]
+      description: The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
     ClusterVariableScopeEnum:
       type: string
       enum: [ GLOBAL, TENANT ]
@@ -484,8 +488,14 @@ components:
             oneOf:
               - type: string
               - type: number
+        kind:
+          description: The kind of the cluster variable. Defaults to JSON if not specified.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
       x-properties-added-in-version:
         - propertyName: "metadata"
+          addedInVersion: "8.10"
+        - propertyName: "kind"
           addedInVersion: "8.10"
     UpdateClusterVariableRequest:
       type: object
@@ -543,6 +553,7 @@ components:
         - scope
         - tenantId
         - metadata
+        - kind
       properties:
         name:
           description: The name of the cluster variable. Unique within its scope (global or tenant-specific).
@@ -564,8 +575,12 @@ components:
             oneOf:
               - type: string
               - type: number
+        kind:
+          $ref: '#/components/schemas/ClusterVariableKindEnum'
       x-properties-added-in-version:
         - propertyName: "metadata"
+          addedInVersion: "8.10"
+        - propertyName: "kind"
           addedInVersion: "8.10"
     ClusterVariableSearchQueryRequest:
       description: Cluster variable search query request.
@@ -622,6 +637,13 @@ components:
           description: |
             Filter cluster variables by truncation status of their stored values. When true, returns only variables whose stored values are truncated (i.e., the value exceeds the storage size limit and is truncated in storage). When false, returns only variables with non-truncated stored values. This filter is based on the underlying storage characteristic, not the response format.
           type: boolean
+        kind:
+          description: The kind filter for cluster variables.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindFilterProperty'
+      x-properties-added-in-version:
+        - propertyName: "kind"
+          addedInVersion: "8.10"
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.
       oneOf:
@@ -652,6 +674,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"
+    ClusterVariableKindFilterProperty:
+      description: ClusterVariableKindEnum property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        - $ref: '#/components/schemas/AdvancedClusterVariableKindFilter'
+    AdvancedClusterVariableKindFilter:
+      title: Advanced filter
+      description: Advanced ClusterVariableKindEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterVariableKindEnum'
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
     ClusterVariableSearchQueryResult:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -27,6 +27,7 @@ import io.camunda.gateway.protocol.model.BatchOperationItemStateFilterProperty;
 import io.camunda.gateway.protocol.model.BatchOperationStateFilterProperty;
 import io.camunda.gateway.protocol.model.BatchOperationTypeFilterProperty;
 import io.camunda.gateway.protocol.model.CategoryFilterProperty;
+import io.camunda.gateway.protocol.model.ClusterVariableKindFilterProperty;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeFilterProperty;
 import io.camunda.gateway.protocol.model.DateTimeFilterProperty;
 import io.camunda.gateway.protocol.model.DecisionEvaluationInstruction;
@@ -63,6 +64,7 @@ import io.camunda.zeebe.gateway.rest.deserializer.BasicStringFilterPropertyDeser
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperatioItemStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.BatchOperationTypeFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.deserializer.ClusterVariableKindFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ClusterVariableScopeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.DateTimeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.DecisionEvaluationInstructionDeserializer;
@@ -114,6 +116,9 @@ public class JacksonConfig {
     module.addDeserializer(
         ClusterVariableScopeFilterProperty.class,
         new ClusterVariableScopeFilterPropertyDeserializer());
+    module.addDeserializer(
+        ClusterVariableKindFilterProperty.class,
+        new ClusterVariableKindFilterPropertyDeserializer());
     module.addDeserializer(
         BatchOperationItemStateFilterProperty.class,
         new BatchOperatioItemStateFilterPropertyDeserializer());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/ClusterVariableKindFilterPropertyDeserializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/deserializer/ClusterVariableKindFilterPropertyDeserializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.deserializer;
+
+import io.camunda.gateway.protocol.model.AdvancedClusterVariableKindFilter;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
+import io.camunda.gateway.protocol.model.ClusterVariableKindFilterProperty;
+
+public class ClusterVariableKindFilterPropertyDeserializer
+    extends FilterDeserializer<ClusterVariableKindFilterProperty, ClusterVariableKindEnum> {
+
+  @Override
+  protected Class<? extends ClusterVariableKindFilterProperty> getFinalType() {
+    return AdvancedClusterVariableKindFilter.class;
+  }
+
+  @Override
+  protected Class<ClusterVariableKindEnum> getImplicitValueType() {
+    return ClusterVariableKindEnum.class;
+  }
+
+  @Override
+  protected ClusterVariableKindFilterProperty createFromImplicitValue(
+      final ClusterVariableKindEnum value) {
+    return AdvancedClusterVariableKindFilter.Builder.create().$eq(value).build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -15,7 +15,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.ClusterVariableServices;
@@ -25,6 +28,7 @@ import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
@@ -55,11 +59,13 @@ public class ClusterVariableControllerTest extends RestControllerTest {
   static final String GLOBAL_WITH_NAME_URL = GLOBAL_URL + "/%s";
   static final String TENANT_URL = CLUSTER_VARIABLE_PREFIX_URL + "/tenants/%s";
   static final String TENANT_WITH_NAME_URL = TENANT_URL + "/%s";
+  static final String SEARCH_URL = CLUSTER_VARIABLE_PREFIX_URL + "/search";
   // large enough that 101 minimal metadata entries (~1.8k serialized chars) don't also trip
   // this limit, so the too-many-entries test exercises only the entry-count check
   static final int TEST_MAX_CLUSTER_VARIABLE_METADATA_SIZE = 2000;
 
   @Captor ArgumentCaptor<ClusterVariableRequest> createRequestCaptor;
+  @Captor ArgumentCaptor<ClusterVariableQuery> searchQueryCaptor;
   @MockitoBean ClusterVariableServices clusterVariableServices;
   @MockitoBean CamundaSecurityLibraryProperties cslProperties;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
@@ -1195,6 +1201,64 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .json("{\"kind\":\"JSON\"}", JsonCompareMode.LENIENT);
 
     assertThat(createRequestCaptor.getValue().kind()).isNull();
+  }
+
+  @Test
+  void shouldSearchClusterVariablesByKindFilter() {
+    // given
+    when(clusterVariableServices.search(any(), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<ClusterVariableEntity>()
+                .total(0)
+                .items(List.of())
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(clusterVariableServices).search(searchQueryCaptor.capture(), any());
+    final var capturedQuery = searchQueryCaptor.getValue();
+    assertThat(capturedQuery).isNotNull();
+  }
+
+  @Test
+  void shouldReturnKindInClusterVariableSearchResults() {
+    // given
+    final var entity = mock(ClusterVariableEntity.class);
+    when(entity.name()).thenReturn("myVar");
+    when(entity.value()).thenReturn("\"val\"");
+    when(entity.isPreview()).thenReturn(false);
+    when(entity.scope()).thenReturn(ClusterVariableScope.GLOBAL);
+    when(entity.kind()).thenReturn(ClusterVariableKind.SECRET_REFERENCE);
+    when(entity.metadata()).thenReturn(List.of());
+    when(clusterVariableServices.search(any(), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<ClusterVariableEntity>()
+                .total(1)
+                .items(List.of(entity))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.items[0].kind")
+        .isEqualTo("SECRET_REFERENCE");
   }
 
   @TestConfiguration

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -1135,6 +1135,68 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .json(expectedBody, JsonCompareMode.STRICT);
   }
 
+  @Test
+  void shouldCreateGlobalClusterVariableWithSecretReferenceKind() {
+    // given
+    final var record =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL)
+            .setKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+    when(clusterVariableServices.createGloballyScopedClusterVariable(
+            createRequestCaptor.capture(), any()))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            "{\"name\":\"myVar\",\"value\":\"camunda.secrets.MY_SECRET\",\"kind\":\"SECRET_REFERENCE\"}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json("{\"kind\":\"SECRET_REFERENCE\"}", JsonCompareMode.LENIENT);
+
+    assertThat(createRequestCaptor.getValue().kind())
+        .isEqualTo(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldCreateGlobalClusterVariableWithDefaultJsonKind() {
+    // given
+    final var record =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL)
+            .setKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON);
+    when(clusterVariableServices.createGloballyScopedClusterVariable(
+            createRequestCaptor.capture(), any()))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"name\":\"myVar\",\"value\":\"val\"}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json("{\"kind\":\"JSON\"}", JsonCompareMode.LENIENT);
+
+    assertThat(createRequestCaptor.getValue().kind()).isNull();
+  }
+
   @TestConfiguration
   static class TestConfig {
     @Bean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds `kind` to the search domain, REST API, and gateway mapping layer. Part of the #57920 stack — depends on the ES/OS PR (which introduces `ClusterVariableIndex.KIND` and the webapps-schema entity shape used by the entity transformer).

1. `ClusterVariableKind` enum in `search/search-domain`; `ClusterVariableEntity` gains a `kind` component; `ClusterVariableFilter` gains `kindOperations`.
2. `ClusterVariableFilterTransformer` emits a kind query using `ClusterVariableIndex.KIND`.
3. `ClusterVariableEntityTransformer` maps `webapps-schema.ClusterVariableKind` → `search.entities.ClusterVariableKind` with a null→JSON fallback for old documents.
4. OpenAPI spec (`cluster-variables.yaml`) gains `ClusterVariableKindEnum`, `ClusterVariableKindFilterProperty`, `AdvancedClusterVariableKindFilter`; `kind` is optional on create (defaults to `JSON`) and required on result types.
5. Gateway mappers and `ClusterVariableServices.ClusterVariableRequest` wired end-to-end.

**Stack** (merge in order):
- Engine PR — #57981
- ES/OS exporter PR — #57982
- 👉 **This PR** — API + search layer
- RDBMS exporter
- CamundaClient

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #57920