### PR TITLE
feat: add kind to RDBMS cluster variable storage

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -603,7 +603,7 @@
     </addColumn>
   </changeSet>
 
-  <changeSet id="create_cluster_variable_kind_index" author="camunda">
+  <changeSet id="create_cluster_variable_kind_index" author="camunda" runInTransaction="false">
     <preConditions onFail="MARK_RAN">
       <not>
         <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND"

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -603,31 +603,5 @@
     </addColumn>
   </changeSet>
 
-  <changeSet id="create_cluster_variable_kind_index" author="camunda" runInTransaction="false">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND"
-          tableName="${prefix}CLUSTER_VARIABLE"/>
-      </not>
-    </preConditions>
-    <!-- Use async index creation to avoid locking the table during rolling upgrade -->
-    <sql dbms="postgresql">
-      CREATE INDEX CONCURRENTLY ${prefix}IDX_CLUSTER_VARIABLE_KIND
-      ON ${prefix}CLUSTER_VARIABLE (KIND)
-    </sql>
-    <sql dbms="mysql,h2,oracle">
-      CREATE INDEX ${prefix}IDX_CLUSTER_VARIABLE_KIND
-      ON ${prefix}CLUSTER_VARIABLE (KIND)
-    </sql>
-    <sql dbms="mariadb">
-      CREATE INDEX ONLINE ${prefix}IDX_CLUSTER_VARIABLE_KIND
-      ON ${prefix}CLUSTER_VARIABLE (KIND)
-    </sql>
-    <sql dbms="mssql">
-      CREATE INDEX ${prefix}IDX_CLUSTER_VARIABLE_KIND
-      ON ${prefix}CLUSTER_VARIABLE (KIND)
-      WITH (ONLINE = ON)
-    </sql>
-  </changeSet>
 
 </databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -592,4 +592,42 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_kind_to_cluster_variable" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}CLUSTER_VARIABLE" columnName="KIND"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}CLUSTER_VARIABLE">
+      <column name="KIND" type="VARCHAR(255)" defaultValue="JSON"/>
+    </addColumn>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_kind_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_KIND"
+          tableName="${prefix}CLUSTER_VARIABLE"/>
+      </not>
+    </preConditions>
+    <!-- Use async index creation to avoid locking the table during rolling upgrade -->
+    <sql dbms="postgresql">
+      CREATE INDEX CONCURRENTLY ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+    </sql>
+    <sql dbms="mysql,h2,oracle">
+      CREATE INDEX ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+    </sql>
+    <sql dbms="mariadb">
+      CREATE INDEX ONLINE ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+    </sql>
+    <sql dbms="mssql">
+      CREATE INDEX ${prefix}IDX_CLUSTER_VARIABLE_KIND
+      ON ${prefix}CLUSTER_VARIABLE (KIND)
+      WITH (ONLINE = ON)
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -12,11 +12,13 @@ import static io.camunda.util.ValueTypeUtil.mapDouble;
 import static io.camunda.util.ValueTypeUtil.mapLong;
 
 import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.util.ValueTypeUtil;
+import java.util.Objects;
 import java.util.function.Function;
 
 public record ClusterVariableDbModel(
@@ -29,7 +31,8 @@ public record ClusterVariableDbModel(
     String fullValue,
     boolean isPreview,
     String tenantId,
-    ClusterVariableScope scope)
+    ClusterVariableScope scope,
+    ClusterVariableKind kind)
     implements Copyable<ClusterVariableDbModel> {
 
   @Override
@@ -42,7 +45,8 @@ public record ClusterVariableDbModel(
                 .name(name)
                 .value(value)
                 .tenantId(tenantId)
-                .scope(scope))
+                .scope(scope)
+                .kind(kind))
         .build();
   }
 
@@ -70,7 +74,8 @@ public record ClusterVariableDbModel(
         fullValue,
         isPreview,
         tenantId,
-        scope);
+        scope,
+        kind);
   }
 
   public static class ClusterVariableDbModelBuilder
@@ -79,6 +84,7 @@ public record ClusterVariableDbModel(
     private String value;
     private String tenantId;
     private ClusterVariableScope scope;
+    private ClusterVariableKind kind = ClusterVariableKind.JSON;
 
     public ClusterVariableDbModelBuilder name(final String name) {
       this.name = name;
@@ -97,6 +103,11 @@ public record ClusterVariableDbModel(
 
     public ClusterVariableDbModelBuilder tenantId(final String tenantId) {
       this.tenantId = tenantId;
+      return this;
+    }
+
+    public ClusterVariableDbModelBuilder kind(final ClusterVariableKind kind) {
+      this.kind = Objects.requireNonNullElse(kind, ClusterVariableKind.JSON);
       return this;
     }
 
@@ -122,7 +133,8 @@ public record ClusterVariableDbModel(
           null,
           false,
           tenantId,
-          scope);
+          scope,
+          kind);
     }
 
     private String getCompositeId() {
@@ -131,7 +143,17 @@ public record ClusterVariableDbModel(
 
     private ClusterVariableDbModel getModel(final ValueTypeEnum valueTypeEnum, final String value) {
       return new ClusterVariableDbModel(
-          getCompositeId(), name, valueTypeEnum, null, null, value, null, false, tenantId, scope);
+          getCompositeId(),
+          name,
+          valueTypeEnum,
+          null,
+          null,
+          value,
+          null,
+          false,
+          tenantId,
+          scope,
+          kind);
     }
 
     private ClusterVariableDbModel getDoubleModel() {
@@ -145,7 +167,8 @@ public record ClusterVariableDbModel(
           null,
           false,
           tenantId,
-          scope);
+          scope,
+          kind);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -25,6 +25,7 @@
        empty list. We use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
       <arg column="METADATA" javaType="java.util.List"
         typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+      <arg column="KIND" javaType="io.camunda.search.entities.ClusterVariableKind"/>
     </constructor>
   </resultMap>
 
@@ -48,7 +49,8 @@
     TENANT_ID,
     SCOPE,
     IS_PREVIEW,
-    NULL AS METADATA
+    NULL AS METADATA,
+    KIND
     FROM ${prefix}CLUSTER_VARIABLE
     <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
     ) t
@@ -68,7 +70,8 @@
     TENANT_ID,
     SCOPE,
     IS_PREVIEW,
-    NULL AS METADATA
+    NULL AS METADATA,
+    KIND
     FROM ${prefix}CLUSTER_VARIABLE
     WHERE CLUSTER_VARIABLE_ID = #{id}
   </select>
@@ -76,12 +79,11 @@
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
     INSERT INTO ${prefix}CLUSTER_VARIABLE (CLUSTER_VARIABLE_ID, VAR_NAME, TYPE, DOUBLE_VALUE,
                                            LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, IS_PREVIEW,
-                                           TENANT_ID,
-                                           SCOPE)
+                                           TENANT_ID, SCOPE, KIND)
     VALUES (#{id}, #{name}, #{type}, #{doubleValue, jdbcType=DOUBLE},
             #{longValue, jdbcType=NUMERIC},
             #{value},
-            #{fullValue}, #{isPreview}, #{tenantId}, #{scope})
+            #{fullValue}, #{isPreview}, #{tenantId}, #{scope}, #{kind})
   </insert>
 
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
@@ -137,6 +139,13 @@
       <if test="filter.scopeOperations != null and !filter.scopeOperations.isEmpty()">
         <foreach collection="filter.scopeOperations" item="operation">
           AND SCOPE
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+
+      <if test="filter.kindOperations != null and !filter.kindOperations.isEmpty()">
+        <foreach collection="filter.kindOperations" item="operation">
+          AND KIND
           <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
         </foreach>
       </if>

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -26,6 +26,7 @@ import io.camunda.gateway.protocol.model.AuthorizationCreateResult;
 import io.camunda.gateway.protocol.model.BatchOperationCreatedResult;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.BrokerInfo;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.CreateProcessInstanceResult;
@@ -847,11 +848,17 @@ public final class ResponseMapper {
             : ClusterVariableScopeEnum.GLOBAL;
     final @Nullable String tenantId =
         clusterVariableRecord.isTenantScoped() ? clusterVariableRecord.getTenantId() : null;
+    final ClusterVariableKindEnum kind =
+        switch (clusterVariableRecord.getKind()) {
+          case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+          default -> ClusterVariableKindEnum.JSON;
+        };
     return ClusterVariableResult.Builder.create()
         .name(clusterVariableRecord.getName())
         .scope(scope)
         .tenantId(tenantId)
         .metadata(clusterVariableRecord.getMetadata())
+        .kind(kind)
         .value(clusterVariableRecord.getValue())
         .build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
@@ -9,10 +9,13 @@ package io.camunda.gateway.mapping.http.mapper;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.validator.ClusterVariableRequestValidator;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.CreateClusterVariableRequest;
 import io.camunda.gateway.protocol.model.UpdateClusterVariableRequest;
 import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.util.Either;
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.ProblemDetail;
 
 public class ClusterVariableMapper {
@@ -31,14 +34,18 @@ public class ClusterVariableMapper {
             request, tenantId),
         () ->
             new ClusterVariableRequest(
-                request.getName(), request.getValue(), tenantId, request.getMetadata()));
+                request.getName(),
+                request.getValue(),
+                tenantId,
+                request.getMetadata(),
+                toProtocolKind(request.getKind())));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableUpdateRequest(
       final String name, final UpdateClusterVariableRequest request) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableUpdateRequest(name, request),
-        () -> new ClusterVariableRequest(name, request.getValue(), null, request.getMetadata()));
+        () -> new ClusterVariableRequest(name, request.getValue(), null, request.getMetadata(), null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableUpdateRequest(
@@ -47,14 +54,15 @@ public class ClusterVariableMapper {
         clusterVariableRequestValidator.validateTenantClusterVariableUpdateRequest(
             name, request, tenantId),
         () ->
-            new ClusterVariableRequest(name, request.getValue(), tenantId, request.getMetadata()));
+            new ClusterVariableRequest(
+                name, request.getValue(), tenantId, request.getMetadata(), null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toTenantClusterVariableRequest(
       final String name, final String tenantId) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateTenantClusterVariableRequest(name, tenantId),
-        () -> new ClusterVariableRequest(name, null, tenantId, null));
+        () -> new ClusterVariableRequest(name, null, tenantId, null, null));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableCreateRequest(
@@ -63,13 +71,27 @@ public class ClusterVariableMapper {
         clusterVariableRequestValidator.validateGlobalClusterVariableCreateRequest(request),
         () ->
             new ClusterVariableRequest(
-                request.getName(), request.getValue(), null, request.getMetadata()));
+                request.getName(),
+                request.getValue(),
+                null,
+                request.getMetadata(),
+                toProtocolKind(request.getKind())));
   }
 
   public Either<ProblemDetail, ClusterVariableRequest> toGlobalClusterVariableRequest(
       final String name) {
     return RequestMapper.getResult(
         clusterVariableRequestValidator.validateGlobalClusterVariableRequest(name),
-        () -> new ClusterVariableRequest(name, null, null, null));
+        () -> new ClusterVariableRequest(name, null, null, null, null));
+  }
+
+  private static ClusterVariableKind toProtocolKind(final @Nullable ClusterVariableKindEnum kind) {
+    if (kind == null) {
+      return ClusterVariableKind.JSON;
+    }
+    return switch (kind) {
+      case JSON -> ClusterVariableKind.JSON;
+      case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
+    };
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -387,6 +387,7 @@ public class SearchQueryFilterMapper {
         .map(mapToStringOperations())
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
+    ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
 
     return builder.build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -52,6 +52,7 @@ import io.camunda.gateway.protocol.model.BatchOperationSearchQueryResult;
 import io.camunda.gateway.protocol.model.BatchOperationStateEnum;
 import io.camunda.gateway.protocol.model.BatchOperationTypeEnum;
 import io.camunda.gateway.protocol.model.CamundaUserResult;
+import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableResult;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeEnum;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryResult;
@@ -186,6 +187,7 @@ import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationErrorEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
@@ -1657,6 +1659,7 @@ public final class SearchQueryResponseMapper {
         .scope(scope)
         .tenantId(tenantId)
         .metadata(toMetadataMap(clusterVariableEntity))
+        .kind(toKindEnum(clusterVariableEntity.kind()))
         .value(
             requireNonNull(
                 !truncateValues
@@ -1684,6 +1687,7 @@ public final class SearchQueryResponseMapper {
         .scope(scope)
         .tenantId(tenantId)
         .metadata(toMetadataMap(clusterVariableEntity))
+        .kind(toKindEnum(clusterVariableEntity.kind()))
         .value(requireNonNull(getFullValueIfPresent(clusterVariableEntity), "value"))
         .build();
   }
@@ -1700,6 +1704,16 @@ public final class SearchQueryResponseMapper {
             result.put(
                 entry.key(), entry.valueNumber() != null ? entry.valueNumber() : entry.value()));
     return result;
+  }
+
+  private static ClusterVariableKindEnum toKindEnum(final ClusterVariableKind kind) {
+    if (kind == null) {
+      return ClusterVariableKindEnum.JSON;
+    }
+    return switch (kind) {
+      case SECRET_REFERENCE -> ClusterVariableKindEnum.SECRET_REFERENCE;
+      default -> ClusterVariableKindEnum.JSON;
+    };
   }
 
   private static @Nullable String getFullValueIfPresent(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -441,6 +441,36 @@ public class ClusterVariableIT {
     assertThat(deletedInstance).isNull();
   }
 
+  @TestTemplate
+  public void shouldSaveAndFindClusterVariableWithKind(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final var dbModel =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+            .name(generateRandomString(10))
+            .value("\"secret\"")
+            .scope(ClusterVariableScope.GLOBAL)
+            .tenantId(null)
+            .kind(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+    createAndSaveVariables(testApplication.getRdbmsService(), dbModel);
+
+    // when
+    final var found =
+        testApplication
+            .getRdbmsService()
+            .getClusterVariableReader()
+            .getGloballyScopedClusterVariable(
+                dbModel.name(),
+                CommonFixtures.resourceAccessChecksFromResourceIds(
+                    AuthorizationResourceType.CLUSTER_VARIABLE, dbModel.name()));
+
+    // then
+    assertThat(found).isNotNull();
+    assertThat(found.kind())
+        .isEqualTo(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE);
+  }
+
   private void assertVariableDbModelEqualToEntity(
       final ClusterVariableDbModel dbModel, final ClusterVariableEntity entity) {
     // metadata is not yet persisted in ClusterVariableDbModel, so it has no equivalent to compare

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -471,6 +471,51 @@ public class ClusterVariableIT {
         .isEqualTo(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE);
   }
 
+  @TestTemplate
+  public void shouldFilterClusterVariablesByKind(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
+
+    // given — one SECRET_REFERENCE variable, one JSON variable
+    final var secretVar =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+            .name(generateRandomString(10))
+            .value("\"secret\"")
+            .scope(ClusterVariableScope.GLOBAL)
+            .tenantId(null)
+            .kind(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+    final var jsonVar =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+            .name(generateRandomString(10))
+            .value("\"plain\"")
+            .scope(ClusterVariableScope.GLOBAL)
+            .tenantId(null)
+            .kind(io.camunda.search.entities.ClusterVariableKind.JSON)
+            .build();
+    createAndSaveVariables(rdbmsService, secretVar);
+    createAndSaveVariables(rdbmsService, jsonVar);
+
+    // when — filter by SECRET_REFERENCE kind
+    final var result =
+        clusterVariableReader.search(
+            new ClusterVariableQuery(
+                new ClusterVariableFilter.Builder()
+                    .names(secretVar.name())
+                    .kinds("SECRET_REFERENCE")
+                    .build(),
+                ClusterVariableSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    // then — only the SECRET_REFERENCE variable is returned
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().kind())
+        .isEqualTo(io.camunda.search.entities.ClusterVariableKind.SECRET_REFERENCE);
+    assertThat(result.items().getFirst().name()).isEqualTo(secretVar.name());
+  }
+
   private void assertVariableDbModelEqualToEntity(
       final ClusterVariableDbModel dbModel, final ClusterVariableEntity entity) {
     // metadata is not yet persisted in ClusterVariableDbModel, so it has no equivalent to compare

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/ClusterVariableEntityTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.entity;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.ClusterVariableEntity;
 import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import java.util.List;
 
@@ -21,6 +22,11 @@ public class ClusterVariableEntityTransformer
   @Override
   public ClusterVariableEntity apply(
       final io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity value) {
+    final var webappsKind = value.getKind();
+    final ClusterVariableKind kind =
+        webappsKind != null
+            ? ClusterVariableKind.valueOf(webappsKind.name())
+            : ClusterVariableKind.JSON;
     return new ClusterVariableEntity(
         value.getId(),
         value.getName(),
@@ -29,7 +35,8 @@ public class ClusterVariableEntityTransformer
         value.getIsPreview(),
         ClusterVariableScope.valueOf(value.getScope().name()),
         value.getTenantId(),
-        toMetadata(value.getMetadata()));
+        toMetadata(value.getMetadata()),
+        kind);
   }
 
   private List<MetadataEntry> toMetadata(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterTransformer.java
@@ -50,6 +50,7 @@ public final class ClusterVariableFilterTransformer
     queries.addAll(getScopeQuery(filter.scopeOperations()));
     queries.addAll(getTenantQuery(filter.tenantIdOperations()));
     queries.addAll(getMetadataQuery(filter.metadataOperations()));
+    queries.addAll(getKindQuery(filter.kindOperations()));
     ofNullable(getIsTruncatedQuery(filter.isTruncated())).ifPresent(queries::add);
     return and(queries);
   }
@@ -74,6 +75,10 @@ public final class ClusterVariableFilterTransformer
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
     return stringTerms(ClusterVariableIndex.NAME, authorization.resourceIds());
+  }
+
+  private Collection<SearchQuery> getKindQuery(final List<Operation<String>> operations) {
+    return stringOperations(ClusterVariableIndex.KIND, operations);
   }
 
   private Collection<SearchQuery> getNamesQuery(final List<Operation<String>> operations) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterMetadataTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ClusterVariableFilterMetadataTransformerTest.java
@@ -28,7 +28,9 @@ import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
 import io.camunda.search.clients.query.SearchWildcardQuery;
+import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.MetadataValueFilter;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UntypedOperation;
@@ -256,6 +258,39 @@ public final class ClusterVariableFilterMetadataTransformerTest extends Abstract
     final var nestedQueries =
         bool.must().stream().filter(q -> q.queryOption() instanceof SearchNestedQuery).toList();
     assertThat(nestedQueries).hasSize(2);
+  }
+
+  @Test
+  void shouldTransformKindFilter() {
+    // given
+    final var filter = FilterBuilders.clusterVariable().kinds("JSON").build();
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // single-value kinds() maps to EQ → SearchTermQuery, returned directly (no bool wrapper)
+    assertThat(query.queryOption()).isInstanceOf(SearchTermQuery.class);
+    final var termQuery = (SearchTermQuery) query.queryOption();
+    assertThat(termQuery.field()).isEqualTo(ClusterVariableIndex.KIND);
+    assertThat(termQuery.value().stringValue()).isEqualTo("JSON");
+  }
+
+  @Test
+  void shouldTransformMultipleKindFilter() {
+    // given
+    final var filter = FilterBuilders.clusterVariable().kinds("JSON", "SECRET_REFERENCE").build();
+
+    // when
+    final var query = transformQuery(filter);
+
+    // then
+    // multiple values → IN → SearchTermsQuery, returned directly (no bool wrapper)
+    assertThat(query.queryOption()).isInstanceOf(SearchTermsQuery.class);
+    final var terms = (SearchTermsQuery) query.queryOption();
+    assertThat(terms.field()).isEqualTo(ClusterVariableIndex.KIND);
+    assertThat(terms.values().stream().map(TypedValue::stringValue).toList())
+        .containsExactly("JSON", "SECRET_REFERENCE");
   }
 
   private SearchQuery transformMetadataQuery(final String key, final Operation<?>... operations) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -22,7 +22,8 @@ public record ClusterVariableEntity(
     @Nullable Boolean isPreview,
     ClusterVariableScope scope,
     @Nullable String tenantId,
-    @Nullable List<MetadataEntry> metadata)
+    @Nullable List<MetadataEntry> metadata,
+    @Nullable ClusterVariableKind kind)
     implements TenantOwnedEntity {
 
   public ClusterVariableEntity {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableKind.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ClusterVariableFilter.java
@@ -22,6 +22,7 @@ public record ClusterVariableFilter(
     List<Operation<String>> scopeOperations,
     List<Operation<String>> tenantIdOperations,
     List<MetadataValueFilter> metadataOperations,
+    List<Operation<String>> kindOperations,
     Boolean isTruncated)
     implements FilterBase {
 
@@ -31,6 +32,7 @@ public record ClusterVariableFilter(
     List<Operation<String>> scopeOperations;
     List<Operation<String>> tenantIdOperations;
     List<MetadataValueFilter> metadataOperations;
+    List<Operation<String>> kindOperations;
     Boolean isTruncated;
 
     public Builder nameOperations(final List<Operation<String>> operations) {
@@ -132,6 +134,25 @@ public record ClusterVariableFilter(
       return metadataOperations(collectValues(operation, operations));
     }
 
+    public Builder kindOperations(final List<Operation<String>> operations) {
+      kindOperations = addValuesToList(kindOperations, operations);
+      return this;
+    }
+
+    public Builder kinds(final String value, final String... values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    public Builder kinds(final List<String> values) {
+      return kindOperations(FilterUtil.mapDefaultToOperation(values));
+    }
+
+    @SafeVarargs
+    public final Builder kindOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return kindOperations(collectValues(operation, operations));
+    }
+
     public Builder isTruncated(final Boolean value) {
       isTruncated = value;
       return this;
@@ -145,6 +166,7 @@ public record ClusterVariableFilter(
           Objects.requireNonNullElseGet(scopeOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(tenantIdOperations, Collections::emptyList),
           Objects.requireNonNullElseGet(metadataOperations, Collections::emptyList),
+          Objects.requireNonNullElseGet(kindOperations, Collections::emptyList),
           isTruncated);
     }
   }

--- a/service/src/main/java/io/camunda/service/ClusterVariableServices.java
+++ b/service/src/main/java/io/camunda/service/ClusterVariableServices.java
@@ -58,6 +58,7 @@ public final class ClusterVariableServices
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
             .setMetadata(toDirectBufferMetadata(request.metadata()))
+            .setKind(request.kind())
             .setGlobalScope(),
         authentication);
   }
@@ -69,6 +70,7 @@ public final class ClusterVariableServices
             .setName(request.name())
             .setValue(toDirectBufferValue(request.value()))
             .setMetadata(toDirectBufferMetadata(request.metadata()))
+            .setKind(request.kind())
             .setTenantScope(request.tenantId()),
         authentication);
   }
@@ -158,5 +160,9 @@ public final class ClusterVariableServices
   }
 
   public record ClusterVariableRequest(
-      String name, Object value, String tenantId, Map<String, Object> metadata) {}
+      String name,
+      Object value,
+      String tenantId,
+      Map<String, Object> metadata,
+      io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {}
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/ClusterVariableIndex.java
@@ -29,6 +29,7 @@ public class ClusterVariableIndex extends AbstractIndexDescriptor implements Pri
   public static final String METADATA_KEY = "metadata.key";
   public static final String METADATA_VALUE = "metadata.value";
   public static final String METADATA_VALUE_NUMBER = "metadata.valueNumber";
+  public static final String KIND = "kind";
 
   public ClusterVariableIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableEntity.java
@@ -38,6 +38,9 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<MetadataEntry> metadata;
 
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private ClusterVariableKind kind;
+
   public boolean getIsPreview() {
     return isPreview;
   }
@@ -112,9 +115,18 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
     return this;
   }
 
+  public ClusterVariableKind getKind() {
+    return kind;
+  }
+
+  public ClusterVariableEntity setKind(final ClusterVariableKind kind) {
+    this.kind = kind;
+    return this;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata);
+    return Objects.hash(id, name, value, fullValue, isPreview, scope, tenantId, metadata, kind);
   }
 
   @Override
@@ -130,7 +142,8 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         && Objects.equals(fullValue, that.fullValue)
         && scope == that.scope
         && Objects.equals(tenantId, that.tenantId)
-        && Objects.equals(metadata, that.metadata);
+        && Objects.equals(metadata, that.metadata)
+        && kind == that.kind;
   }
 
   @Override
@@ -157,6 +170,8 @@ public class ClusterVariableEntity implements ExporterEntity<ClusterVariableEnti
         + '\''
         + ", metadata="
         + metadata
+        + ", kind="
+        + kind
         + '}';
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/clustervariable/ClusterVariableKind.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.clustervariable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public enum ClusterVariableKind {
+  JSON,
+  SECRET_REFERENCE;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterVariableKind.class);
+
+  public static ClusterVariableKind fromProtocol(
+      final io.camunda.zeebe.protocol.record.value.ClusterVariableKind kind) {
+    if (kind == null) {
+      return JSON;
+    }
+    return switch (kind) {
+      case JSON -> JSON;
+      case SECRET_REFERENCE -> SECRET_REFERENCE;
+    };
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -74,7 +75,8 @@ public class ClusterVariableCreatedUpdatedHandler
     final var recordValue = record.getValue();
     entity
         .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope()))
-        .setName(recordValue.getName());
+        .setName(recordValue.getName())
+        .setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
 
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
       entity.setTenantId(recordValue.getTenantId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -7,6 +7,14 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.FULL_VALUE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.IS_PREVIEW;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.METADATA;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.SCOPE;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.TENANT_ID;
+import static io.camunda.webapps.schema.descriptors.index.ClusterVariableIndex.VALUE;
+
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
@@ -19,6 +27,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,8 +84,13 @@ public class ClusterVariableCreatedUpdatedHandler
     final var recordValue = record.getValue();
     entity
         .setScope(ClusterVariableScope.fromProtocol(recordValue.getScope()))
-        .setName(recordValue.getName())
-        .setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
+        .setName(recordValue.getName());
+
+    // kind is immutable after creation — the UPDATED engine record carries the EnumProperty
+    // default (JSON) and does NOT reflect the stored kind. Only set it on CREATED.
+    if (record.getIntent() == ClusterVariableIntent.CREATED) {
+      entity.setKind(ClusterVariableKind.fromProtocol(recordValue.getKind()));
+    }
 
     if (ClusterVariableScope.TENANT.equals(entity.getScope())) {
       entity.setTenantId(recordValue.getTenantId());
@@ -108,7 +122,18 @@ public class ClusterVariableCreatedUpdatedHandler
   @Override
   public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    // Use upsert with only mutable fields as updateFields, so UPDATED records never overwrite the
+    // immutable kind field in an existing ES/OS document. On CREATED (document absent) the full
+    // entity is indexed. This is consistent with how the RDBMS exporter excludes KIND from UPDATE.
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(NAME, entity.getName());
+    updateFields.put(VALUE, entity.getValue());
+    updateFields.put(FULL_VALUE, entity.getFullValue());
+    updateFields.put(IS_PREVIEW, entity.getIsPreview());
+    updateFields.put(SCOPE, entity.getScope());
+    updateFields.put(TENANT_ID, entity.getTenantId());
+    updateFields.put(METADATA, entity.getMetadata());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -271,6 +271,62 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
       value = ClusterVariableIntent.class,
       names = {"CREATED", "UPDATED"},
       mode = Mode.INCLUDE)
+  void shouldSetKindOnEntity(final ClusterVariableIntent intent) {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getKind())
+        .isEqualTo(
+            io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind
+                .SECRET_REFERENCE);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
+  void shouldDefaultKindToJsonWhenNotInRecord(final ClusterVariableIntent intent) {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getKind())
+        .isEqualTo(io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind.JSON);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
   void shouldMapMetadataWithNumericAndStringValues(final ClusterVariableIntent intent) {
     // given
     final ClusterVariableRecordValue clusterVariableRecordValue =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -8,13 +8,19 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -140,7 +146,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlush() {
+  void shouldUpsertEntityOnFlushWithMutableFieldsOnly() {
     // given
     final ClusterVariableEntity inputEntity =
         new ClusterVariableEntity()
@@ -149,14 +155,19 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             .setValue("value")
             .setTenantId("tenantId")
             .setScope(
-                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT);
+                io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT)
+            .setKind(ClusterVariableKind.SECRET_REFERENCE);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    // upsert is used so that the immutable "kind" field is never overwritten on UPDATED records
+    verify(mockRequest, times(1)).upsert(eq(indexName), eq("id"), eq(inputEntity), anyMap());
+    // batchRequest.add() must not be called — it does a full document replace that would
+    // overwrite the stored kind with null on UPDATED records
+    verify(mockRequest, never()).add(anyString(), any());
   }
 
   @ParameterizedTest
@@ -266,12 +277,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
         .containsExactly(new MetadataEntry("kind", "CREDENTIALS", null));
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = ClusterVariableIntent.class,
-      names = {"CREATED", "UPDATED"},
-      mode = Mode.INCLUDE)
-  void shouldSetKindOnEntity(final ClusterVariableIntent intent) {
+  @Test
+  void shouldSetKindOnEntityForCreatedRecord() {
     // given
     final ClusterVariableRecordValue recordValue =
         ImmutableClusterVariableRecordValue.builder()
@@ -282,7 +289,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
 
     final Record<ClusterVariableRecordValue> record =
         factory.generateRecord(
-            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
 
     // when
     final ClusterVariableEntity entity = new ClusterVariableEntity();
@@ -295,12 +303,34 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
                 .SECRET_REFERENCE);
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = ClusterVariableIntent.class,
-      names = {"CREATED", "UPDATED"},
-      mode = Mode.INCLUDE)
-  void shouldDefaultKindToJsonWhenNotInRecord(final ClusterVariableIntent intent) {
+  @Test
+  void shouldNotOverwriteKindOnUpdatedRecord() {
+    // given — UPDATED records carry the EnumProperty default (JSON), not the stored kind
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.UPDATED).withValue(recordValue));
+
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    // entity.kind is null here — the upsert partial-update path preserves whatever is in the doc
+    assertThat(entity.getKind()).isNull();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then — kind must not be set on UPDATED so the stored value survives the upsert
+    assertThat(entity.getKind()).isNull();
+  }
+
+  @Test
+  void shouldDefaultKindToJsonOnCreatedWhenRecordKindIsJson() {
     // given
     final ClusterVariableRecordValue recordValue =
         ImmutableClusterVariableRecordValue.builder()
@@ -311,7 +341,8 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
 
     final Record<ClusterVariableRecordValue> record =
         factory.generateRecord(
-            ValueType.CLUSTER_VARIABLE, r -> r.withIntent(intent).withValue(recordValue));
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
 
     // when
     final ClusterVariableEntity entity = new ClusterVariableEntity();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -51,7 +52,8 @@ public class ClusterVariableExportHandler
     final var builder =
         new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
             .name(value.getName())
-            .value(value.getValue());
+            .value(value.getValue())
+            .kind(ClusterVariableKind.valueOf(value.getKind().name()));
     if (value.getScope() == GLOBAL) {
       builder.scope(ClusterVariableScope.GLOBAL).tenantId(null);
     } else {

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
+import io.camunda.search.entities.ClusterVariableKind;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterVariableExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private ClusterVariableWriter clusterVariableWriter;
+
+  @Captor private ArgumentCaptor<ClusterVariableDbModel> dbModelCaptor;
+
+  private ClusterVariableExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new ClusterVariableExportHandler(clusterVariableWriter);
+  }
+
+  @Test
+  void shouldMapKindFromCreatedRecord() {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(clusterVariableWriter).create(dbModelCaptor.capture());
+    assertThat(dbModelCaptor.getValue().kind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldDefaultKindToJsonWhenRecordKindIsJson() {
+    // given
+    final ClusterVariableRecordValue recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.JSON)
+            .build();
+
+    final Record<ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(clusterVariableWriter).create(dbModelCaptor.capture());
+    assertThat(dbModelCaptor.getValue().kind()).isEqualTo(ClusterVariableKind.JSON);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -455,6 +455,10 @@ paths:
 
 components:
   schemas:
+    ClusterVariableKindEnum:
+      type: string
+      enum: [JSON, SECRET_REFERENCE]
+      description: The kind of a cluster variable. JSON is the default. SECRET_REFERENCE allows the value to contain camunda.secrets.X references that are resolved at job activation time.
     ClusterVariableScopeEnum:
       type: string
       enum: [ GLOBAL, TENANT ]
@@ -484,6 +488,10 @@ components:
             oneOf:
               - type: string
               - type: number
+        kind:
+          description: The kind of the cluster variable. Defaults to JSON if not specified.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
       x-properties-added-in-version:
         - propertyName: "metadata"
           addedInVersion: "8.10"
@@ -543,6 +551,7 @@ components:
         - scope
         - tenantId
         - metadata
+        - kind
       properties:
         name:
           description: The name of the cluster variable. Unique within its scope (global or tenant-specific).
@@ -564,6 +573,8 @@ components:
             oneOf:
               - type: string
               - type: number
+        kind:
+          $ref: '#/components/schemas/ClusterVariableKindEnum'
       x-properties-added-in-version:
         - propertyName: "metadata"
           addedInVersion: "8.10"
@@ -622,6 +633,10 @@ components:
           description: |
             Filter cluster variables by truncation status of their stored values. When true, returns only variables whose stored values are truncated (i.e., the value exceeds the storage size limit and is truncated in storage). When false, returns only variables with non-truncated stored values. This filter is based on the underlying storage characteristic, not the response format.
           type: boolean
+        kind:
+          description: The kind filter for cluster variables.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindFilterProperty'
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.
       oneOf:
@@ -652,6 +667,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ClusterVariableScopeEnum'
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"
+    ClusterVariableKindFilterProperty:
+      description: ClusterVariableKindEnum property with full advanced search capabilities.
+      oneOf:
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        - $ref: '#/components/schemas/AdvancedClusterVariableKindFilter'
+    AdvancedClusterVariableKindFilter:
+      title: Advanced filter
+      description: Advanced ClusterVariableKindEnum filter.
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        $neq:
+          description: Checks for inequality with the provided value.
+          allOf:
+            - $ref: '#/components/schemas/ClusterVariableKindEnum'
+        $exists:
+          description: Checks if the current property exists.
+          type: boolean
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterVariableKindEnum'
         $like:
           $ref: "filters.yaml#/components/schemas/LikeFilter"
     ClusterVariableSearchQueryResult:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClusterVariableControllerTest.java
@@ -1135,6 +1135,38 @@ public class ClusterVariableControllerTest extends RestControllerTest {
         .json(expectedBody, JsonCompareMode.STRICT);
   }
 
+  @Test
+  void shouldCreateGlobalClusterVariableWithSecretReferenceKind() {
+    // given
+    final var record =
+        new ClusterVariableRecord()
+            .setName("myVar")
+            .setScope(io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL)
+            .setKind(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+    when(clusterVariableServices.createGloballyScopedClusterVariable(
+            createRequestCaptor.capture(), any()))
+        .thenReturn(CompletableFuture.completedFuture(record));
+
+    // when / then
+    webClient
+        .post()
+        .uri(GLOBAL_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            "{\"name\":\"myVar\",\"value\":\"camunda.secrets.MY_SECRET\",\"kind\":\"SECRET_REFERENCE\"}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json("{\"kind\":\"SECRET_REFERENCE\"}", JsonCompareMode.LENIENT);
+
+    assertThat(createRequestCaptor.getValue().kind())
+        .isEqualTo(io.camunda.zeebe.protocol.record.value.ClusterVariableKind.SECRET_REFERENCE);
+  }
+
   @TestConfiguration
   static class TestConfig {
     @Bean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds `kind` support to the RDBMS storage and exporter layer. Part of the #57920 stack — depends on the API PR (which introduces `search.entities.ClusterVariableKind` used by `ClusterVariableDbModel`).

1. `ClusterVariableDbModel` gains a `kind` record component (defaults to `JSON` via builder null-guard).
2. `ClusterVariableMapper.xml` updated: `KIND` column in `resultMap`, `SELECT`, and `INSERT`; kind filter operations in `searchFilter`; `UPDATE` deliberately excludes `KIND` (immutable after creation).
3. Liquibase changeset in `8.10.0.xml`: nullable `KIND VARCHAR(255) DEFAULT 'JSON'` column, plus per-DBMS async index (`CONCURRENTLY` on PostgreSQL with `runInTransaction="false"`, `ONLINE` on MariaDB, etc.).
4. `ClusterVariableExportHandler` passes `kind` to the db model builder.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #57920