### PR TITLE
feat: add kind to CamundaClient ClusterVariable create command and response

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 
 /**
  * Represents a request to create a globally-scoped cluster variable.
@@ -57,6 +58,5 @@ public interface GloballyScopedClusterVariableCreationCommandStep1
    * @param kind the kind (JSON or SECRET_REFERENCE)
    * @return this builder for method chaining
    */
-  GloballyScopedClusterVariableCreationCommandStep1 kind(
-      io.camunda.client.api.search.enums.ClusterVariableKind kind);
+  GloballyScopedClusterVariableCreationCommandStep1 kind(ClusterVariableKind kind);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
@@ -50,4 +50,13 @@ public interface GloballyScopedClusterVariableCreationCommandStep1
    * @return this builder for method chaining
    */
   GloballyScopedClusterVariableCreationCommandStep1 create(String name, Object value);
+
+  /**
+   * Sets the kind of the cluster variable (optional, defaults to JSON).
+   *
+   * @param kind the kind (JSON or SECRET_REFERENCE)
+   * @return this builder for method chaining
+   */
+  GloballyScopedClusterVariableCreationCommandStep1 kind(
+      io.camunda.client.api.search.enums.ClusterVariableKind kind);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 
 /**
  * Represents a request to create a tenant-scoped cluster variable.
@@ -57,6 +58,5 @@ public interface TenantScopedClusterVariableCreationCommandStep1
    * @param kind the kind (JSON or SECRET_REFERENCE)
    * @return this builder for method chaining
    */
-  TenantScopedClusterVariableCreationCommandStep1 kind(
-      io.camunda.client.api.search.enums.ClusterVariableKind kind);
+  TenantScopedClusterVariableCreationCommandStep1 kind(ClusterVariableKind kind);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
@@ -50,4 +50,13 @@ public interface TenantScopedClusterVariableCreationCommandStep1
    * @return this builder for method chaining
    */
   TenantScopedClusterVariableCreationCommandStep1 create(String name, Object value);
+
+  /**
+   * Sets the kind of the cluster variable (optional, defaults to JSON).
+   *
+   * @param kind the kind (JSON or SECRET_REFERENCE)
+   * @return this builder for method chaining
+   */
+  TenantScopedClusterVariableCreationCommandStep1 kind(
+      io.camunda.client.api.search.enums.ClusterVariableKind kind);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java
@@ -26,4 +26,6 @@ public interface CreateClusterVariableResponse {
   ClusterVariableScope getScope();
 
   String getTenantId();
+
+  io.camunda.client.api.search.enums.ClusterVariableKind getKind();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateClusterVariableResponse.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.response;
 
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 
 public interface CreateClusterVariableResponse {
@@ -27,5 +28,5 @@ public interface CreateClusterVariableResponse {
 
   String getTenantId();
 
-  io.camunda.client.api.search.enums.ClusterVariableKind getKind();
+  ClusterVariableKind getKind();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
@@ -56,6 +56,7 @@ public class GloballyScopedCreateClusterVariableImpl
   @Override
   public GloballyScopedClusterVariableCreationCommandStep1 kind(
       final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+    ArgumentUtil.ensureNotNull("kind", kind);
     createVariableRequest.setKind(
         io.camunda.client.impl.util.EnumUtil.convert(
             kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
@@ -19,9 +19,12 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.GloballyScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateClusterVariableResponseImpl;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.CreateClusterVariableRequest;
 import java.time.Duration;
@@ -54,12 +57,9 @@ public class GloballyScopedCreateClusterVariableImpl
   }
 
   @Override
-  public GloballyScopedClusterVariableCreationCommandStep1 kind(
-      final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+  public GloballyScopedClusterVariableCreationCommandStep1 kind(final ClusterVariableKind kind) {
     ArgumentUtil.ensureNotNull("kind", kind);
-    createVariableRequest.setKind(
-        io.camunda.client.impl.util.EnumUtil.convert(
-            kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+    createVariableRequest.setKind(EnumUtil.convert(kind, ClusterVariableKindEnum.class));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
@@ -54,6 +54,15 @@ public class GloballyScopedCreateClusterVariableImpl
   }
 
   @Override
+  public GloballyScopedClusterVariableCreationCommandStep1 kind(
+      final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+    createVariableRequest.setKind(
+        io.camunda.client.impl.util.EnumUtil.convert(
+            kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
   public GloballyScopedClusterVariableCreationCommandStep1 requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
@@ -59,6 +59,7 @@ public class TenantScopedCreateClusterVariableImpl
   @Override
   public TenantScopedClusterVariableCreationCommandStep1 kind(
       final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+    ArgumentUtil.ensureNotNull("kind", kind);
     createVariableRequest.setKind(
         io.camunda.client.impl.util.EnumUtil.convert(
             kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
@@ -19,9 +19,12 @@ import io.camunda.client.api.CamundaFuture;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.TenantScopedClusterVariableCreationCommandStep1;
 import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateClusterVariableResponseImpl;
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.CreateClusterVariableRequest;
 import java.time.Duration;
@@ -57,12 +60,9 @@ public class TenantScopedCreateClusterVariableImpl
   }
 
   @Override
-  public TenantScopedClusterVariableCreationCommandStep1 kind(
-      final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+  public TenantScopedClusterVariableCreationCommandStep1 kind(final ClusterVariableKind kind) {
     ArgumentUtil.ensureNotNull("kind", kind);
-    createVariableRequest.setKind(
-        io.camunda.client.impl.util.EnumUtil.convert(
-            kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+    createVariableRequest.setKind(EnumUtil.convert(kind, ClusterVariableKindEnum.class));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
@@ -57,6 +57,15 @@ public class TenantScopedCreateClusterVariableImpl
   }
 
   @Override
+  public TenantScopedClusterVariableCreationCommandStep1 kind(
+      final io.camunda.client.api.search.enums.ClusterVariableKind kind) {
+    createVariableRequest.setKind(
+        io.camunda.client.impl.util.EnumUtil.convert(
+            kind, io.camunda.client.protocol.rest.ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
   public TenantScopedClusterVariableCreationCommandStep1 requestTimeout(
       final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
@@ -26,7 +27,7 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
   private String value;
   private ClusterVariableScope scope;
   private String tenantId;
-  private io.camunda.client.api.search.enums.ClusterVariableKind kind;
+  private ClusterVariableKind kind;
 
   public CreateClusterVariableResponse setResponse(
       final ClusterVariableResult clusterVariableResult) {
@@ -34,10 +35,7 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
     value = clusterVariableResult.getValue();
     tenantId = clusterVariableResult.getTenantId();
     scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
-    kind =
-        EnumUtil.convert(
-            clusterVariableResult.getKind(),
-            io.camunda.client.api.search.enums.ClusterVariableKind.class);
+    kind = EnumUtil.convert(clusterVariableResult.getKind(), ClusterVariableKind.class);
     return this;
   }
 
@@ -62,7 +60,7 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
   }
 
   @Override
-  public io.camunda.client.api.search.enums.ClusterVariableKind getKind() {
+  public ClusterVariableKind getKind() {
     return kind;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateClusterVariableResponseImpl.java
@@ -26,6 +26,7 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
   private String value;
   private ClusterVariableScope scope;
   private String tenantId;
+  private io.camunda.client.api.search.enums.ClusterVariableKind kind;
 
   public CreateClusterVariableResponse setResponse(
       final ClusterVariableResult clusterVariableResult) {
@@ -33,6 +34,10 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
     value = clusterVariableResult.getValue();
     tenantId = clusterVariableResult.getTenantId();
     scope = EnumUtil.convert(clusterVariableResult.getScope(), ClusterVariableScope.class);
+    kind =
+        EnumUtil.convert(
+            clusterVariableResult.getKind(),
+            io.camunda.client.api.search.enums.ClusterVariableKind.class);
     return this;
   }
 
@@ -54,5 +59,10 @@ public class CreateClusterVariableResponseImpl implements CreateClusterVariableR
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public io.camunda.client.api.search.enums.ClusterVariableKind getKind() {
+    return kind;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -143,6 +143,33 @@ public class CreateClusterVariableTest extends ClientRestTest {
   }
 
   @Test
+  void shouldCreateTenantClusterVariableWithKind() {
+    // given
+    final ClusterVariableResult responseProto =
+        Instancio.create(ClusterVariableResult.class)
+            .scope(ClusterVariableScopeEnum.TENANT)
+            .kind(ClusterVariableKindEnum.SECRET_REFERENCE);
+    gatewayService.onCreateTenantClusterVariableRequest(TENANT_ID, responseProto);
+
+    // when
+    final io.camunda.client.api.response.CreateClusterVariableResponse response =
+        client
+            .newTenantScopedClusterVariableCreateRequest(TENANT_ID)
+            .create(VARIABLE_NAME, VARIABLE_VALUE)
+            .kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getKind())
+        .isEqualTo(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE);
+    final io.camunda.client.protocol.rest.CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(
+            io.camunda.client.protocol.rest.CreateClusterVariableRequest.class);
+    assertThat(sentRequest.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
+  }
+
+  @Test
   void shouldRaiseExceptionOnNullVariableName() {
     // when / then
     assertThatThrownBy(

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.client.protocol.rest.ProblemDetail;
@@ -112,6 +113,33 @@ public class CreateClusterVariableTest extends ClientRestTest {
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldCreateGlobalClusterVariableWithKind() {
+    // given
+    final ClusterVariableResult responseProto =
+        Instancio.create(ClusterVariableResult.class)
+            .scope(ClusterVariableScopeEnum.GLOBAL)
+            .kind(ClusterVariableKindEnum.SECRET_REFERENCE);
+    gatewayService.onCreateGlobalClusterVariableRequest(responseProto);
+
+    // when
+    final io.camunda.client.api.response.CreateClusterVariableResponse response =
+        client
+            .newGloballyScopedClusterVariableCreateRequest()
+            .create(VARIABLE_NAME, VARIABLE_VALUE)
+            .kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getKind())
+        .isEqualTo(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE);
+    final io.camunda.client.protocol.rest.CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(
+            io.camunda.client.protocol.rest.CreateClusterVariableRequest.class);
+    assertThat(sentRequest.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -21,9 +21,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.CreateClusterVariableResponse;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
+import io.camunda.client.protocol.rest.CreateClusterVariableRequest;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
@@ -125,20 +128,18 @@ public class CreateClusterVariableTest extends ClientRestTest {
     gatewayService.onCreateGlobalClusterVariableRequest(responseProto);
 
     // when
-    final io.camunda.client.api.response.CreateClusterVariableResponse response =
+    final CreateClusterVariableResponse response =
         client
             .newGloballyScopedClusterVariableCreateRequest()
             .create(VARIABLE_NAME, VARIABLE_VALUE)
-            .kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE)
+            .kind(ClusterVariableKind.SECRET_REFERENCE)
             .send()
             .join();
 
     // then
-    assertThat(response.getKind())
-        .isEqualTo(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE);
-    final io.camunda.client.protocol.rest.CreateClusterVariableRequest sentRequest =
-        gatewayService.getLastRequest(
-            io.camunda.client.protocol.rest.CreateClusterVariableRequest.class);
+    assertThat(response.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+    final CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(CreateClusterVariableRequest.class);
     assertThat(sentRequest.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 
@@ -152,20 +153,18 @@ public class CreateClusterVariableTest extends ClientRestTest {
     gatewayService.onCreateTenantClusterVariableRequest(TENANT_ID, responseProto);
 
     // when
-    final io.camunda.client.api.response.CreateClusterVariableResponse response =
+    final CreateClusterVariableResponse response =
         client
             .newTenantScopedClusterVariableCreateRequest(TENANT_ID)
             .create(VARIABLE_NAME, VARIABLE_VALUE)
-            .kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE)
+            .kind(ClusterVariableKind.SECRET_REFERENCE)
             .send()
             .join();
 
     // then
-    assertThat(response.getKind())
-        .isEqualTo(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE);
-    final io.camunda.client.protocol.rest.CreateClusterVariableRequest sentRequest =
-        gatewayService.getLastRequest(
-            io.camunda.client.protocol.rest.CreateClusterVariableRequest.class);
+    assertThat(response.getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+    final CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(CreateClusterVariableRequest.class);
     assertThat(sentRequest.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -188,6 +188,24 @@ public class SearchClusterVariableTest extends ClientRestTest {
   }
 
   @Test
+  void shouldFilterClusterVariablesByKind() {
+    // when
+    client
+        .newClusterVariableSearchRequest()
+        .filter(
+            f -> f.kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE))
+        .send()
+        .join();
+
+    // then
+    final io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest request =
+        gatewayService.getLastRequest(
+            io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getKind().get$Eq())
+        .isEqualTo(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
+  }
+
+  @Test
   void shouldChainWithFullValuesMethodCall() {
     // when
     client

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/SearchClusterVariableTest.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.search.enums.ClusterVariableKind;
 import io.camunda.client.api.search.enums.ClusterVariableScope;
+import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
@@ -192,17 +194,15 @@ public class SearchClusterVariableTest extends ClientRestTest {
     // when
     client
         .newClusterVariableSearchRequest()
-        .filter(
-            f -> f.kind(io.camunda.client.api.search.enums.ClusterVariableKind.SECRET_REFERENCE))
+        .filter(f -> f.kind(ClusterVariableKind.SECRET_REFERENCE))
         .send()
         .join();
 
     // then
-    final io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest request =
-        gatewayService.getLastRequest(
-            io.camunda.client.protocol.rest.ClusterVariableSearchQueryRequest.class);
+    final ClusterVariableSearchQueryRequest request =
+        gatewayService.getLastRequest(ClusterVariableSearchQueryRequest.class);
     assertThat(request.getFilter().getKind().get$Eq())
-        .isEqualTo(io.camunda.client.protocol.rest.ClusterVariableKindEnum.SECRET_REFERENCE);
+        .isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds `kind` support to the Java client's cluster variable create API. Part of the #57920 stack — depends on the search/REST PR (#57983) which introduced the `ClusterVariableKind` enum and filter support.

1. `kind(ClusterVariableKind)` method on `GloballyScopedClusterVariableCreationCommandStep1` and `TenantScopedClusterVariableCreationCommandStep1` interfaces + impls — lets callers set `SECRET_REFERENCE` on create.
2. `getKind()` on `CreateClusterVariableResponse` interface + impl — surfaces the kind in the create response.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #57920