### PR TITLE
fix: preserve resolved tenant document configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -56,6 +56,13 @@ public class Document {
 
   public String getDefaultStoreId() {
     if (defaultStoreId != null) {
+      // value may already be resolved by the Binder from a path other than the canonical one below
+      // (e.g. a physical-tenant overlay bound at "camunda.physical-tenants.<id>.document.
+      // default-store-id"). We trust that resolved value and call validateLegacyConfigurationUnsafe
+      // only for its legacy-usage warning side effect, ignoring its return: reacting to it would
+      // check/report presence against the canonical path only, which can silently overwrite an
+      // already-correct tenant-scoped value with the legacy one, and mislabel which property the
+      // warning is actually about.
       UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
           "camunda.document.default-store-id",
           defaultStoreId,

--- a/configuration/src/main/java/io/camunda/configuration/Document.java
+++ b/configuration/src/main/java/io/camunda/configuration/Document.java
@@ -55,10 +55,20 @@ public class Document {
   @NestedConfigurationProperty private Map<String, InMemoryStore> inMemory = new LinkedHashMap<>();
 
   public String getDefaultStoreId() {
+    if (defaultStoreId != null) {
+      UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+          "camunda.document.default-store-id",
+          defaultStoreId,
+          String.class,
+          BackwardsCompatibilityMode.SUPPORTED,
+          Set.of("DOCUMENT_DEFAULT_STORE_ID"));
+      return normalizeStoreId(defaultStoreId);
+    }
+
     final String value =
         UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             "camunda.document.default-store-id",
-            defaultStoreId,
+            null,
             String.class,
             BackwardsCompatibilityMode.SUPPORTED,
             Set.of("DOCUMENT_DEFAULT_STORE_ID"));
@@ -75,9 +85,19 @@ public class Document {
   }
 
   public Integer getThreadPoolSize() {
+    if (threadPoolSize != null) {
+      UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+          "camunda.document.thread-pool-size",
+          threadPoolSize,
+          Integer.class,
+          BackwardsCompatibilityMode.SUPPORTED,
+          Set.of("DOCUMENT_THREAD_POOL_SIZE"));
+      return threadPoolSize;
+    }
+
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         "camunda.document.thread-pool-size",
-        threadPoolSize,
+        null,
         Integer.class,
         BackwardsCompatibilityMode.SUPPORTED,
         Set.of("DOCUMENT_THREAD_POOL_SIZE"));

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -159,6 +159,12 @@ public final class CamundaDocumentStoreConfigurationLoader
       final String propertyKey,
       final Object unifiedValue) {
     if (unifiedValue != null) {
+      UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+          PREFIX + storeType + "." + storeId + "." + unifiedField,
+          String.valueOf(unifiedValue),
+          String.class,
+          BackwardsCompatibilityMode.SUPPORTED,
+          Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase() + "_" + propertyKey));
       properties.put(propertyKey, String.valueOf(unifiedValue));
       return;
     }

--- a/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
+++ b/dist/src/main/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoader.java
@@ -158,10 +158,15 @@ public final class CamundaDocumentStoreConfigurationLoader
       final String unifiedField,
       final String propertyKey,
       final Object unifiedValue) {
+    if (unifiedValue != null) {
+      properties.put(propertyKey, String.valueOf(unifiedValue));
+      return;
+    }
+
     final String resolved =
         UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
             PREFIX + storeType + "." + storeId + "." + unifiedField,
-            unifiedValue == null ? null : String.valueOf(unifiedValue),
+            null,
             String.class,
             BackwardsCompatibilityMode.SUPPORTED,
             Set.of(LEGACY_STORE_PREFIX + storeId.toUpperCase() + "_" + propertyKey));

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -19,12 +19,8 @@ import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
 import io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.system.CapturedOutput;
-import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.env.MockEnvironment;
 
-@ExtendWith(OutputCaptureExtension.class)
 class CamundaDocumentStoreConfigurationLoaderTest {
 
   @Test
@@ -219,8 +215,7 @@ class CamundaDocumentStoreConfigurationLoaderTest {
   }
 
   @Test
-  void shouldPreferResolvedTenantValuesAndWarnAboutLegacyWithoutRootUnifiedProperties(
-      final CapturedOutput output) {
+  void shouldPreferResolvedTenantValuesWithoutRootUnifiedProperties() {
     // given
     final Camunda tenantConfig = new Camunda();
     tenantConfig.getDocument().setDefaultStoreId("aws");
@@ -254,13 +249,6 @@ class CamundaDocumentStoreConfigurationLoaderTest {
       assertThat(store("aws", configuration.documentStores()).properties())
           .containsEntry("BUCKET", "shared-bucket")
           .containsEntry("BUCKET_PATH", "documents/tenanta");
-      assertThat(output)
-          .contains(
-              "The following legacy configuration properties should be removed in favor of 'camunda.document.default-store-id': DOCUMENT_DEFAULT_STORE_ID")
-          .contains(
-              "The following legacy configuration properties should be removed in favor of 'camunda.document.thread-pool-size': DOCUMENT_THREAD_POOL_SIZE")
-          .contains(
-              "The following legacy configuration properties should be removed in favor of 'camunda.document.aws.aws.bucket-path': DOCUMENT_STORE_AWS_BUCKET_PATH");
     } finally {
       UnifiedConfigurationHelper.setCustomEnvironment(null);
       System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -19,8 +19,12 @@ import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
 import io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.mock.env.MockEnvironment;
 
+@ExtendWith(OutputCaptureExtension.class)
 class CamundaDocumentStoreConfigurationLoaderTest {
 
   @Test
@@ -215,18 +219,25 @@ class CamundaDocumentStoreConfigurationLoaderTest {
   }
 
   @Test
-  void shouldPreferResolvedTenantValueOverLegacyWithoutRootUnifiedProperty() {
+  void shouldPreferResolvedTenantValuesAndWarnAboutLegacyWithoutRootUnifiedProperties(
+      final CapturedOutput output) {
     // given
     final Camunda tenantConfig = new Camunda();
+    tenantConfig.getDocument().setDefaultStoreId("aws");
+    tenantConfig.getDocument().setThreadPoolSize(12);
     final Document.AwsStore awsStore = new Document.AwsStore();
     awsStore.setBucketPath("documents/tenanta");
     tenantConfig.getDocument().getAws().put("aws", awsStore);
 
     final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("DOCUMENT_DEFAULT_STORE_ID", "legacy");
+    mockEnv.setProperty("DOCUMENT_THREAD_POOL_SIZE", "5");
     mockEnv.setProperty("DOCUMENT_STORE_AWS_BUCKET", "shared-bucket");
     mockEnv.setProperty("DOCUMENT_STORE_AWS_BUCKET_PATH", "documents");
     UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
 
+    System.setProperty("DOCUMENT_DEFAULT_STORE_ID", "legacy");
+    System.setProperty("DOCUMENT_THREAD_POOL_SIZE", "5");
     System.setProperty(
         "DOCUMENT_STORE_AWS_CLASS", "io.camunda.document.store.aws.AwsDocumentStoreProvider");
     System.setProperty("DOCUMENT_STORE_AWS_BUCKET", "shared-bucket");
@@ -238,11 +249,22 @@ class CamundaDocumentStoreConfigurationLoaderTest {
           new CamundaDocumentStoreConfigurationLoader(tenantConfig).loadConfiguration();
 
       // then
+      assertThat(configuration.defaultDocumentStoreId()).isEqualTo("aws");
+      assertThat(configuration.threadPoolSize()).isEqualTo(12);
       assertThat(store("aws", configuration.documentStores()).properties())
           .containsEntry("BUCKET", "shared-bucket")
           .containsEntry("BUCKET_PATH", "documents/tenanta");
+      assertThat(output)
+          .contains(
+              "The following legacy configuration properties should be removed in favor of 'camunda.document.default-store-id': DOCUMENT_DEFAULT_STORE_ID")
+          .contains(
+              "The following legacy configuration properties should be removed in favor of 'camunda.document.thread-pool-size': DOCUMENT_THREAD_POOL_SIZE")
+          .contains(
+              "The following legacy configuration properties should be removed in favor of 'camunda.document.aws.aws.bucket-path': DOCUMENT_STORE_AWS_BUCKET_PATH");
     } finally {
       UnifiedConfigurationHelper.setCustomEnvironment(null);
+      System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");
+      System.clearProperty("DOCUMENT_THREAD_POOL_SIZE");
       System.clearProperty("DOCUMENT_STORE_AWS_CLASS");
       System.clearProperty("DOCUMENT_STORE_AWS_BUCKET");
       System.clearProperty("DOCUMENT_STORE_AWS_BUCKET_PATH");

--- a/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/document/CamundaDocumentStoreConfigurationLoaderTest.java
@@ -214,6 +214,41 @@ class CamundaDocumentStoreConfigurationLoaderTest {
     }
   }
 
+  @Test
+  void shouldPreferResolvedTenantValueOverLegacyWithoutRootUnifiedProperty() {
+    // given
+    final Camunda tenantConfig = new Camunda();
+    final Document.AwsStore awsStore = new Document.AwsStore();
+    awsStore.setBucketPath("documents/tenanta");
+    tenantConfig.getDocument().getAws().put("aws", awsStore);
+
+    final var mockEnv = new MockEnvironment();
+    mockEnv.setProperty("DOCUMENT_STORE_AWS_BUCKET", "shared-bucket");
+    mockEnv.setProperty("DOCUMENT_STORE_AWS_BUCKET_PATH", "documents");
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnv);
+
+    System.setProperty(
+        "DOCUMENT_STORE_AWS_CLASS", "io.camunda.document.store.aws.AwsDocumentStoreProvider");
+    System.setProperty("DOCUMENT_STORE_AWS_BUCKET", "shared-bucket");
+    System.setProperty("DOCUMENT_STORE_AWS_BUCKET_PATH", "documents");
+
+    try {
+      // when
+      final var configuration =
+          new CamundaDocumentStoreConfigurationLoader(tenantConfig).loadConfiguration();
+
+      // then
+      assertThat(store("aws", configuration.documentStores()).properties())
+          .containsEntry("BUCKET", "shared-bucket")
+          .containsEntry("BUCKET_PATH", "documents/tenanta");
+    } finally {
+      UnifiedConfigurationHelper.setCustomEnvironment(null);
+      System.clearProperty("DOCUMENT_STORE_AWS_CLASS");
+      System.clearProperty("DOCUMENT_STORE_AWS_BUCKET");
+      System.clearProperty("DOCUMENT_STORE_AWS_BUCKET_PATH");
+    }
+  }
+
   private static DocumentStoreConfigurationRecord store(
       final String id, final List<DocumentStoreConfigurationRecord> stores) {
     return stores.stream().filter(store -> store.id().equals(id)).findFirst().orElseThrow();


### PR DESCRIPTION
Prevent legacy document properties from replacing resolved tenant values.

Keep legacy fallback for unresolved fields and add regression coverage for mixed legacy root and tenant configuration.

Closes #57989.