### PR TITLE
docs: rename Monorepo DevOps team to EngOps, part 2

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -10,7 +10,7 @@ global:
     app: monorepo
     camunda.cloud/managed-by: Helm
     camunda.cloud/source: argocd
-    team: monorepo-devops
+    team: engineering-operations
 
   image:
     pullSecrets:

--- a/.claude/skills/ci-fix-failure/references/infra-transient.md
+++ b/.claude/skills/ci-fix-failure/references/infra-transient.md
@@ -33,7 +33,7 @@ actions and the caching policy for this repo. Common shapes:
 - **Docker builds**: do **not** add `cache-from: type=gha` / `cache-to: type=gha` to
   `docker/build-push-action` — `ci.md` explicitly forbids it.
 - **External registry / dependency that has caused outages**: configure a mirror or fallback URL
-  if one exists, or pin to a known-good version. Coordinate with monorepo-devops if the change
+  if one exists, or pin to a known-good version. Coordinate with Engineering Operations if the change
   touches `Artifactory` / `DockerHub` integration.
 - **Right-sizing / Splitting** (runner class): only justified when the timeout is the
   actual constraint *and* the slowdown is intrinsic. Don't bump timeouts. Use

--- a/.github/actions/post-failure-feedback/feedback.mjs
+++ b/.github/actions/post-failure-feedback/feedback.mjs
@@ -27,11 +27,11 @@ const RELIABILITY =
 const MEDIC = {
   '@camunda/test-automation-team': '<!subteam^S09UF0EV0HG|test-automation-medic>',
   '@camunda/distribution': '<!subteam^S053K7C7QKU|distribution-medic>',
-  '@camunda/monorepo-devops-team': '<!subteam^S07D6C6B18T|monorepo-devops-medic>',
+  '@camunda/engineering-operations': '<!subteam^S07D6C6B18T|monorepo-ci-medic>',
   '@camunda/core-features': '<!subteam^S08P2CU9V8W|core-features-medic>',
 };
 // No fallback: an unmapped/missing owner (e.g. the "unknown" default) must not
-// silently page monorepo-devops-medic. Returns '' (nothing to concatenate) when
+// silently page monorepo-ci-medic. Returns '' (nothing to concatenate) when
 // there's no mapping, so callers don't need to worry about spacing either.
 const medicMention = (owner) => (MEDIC[owner] ? ` ${MEDIC[owner]}` : '');
 

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -169,7 +169,7 @@ jobs:
           labeled: component/feel-js, component/feel-scala
 
       # Engineering Operations (#115)
-      - id: add-to-devops
+      - id: add-to-engops
         if: >
           github.event.action != 'labeled'
             || github.event.label.name == 'component/build-pipeline'

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -42,7 +42,7 @@ env:
   PARENT_WORKFLOW_FILE: 'docker-build-helm-integration.yml'
   MEDIC_TEST_AUTOMATION: '<!subteam^S09UF0EV0HG|test-automation-medic>'
   MEDIC_DISTRIBUTION: '<!subteam^S053K7C7QKU|distribution-medic>'
-  MEDIC_MONOREPO_DEVOPS: '<!subteam^S07D6C6B18T|monorepo-devops-medic>'
+  MEDIC_ENGINEERING_OPERATIONS: '<!subteam^S07D6C6B18T|monorepo-ci-medic>'
   MEDIC_CORE_FEATURES: '<!subteam^S08P2CU9V8W|core-features-medic>'
   STREAK_MARKER_ACTIVE: 'AlwaysGreen streak (active)'
   STREAK_MARKER_RESOLVED: 'AlwaysGreen streak (resolved)'
@@ -202,7 +202,7 @@ jobs:
             # ----------------------------------------------------------------
             # Build medic pings from failure-context artifacts on the latest run.
             # ----------------------------------------------------------------
-            MEDIC_PINGS="${MEDIC_MONOREPO_DEVOPS}"   # default owner: pipeline plumbing
+            MEDIC_PINGS="${MEDIC_ENGINEERING_OPERATIONS}"   # default owner: pipeline plumbing
 
             if [[ "${IS_STREAK}" == "true" ]]; then
               WORK_DIR="${RUNNER_TEMP}/streak-context-${BASE_REF//\//-}"
@@ -224,7 +224,7 @@ jobs:
                   case "$owner" in
                     "@camunda/test-automation-team")   mentions+=("${MEDIC_TEST_AUTOMATION}") ;;
                     "@camunda/distribution")            mentions+=("${MEDIC_DISTRIBUTION}") ;;
-                    "@camunda/engineering-operations")    mentions+=("${MEDIC_MONOREPO_DEVOPS}") ;;
+                    "@camunda/engineering-operations")    mentions+=("${MEDIC_ENGINEERING_OPERATIONS}") ;;
                     "@camunda/core-features")           mentions+=("${MEDIC_CORE_FEATURES}") ;;
                   esac
                 done <<<"$OWNERS"

--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -153,7 +153,7 @@ jobs:
               '```',
               '',
               '### Need an exception?',
-              'If this action genuinely cannot be SHA-pinned (e.g. the vendor publishes only tags, or there is a policy reason), please contact the **monorepo-devops team on Slack**. The team owns the pinning policy and can apply the right exception centrally.',
+              'If this action genuinely cannot be SHA-pinned (e.g. the vendor publishes only tags, or there is a policy reason), please contact the **Engineering Operations team on Slack**. The team owns the pinning policy and can apply the right exception centrally.',
             ].join('\n');
 
             const resolvedBody = () => [

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1012,7 +1012,7 @@ jobs:
                 # The artifact was unreachable. Distinguish this from a
                 # genuinely "unknown" categorisation so consumers don't
                 # confuse "we couldn't tell" with "we tried and the data
-                # was ambiguous". Routing falls to monorepo-devops since
+                # was ambiguous". Routing falls to monorepo-ci-medic since
                 # this is an integration / permissions problem with the
                 # parent workflow, not a downstream test failure.
                 DOWNLOAD_ERR=$(tr '\n' ' ' < "$DOWNLOAD_LOG" 2>/dev/null | sed 's/  */ /g' | cut -c1-300)

--- a/docs/monorepo-docs/collaboration-guidelines.md
+++ b/docs/monorepo-docs/collaboration-guidelines.md
@@ -32,7 +32,7 @@ Guidelines for collaborating on CI/CD, build automation, release processes, and 
 * Performance-sensitive changes
 * Cross-team dependency workflows
 
-✋ **When in Doubt: Ask early in #ask-monorepo-devops. The Engineering Operations team is here to help! A 5-minute chat can save hours.**
+✋ **When in Doubt: Ask early in #ask-eng-ops. The Engineering Operations team is here to help! A 5-minute chat can save hours.**
 
 ## Heads-Up Pattern (Start Here) 📣
 
@@ -101,7 +101,7 @@ When any of those become true → reach out to the Engineering Operations team f
 
 ### Support Contacts
 
-* Slack: [#ask-monorepo-devops](https://camunda.slack.com/archives/C08NZ7E9ZT2) (Engineering Operations team)
+* Slack: [#ask-eng-ops](https://camunda.slack.com/archives/C08NZ7E9ZT2) (Engineering Operations team)
 * Escalation: Engineering manager – see [Engineering Operations Team page](https://confluence.camunda.com/spaces/HAN/pages/277021448/Monorepo+DevOps+Team) for current EM/DRI details.
 
 ### Key Documentation

--- a/docs/monorepo-docs/flaky-test-gate.md
+++ b/docs/monorepo-docs/flaky-test-gate.md
@@ -249,7 +249,7 @@ To replay a single PR's baseline query at a chosen cutoff (to classify an alert 
 1. **Look at the comment first.** It tells you which test, which job, and how many clean re-runs you have.
 2. **If the test name is from your diff**, you introduced it — fix the method and push. The next 3 clean CI runs will clear it.
 3. **If you didn't touch anything related**, it's a pre-existing flake that just hit you. Apply `ci:flaky-test-bypass` (after opening a `kind/flake` issue) and re-run CI.
-4. **If you're convinced it's a false positive from the gate itself** (e.g. the test has clearly flaked on `main` recently), confirm with the BigQuery replay query and reach out to `#ask-monorepo-devops`. The bypass label always works as an escape hatch.
+4. **If you're convinced it's a false positive from the gate itself** (e.g. the test has clearly flaked on `main` recently), confirm with the BigQuery replay query and reach out to `#ask-eng-ops`. The bypass label always works as an escape hatch.
 
 ### Disabling the gate temporarily
 


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/57742 was incomplete, more mentions of old team name.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

None
