### PR TITLE
fix: support agent details for multi-instance element instances

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -24,13 +24,17 @@ import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscr
 import {mockSearchElementInstanceInspection} from 'modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection';
 import {searchResult} from 'modules/testUtils';
 import * as clientConfig from 'modules/utils/getClientConfig';
-import type {
-  ElementInstance,
-  Job,
-  ProcessInstance,
-  DecisionInstance,
-  UserTask,
-  MessageSubscription,
+import {http, HttpResponse} from 'msw';
+import {mockServer} from 'modules/mock-server/node';
+import {
+  endpoints,
+  type ElementInstance,
+  type Job,
+  type ProcessInstance,
+  type DecisionInstance,
+  type UserTask,
+  type MessageSubscription,
+  type QueryAgentInstancesRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
 import {mockAgentInstance} from 'modules/mocks/mockAgentInstance';
@@ -378,6 +382,46 @@ describe('<DetailsTab />', () => {
         'To view the details, select a single element instance in the instance history.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should render agent-details for a multi-instance element instance by filtering on elementId only', async () => {
+    let agentFilter: QueryAgentInstancesRequestBody['filter'] | undefined;
+    mockServer.use(
+      http.post(
+        endpoints.queryAgentInstances.getUrl(),
+        async ({request}) => {
+          const body = (await request.json()) as QueryAgentInstancesRequestBody;
+          agentFilter = body.filter;
+          return HttpResponse.json(
+            searchResult([mockAgentInstance({elementId: 'Task_1'})]),
+          );
+        },
+        {once: true},
+      ),
+    );
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+    mockFetchElementInstance('999000111').withSuccess({
+      ...mockElementInstance,
+      elementInstanceKey: '999000111',
+      type: 'MULTI_INSTANCE_BODY',
+    });
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper(
+        'elementId=Task_1&elementInstanceKey=999000111&isMultiInstanceBody=true',
+      ),
+    });
+
+    expect(
+      await screen.findByRole('heading', {name: 'AI Agent', level: 5}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {name: 'Element Instance', level: 5}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('999000111')).toBeInTheDocument();
+
+    expect(agentFilter?.elementId).toEqual('Task_1');
+    expect(agentFilter?.elementInstanceKeys).toBeUndefined();
   });
 
   it('should render element instance details when a single instance is resolved', async () => {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -63,6 +63,7 @@ const DetailsTab: React.FC = () => {
     selectedElementId,
     selectedAnchorElementId,
     selectedInstancesCount,
+    isSelectedInstanceMultiInstanceBody,
     isFetchingElement,
   } = useProcessInstanceElementSelection();
 
@@ -170,6 +171,13 @@ const DetailsTab: React.FC = () => {
 
   const messageSubscription = messageSubscriptionResult?.items?.[0] ?? null;
 
+  // Multi-instance bodies have no agent instance associated with the multi-instance
+  // element instance. Agents are assigned to the spawned inner instances.
+  // Fall back to elementId-only filtering when multi-instance body is selected.
+  const agentElementInstanceKey = isSelectedInstanceMultiInstanceBody
+    ? null
+    : elementInstanceKey;
+
   const {
     data: agentInstancesResult,
     isLoading: isAgentLoading,
@@ -177,7 +185,7 @@ const DetailsTab: React.FC = () => {
   } = useAgentInstancesForElement({
     processInstanceKey: processInstance?.processInstanceKey ?? '',
     elementId: effectiveElementId ?? '',
-    elementInstanceKey,
+    elementInstanceKey: agentElementInstanceKey,
     enabled: !!processInstance?.processInstanceKey && !!effectiveElementId,
     enablePeriodicRefetch: true,
   });
@@ -557,7 +565,7 @@ const DetailsTab: React.FC = () => {
           }
           isLoading={isAgentLoading}
           isError={isAgentError}
-          selectedElementInstanceKey={elementInstanceKey}
+          selectedElementInstanceKey={agentElementInstanceKey}
         />
       )}
       {!showAgentInstance && clientConfig.waitStatesEnabled && (


### PR DESCRIPTION
## Description

This PR fixes a bug discovered during QA. Using an AI agent as a multi-instance element does not show agent details when the multi-instance element instance is selected.

The bug is fixed by only using the (resolved) `elementInstanceKey` for filtering agent instances and the conversation history when no multi-instance body is selected. Reason: AI agents are invoked for the inner instances, not the `elementInstanceKey` of the multi-instance instance.

<img width="1356" height="968" alt="Screenshot 2026-07-16 at 16 30 29" src="https://github.com/user-attachments/assets/c613014f-3765-49ca-b768-7fe8012c108c" />

## Related issues

closes #57949
