### PR TITLE
fix: preserve ClusterVariable kind from stored state on update

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -18,6 +18,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ClusterVariableRecordValidator {
 
+  private static final String VARIABLE_NOT_FOUND_MSG =
+      "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'";
+
   private final ClusterVariableState clusterVariableState;
   private final TenantState tenantState;
   private final ClusterVariableValidationConfiguration validationConfig;
@@ -81,12 +84,11 @@ public class ClusterVariableRecordValidator {
     return Either.left(
         new Rejection(
             RejectionType.NOT_FOUND,
-            "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
-                .formatted(
-                    record.getName(),
-                    record.getTenantId().isBlank()
-                        ? "GLOBAL"
-                        : "tenant: '%s'".formatted(record.getTenantId()))));
+            VARIABLE_NOT_FOUND_MSG.formatted(
+                record.getName(),
+                record.getTenantId().isBlank()
+                    ? "GLOBAL"
+                    : "tenant: '%s'".formatted(record.getTenantId()))));
   }
 
   public Either<Rejection, ClusterVariableRecord> loadExisting(
@@ -109,12 +111,11 @@ public class ClusterVariableRecordValidator {
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,
-              "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
-                  .formatted(
-                      command.getName(),
-                      command.getTenantId().isBlank()
-                          ? "GLOBAL"
-                          : "tenant: '%s'".formatted(command.getTenantId()))));
+              VARIABLE_NOT_FOUND_MSG.formatted(
+                  command.getName(),
+                  command.getTenantId().isBlank()
+                      ? "GLOBAL"
+                      : "tenant: '%s'".formatted(command.getTenantId()))));
     }
     return Either.right(stored.get());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.util.Either;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 
 public class ClusterVariableRecordValidator {
@@ -74,18 +75,57 @@ public class ClusterVariableRecordValidator {
 
   public Either<Rejection, ClusterVariableRecord> validateExistence(
       final ClusterVariableRecord record) {
-    if (globallyScopedVariableExists(record) || tenantScopedVariableExists(record)) {
-      return Either.right(record);
+    final boolean exists;
+    if (record.isGloballyScoped()) {
+      exists = clusterVariableState.existsAtGlobalScope(record.getNameBuffer());
+    } else if (record.isTenantScoped()) {
+      exists =
+          clusterVariableState.existsAtTenantScope(record.getNameBuffer(), record.getTenantId());
+    } else {
+      exists = false;
     }
-    return Either.left(
-        new Rejection(
-            RejectionType.NOT_FOUND,
-            "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
-                .formatted(
-                    record.getName(),
-                    record.getTenantId().isBlank()
-                        ? "GLOBAL"
-                        : "tenant: '%s'".formatted(record.getTenantId()))));
+    if (!exists) {
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
+                  .formatted(
+                      record.getName(),
+                      record.getTenantId().isBlank()
+                          ? "GLOBAL"
+                          : "tenant: '%s'".formatted(record.getTenantId()))));
+    }
+    return Either.right(record);
+  }
+
+  public Either<Rejection, ClusterVariableRecord> loadExisting(
+      final ClusterVariableRecord command) {
+    final Optional<ClusterVariableRecord> stored;
+    if (command.isGloballyScoped()) {
+      stored =
+          clusterVariableState
+              .getGloballyScopedClusterVariable(command.getNameBuffer())
+              .map(i -> i.getRecord());
+    } else if (command.isTenantScoped()) {
+      stored =
+          clusterVariableState
+              .getTenantScopedClusterVariable(command.getNameBuffer(), command.getTenantId())
+              .map(i -> i.getRecord());
+    } else {
+      stored = Optional.empty();
+    }
+    if (stored.isEmpty()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
+                  .formatted(
+                      command.getName(),
+                      command.getTenantId().isBlank()
+                          ? "GLOBAL"
+                          : "tenant: '%s'".formatted(command.getTenantId()))));
+    }
+    return Either.right(stored.get());
   }
 
   private boolean tenantScopedVariableExists(final ClusterVariableRecord clusterVariableRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableRecordValidator.java
@@ -75,27 +75,18 @@ public class ClusterVariableRecordValidator {
 
   public Either<Rejection, ClusterVariableRecord> validateExistence(
       final ClusterVariableRecord record) {
-    final boolean exists;
-    if (record.isGloballyScoped()) {
-      exists = clusterVariableState.existsAtGlobalScope(record.getNameBuffer());
-    } else if (record.isTenantScoped()) {
-      exists =
-          clusterVariableState.existsAtTenantScope(record.getNameBuffer(), record.getTenantId());
-    } else {
-      exists = false;
+    if (globallyScopedVariableExists(record) || tenantScopedVariableExists(record)) {
+      return Either.right(record);
     }
-    if (!exists) {
-      return Either.left(
-          new Rejection(
-              RejectionType.NOT_FOUND,
-              "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
-                  .formatted(
-                      record.getName(),
-                      record.getTenantId().isBlank()
-                          ? "GLOBAL"
-                          : "tenant: '%s'".formatted(record.getTenantId()))));
-    }
-    return Either.right(record);
+    return Either.left(
+        new Rejection(
+            RejectionType.NOT_FOUND,
+            "Invalid cluster variable name: '%s'. The variable does not exist in the scope '%s'"
+                .formatted(
+                    record.getName(),
+                    record.getTenantId().isBlank()
+                        ? "GLOBAL"
+                        : "tenant: '%s'".formatted(record.getTenantId()))));
   }
 
   public Either<Rejection, ClusterVariableRecord> loadExisting(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -55,7 +55,7 @@ public class ClusterVariableUpdateProcessor
     clusterVariableRecordValidator
         .ensureValidScope(commandRecord)
         .flatMap(clusterVariableRecordValidator::loadExisting)
-        .flatMap(stored -> applyUpdate(stored, commandRecord))
+        .map(stored -> applyUpdate(stored, commandRecord))
         .flatMap(record -> isAuthorized(record, command))
         .ifRightOrLeft(
             record -> {
@@ -83,7 +83,7 @@ public class ClusterVariableUpdateProcessor
     final var commandRecord = command.getValue();
     clusterVariableRecordValidator
         .loadExisting(commandRecord)
-        .flatMap(stored -> applyUpdate(stored, commandRecord))
+        .map(stored -> applyUpdate(stored, commandRecord))
         .ifRightOrLeft(
             record ->
                 writers
@@ -94,11 +94,11 @@ public class ClusterVariableUpdateProcessor
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private Either<Rejection, ClusterVariableRecord> applyUpdate(
+  private ClusterVariableRecord applyUpdate(
       final ClusterVariableRecord stored, final ClusterVariableRecord command) {
     stored.setValue(command.getValueBuffer());
     stored.setMetadata(command.getMetadataBuffer());
-    return Either.right(stored);
+    return stored;
   }
 
   private Either<Rejection, ClusterVariableRecord> isAuthorized(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -51,24 +51,23 @@ public class ClusterVariableUpdateProcessor
 
   @Override
   public void processNewCommand(final TypedRecord<ClusterVariableRecord> command) {
-    final ClusterVariableRecord clusterVariableRecord = command.getValue();
+    final ClusterVariableRecord commandRecord = command.getValue();
     clusterVariableRecordValidator
-        .ensureValidScope(clusterVariableRecord)
-        .flatMap(clusterVariableRecordValidator::validateExistence)
+        .ensureValidScope(commandRecord)
+        .flatMap(clusterVariableRecordValidator::loadExisting)
+        .flatMap(stored -> applyUpdate(stored, commandRecord))
         .flatMap(record -> isAuthorized(record, command))
         .ifRightOrLeft(
             record -> {
               final long key = keyGenerator.nextKey();
-              writers
-                  .state()
-                  .appendFollowUpEvent(key, ClusterVariableIntent.UPDATED, clusterVariableRecord);
+              writers.state().appendFollowUpEvent(key, ClusterVariableIntent.UPDATED, record);
               writers
                   .response()
                   .writeAcceptedResponseOnCommand(
-                      key, ClusterVariableIntent.UPDATED, clusterVariableRecord, command);
+                      key, ClusterVariableIntent.UPDATED, record, command);
               commandDistributionBehavior
                   .withKey(key)
-                  .inQueue(clusterVariableRecord.getName())
+                  .inQueue(record.getName())
                   .distribute(command);
             },
             rejection -> {
@@ -81,9 +80,10 @@ public class ClusterVariableUpdateProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<ClusterVariableRecord> command) {
-    final var clusterVariableRecord = command.getValue();
+    final var commandRecord = command.getValue();
     clusterVariableRecordValidator
-        .validateExistence(clusterVariableRecord)
+        .loadExisting(commandRecord)
+        .flatMap(stored -> applyUpdate(stored, commandRecord))
         .ifRightOrLeft(
             record ->
                 writers
@@ -92,6 +92,13 @@ public class ClusterVariableUpdateProcessor
             rejection ->
                 writers.rejection().appendRejection(command, rejection.type(), rejection.reason()));
     commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private Either<Rejection, ClusterVariableRecord> applyUpdate(
+      final ClusterVariableRecord stored, final ClusterVariableRecord command) {
+    stored.setValue(command.getValueBuffer());
+    stored.setMetadata(command.getMetadataBuffer());
+    return Either.right(stored);
   }
 
   private Either<Rejection, ClusterVariableRecord> isAuthorized(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Map;
 import org.junit.BeforeClass;
@@ -349,5 +350,61 @@ public final class UpdateClusterVariableTest {
         .hasIntent(ClusterVariableIntent.UPDATED)
         .hasRecordType(RecordType.EVENT);
     assertThat(record.getValue().getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  public void shouldPreserveKindFromStoredStateOnGlobalUpdate() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_KIND_GLOBAL")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .create();
+
+    // when — update command carries no kind (defaults to JSON)
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_KIND_GLOBAL")
+            .setGlobalScope()
+            .withValue("\"UPDATED_VALUE\"")
+            .update();
+
+    // then — UPDATED event must carry the original stored kind
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
+  }
+
+  @Test
+  public void shouldPreserveKindFromStoredStateOnTenantUpdate() {
+    // given
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_KIND_TENANT")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withValue("\"VALUE\"")
+        .withKind(ClusterVariableKind.SECRET_REFERENCE)
+        .create();
+
+    // when — update command carries no kind (defaults to JSON)
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_KIND_TENANT")
+            .setTenantScope()
+            .withTenantId(TENANT)
+            .withValue("\"UPDATED_VALUE\"")
+            .update();
+
+    // then — UPDATED event must carry the original stored kind
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clustervariable/UpdateClusterVariableTest.java
@@ -407,4 +407,60 @@ public final class UpdateClusterVariableTest {
         .hasRecordType(RecordType.EVENT);
     assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.SECRET_REFERENCE);
   }
+
+  @Test
+  public void shouldIgnoreKindOnCommandForGlobalUpdate() {
+    // given — variable created with default JSON kind
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_KIND_IGNORE_GLOBAL")
+        .setGlobalScope()
+        .withValue("\"VALUE\"")
+        .create();
+
+    // when — update command explicitly carries SECRET_REFERENCE kind
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_KIND_IGNORE_GLOBAL")
+            .setGlobalScope()
+            .withValue("\"UPDATED_VALUE\"")
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .update();
+
+    // then — UPDATED event must carry the stored JSON kind, not the command's kind
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.JSON);
+  }
+
+  @Test
+  public void shouldIgnoreKindOnCommandForTenantUpdate() {
+    // given — variable created with default JSON kind
+    ENGINE_RULE
+        .clusterVariables()
+        .withName("KEY_KIND_IGNORE_TENANT")
+        .setTenantScope()
+        .withTenantId(TENANT)
+        .withValue("\"VALUE\"")
+        .create();
+
+    // when — update command explicitly carries SECRET_REFERENCE kind
+    final var record =
+        ENGINE_RULE
+            .clusterVariables()
+            .withName("KEY_KIND_IGNORE_TENANT")
+            .setTenantScope()
+            .withTenantId(TENANT)
+            .withValue("\"UPDATED_VALUE\"")
+            .withKind(ClusterVariableKind.SECRET_REFERENCE)
+            .update();
+
+    // then — UPDATED event must carry the stored JSON kind, not the command's kind
+    Assertions.assertThat(record)
+        .hasIntent(ClusterVariableIntent.UPDATED)
+        .hasRecordType(RecordType.EVENT);
+    assertThat(record.getValue().getKind()).isEqualTo(ClusterVariableKind.JSON);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClusterVariableClient.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.clustervariable.ClusterVariableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Map;
@@ -84,6 +85,11 @@ public final class ClusterVariableClient {
 
   public ClusterVariableClient setGlobalScope() {
     clusterVariableRecord.setGlobalScope();
+    return this;
+  }
+
+  public ClusterVariableClient withKind(final ClusterVariableKind kind) {
+    clusterVariableRecord.setKind(kind);
     return this;
   }
 


### PR DESCRIPTION
## Description

Ensures `kind` is truly immutable after creation by loading the stored record and using it as the base for the UPDATED event.

The `ClusterVariableUpdateProcessor` forwarded the command record (with no `kind` field set by the caller) straight to `appendFollowUpEvent`. The `EnumProperty` default kicked in and the record carried `kind=JSON`, so any `SECRET_REFERENCE` variable silently got the wrong kind in its UPDATED event.

The fix introduces two new methods: `loadExisting` on `ClusterVariableRecordValidator` loads the full stored `ClusterVariableRecord` from engine state and returns it as the chain value; `applyUpdate` in the processor copies only the mutable fields (`value`, `metadata`) from the command onto the stored record. Immutable fields like `kind` come naturally from the stored record — no mutation of the command record anywhere. `validateExistence` remains a pure, cheap key-only existence check (used by the delete processor). Both `processNewCommand` and `processDistributedCommand` use `loadExisting` for the update path, so both are fixed in one place.

Four engine tests verify the fix: two tests create a `SECRET_REFERENCE` variable and assert an UPDATE command carrying the default `JSON` kind produces an UPDATED event with `SECRET_REFERENCE`; two tests create a `JSON` variable and assert an UPDATE command explicitly carrying `SECRET_REFERENCE` produces an UPDATED event with `JSON`.

**Stack** (merge in order):
- Engine PR — #57981
- 👉 **This PR** — kind immutability in update processor
- ES/OS exporter — #57982
- API — #57983
- RDBMS exporter — #57984
- CamundaClient — #57985

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #57920