### PR TITLE
feat: introduce SecretReferenceState with three column families

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -94,6 +94,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableResourceState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
@@ -103,6 +104,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+import io.camunda.zeebe.engine.state.secretreference.DbSecretReferenceState;
 import io.camunda.zeebe.engine.state.signal.DbSignalSubscriptionState;
 import io.camunda.zeebe.engine.state.tenant.DbTenantState;
 import io.camunda.zeebe.engine.state.user.DbUserState;
@@ -162,6 +164,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableConditionalSubscriptionState conditionalSubscriptionState;
   private final MutableGlobalListenersState globalListenersState;
   private final MutableJobMetricsState jobMetricsState;
+  private final MutableSecretReferenceState secretReferenceState;
   private final int partitionId;
 
   public ProcessingDbState(
@@ -237,6 +240,7 @@ public class ProcessingDbState implements MutableProcessingState {
     conditionalSubscriptionState = new DbConditionalSubscriptionState(zeebeDb, transactionContext);
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
     globalListenersState = new DbGlobalListenersState(zeebeDb, transactionContext);
+    secretReferenceState = new DbSecretReferenceState(zeebeDb, transactionContext);
     if (config.isJobMetricsExportEnabled()) {
       jobMetricsState = new DbJobMetricsState(zeebeDb, transactionContext, clock, config);
     } else {
@@ -466,6 +470,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableJobMetricsState getJobMetricsState() {
     return jobMetricsState;
+  }
+
+  @Override
+  public MutableSecretReferenceState getSecretReferenceState() {
+    return secretReferenceState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -109,4 +109,6 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
   GlobalListenersState getGlobalListenersState();
 
   JobMetricsState getJobMetricsState();
+
+  SecretReferenceState getSecretReferenceState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
-import java.util.function.BiConsumer;
-import java.util.function.LongConsumer;
+import java.util.function.BiPredicate;
+import java.util.function.LongPredicate;
 
 public interface SecretReferenceState {
 
@@ -17,13 +17,14 @@ public interface SecretReferenceState {
 
   /**
    * Visits all job keys waiting for the given (storeId, secretReference) pair. The visitor receives
-   * each jobKey.
+   * each jobKey and returns {@code true} to continue iteration or {@code false} to stop early.
    */
-  void visitJobsBySecretReference(String storeId, String secretReference, LongConsumer visitor);
+  void visitJobsBySecretReference(String storeId, String secretReference, LongPredicate visitor);
 
   /**
    * Visits all (storeId, secretReference) pairs that the given job is waiting for. The visitor
-   * receives (storeId, secretReference).
+   * receives (storeId, secretReference) and returns {@code true} to continue iteration or {@code
+   * false} to stop early.
    */
-  void visitSecretReferencesByJob(long jobKey, BiConsumer<String, String> visitor);
+  void visitSecretReferencesByJob(long jobKey, BiPredicate<String, String> visitor);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import java.util.function.BiConsumer;
+import java.util.function.LongConsumer;
+
+public interface SecretReferenceState {
+
+  /** Returns true if the secret is pending resolution. */
+  boolean isPending(String storeId, String secretReference);
+
+  /**
+   * Visits all job keys waiting for the given (storeId, secretReference) pair. The visitor receives
+   * each jobKey.
+   */
+  void visitJobsBySecretReference(String storeId, String secretReference, LongConsumer visitor);
+
+  /**
+   * Visits all (storeId, secretReference) pairs that the given job is waiting for. The visitor
+   * receives (storeId, secretReference).
+   */
+  void visitSecretReferencesByJob(long jobKey, BiConsumer<String, String> visitor);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -142,5 +142,8 @@ public interface MutableProcessingState extends ProcessingState {
   @Override
   MutableJobMetricsState getJobMetricsState();
 
+  @Override
+  MutableSecretReferenceState getSecretReferenceState();
+
   KeyGenerator getKeyGenerator();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSecretReferenceState.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
+
+public interface MutableSecretReferenceState extends SecretReferenceState {
+
+  void addPendingSecretReference(String storeId, String secretReference);
+
+  void removePendingSecretReference(String storeId, String secretReference);
+
+  /** Writes to both waiting-job indexes. Always writes both together. */
+  void addWaitingJob(String storeId, String secretReference, long jobKey);
+
+  /** Removes from both waiting-job indexes. Always removes both together. */
+  void removeWaitingJob(String storeId, String secretReference, long jobKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
@@ -108,7 +108,8 @@ public final class DbSecretReferenceState implements MutableSecretReferenceState
     waitingJobsByJobKeyColumnFamily.whileEqualPrefix(
         this.jobKey,
         (key, value) -> {
-          visitor.accept(storeId.toString(), secretReference.toString());
+          visitor.accept(
+              key.second().inner().first().toString(), key.second().inner().second().toString());
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.secretreference;
 
 import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.KeyValuePairVisitor;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
@@ -17,8 +18,8 @@ import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
-import java.util.function.BiConsumer;
-import java.util.function.LongConsumer;
+import java.util.function.BiPredicate;
+import java.util.function.LongPredicate;
 
 public final class DbSecretReferenceState implements MutableSecretReferenceState {
 
@@ -91,26 +92,27 @@ public final class DbSecretReferenceState implements MutableSecretReferenceState
 
   @Override
   public void visitJobsBySecretReference(
-      final String storeId, final String secretReference, final LongConsumer visitor) {
+      final String storeId, final String secretReference, final LongPredicate visitor) {
     this.storeId.wrapString(storeId);
     this.secretReference.wrapString(secretReference);
-    waitingJobsBySecretRefColumnFamily.whileEqualPrefix(
-        fkStoreIdAndSecretReference,
-        (key, value) -> {
-          visitor.accept(key.second().getValue());
-        });
+    final KeyValuePairVisitor<
+            DbCompositeKey<DbForeignKey<DbCompositeKey<DbString, DbString>>, DbLong>, DbNil>
+        kvVisitor = (key, value) -> visitor.test(key.second().getValue());
+    waitingJobsBySecretRefColumnFamily.whileEqualPrefix(fkStoreIdAndSecretReference, kvVisitor);
   }
 
   @Override
   public void visitSecretReferencesByJob(
-      final long jobKey, final BiConsumer<String, String> visitor) {
+      final long jobKey, final BiPredicate<String, String> visitor) {
     this.jobKey.wrapLong(jobKey);
-    waitingJobsByJobKeyColumnFamily.whileEqualPrefix(
-        this.jobKey,
-        (key, value) -> {
-          visitor.accept(
-              key.second().inner().first().toString(), key.second().inner().second().toString());
-        });
+    final KeyValuePairVisitor<
+            DbCompositeKey<DbLong, DbForeignKey<DbCompositeKey<DbString, DbString>>>, DbNil>
+        kvVisitor =
+            (key, value) ->
+                visitor.test(
+                    key.second().inner().first().toString(),
+                    key.second().inner().second().toString());
+    waitingJobsByJobKeyColumnFamily.whileEqualPrefix(this.jobKey, kvVisitor);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.secretreference;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.function.BiConsumer;
+import java.util.function.LongConsumer;
+
+public final class DbSecretReferenceState implements MutableSecretReferenceState {
+
+  private final DbString storeId;
+  private final DbString secretReference;
+  private final DbCompositeKey<DbString, DbString> storeIdAndSecretReference;
+
+  // pending secret references: (storeId, secretReference) → ∅
+  private final ColumnFamily<DbCompositeKey<DbString, DbString>, DbNil>
+      pendingSecretReferencesColumnFamily;
+
+  private final DbLong jobKey;
+  private final DbForeignKey<DbCompositeKey<DbString, DbString>> fkStoreIdAndSecretReference;
+
+  // secondary index: (jobKey, storeId, secretReference) → ∅; supports prefix iteration by job key
+  private final DbCompositeKey<DbLong, DbForeignKey<DbCompositeKey<DbString, DbString>>>
+      jobKeyAndSecretRef;
+  private final ColumnFamily<
+          DbCompositeKey<DbLong, DbForeignKey<DbCompositeKey<DbString, DbString>>>, DbNil>
+      waitingJobsByJobKeyColumnFamily;
+
+  // secondary index: (storeId, secretReference, jobKey) → ∅; supports prefix iteration by
+  // (storeId, secretReference)
+  private final DbCompositeKey<DbForeignKey<DbCompositeKey<DbString, DbString>>, DbLong>
+      secretRefAndJobKey;
+  private final ColumnFamily<
+          DbCompositeKey<DbForeignKey<DbCompositeKey<DbString, DbString>>, DbLong>, DbNil>
+      waitingJobsBySecretRefColumnFamily;
+
+  public DbSecretReferenceState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    storeId = new DbString();
+    secretReference = new DbString();
+    storeIdAndSecretReference = new DbCompositeKey<>(storeId, secretReference);
+
+    pendingSecretReferencesColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PENDING_SECRET_REFERENCES,
+            transactionContext,
+            storeIdAndSecretReference,
+            DbNil.INSTANCE);
+
+    jobKey = new DbLong();
+    fkStoreIdAndSecretReference =
+        new DbForeignKey<>(storeIdAndSecretReference, ZbColumnFamilies.PENDING_SECRET_REFERENCES);
+
+    jobKeyAndSecretRef = new DbCompositeKey<>(jobKey, fkStoreIdAndSecretReference);
+    waitingJobsByJobKeyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.SECRET_REFERENCES_BY_JOB,
+            transactionContext,
+            jobKeyAndSecretRef,
+            DbNil.INSTANCE);
+
+    secretRefAndJobKey = new DbCompositeKey<>(fkStoreIdAndSecretReference, jobKey);
+    waitingJobsBySecretRefColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.JOBS_BY_SECRET_REFERENCE,
+            transactionContext,
+            secretRefAndJobKey,
+            DbNil.INSTANCE);
+  }
+
+  @Override
+  public boolean isPending(final String storeId, final String secretReference) {
+    this.storeId.wrapString(storeId);
+    this.secretReference.wrapString(secretReference);
+    return pendingSecretReferencesColumnFamily.exists(storeIdAndSecretReference);
+  }
+
+  @Override
+  public void visitJobsBySecretReference(
+      final String storeId, final String secretReference, final LongConsumer visitor) {
+    this.storeId.wrapString(storeId);
+    this.secretReference.wrapString(secretReference);
+    waitingJobsBySecretRefColumnFamily.whileEqualPrefix(
+        fkStoreIdAndSecretReference,
+        (key, value) -> {
+          visitor.accept(key.second().getValue());
+        });
+  }
+
+  @Override
+  public void visitSecretReferencesByJob(
+      final long jobKey, final BiConsumer<String, String> visitor) {
+    this.jobKey.wrapLong(jobKey);
+    waitingJobsByJobKeyColumnFamily.whileEqualPrefix(
+        this.jobKey,
+        (key, value) -> {
+          visitor.accept(storeId.toString(), secretReference.toString());
+        });
+  }
+
+  @Override
+  public void addPendingSecretReference(final String storeId, final String secretReference) {
+    this.storeId.wrapString(storeId);
+    this.secretReference.wrapString(secretReference);
+    pendingSecretReferencesColumnFamily.upsert(storeIdAndSecretReference, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void removePendingSecretReference(final String storeId, final String secretReference) {
+    this.storeId.wrapString(storeId);
+    this.secretReference.wrapString(secretReference);
+    pendingSecretReferencesColumnFamily.deleteExisting(storeIdAndSecretReference);
+  }
+
+  @Override
+  public void addWaitingJob(final String storeId, final String secretReference, final long jobKey) {
+    this.storeId.wrapString(storeId);
+    this.secretReference.wrapString(secretReference);
+    this.jobKey.wrapLong(jobKey);
+    waitingJobsByJobKeyColumnFamily.upsert(jobKeyAndSecretRef, DbNil.INSTANCE);
+    waitingJobsBySecretRefColumnFamily.upsert(secretRefAndJobKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void removeWaitingJob(
+      final String storeId, final String secretReference, final long jobKey) {
+    this.storeId.wrapString(storeId);
+    this.secretReference.wrapString(secretReference);
+    this.jobKey.wrapLong(jobKey);
+    waitingJobsByJobKeyColumnFamily.deleteExisting(jobKeyAndSecretRef);
+    waitingJobsBySecretRefColumnFamily.deleteExisting(secretRefAndJobKey);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
@@ -11,23 +11,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.db.ZeebeDbInconsistentException;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
-import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ProcessingStateExtension.class)
 public final class DbSecretReferenceStateTest {
 
-  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+  private MutableProcessingState processingState;
 
   private MutableSecretReferenceState state;
 
-  @Before
+  @BeforeEach
   public void setUp() {
-    state = stateRule.getProcessingState().getSecretReferenceState();
+    state = processingState.getSecretReferenceState();
   }
 
   @Test
@@ -76,7 +78,13 @@ public final class DbSecretReferenceStateTest {
 
     // then
     final List<Long> visitedJobs = new ArrayList<>();
-    state.visitJobsBySecretReference(storeId, secretRef, visitedJobs::add);
+    state.visitJobsBySecretReference(
+        storeId,
+        secretRef,
+        key -> {
+          visitedJobs.add(key);
+          return true;
+        });
     assertThat(visitedJobs).containsExactly(jobKey);
   }
 
@@ -99,6 +107,7 @@ public final class DbSecretReferenceStateTest {
         (sid, sref) -> {
           visitedStoreIds.add(sid);
           visitedSecretRefs.add(sref);
+          return true;
         });
     assertThat(visitedStoreIds).containsExactly(storeId);
     assertThat(visitedSecretRefs).containsExactly(secretRef);
@@ -118,11 +127,22 @@ public final class DbSecretReferenceStateTest {
 
     // then
     final List<Long> visitedBySecret = new ArrayList<>();
-    state.visitJobsBySecretReference(storeId, secretRef, visitedBySecret::add);
+    state.visitJobsBySecretReference(
+        storeId,
+        secretRef,
+        key -> {
+          visitedBySecret.add(key);
+          return true;
+        });
     assertThat(visitedBySecret).isEmpty();
 
     final List<String> visitedByJob = new ArrayList<>();
-    state.visitSecretReferencesByJob(jobKey, (sid, sref) -> visitedByJob.add(sid));
+    state.visitSecretReferencesByJob(
+        jobKey,
+        (sid, sref) -> {
+          visitedByJob.add(sid);
+          return true;
+        });
     assertThat(visitedByJob).isEmpty();
   }
 
@@ -152,9 +172,125 @@ public final class DbSecretReferenceStateTest {
 
     // when visiting only secretRef1
     final List<Long> visitedJobs = new ArrayList<>();
-    state.visitJobsBySecretReference(storeId, secretRef1, visitedJobs::add);
+    state.visitJobsBySecretReference(
+        storeId,
+        secretRef1,
+        key -> {
+          visitedJobs.add(key);
+          return true;
+        });
 
     // then only jobKey1 is returned, not jobKey2
     assertThat(visitedJobs).containsExactly(jobKey1);
+  }
+
+  @Test
+  public void shouldVisitMultipleJobsWaitingOnSameSecretReference() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    final long jobKey1 = 10L;
+    final long jobKey2 = 20L;
+    state.addPendingSecretReference(storeId, secretRef);
+    state.addWaitingJob(storeId, secretRef, jobKey1);
+    state.addWaitingJob(storeId, secretRef, jobKey2);
+
+    // when
+    final List<Long> visitedJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        storeId,
+        secretRef,
+        key -> {
+          visitedJobs.add(key);
+          return true;
+        });
+
+    // then both jobs are returned
+    assertThat(visitedJobs).containsExactlyInAnyOrder(jobKey1, jobKey2);
+  }
+
+  @Test
+  public void shouldVisitMultipleSecretReferencesForSameJob() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef1 = "secret1";
+    final String secretRef2 = "secret2";
+    final long jobKey = 42L;
+    state.addPendingSecretReference(storeId, secretRef1);
+    state.addPendingSecretReference(storeId, secretRef2);
+    state.addWaitingJob(storeId, secretRef1, jobKey);
+    state.addWaitingJob(storeId, secretRef2, jobKey);
+
+    // when
+    final List<String> visitedSecretRefs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        jobKey,
+        (sid, sref) -> {
+          visitedSecretRefs.add(sref);
+          return true;
+        });
+
+    // then both secret references are returned
+    assertThat(visitedSecretRefs).containsExactlyInAnyOrder(secretRef1, secretRef2);
+  }
+
+  @Test
+  public void shouldNotVisitSecretReferencesForOtherJob() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    final long jobKey1 = 10L;
+    final long jobKey2 = 20L;
+    state.addPendingSecretReference(storeId, secretRef);
+    state.addWaitingJob(storeId, secretRef, jobKey1);
+    state.addWaitingJob(storeId, secretRef, jobKey2);
+
+    // when visiting secret references for jobKey1 only
+    final List<String> visitedSecretRefs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        jobKey1,
+        (sid, sref) -> {
+          visitedSecretRefs.add(sref);
+          return true;
+        });
+
+    // then only the secret reference for jobKey1 is returned, not jobKey2
+    assertThat(visitedSecretRefs).containsExactly(secretRef);
+  }
+
+  @Test
+  public void shouldPreserveRemainingEntryWhenOneWaitingJobIsRemoved() {
+    // given — two jobs waiting on the same secret; remove one, the other must remain
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    final long jobKey1 = 10L;
+    final long jobKey2 = 20L;
+    state.addPendingSecretReference(storeId, secretRef);
+    state.addWaitingJob(storeId, secretRef, jobKey1);
+    state.addWaitingJob(storeId, secretRef, jobKey2);
+
+    // when
+    state.removeWaitingJob(storeId, secretRef, jobKey1);
+
+    // then jobKey2 is still indexed under the secret reference
+    final List<Long> visitedBySecret = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        storeId,
+        secretRef,
+        key -> {
+          visitedBySecret.add(key);
+          return true;
+        });
+    assertThat(visitedBySecret).containsExactly(jobKey2);
+
+    // and jobKey1 no longer appears in the by-job index
+    final List<String> visitedByJob1 = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        jobKey1,
+        (sid, sref) -> {
+          visitedByJob1.add(sref);
+          return true;
+        });
+    assertThat(visitedByJob1).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.secretreference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class DbSecretReferenceStateTest {
+
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+
+  private MutableSecretReferenceState state;
+
+  @Before
+  public void setUp() {
+    state = stateRule.getProcessingState().getSecretReferenceState();
+  }
+
+  @Test
+  public void shouldReturnFalseForNonExistentPendingSecretReference() {
+    // given / when / then
+    assertThat(state.isPending("storeA", "secret1")).isFalse();
+  }
+
+  @Test
+  public void shouldAddAndReturnPendingSecretReference() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+
+    // when
+    state.addPendingSecretReference(storeId, secretRef);
+
+    // then
+    assertThat(state.isPending(storeId, secretRef)).isTrue();
+  }
+
+  @Test
+  public void shouldRemovePendingSecretReference() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    state.addPendingSecretReference(storeId, secretRef);
+
+    // when
+    state.removePendingSecretReference(storeId, secretRef);
+
+    // then
+    assertThat(state.isPending(storeId, secretRef)).isFalse();
+  }
+
+  @Test
+  public void shouldAddWaitingJobAndVisitBySecretReference() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    final long jobKey = 42L;
+
+    // when
+    state.addPendingSecretReference(storeId, secretRef);
+    state.addWaitingJob(storeId, secretRef, jobKey);
+
+    // then
+    final List<Long> visitedJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(storeId, secretRef, visitedJobs::add);
+    assertThat(visitedJobs).containsExactly(jobKey);
+  }
+
+  @Test
+  public void shouldAddWaitingJobAndVisitByJobKey() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    final long jobKey = 42L;
+
+    // when
+    state.addPendingSecretReference(storeId, secretRef);
+    state.addWaitingJob(storeId, secretRef, jobKey);
+
+    // then
+    final List<String> visitedStoreIds = new ArrayList<>();
+    final List<String> visitedSecretRefs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        jobKey,
+        (sid, sref) -> {
+          visitedStoreIds.add(sid);
+          visitedSecretRefs.add(sref);
+        });
+    assertThat(visitedStoreIds).containsExactly(storeId);
+    assertThat(visitedSecretRefs).containsExactly(secretRef);
+  }
+
+  @Test
+  public void shouldRemoveWaitingJobFromBothIndexes() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+    final long jobKey = 42L;
+    state.addPendingSecretReference(storeId, secretRef);
+    state.addWaitingJob(storeId, secretRef, jobKey);
+
+    // when
+    state.removeWaitingJob(storeId, secretRef, jobKey);
+
+    // then
+    final List<Long> visitedBySecret = new ArrayList<>();
+    state.visitJobsBySecretReference(storeId, secretRef, visitedBySecret::add);
+    assertThat(visitedBySecret).isEmpty();
+
+    final List<String> visitedByJob = new ArrayList<>();
+    state.visitSecretReferencesByJob(jobKey, (sid, sref) -> visitedByJob.add(sid));
+    assertThat(visitedByJob).isEmpty();
+  }
+
+  @Test
+  public void shouldNotVisitOtherSecretReferencesWhenPrefixing() {
+    // given
+    final String storeId = "storeA";
+    final String secretRef1 = "secret1";
+    final String secretRef2 = "secret2";
+    final long jobKey1 = 10L;
+    final long jobKey2 = 20L;
+    state.addPendingSecretReference(storeId, secretRef1);
+    state.addPendingSecretReference(storeId, secretRef2);
+    state.addWaitingJob(storeId, secretRef1, jobKey1);
+    state.addWaitingJob(storeId, secretRef2, jobKey2);
+
+    // when visiting only secretRef1
+    final List<Long> visitedJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(storeId, secretRef1, visitedJobs::add);
+
+    // then only jobKey1 is returned, not jobKey2
+    assertThat(visitedJobs).containsExactly(jobKey1);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.engine.state.secretreference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import java.util.ArrayList;
@@ -122,6 +124,17 @@ public final class DbSecretReferenceStateTest {
     final List<String> visitedByJob = new ArrayList<>();
     state.visitSecretReferencesByJob(jobKey, (sid, sref) -> visitedByJob.add(sid));
     assertThat(visitedByJob).isEmpty();
+  }
+
+  @Test
+  public void shouldRejectWaitingJobWithoutPendingSecretReference() {
+    // given — no addPendingSecretReference call
+    final String storeId = "storeA";
+    final String secretRef = "secret1";
+
+    // when / then — FK constraint must fire
+    assertThatThrownBy(() -> state.addWaitingJob(storeId, secretRef, 42L))
+        .isInstanceOf(ZeebeDbInconsistentException.class);
   }
 
   @Test

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -331,7 +331,14 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   AGENT_HISTORY_BY_JOB_KEY(151, PARTITION_LOCAL),
   // secondary index: (processInstanceKey, agentInstanceKey) → ∅; supports prefix iteration by
   // process instance key to find every agent instance still associated with it
-  AGENT_INSTANCES_BY_PROCESS_INSTANCE_KEY(152, PARTITION_LOCAL);
+  AGENT_INSTANCES_BY_PROCESS_INSTANCE_KEY(152, PARTITION_LOCAL),
+  // pending secret references: (storeId, secretReference) → ∅
+  PENDING_SECRET_REFERENCES(153, PARTITION_LOCAL),
+  // secondary index: (jobKey, storeId, secretReference) → ∅; supports prefix iteration by job key
+  SECRET_REFERENCES_BY_JOB(154, PARTITION_LOCAL),
+  // secondary index: (storeId, secretReference, jobKey) → ∅; supports prefix iteration by (storeId,
+  // secretReference)
+  JOBS_BY_SECRET_REFERENCE(155, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

Introduces `SecretReferenceState` backed by three RocksDB column families, as specified in #57845:

1. `PENDING_SECRET_REFERENCES` — `(storeId, secretReference)` → ∅ — tracks secrets awaiting resolution
2. `SECRET_REFERENCES_BY_JOB` — `(jobKey, storeId, secretReference)` → ∅ — which secrets a job is waiting for (prefix-iterable by job key)
3. `JOBS_BY_SECRET_REFERENCE` — `(storeId, secretReference, jobKey)` → ∅ — which jobs are waiting for a given secret (prefix-iterable by store+secretRef)

Column families 2 and 3 use a `DbForeignKey` on `storeIdAndSecretReference` referencing `PENDING_SECRET_REFERENCES`, so the engine validates referential integrity on every write — consistent with how other state classes (e.g. `DbJobState`) handle FK constraints.

The state is wired into `ProcessingState` / `MutableProcessingState` and accessible to processors and event appliers via `getSecretReferenceState()`. The processors introduced in #57869 are still NOOP; subsequent issues will implement the actual resolution logic against this state.

## Checklist

<!-- Remove items that do not apply -->

- [ ] My changes have tests
- [ ] My changes have documentation if necessary
- [ ] My changes are backward compatible

## Related issues

closes #57845