### PR TITLE
feat(ci): add RC delta Slack summary workflow

### DIFF
--- a/.github/scripts/rc-delta-slack-summary.sh
+++ b/.github/scripts/rc-delta-slack-summary.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Computes a deterministic delta summary (merged PRs + direct commits) between the
+# previous RC tag and the current RC tag, and prints a Slack Block Kit payload to stdout.
+#
+# Design (issue #40007 — deterministic core only, no AI/agentic categorization):
+#   * git ancestry is authoritative: the commit set is `git log PREV_TAG..RC_VERSION`
+#     computed locally — zero GitHub API calls to enumerate the delta.
+#   * commit -> PR linking uses ONE batched GraphQL query (associatedPullRequests keyed
+#     by commit OID, chunked), not one REST call per commit. This reliably collapses the
+#     individual (non-squashed) backport commits on release branches back into their
+#     parent PRs — commit-message regex alone misses the majority of them.
+#   * commits with no associated PR are still listed under "Other changes" — nothing is
+#     silently dropped.
+#
+# The previous RC tag is resolved upstream by the `previous-version` infra action and
+# passed in as PREV_VERSION. If PREV_VERSION is not an RC tag for the same prefix (i.e.
+# this is the first candidate — RC1), a fixed "no delta" note is printed instead.
+#
+# Requires: a checkout with fetch-depth: 0 (full tag history), gh CLI, jq.
+#
+# Env vars:
+#   RC_VERSION    - required. RC tag to summarize, e.g. "8.9.0-alpha3-rc2" or "8.9.0-rc2"
+#   PREV_VERSION  - required. Previous version from the previous-version action (may be a
+#                   non-RC fallback such as "8.8.0" for a first candidate).
+#   REPOSITORY    - optional. owner/repo, defaults to camunda/camunda
+#   GH_TOKEN      - required by gh CLI for the GraphQL enrichment call
+
+set -euo pipefail
+
+RC_VERSION="${RC_VERSION:?RC_VERSION is required}"
+PREV_VERSION="${PREV_VERSION:?PREV_VERSION is required}"
+REPOSITORY="${REPOSITORY:-camunda/camunda}"
+OWNER="${REPOSITORY%%/*}"
+REPO="${REPOSITORY##*/}"
+
+# RC tags follow "<prefix>-rc<N>", e.g. "8.9.0-alpha3-rc2" -> prefix "8.9.0-alpha3".
+if [[ ! "$RC_VERSION" =~ ^(.+)-rc([0-9]+)$ ]]; then
+  echo "RC_VERSION '$RC_VERSION' does not match the expected '<prefix>-rc<N>' format" >&2
+  exit 1
+fi
+PREFIX="${BASH_REMATCH[1]}"
+
+# First-candidate guard: only compute a delta when PREV_VERSION is a real RC tag for the
+# SAME prefix. For RC1 (of a release or of an alpha stage) the previous-version action
+# returns a non-RC baseline (e.g. "8.8.0" or the prior alpha), which we deliberately never
+# diff against — post a fixed note instead.
+if [[ "$PREV_VERSION" != "${PREFIX}-rc"[0-9]* ]]; then
+  jq -n --arg version "$RC_VERSION" '{
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: ("*RC delta summary — " + $version + "* :sparkles-rainbow:\n_First candidate — full regression expected. No potion to brew yet!_ :cat-wizard:")
+        }
+      }
+    ]
+  }'
+  exit 0
+fi
+
+PREV_TAG="$PREV_VERSION"
+COMPARE_URL="https://github.com/${REPOSITORY}/compare/${PREV_TAG}...${RC_VERSION}"
+
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# Commit set (authoritative), newest first, as {sha, subject} objects — zero API calls.
+# Each commit is emitted as two lines (%H then %s) rather than a tab-delimited pair:
+# a commit subject may legally contain a tab, which would corrupt a "\t"-split, but it
+# can never contain a newline (it's only the first line of the message).
+# Release due-diligence no-ops are excluded from the delta entirely: the maven-release-plugin
+# commits (prepare release / next dev iteration) AND their `Revert "[maven-release-plugin] …"`
+# counterparts, which the RC-rerun mechanics create and which map only to the release-branch PR.
+git log --format=$'%H%n%s' "${PREV_TAG}..${RC_VERSION}" \
+  | jq -R -s 'split("\n")
+      | (if .[-1] == "" then .[0:-1] else . end)
+      | [range(0; length; 2) as $i | {sha: .[$i], subject: (.[$i + 1] // "")}]
+      | map(select(.subject | test("^(\\[maven-release-plugin\\]|Revert \"\\[maven-release-plugin\\])") | not))' \
+  > "$TMPDIR_WORK/commits.json"
+
+TOTAL_COMMITS=$(jq 'length' "$TMPDIR_WORK/commits.json")
+
+# Enrich commits -> PRs via batched GraphQL. The commit OID doubles as the field alias
+# (prefixed with "_" so it's a valid GraphQL name), so results map back without bookkeeping.
+echo '{}' > "$TMPDIR_WORK/prmap.json"
+
+if (( TOTAL_COMMITS > 0 )); then
+  mapfile -t SHAS < <(jq -r '.[].sha' "$TMPDIR_WORK/commits.json")
+
+  CHUNK_SIZE=100
+  for (( start = 0; start < ${#SHAS[@]}; start += CHUNK_SIZE )); do
+    query="query{repository(owner:\"${OWNER}\",name:\"${REPO}\"){"
+    for sha in "${SHAS[@]:start:CHUNK_SIZE}"; do
+      query+="_${sha}:object(oid:\"${sha}\"){... on Commit{associatedPullRequests(first:1){nodes{number title url}}}}"
+    done
+    query+="}}"
+
+    gh api graphql -f query="$query" --jq '.data.repository' > "$TMPDIR_WORK/chunk.json"
+    jq -s '.[0] * .[1]' "$TMPDIR_WORK/prmap.json" "$TMPDIR_WORK/chunk.json" > "$TMPDIR_WORK/prmap_tmp.json"
+    mv "$TMPDIR_WORK/prmap_tmp.json" "$TMPDIR_WORK/prmap.json"
+  done
+fi
+
+# Attach each commit's associated PR (if any), then split into deduplicated PRs and
+# "other" direct commits that resolved to no PR.
+jq -n \
+  --slurpfile commits "$TMPDIR_WORK/commits.json" \
+  --slurpfile prmap "$TMPDIR_WORK/prmap.json" \
+  '
+  ($commits[0]) as $commits |
+  ($prmap[0]) as $prmap |
+  ($commits | map(. + {pr: ($prmap["_" + .sha].associatedPullRequests.nodes[0] // null)})) as $enriched |
+  {
+    prs: ($enriched | map(select(.pr != null) | .pr) | unique_by(.number) | sort_by(-.number)),
+    others: ($enriched | map(select(.pr == null) | {sha, subject}))
+  }
+  ' > "$TMPDIR_WORK/summary.json"
+
+PR_COUNT=$(jq '.prs | length' "$TMPDIR_WORK/summary.json")
+OTHER_COUNT=$(jq '.others | length' "$TMPDIR_WORK/summary.json")
+
+PR_TRUNCATE_AT=25
+OTHER_TRUNCATE_AT=10
+
+# Strip leading "[Backport …]" prefixes (including repeated/nested ones such as
+# "[Backport release-8.9.0] [Backport stable/8.9] ") — they're release-branch plumbing,
+# not signal, and just add noise to the digest.
+pr_lines=$(jq -r --argjson limit "$PR_TRUNCATE_AT" \
+  '.prs[:$limit][]
+   | (.title | gsub("^(\\s*\\[Backport[^\\]]*\\]\\s*)+"; "")) as $title
+   | "- <\(.url)|#\(.number)> \($title)"' "$TMPDIR_WORK/summary.json")
+if [[ -z "$pr_lines" ]]; then
+  pr_lines="_No merged PRs found in this range._"
+fi
+pr_remaining=$(( PR_COUNT > PR_TRUNCATE_AT ? PR_COUNT - PR_TRUNCATE_AT : 0 ))
+if (( pr_remaining > 0 )); then
+  pr_lines="${pr_lines}"$'\n'":party-wizard: _…and ${pr_remaining} more bubbling in the cauldron — see <${COMPARE_URL}|the full compare>_"
+fi
+
+other_lines=""
+if (( OTHER_COUNT > 0 )); then
+  other_lines=$(jq -r --argjson limit "$OTHER_TRUNCATE_AT" \
+    '.others[:$limit][] | "- `\(.sha[0:7])` \(.subject)"' "$TMPDIR_WORK/summary.json")
+  other_remaining=$(( OTHER_COUNT > OTHER_TRUNCATE_AT ? OTHER_COUNT - OTHER_TRUNCATE_AT : 0 ))
+  if (( other_remaining > 0 )); then
+    other_lines="${other_lines}"$'\n'"…and ${other_remaining} more"
+  fi
+fi
+
+jq -n \
+  --arg version "$RC_VERSION" \
+  --arg prev "$PREV_TAG" \
+  --arg compare "$COMPARE_URL" \
+  --arg pr_lines "$pr_lines" \
+  --arg other_lines "$other_lines" \
+  --argjson pr_count "$PR_COUNT" \
+  --argjson other_count "$OTHER_COUNT" \
+  '{
+    blocks: (
+      [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: ("*RC delta summary — " + $version + "* :sparkles-rainbow:\n_A little magic has happened since `" + $prev + "`: " + ($pr_count | tostring) + " PR(s) stirred into the cauldron!_ :cat-wizard:")
+          }
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: ("*:meow-merged: Merged PRs:*\n" + $pr_lines) }
+        }
+      ]
+      + (if $other_count > 0 then
+          [{ type: "section", text: { type: "mrkdwn", text: ("*:hammer_and_wrench: Other changes (loose commits):*\n" + $other_lines) } }]
+        else [] end)
+      + [{ type: "context", elements: [{ type: "mrkdwn", text: (":party-wizard: <" + $compare + "|Peek at the full compare>") }] }]
+    )
+  }'

--- a/.github/workflows/rc-delta-slack-summary.yml
+++ b/.github/workflows/rc-delta-slack-summary.yml
@@ -1,0 +1,157 @@
+# description: Posts a deterministic delta summary (merged PRs + direct commits) since the
+#   previous RC tag to Slack, for every RC past RC1. RC1 posts a fixed "no delta" note instead.
+#   No AI/agentic categorization is performed — deterministic core only (issue #40007).
+#   Trigger wiring (BPMN dispatch after a successful RC build) is deferred to a follow-up change;
+#   for now this workflow is invoked manually via workflow_dispatch.
+# type: CI Helper
+# owner: camunda/monorepo-devops-team
+---
+name: RC Delta Slack Summary
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_version:
+        description: 'RC tag to summarize, e.g. "8.9.0-alpha3-rc2" or "8.9.0-rc2"'
+        required: true
+        type: string
+      slack_channel_id:
+        description: 'Slack channel ID to post the digest to'
+        required: true
+        type: string
+      slack_thread_id:
+        description: 'Slack thread (message ts) to post into. Leave empty to post to the channel root.'
+        required: false
+        default: ''
+        type: string
+      dry_run:
+        description: 'Dry run — compute and log the digest, do not post to Slack'
+        required: false
+        default: true
+        type: boolean
+
+env:
+  TEST_OWNER: '@camunda/monorepo-devops-team'
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  compute-and-post-digest:
+    name: Compute RC delta and post to Slack
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      TEST_PRODUCT: Release Process
+      TEST_TYPE: CI Helper
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+
+      - name: Verify RC tag exists
+        env:
+          RC_VERSION: ${{ inputs.rc_version }}
+        run: |
+          if ! git rev-parse -q --verify "refs/tags/${RC_VERSION}" >/dev/null; then
+            echo "::error::Tag '${RC_VERSION}' not found. Check the version input, or that the checkout fetched full tag history."
+            exit 1
+          fi
+
+      - name: Identify previous release version
+        id: prev_version
+        uses: camunda/infra-global-github-actions/previous-version@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # previous-version: v1.0.0
+        with:
+          version: ${{ inputs.rc_version }}
+          verbose: 'false'
+
+      - name: Compute RC delta digest
+        id: digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RC_VERSION: ${{ inputs.rc_version }}
+          PREV_VERSION: ${{ steps.prev_version.outputs.previous_version }}
+        run: |
+          payload=$(bash .github/scripts/rc-delta-slack-summary.sh)
+
+          {
+            echo "payload<<PAYLOAD_EOF"
+            echo "$payload"
+            echo "PAYLOAD_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### RC delta digest — ${{ inputs.rc_version }}"
+            echo '```json'
+            echo "$payload" | jq .
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log digest (dry run)
+        if: ${{ inputs.dry_run }}
+        env:
+          SLACK_CHANNEL: ${{ inputs.slack_channel_id }}
+          SLACK_THREAD_TS: ${{ inputs.slack_thread_id }}
+          PAYLOAD: ${{ steps.digest.outputs.payload }}
+        run: |
+          echo "🧪 Dry run — would post the following to Slack channel ${SLACK_CHANNEL} (thread: ${SLACK_THREAD_TS:-channel root}):"
+          printf '%s\n' "$PAYLOAD" | jq .
+
+      - name: Get Slack bot token from Vault
+        if: ${{ !inputs.dry_run }}
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN;
+
+      - name: Post digest to Slack
+        if: ${{ !inputs.dry_run }}
+        env:
+          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_C8_MONOREPO_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ inputs.slack_channel_id }}
+          SLACK_THREAD_TS: ${{ inputs.slack_thread_id }}
+          PAYLOAD: ${{ steps.digest.outputs.payload }}
+        run: |
+          body=$(jq -c --arg channel "$SLACK_CHANNEL" --arg thread_ts "$SLACK_THREAD_TS" \
+            '. + {channel: $channel} + (if $thread_ts != "" then {thread_ts: $thread_ts} else {} end)' \
+            <<< "$PAYLOAD")
+
+          response=$(curl -s -X POST "https://slack.com/api/chat.postMessage" \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$body")
+
+          ok=$(echo "$response" | jq -r '.ok')
+          if [[ "$ok" != "true" ]]; then
+            echo "::error::Slack chat.postMessage failed: $(echo "$response" | jq -r '.error // "unknown"')"
+            exit 1
+          fi
+          echo "✅ Posted to Slack (ts: $(echo "$response" | jq -r '.ts'))"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/release-rc-delta-slack-summary.yml
+++ b/.github/workflows/release-rc-delta-slack-summary.yml
@@ -4,7 +4,7 @@
 #   Trigger wiring (BPMN dispatch after a successful RC build) is deferred to a follow-up change;
 #   for now this workflow is invoked manually via workflow_dispatch.
 # type: CI Helper
-# owner: camunda/monorepo-devops-team
+# owner: camunda/engineering-operations
 ---
 name: RC Delta Slack Summary
 
@@ -31,7 +31,7 @@ on:
         type: boolean
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions: {}
@@ -44,7 +44,7 @@ jobs:
   compute-and-post-digest:
     name: Compute RC delta and post to Slack
     runs-on: ubuntu-slim
-    timeout-minutes: 15
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -56,6 +56,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # Read-only git (git log / rev-parse) only; the API is authenticated
+          # separately via GH_TOKEN, so no on-disk credential is needed.
+          persist-credentials: false
 
       - name: Print metadata
         uses: ./.github/actions/print-metadata
@@ -93,7 +96,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           {
-            echo "### RC delta digest — ${{ inputs.rc_version }}"
+            echo "### RC delta digest — ${RC_VERSION}"
             echo '```json'
             echo "$payload" | jq .
             echo '```'


### PR DESCRIPTION
## What

Adds a deterministic workflow that posts an RC delta summary (merged PRs + direct commits since the previous RC tag) to Slack.

<img width="625" height="146" alt="image" src="https://github.com/user-attachments/assets/d23265f2-29ad-4416-9fc4-1b7b9c707c21" />

Related to [#40007](https://github.com/camunda/camunda/issues/40007)

## Why

After RC1, reviewers need to know what actually changed between release candidates to scope regression testing. Today that delta is assembled by hand.

## How

Two files, no build-pipeline coupling — a standalone `workflow_dispatch` with a `dry_run` default (BPMN trigger wiring is deferred to a follow-up):

- `.github/scripts/rc-delta-slack-summary.sh` - computes the delta and prints a Slack Block Kit payload.
- `.github/workflows/rc-delta-slack-summary.yml` - resolves the previous RC, runs the script, and posts (or, in dry run, logs) the digest.

Key design decisions:

| Concern | Approach |
|---|---|
| Enumerate the delta | `git log PREV_TAG..RC_VERSION` - authoritative, **zero** API calls |
| commit -> PR linking | **one** batched GraphQL `associatedPullRequests` query (chunked at 100), not one REST call per commit - reliably collapses non-squashed backport commits back into their parent PRs |
| Previous RC resolution | reuses the `previous-version` infra action (already an approved dependency), not hand-rolled |
| First candidate (RC1) | fixed "no delta" note - never diffs against a non-RC baseline |
| Release no-ops | `[maven-release-plugin]` commits **and** their `Revert "[maven-release-plugin] …"` counterparts are filtered out |
| Title noise | leading `[Backport …]` prefixes (incl. nested) stripped from displayed PR titles |

Validated against `8.9.0-rc1...8.9.0-rc2`: 53 commits collapsed into 18 PRs with a single GraphQL call; `actionlint` + `shellcheck` clean.
