### PR TITLE
feat: aggregate gateway health indicators across all partition groups

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -161,11 +161,6 @@ public class GatewayModuleConfiguration implements CloseableSilently {
             maxVariableNameLength,
             physicalTenantIds);
     springGatewayBridge.registerGatewayStatusSupplier(gateway::getStatus);
-    springGatewayBridge.registerClusterStateSupplier(
-        () ->
-            Optional.ofNullable(gateway.getBrokerClient())
-                .map(BrokerClient::getTopologyManager)
-                .map(BrokerTopologyManager::getTopology));
     springGatewayBridge.registerClusterStatesSupplier(this::clusterStatesByPhysicalTenant);
     springGatewayBridge.registerJobStreamClient(() -> jobStreamClient);
 

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.security.spring.oidc.ScopedOidcClaimsProviderFactory;
 import io.camunda.service.UserServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -164,6 +166,7 @@ public class GatewayModuleConfiguration implements CloseableSilently {
             Optional.ofNullable(gateway.getBrokerClient())
                 .map(BrokerClient::getTopologyManager)
                 .map(BrokerTopologyManager::getTopology));
+    springGatewayBridge.registerClusterStatesSupplier(this::clusterStatesByPhysicalTenant);
     springGatewayBridge.registerJobStreamClient(() -> jobStreamClient);
 
     atomixClusterStartFuture.join();
@@ -171,6 +174,34 @@ public class GatewayModuleConfiguration implements CloseableSilently {
     LOGGER.info("Standalone gateway is started!");
 
     return gateway;
+  }
+
+  /**
+   * Builds the cluster topology for every configured physical tenant (partition group), keyed by
+   * physical tenant id. Used by health indicators that must not privilege the default physical
+   * tenant and instead aggregate readiness across all of them (OR-semantics).
+   *
+   * <p>Groups for which {@link BrokerTopologyManager#getTopology(String)} returns {@code null}
+   * (permitted by its contract) are skipped rather than collected, since {@link
+   * java.util.stream.Collectors#toMap} does not tolerate null values.
+   */
+  private Map<String, BrokerClusterState> clusterStatesByPhysicalTenant() {
+    final var topologyManager =
+        Optional.ofNullable(gateway.getBrokerClient())
+            .map(BrokerClient::getTopologyManager)
+            .orElse(null);
+    if (topologyManager == null) {
+      return Map.of();
+    }
+
+    final Map<String, BrokerClusterState> clusterStates = new HashMap<>();
+    for (final var physicalTenantId : physicalTenantIds.known()) {
+      final var topology = topologyManager.getTopology(physicalTenantId);
+      if (topology != null) {
+        clusterStates.put(physicalTenantId, topology);
+      }
+    }
+    return clusterStates;
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.impl;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.health.Status;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ public class SpringGatewayBridge {
 
   private Supplier<Status> gatewayStatusSupplier;
   private Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
+  private Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
 
   public void registerGatewayStatusSupplier(final Supplier<Status> gatewayStatusSupplier) {
@@ -34,12 +36,31 @@ public class SpringGatewayBridge {
     this.clusterStateSupplier = clusterStateSupplier;
   }
 
+  /**
+   * Registers a supplier of the cluster topology for every known physical tenant (partition group),
+   * keyed by physical tenant id. Used by health indicators that must aggregate across all physical
+   * tenants rather than the default one only.
+   */
+  public void registerClusterStatesSupplier(
+      final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier) {
+    this.clusterStatesSupplier = clusterStatesSupplier;
+  }
+
   public Optional<Status> getGatewayStatus() {
     return Optional.ofNullable(gatewayStatusSupplier).map(Supplier::get);
   }
 
   public Optional<BrokerClusterState> getClusterState() {
     return Optional.ofNullable(clusterStateSupplier).flatMap(Supplier::get);
+  }
+
+  /**
+   * Returns the cluster topology for every known physical tenant, keyed by physical tenant id.
+   * Returns an empty map when no supplier has been registered yet or the registered supplier yields
+   * {@code null}.
+   */
+  public Map<String, BrokerClusterState> getClusterStates() {
+    return Optional.ofNullable(clusterStatesSupplier).map(Supplier::get).orElse(Map.of());
   }
 
   public Optional<JobStreamClient> getJobStreamClient() {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java
@@ -23,17 +23,11 @@ import org.springframework.stereotype.Component;
 public class SpringGatewayBridge {
 
   private Supplier<Status> gatewayStatusSupplier;
-  private Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
   private Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
 
   public void registerGatewayStatusSupplier(final Supplier<Status> gatewayStatusSupplier) {
     this.gatewayStatusSupplier = gatewayStatusSupplier;
-  }
-
-  public void registerClusterStateSupplier(
-      final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
-    this.clusterStateSupplier = clusterStateSupplier;
   }
 
   /**
@@ -48,10 +42,6 @@ public class SpringGatewayBridge {
 
   public Optional<Status> getGatewayStatus() {
     return Optional.ofNullable(gatewayStatusSupplier).map(Supplier::get);
-  }
-
-  public Optional<BrokerClusterState> getClusterState() {
-    return Optional.ofNullable(clusterStateSupplier).flatMap(Supplier::get);
   }
 
   /**

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicator.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.boot.health.contributor.Health;
@@ -20,7 +21,8 @@ import org.springframework.boot.health.contributor.HealthIndicator;
  * aggregates across all partition groups (physical tenants): the indicator reports UP as soon as
  * any physical tenant has a known broker, so that a gateway serving multiple physical tenants stays
  * ready even if only some of them are reachable. If the gateway is not aware of any nodes in any
- * physical tenant this indicates a potential network topology problem.
+ * physical tenant this indicates a potential network topology problem. The details report the
+ * number of known brokers per physical tenant.
  */
 public class ClusterAwarenessHealthIndicator implements HealthIndicator {
 
@@ -35,13 +37,15 @@ public class ClusterAwarenessHealthIndicator implements HealthIndicator {
   public Health health() {
     final var clusterStates = clusterStatesSupplier.get();
 
-    final var hasKnownBroker =
-        clusterStates.values().stream().anyMatch(state -> !state.getBrokers().isEmpty());
-
-    if (hasKnownBroker) {
-      return Health.up().build();
-    } else {
-      return Health.down().build();
+    var hasKnownBroker = false;
+    final var details = new HashMap<String, Object>();
+    for (final var entry : clusterStates.entrySet()) {
+      final var brokers = entry.getValue().getBrokers().size();
+      hasKnownBroker |= brokers > 0;
+      details.put(entry.getKey(), Map.of("brokers", brokers));
     }
+
+    final var health = hasKnownBroker ? Health.up() : Health.down();
+    return health.withDetails(details).build();
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicator.java
@@ -10,36 +10,38 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
 
 /**
- * Health indicator that signals whether the gateway is aware of any nodes in the cluster. If the
- * gateway is not aware of any nodes this indicates a potential network topology problem
+ * Health indicator that signals whether the gateway is aware of any nodes in the cluster. This
+ * aggregates across all partition groups (physical tenants): the indicator reports UP as soon as
+ * any physical tenant has a known broker, so that a gateway serving multiple physical tenants stays
+ * ready even if only some of them are reachable. If the gateway is not aware of any nodes in any
+ * physical tenant this indicates a potential network topology problem.
  */
 public class ClusterAwarenessHealthIndicator implements HealthIndicator {
 
-  private final Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
+  private final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier;
 
   public ClusterAwarenessHealthIndicator(
-      final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
-    this.clusterStateSupplier = requireNonNull(clusterStateSupplier);
+      final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier) {
+    this.clusterStatesSupplier = requireNonNull(clusterStatesSupplier);
   }
 
   @Override
   public Health health() {
-    final var optClusterState = clusterStateSupplier.get();
+    final var clusterStates = clusterStatesSupplier.get();
 
-    if (optClusterState.isEmpty()) {
-      return Health.down().build();
+    final var hasKnownBroker =
+        clusterStates.values().stream().anyMatch(state -> !state.getBrokers().isEmpty());
+
+    if (hasKnownBroker) {
+      return Health.up().build();
     } else {
-      if (optClusterState.get().getBrokers().isEmpty()) {
-        return Health.down().build();
-      } else {
-        return Health.up().build();
-      }
+      return Health.down().build();
     }
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorAutoConfiguration.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorAutoConfiguration.java
@@ -33,11 +33,11 @@ public class ClusterAwarenessHealthIndicatorAutoConfiguration {
      *
      * <p>The first supplier created here and passed into the constructor of the health indicator is
      * created first. This happens very early in the application's life cycle. At this point in
-     * time, the cluster status supplier inside gateway bridge is not yet registered.
+     * time, the cluster states supplier inside gateway bridge is not yet registered.
      *
-     * <p>Later, the actual cluster status supplier will be registered at gatewayBridge. The
+     * <p>Later, the actual cluster states supplier will be registered at gatewayBridge. The
      * chaining allows us to delegate over two hops.
      */
-    return new ClusterAwarenessHealthIndicator(gatewayBridge::getClusterState);
+    return new ClusterAwarenessHealthIndicator(gatewayBridge::getClusterStates);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static java.util.Objects.requireNonNull;
 
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.HashMap;
@@ -19,17 +18,18 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
 
 /**
  * The cluster health indicator signals if there are still any healthy partition available, if not
- * then is set as down as no processing is happening. In the details also indicates the health
- * status of all partitions.
- *
- * <p>This indicator reports the default physical tenant only. Aggregation across all physical
- * tenants is served by the cluster-level status endpoint instead (ADR
- * docs/adr/management/001-physical-tenant-health-status-topology.md).
+ * then is set as down as no processing is happening. It aggregates across all partition groups
+ * (physical tenants): UP when every physical tenant is fully healthy, DOWN when no physical tenant
+ * can process work, DEGRADED otherwise. The details report, per physical tenant, its status and the
+ * health status of all its partitions.
  */
 public class ClusterHealthIndicator implements HealthIndicator {
+
+  private static final Status DEGRADED = new Status("DEGRADED");
 
   private final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier;
 
@@ -40,27 +40,44 @@ public class ClusterHealthIndicator implements HealthIndicator {
 
   @Override
   public Health health() {
-    final var optClusterState =
-        Optional.ofNullable(
-            clusterStatesSupplier.get().get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
-
-    if (optClusterState.isEmpty()) {
+    final var clusterStates = clusterStatesSupplier.get();
+    if (clusterStates.isEmpty()) {
       return Health.down().build();
-    } else {
-      if (optClusterState.get().getBrokers().isEmpty()) {
-        return Health.down().build();
-      } else {
-        if (!optClusterState.get().getPartitions().isEmpty()) {
-          final List<Integer> partitions = optClusterState.get().getPartitions();
-
-          final Map<String, PartitionHealthStatus> partitionDetails =
-              getPartitionsHealthStatus(partitions, optClusterState.get());
-          return getStatus(partitions.size(), partitionDetails);
-        } else {
-          return Health.down().build();
-        }
-      }
     }
+
+    var allUp = true;
+    var allDown = true;
+    final var details = new HashMap<String, Object>();
+    for (final var entry : clusterStates.entrySet()) {
+      final var groupHealth = groupHealth(entry.getValue());
+      allUp &= Status.UP.equals(groupHealth.getStatus());
+      allDown &= Status.DOWN.equals(groupHealth.getStatus());
+      details.put(
+          entry.getKey(),
+          Map.of(
+              "status", groupHealth.getStatus().getCode(),
+              "partitions", groupHealth.getDetails()));
+    }
+
+    final Health.Builder health;
+    if (allUp) {
+      health = Health.up();
+    } else if (allDown) {
+      health = Health.down();
+    } else {
+      health = Health.status(DEGRADED);
+    }
+    return health.withDetails(details).build();
+  }
+
+  private Health groupHealth(final BrokerClusterState clusterState) {
+    if (clusterState.getBrokers().isEmpty() || clusterState.getPartitions().isEmpty()) {
+      return Health.down().build();
+    }
+    final List<Integer> partitions = clusterState.getPartitions();
+    final Map<String, PartitionHealthStatus> partitionDetails =
+        getPartitionsHealthStatus(partitions, clusterState);
+    return getStatus(partitions.size(), partitionDetails);
   }
 
   Map<String, PartitionHealthStatus> getPartitionsHealthStatus(
@@ -95,7 +112,7 @@ public class ClusterHealthIndicator implements HealthIndicator {
     } else if (hasOnlyHealthyPartitions) {
       return Health.up().withDetails(partitionDetails).build();
     } else {
-      return Health.status("DEGRADED").withDetails(partitionDetails).build();
+      return Health.status(DEGRADED).withDetails(partitionDetails).build();
     }
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 
 import static java.util.Objects.requireNonNull;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.HashMap;
@@ -23,18 +24,25 @@ import org.springframework.boot.health.contributor.HealthIndicator;
  * The cluster health indicator signals if there are still any healthy partition available, if not
  * then is set as down as no processing is happening. In the details also indicates the health
  * status of all partitions.
+ *
+ * <p>This indicator reports the default physical tenant only. Aggregation across all physical
+ * tenants is served by the cluster-level status endpoint instead (ADR
+ * docs/adr/management/001-physical-tenant-health-status-topology.md).
  */
 public class ClusterHealthIndicator implements HealthIndicator {
 
-  private final Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
+  private final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier;
 
-  public ClusterHealthIndicator(final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
-    this.clusterStateSupplier = requireNonNull(clusterStateSupplier);
+  public ClusterHealthIndicator(
+      final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier) {
+    this.clusterStatesSupplier = requireNonNull(clusterStatesSupplier);
   }
 
   @Override
   public Health health() {
-    final var optClusterState = clusterStateSupplier.get();
+    final var optClusterState =
+        Optional.ofNullable(
+            clusterStatesSupplier.get().get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
 
     if (optClusterState.isEmpty()) {
       return Health.down().build();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorAutoConfiguration.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorAutoConfiguration.java
@@ -26,6 +26,6 @@ public class ClusterHealthIndicatorAutoConfiguration {
   @ConditionalOnMissingBean(name = "gatewayClusterHealthIndicator")
   public ClusterHealthIndicator gatewayClusterHealthIndicator(
       final SpringGatewayBridge gatewayBridge) {
-    return new ClusterHealthIndicator(gatewayBridge::getClusterState);
+    return new ClusterHealthIndicator(gatewayBridge::getClusterStates);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.boot.health.contributor.Health;
@@ -20,7 +21,8 @@ import org.springframework.boot.health.contributor.HealthIndicator;
  * This aggregates across all partition groups (physical tenants): the indicator reports UP as soon
  * as any physical tenant has a partition with a known leader, so that a gateway serving multiple
  * physical tenants stays ready even if only some of them can currently be served. If the gateway is
- * not aware of any partition leaders in any physical tenant, it cannot relay any requests.
+ * not aware of any partition leaders in any physical tenant, it cannot relay any requests. The
+ * details report the number of known partitions and partitions with a leader per physical tenant.
  */
 public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator {
 
@@ -35,17 +37,22 @@ public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator 
   public Health health() {
     final var clusterStates = clusterStatesSupplier.get();
 
-    final var hasKnownLeader =
-        clusterStates.values().stream()
-            .anyMatch(
-                clusterState ->
-                    clusterState.getPartitions().stream()
-                        .anyMatch(index -> clusterState.getLeaderForPartition(index) != null));
-
-    if (hasKnownLeader) {
-      return Health.up().build();
-    } else {
-      return Health.down().build();
+    var hasKnownLeader = false;
+    final var details = new HashMap<String, Object>();
+    for (final var entry : clusterStates.entrySet()) {
+      final var clusterState = entry.getValue();
+      final var partitions = clusterState.getPartitions();
+      final var partitionsWithLeader =
+          partitions.stream()
+              .filter(index -> clusterState.getLeaderForPartition(index) != null)
+              .count();
+      hasKnownLeader |= partitionsWithLeader > 0;
+      details.put(
+          entry.getKey(),
+          Map.of("partitions", partitions.size(), "partitionsWithLeader", partitionsWithLeader));
     }
+
+    final var health = hasKnownLeader ? Health.up() : Health.down();
+    return health.withDetails(details).build();
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java
@@ -10,40 +10,42 @@ package io.camunda.zeebe.gateway.impl.probes.health;
 import static java.util.Objects.requireNonNull;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
 
 /**
  * Health indicator that signals whether the gateway is aware of partition leaders in the cluster.
- * If the gateway is not aware of any partition leaders, it cannot relay any requests
+ * This aggregates across all partition groups (physical tenants): the indicator reports UP as soon
+ * as any physical tenant has a partition with a known leader, so that a gateway serving multiple
+ * physical tenants stays ready even if only some of them can currently be served. If the gateway is
+ * not aware of any partition leaders in any physical tenant, it cannot relay any requests.
  */
 public class PartitionLeaderAwarenessHealthIndicator implements HealthIndicator {
 
-  private final Supplier<Optional<BrokerClusterState>> clusterStateSupplier;
+  private final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier;
 
   public PartitionLeaderAwarenessHealthIndicator(
-      final Supplier<Optional<BrokerClusterState>> clusterStateSupplier) {
-    this.clusterStateSupplier = requireNonNull(clusterStateSupplier);
+      final Supplier<Map<String, BrokerClusterState>> clusterStatesSupplier) {
+    this.clusterStatesSupplier = requireNonNull(clusterStatesSupplier);
   }
 
   @Override
   public Health health() {
-    final var optClusterState = clusterStateSupplier.get();
+    final var clusterStates = clusterStatesSupplier.get();
 
-    if (optClusterState.isEmpty()) {
-      return Health.down().build();
+    final var hasKnownLeader =
+        clusterStates.values().stream()
+            .anyMatch(
+                clusterState ->
+                    clusterState.getPartitions().stream()
+                        .anyMatch(index -> clusterState.getLeaderForPartition(index) != null));
+
+    if (hasKnownLeader) {
+      return Health.up().build();
     } else {
-      final var clusterState = optClusterState.get();
-      final var hasKnownLeader =
-          clusterState.getPartitions().stream()
-              .anyMatch(index -> clusterState.getLeaderForPartition(index) != null);
-      if (hasKnownLeader) {
-        return Health.up().build();
-      } else {
-        return Health.down().build();
-      }
+      return Health.down().build();
     }
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorAutoConfiguration.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorAutoConfiguration.java
@@ -30,6 +30,6 @@ public class PartitionLeaderAwarenessHealthIndicatorAutoConfiguration {
   public PartitionLeaderAwarenessHealthIndicator gatewayPartitionLeaderAwarenessHealthIndicator(
       final SpringGatewayBridge gatewayBridge) {
     // Here we effectively chain two suppliers to decouple their creation in time.
-    return new PartitionLeaderAwarenessHealthIndicator(gatewayBridge::getClusterState);
+    return new PartitionLeaderAwarenessHealthIndicator(gatewayBridge::getClusterStates);
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.health.Status;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,5 +71,29 @@ public class SpringGatewayBridgeTest {
 
     // then
     assertThat(actual).contains(mockClusterState);
+  }
+
+  @Test
+  public void shouldReturnEmptyClusterStatesByDefault() {
+    // when
+    final var actual = sutBrigde.getClusterStates();
+
+    // then
+    assertThat(actual).describedAs("Cluster states when no supplier is set").isEmpty();
+  }
+
+  @Test
+  public void shouldUseClusterStatesSupplierWhenRegistered() {
+    // given
+    final var mockClusterState = Mockito.mock(BrokerClusterState.class);
+    final Supplier<Map<String, BrokerClusterState>> testSupplier =
+        () -> Map.of("default", mockClusterState);
+    sutBrigde.registerClusterStatesSupplier(testSupplier);
+
+    // when
+    final var actual = sutBrigde.getClusterStates();
+
+    // then
+    assertThat(actual).containsExactly(Map.entry("default", mockClusterState));
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
@@ -50,30 +50,6 @@ public class SpringGatewayBridgeTest {
   }
 
   @Test
-  public void shouldReturnNoClusterStateByDefault() {
-    // when
-    final var actual = sutBrigde.getClusterState();
-
-    // then
-    assertThat(actual).describedAs("Cluster status when no supplier is set").isEmpty();
-  }
-
-  @Test
-  public void shouldUseClusterStateSupplierWhenSet() {
-    // given
-    final var mockClusterState = Mockito.mock(BrokerClusterState.class);
-
-    final Supplier<Optional<BrokerClusterState>> testSupplier = () -> Optional.of(mockClusterState);
-    sutBrigde.registerClusterStateSupplier(testSupplier);
-
-    // when
-    final var actual = sutBrigde.getClusterState();
-
-    // then
-    assertThat(actual).contains(mockClusterState);
-  }
-
-  @Test
   public void shouldReturnEmptyClusterStatesByDefault() {
     // when
     final var actual = sutBrigde.getClusterStates();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridgeTest.java
@@ -13,15 +13,15 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.health.Status;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class SpringGatewayBridgeTest {
 
   private SpringGatewayBridge sutBrigde;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     sutBrigde = new SpringGatewayBridge();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
@@ -81,6 +81,9 @@ public class ClusterAwarenessHealthIndicatorTest {
     // then
     assertThat(actualHealth).isNotNull();
     assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
+    assertThat(actualHealth.getDetails())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of("default", Map.of("brokers", 0), "tenant-b", Map.of("brokers", 1)));
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.probes.health;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -16,7 +15,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Status;
@@ -24,17 +23,17 @@ import org.springframework.boot.health.contributor.Status;
 public class ClusterAwarenessHealthIndicatorTest {
 
   @Test
-  public void shouldRejectNullInConstructor() {
+  public void shouldRejectNullSupplierInConstructor() {
     // when + then
     assertThatThrownBy(() -> new ClusterAwarenessHealthIndicator(null))
         .isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  public void shouldReportDownIfSupplierReturnsEmpty() {
+  public void shouldReportDownIfSupplierReturnsEmptyMap() {
     // given
-    final Supplier<Optional<BrokerClusterState>> stateSupplier = () -> Optional.empty();
-    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(stateSupplier);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier = Map::of;
+    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(statesSupplier);
 
     // when
     final var actualHealth = sutHealthIndicator.health();
@@ -45,14 +44,36 @@ public class ClusterAwarenessHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportUpIfListOfBrokersIsNotEmpty() {
+  public void shouldReportDownIfNoGroupHasBrokers() {
     // given
-    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getBrokers()).thenReturn(List.of());
+    final BrokerClusterState secondState = mock(BrokerClusterState.class);
+    when(secondState.getBrokers()).thenReturn(List.of());
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
-    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(stateSupplier);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState, "tenant-b", secondState);
+    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(statesSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  public void shouldReportUpIfAnyGroupHasBrokers() {
+    // given
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getBrokers()).thenReturn(List.of());
+    final BrokerClusterState secondState = mock(BrokerClusterState.class);
+    when(secondState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
+
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState, "tenant-b", secondState);
+    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(statesSupplier);
 
     // when
     final var actualHealth = sutHealthIndicator.health();
@@ -63,20 +84,20 @@ public class ClusterAwarenessHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportDownIfListOfBrokersIsEmpty() {
+  public void shouldReportUpIfSingleGroupHasBrokers() {
     // given
-    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getBrokers()).thenReturn(emptyList());
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
-    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(stateSupplier);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState);
+    final var sutHealthIndicator = new ClusterAwarenessHealthIndicator(statesSupplier);
 
     // when
     final var actualHealth = sutHealthIndicator.health();
 
     // then
     assertThat(actualHealth).isNotNull();
-    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
   }
 }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicatorTest.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Status;
 
 public class ClusterAwarenessHealthIndicatorTest {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -47,8 +47,8 @@ public class ClusterHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportDownIfOnlyNonDefaultTenantIsKnown() {
-    // given the indicator only considers the default physical tenant
+  public void shouldReportUpIfOnlyNonDefaultTenantIsKnownAndHealthy() {
+    // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
@@ -58,6 +58,71 @@ public class ClusterHealthIndicatorTest {
 
     final Supplier<Map<String, BrokerClusterState>> stateSupplier =
         () -> Map.of("other-tenant", mockClusterState);
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
+  public void shouldReportDegradedIfOneTenantIsDownAndAnotherIsHealthy() {
+    // given
+    final BrokerClusterState downState = mock(BrokerClusterState.class);
+    when(downState.getBrokers()).thenReturn(List.of());
+    final BrokerClusterState healthyState = mock(BrokerClusterState.class);
+    when(healthyState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
+    when(healthyState.getPartitions()).thenReturn(List.of(1));
+    when(healthyState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(healthyState.getPartitionHealth(BrokerMemberId.from(1), 1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () ->
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                downState,
+                "other-tenant",
+                healthyState);
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(new Status("DEGRADED"));
+    assertThat(actualHealth.getDetails())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                Map.of("status", "DOWN", "partitions", Map.of()),
+                "other-tenant",
+                Map.of(
+                    "status",
+                    "UP",
+                    "partitions",
+                    Map.of("Partition 1", PartitionHealthStatus.HEALTHY))));
+  }
+
+  @Test
+  public void shouldReportDownIfAllTenantsAreDown() {
+    // given
+    final BrokerClusterState downState = mock(BrokerClusterState.class);
+    when(downState.getBrokers()).thenReturn(List.of());
+    final BrokerClusterState otherDownState = mock(BrokerClusterState.class);
+    when(otherDownState.getBrokers()).thenReturn(List.of());
+
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () ->
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                downState,
+                "other-tenant",
+                otherDownState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Status;
 
 public class ClusterHealthIndicatorTest {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicatorTest.java
@@ -14,10 +14,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Status;
@@ -32,9 +33,31 @@ public class ClusterHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportDownIfSupplierReturnsEmpty() {
+  public void shouldReportDownIfSupplierReturnsEmptyMap() {
     // given
-    final Supplier<Optional<BrokerClusterState>> stateSupplier = () -> Optional.empty();
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier = Map::of;
+    final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  public void shouldReportDownIfOnlyNonDefaultTenantIsKnown() {
+    // given the indicator only considers the default physical tenant
+    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
+    when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
+    when(mockClusterState.getPartitions()).thenReturn(List.of(1));
+    when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(1));
+    when(mockClusterState.getPartitionHealth(BrokerMemberId.from(1), 1))
+        .thenReturn(PartitionHealthStatus.HEALTHY);
+
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of("other-tenant", mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when
@@ -52,8 +75,8 @@ public class ClusterHealthIndicatorTest {
     when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
     when(mockClusterState.getPartitions()).thenReturn(List.of());
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when
@@ -74,8 +97,8 @@ public class ClusterHealthIndicatorTest {
     when(mockClusterState.getPartitionHealth(BrokerMemberId.from(1), 1))
         .thenReturn(PartitionHealthStatus.HEALTHY);
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when
@@ -101,8 +124,8 @@ public class ClusterHealthIndicatorTest {
     when(mockClusterState.getPartitionHealth(BrokerMemberId.from(3), 3))
         .thenReturn(PartitionHealthStatus.DEAD);
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when
@@ -128,8 +151,8 @@ public class ClusterHealthIndicatorTest {
     when(mockClusterState.getPartitionHealth(BrokerMemberId.from(3), 3))
         .thenReturn(PartitionHealthStatus.DEAD);
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when
@@ -155,8 +178,8 @@ public class ClusterHealthIndicatorTest {
     when(mockClusterState.getPartitionHealth(BrokerMemberId.from(3), 3))
         .thenReturn(PartitionHealthStatus.UNHEALTHY);
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when
@@ -173,8 +196,8 @@ public class ClusterHealthIndicatorTest {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getBrokers()).thenReturn(emptyList());
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> stateSupplier =
+        () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, mockClusterState);
     final var sutHealthIndicator = new ClusterHealthIndicator(stateSupplier);
 
     // when

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
 
@@ -28,7 +28,7 @@ public class LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest {
 
   private ClusterAwarenessHealthIndicatorAutoConfiguration sutAutoConfig;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     helperGatewayBridge = new SpringGatewayBridge();
     sutAutoConfig = new ClusterAwarenessHealthIndicatorAutoConfiguration();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -15,7 +15,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,19 +45,19 @@ public class LivenessClusterAwarenessHealthIndicatorAutoConfigurationTest {
 
   @Test
   public void
-      shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStateSupplier() {
+      shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStatesSupplier() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", mockClusterState);
 
     final var healthIndicator =
         sutAutoConfig.gatewayClusterAwarenessHealthIndicator(helperGatewayBridge);
 
     // when
-    helperGatewayBridge.registerClusterStateSupplier(stateSupplier);
+    helperGatewayBridge.registerClusterStatesSupplier(statesSupplier);
     final Health actualHealth = healthIndicator.health();
 
     // then

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -15,7 +15,7 @@ import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,19 +46,19 @@ public class LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTes
 
   @Test
   public void
-      shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStateSupplier() {
+      shouldCreateHealthIndicatorThatReportsHealthBasedOnResultOfRegisteredClusterStatesSupplier() {
     // given
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
     when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(42));
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", mockClusterState);
     final var healthIndicator =
         sutAutoConfig.gatewayPartitionLeaderAwarenessHealthIndicator(helperGatewayBridge);
 
     // when
-    helperGatewayBridge.registerClusterStateSupplier(stateSupplier);
+    helperGatewayBridge.registerClusterStatesSupplier(statesSupplier);
     final Health actualHealth = healthIndicator.health();
 
     // then

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTest.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.gateway.impl.SpringGatewayBridge;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.Status;
 
@@ -28,7 +28,7 @@ public class LivenessPartitionLeaderAwarenessHealthIndicatorAutoConfigurationTes
 
   private PartitionLeaderAwarenessHealthIndicatorAutoConfiguration sutAutoConfig;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     helperGatewayBridge = new SpringGatewayBridge();
     sutAutoConfig = new PartitionLeaderAwarenessHealthIndicatorAutoConfiguration();

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
@@ -105,6 +105,11 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
     // then
     assertThat(actualHealth).isNotNull();
     assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
+    assertThat(actualHealth.getDetails())
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "default", Map.of("partitions", 1, "partitionsWithLeader", 0L),
+                "tenant-b", Map.of("partitions", 1, "partitionsWithLeader", 1L)));
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Status;
 
 public class PartitionLeaderAwarenessHealthIndicatorTest {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicatorTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.probes.health;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -16,7 +15,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.health.contributor.Status;
@@ -24,17 +23,17 @@ import org.springframework.boot.health.contributor.Status;
 public class PartitionLeaderAwarenessHealthIndicatorTest {
 
   @Test
-  public void shouldRejectNullInConstructor() {
+  public void shouldRejectNullSupplierInConstructor() {
     // when + then
     assertThatThrownBy(() -> new PartitionLeaderAwarenessHealthIndicator(null))
         .isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  public void shouldReportDownIfSupplierReturnsEmpty() {
+  public void shouldReportDownIfSupplierReturnsEmptyMap() {
     // given
-    final Supplier<Optional<BrokerClusterState>> stateSupplier = () -> Optional.empty();
-    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(stateSupplier);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier = Map::of;
+    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(statesSupplier);
 
     // when
     final var actualHealth = sutHealthIndicator.health();
@@ -45,16 +44,60 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportUpIfAnyPartitionLeaderIsKnown() {
+  public void shouldReportDownIfNoGroupHasPartitions() {
     // given
-    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from(42));
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getPartitions()).thenReturn(List.of());
+    final BrokerClusterState secondState = mock(BrokerClusterState.class);
+    when(secondState.getPartitions()).thenReturn(List.of());
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
-    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(stateSupplier);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState, "tenant-b", secondState);
+    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(statesSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  public void shouldReportDownIfNoGroupHasPartitionLeader() {
+    // given
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getPartitions()).thenReturn(List.of(1));
+    when(defaultState.getLeaderForPartition(1)).thenReturn(null);
+    final BrokerClusterState secondState = mock(BrokerClusterState.class);
+    when(secondState.getPartitions()).thenReturn(List.of(2));
+    when(secondState.getLeaderForPartition(2)).thenReturn(null);
+
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState, "tenant-b", secondState);
+    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(statesSupplier);
+
+    // when
+    final var actualHealth = sutHealthIndicator.health();
+
+    // then
+    assertThat(actualHealth).isNotNull();
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+  }
+
+  @Test
+  public void shouldReportUpIfAnyGroupHasPartitionLeader() {
+    // given
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getPartitions()).thenReturn(List.of(1));
+    when(defaultState.getLeaderForPartition(1)).thenReturn(null);
+    final BrokerClusterState secondState = mock(BrokerClusterState.class);
+    when(secondState.getPartitions()).thenReturn(List.of(2));
+    when(secondState.getLeaderForPartition(2)).thenReturn(BrokerMemberId.from(42));
+
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState, "tenant-b", secondState);
+    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(statesSupplier);
 
     // when
     final var actualHealth = sutHealthIndicator.health();
@@ -65,40 +108,21 @@ public class PartitionLeaderAwarenessHealthIndicatorTest {
   }
 
   @Test
-  public void shouldReportDownIfListOfPartitionsIsEmpty() {
+  public void shouldReportUpIfSingleGroupHasPartitionLeader() {
     // given
-    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getPartitions()).thenReturn(emptyList());
+    final BrokerClusterState defaultState = mock(BrokerClusterState.class);
+    when(defaultState.getPartitions()).thenReturn(List.of(1));
+    when(defaultState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(42));
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
-    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(stateSupplier);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", defaultState);
+    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(statesSupplier);
 
     // when
     final var actualHealth = sutHealthIndicator.health();
 
     // then
     assertThat(actualHealth).isNotNull();
-    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
-  }
-
-  @Test
-  public void shouldReportDownIfNoPartitionLeaderIsKnown() {
-    // given
-    final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
-    when(mockClusterState.getPartitions()).thenReturn(List.of(1, 2));
-    when(mockClusterState.getLeaderForPartition(1)).thenReturn(null);
-    when(mockClusterState.getLeaderForPartition(2)).thenReturn(null);
-
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
-    final var sutHealthIndicator = new PartitionLeaderAwarenessHealthIndicator(stateSupplier);
-
-    // when
-    final var actualHealth = sutHealthIndicator.health();
-
-    // then
-    assertThat(actualHealth).isNotNull();
-    assertThat(actualHealth.getStatus()).isEqualTo(Status.DOWN);
+    assertThat(actualHealth.getStatus()).isEqualTo(Status.UP);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.gateway.impl.probes.health.PartitionLeaderAwarenessHealt
 import io.camunda.zeebe.gateway.impl.probes.health.StartedHealthIndicator;
 import io.camunda.zeebe.it.shared.gateway.GatewayHealthIndicatorsIntegrationTest.Config;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Test;
@@ -52,6 +52,7 @@ public class GatewayHealthIndicatorsIntegrationTest {
   public void tearDown() {
     // reset suppliers
     springGatewayBridge.registerClusterStateSupplier(null);
+    springGatewayBridge.registerClusterStatesSupplier(null);
     springGatewayBridge.registerGatewayStatusSupplier(null);
   }
 
@@ -92,13 +93,13 @@ public class GatewayHealthIndicatorsIntegrationTest {
     final BrokerClusterState mockClusterState = mock(BrokerClusterState.class);
     when(mockClusterState.getBrokers()).thenReturn(List.of(BrokerMemberId.from(1)));
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", mockClusterState);
 
     // when
     final Health actualHealthBeforeRegisteringStatusSupplier =
         clusterAwarenessHealthIndicator.health();
-    springGatewayBridge.registerClusterStateSupplier(stateSupplier);
+    springGatewayBridge.registerClusterStatesSupplier(statesSupplier);
     final Health actualHealthAfterRegisteringStatusSupplier =
         clusterAwarenessHealthIndicator.health();
 
@@ -121,13 +122,13 @@ public class GatewayHealthIndicatorsIntegrationTest {
     when(mockClusterState.getPartitions()).thenReturn(List.of(1));
     when(mockClusterState.getLeaderForPartition(1)).thenReturn(BrokerMemberId.from(42));
 
-    final Supplier<Optional<BrokerClusterState>> stateSupplier =
-        () -> Optional.of(mockClusterState);
+    final Supplier<Map<String, BrokerClusterState>> statesSupplier =
+        () -> Map.of("default", mockClusterState);
 
     // when
     final Health actualHealthBeforeRegisteringStatusSupplier =
         partitionLeaderAwarenessHealthIndicator.health();
-    springGatewayBridge.registerClusterStateSupplier(stateSupplier);
+    springGatewayBridge.registerClusterStatesSupplier(statesSupplier);
     final Health actualHealthAfterRegisteringStatusSupplier =
         partitionLeaderAwarenessHealthIndicator.health();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayHealthIndicatorsIntegrationTest.java
@@ -51,7 +51,6 @@ public class GatewayHealthIndicatorsIntegrationTest {
   @After
   public void tearDown() {
     // reset suppliers
-    springGatewayBridge.registerClusterStateSupplier(null);
     springGatewayBridge.registerClusterStatesSupplier(null);
     springGatewayBridge.registerGatewayStatusSupplier(null);
   }


### PR DESCRIPTION
Closes #57026

On a multi-physical-tenant cluster, `ClusterAwarenessHealthIndicator` and `PartitionLeaderAwarenessHealthIndicator` (readiness) — and their delayed liveness variants, which simply wrap these readiness beans — only ever looked at the default partition group's topology, via the no-arg `BrokerTopologyManager.getTopology()`. A gateway serving several physical tenants could report DOWN purely because the default tenant had no reachable broker or partition leader, even while every other tenant was healthy.

Per ADR [`docs/adr/management/001-physical-tenant-health-status-topology.md`](https://github.com/camunda/camunda/blob/9d53806c28fe82cc639c264fbc33ce38fd98a5b1/docs/adr/management/001-physical-tenant-health-status-topology.md) decision D6, readiness must use OR-semantics across physical tenants: at least one serviceable tenant is enough to report UP, and probes must not privilege the default tenant.

## Changes

- [`SpringGatewayBridge`](https://github.com/camunda/camunda/blob/32a390e217ef622d95c65b96952e07a49005854a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/SpringGatewayBridge.java#L33-L58) now exposes a single map-valued supplier, `registerClusterStatesSupplier`/`getClusterStates`, keyed by physical tenant id. The old single-state supplier is removed — the map subsumes it.
- [`ClusterAwarenessHealthIndicator`](https://github.com/camunda/camunda/blob/bd151a2f288de2779e7c885fbc4d616143ad6b62/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterAwarenessHealthIndicator.java#L36-L50) and [`PartitionLeaderAwarenessHealthIndicator`](https://github.com/camunda/camunda/blob/bd151a2f288de2779e7c885fbc4d616143ad6b62/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/PartitionLeaderAwarenessHealthIndicator.java#L37-L58) take that map-valued supplier and report UP as soon as *any* group satisfies the check (OR-aggregation). They also expose per-physical-tenant counts in the health details (`brokers` / `partitions`+`partitionsWithLeader`), so operators can see which tenant is the problem — these indicators are actuator-only, and the liveness group has `show-details: always`.
- [`GatewayModuleConfiguration`](https://github.com/camunda/camunda/blob/9d53806c28fe82cc639c264fbc33ce38fd98a5b1/dist/src/main/java/io/camunda/zeebe/gateway/GatewayModuleConfiguration.java#L188-L204) builds the supplier from the configured physical tenant set (`physicalTenantIds.known()`), skipping any group for which `BrokerTopologyManager.getTopology(id)` returns `null` (permitted by its contract) rather than changing the `BrokerTopologyManager` interface.
- [`ClusterHealthIndicator`](https://github.com/camunda/camunda/blob/bd151a2f288de2779e7c885fbc4d616143ad6b62/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/probes/health/ClusterHealthIndicator.java#L41-L71) ("gateway-cluster" bean) also aggregates across all physical tenants, using the ADR's D4 semantics: UP when every tenant is fully healthy, DOWN when no tenant can process work, DEGRADED otherwise. Details are nested per tenant (`{status, partitions}`). ⚠️ This changes the previously flat detail shape (`"Partition 1": HEALTHY`) also on single-tenant clusters; the indicator is in no probe group, so Kubernetes behavior is unaffected.
- Liveness variants need no wiring changes: they wrap the readiness beans via `DelayedHealthIndicator`, so fixing the two readiness indicators fixes liveness automatically. Only their test fixtures were updated.

Single-tenant probe *statuses* are unchanged (a lone default group evaluates exactly as before); the only externally visible single-tenant change is the `gateway-cluster` detail shape noted above. Actuator keys (`gateway-clusterawareness`, `gateway-partitionleaderawareness`) and liveness properties are unchanged.

The JUnit 4 → JUnit 5 test migrations are split into separate mechanical `refactor:` commits per repo convention.
