### PR TITLE
feat: assign Business ID to process instance via CompleteJob

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -105,6 +105,26 @@ public interface CompleteJobCommandStep1
    */
   CompleteJobCommandStep1 withLeaseToken(String leaseToken);
 
+  /**
+   * Assigns the given business id to the job's root process instance as part of completing the job,
+   * letting a worker derive the identifier from work it just performed.
+   *
+   * <p>The assignment is single and irreversible and is only accepted while business id uniqueness
+   * is disabled. Only artifacts created after the assignment carry the business id;
+   * already-existing ones are not enriched. Completing with a business id that differs from one
+   * already assigned rejects the whole completion, leaving the job open; re-sending the identical
+   * business id is an idempotent no-op.
+   *
+   * <p>Passing {@code null} leaves the business id unset (no assignment is requested). A blank
+   * business id is rejected with an {@link IllegalArgumentException}.
+   *
+   * @param businessId the business id to assign to the root process instance
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   * @throws IllegalArgumentException if {@code businessId} is blank
+   */
+  CompleteJobCommandStep1 withBusinessId(String businessId);
+
   interface CompleteJobCommandJobResultStep {
     /**
      * Initializes the job result to allow corrections or a denial to be configured.

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -124,6 +124,19 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   }
 
   @Override
+  public CompleteJobCommandStep1 withBusinessId(final String businessId) {
+    if (businessId == null) {
+      return this;
+    }
+    if (businessId.trim().isEmpty()) {
+      throw new IllegalArgumentException("businessId must not be blank");
+    }
+    grpcRequestObjectBuilder.setBusinessId(businessId);
+    httpRequestObject.setBusinessId(businessId);
+    return this;
+  }
+
+  @Override
   public CompleteUserTaskJobResultImpl forUserTask() {
     return new CompleteUserTaskJobResultImpl();
   }

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -18,6 +18,7 @@ package io.camunda.client.job;
 import static io.camunda.client.api.command.enums.JobResultType.AD_HOC_SUB_PROCESS;
 import static io.camunda.client.api.command.enums.JobResultType.USER_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1.CompleteJobCommandJobResultStep;
@@ -96,6 +97,44 @@ public final class CompleteJobTest extends ClientTest {
     // then
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCompleteJobWithBusinessId() {
+    // given
+    final long jobKey = 12;
+    final String businessId = "biz-1";
+
+    // when
+    client.newCompleteCommand(jobKey).withBusinessId(businessId).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  public void shouldNotSetBusinessIdByDefault() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newCompleteCommand(jobKey).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.hasBusinessId()).isFalse();
+  }
+
+  @Test
+  public void shouldRejectBlankBusinessId() {
+    // given
+    final long jobKey = 12;
+
+    // when/then
+    assertThatThrownBy(() -> client.newCompleteCommand(jobKey).withBusinessId("   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("businessId");
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -18,6 +18,7 @@ package io.camunda.client.job.rest;
 import static io.camunda.client.api.command.enums.JobResultType.AD_HOC_SUB_PROCESS;
 import static io.camunda.client.api.command.enums.JobResultType.USER_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.api.command.CompleteJobCommandStep1.CompleteJobCommandJobResultStep;
 import io.camunda.client.api.response.ActivatedJob;
@@ -89,6 +90,44 @@ class CompleteJobRestTest extends ClientRestTest {
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  void shouldCompleteJobWithBusinessId() {
+    // given
+    final long jobKey = 12;
+    final String businessId = "biz-1";
+
+    // when
+    client.newCompleteCommand(jobKey).withBusinessId(businessId).send().join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getBusinessId()).isEqualTo(businessId);
+  }
+
+  @Test
+  void shouldNotSetBusinessIdByDefault() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newCompleteCommand(jobKey).send().join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getBusinessId()).isNull();
+  }
+
+  @Test
+  void shouldRejectBlankBusinessId() {
+    // given
+    final long jobKey = 12;
+
+    // when/then
+    assertThatThrownBy(() -> client.newCompleteCommand(jobKey).withBusinessId("   "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("businessId");
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -17,6 +17,7 @@ import static io.camunda.gateway.mapping.http.validator.ElementRequestValidator.
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.JobRequestValidator.validateJobActivationRequest;
 import static io.camunda.gateway.mapping.http.validator.JobRequestValidator.validateJobBatchUpdateRequest;
+import static io.camunda.gateway.mapping.http.validator.JobRequestValidator.validateJobCompletionRequest;
 import static io.camunda.gateway.mapping.http.validator.JobRequestValidator.validateJobErrorRequest;
 import static io.camunda.gateway.mapping.http.validator.JobRequestValidator.validateJobUpdateRequest;
 import static io.camunda.gateway.mapping.http.validator.MessageRequestValidator.validateMessageCorrelationRequest;
@@ -255,13 +256,17 @@ public class RequestMapper {
                 correlationRequest.getBusinessId()));
   }
 
-  public static CompleteJobRequest toJobCompletionRequest(
+  public static Either<ProblemDetail, CompleteJobRequest> toJobCompletionRequest(
       final JobCompletionRequest completionRequest, final long jobKey) {
-    return new CompleteJobRequest(
-        jobKey,
-        getMapOrEmpty(completionRequest, JobCompletionRequest::getVariables),
-        getJobResultOrDefault(completionRequest),
-        completionRequest == null ? null : completionRequest.getLeaseToken());
+    return getResult(
+        validateJobCompletionRequest(completionRequest),
+        () ->
+            new CompleteJobRequest(
+                jobKey,
+                getMapOrEmpty(completionRequest, JobCompletionRequest::getVariables),
+                getJobResultOrDefault(completionRequest),
+                completionRequest == null ? null : completionRequest.getLeaseToken(),
+                completionRequest == null ? null : completionRequest.getBusinessId()));
   }
 
   public static Either<ProblemDetail, UpdateJobRequest> toJobUpdateRequest(
@@ -946,7 +951,11 @@ public class RequestMapper {
       @Nullable String leaseToken) {}
 
   public record CompleteJobRequest(
-      long jobKey, Map<String, Object> variables, JobResult result, @Nullable String leaseToken) {}
+      long jobKey,
+      Map<String, Object> variables,
+      JobResult result,
+      @Nullable String leaseToken,
+      @Nullable String businessId) {}
 
   public record UpdateJobRequest(
       long jobKey,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/JobRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/JobRequestValidator.java
@@ -11,11 +11,13 @@ import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESS
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
+import static io.camunda.gateway.mapping.http.validator.RequestValidator.validateBusinessId;
 
 import io.camunda.gateway.mapping.http.search.SearchQueryFilterMapper;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.JobBatchUpdateRequest;
 import io.camunda.gateway.protocol.model.JobChangeset;
+import io.camunda.gateway.protocol.model.JobCompletionRequest;
 import io.camunda.gateway.protocol.model.JobErrorRequest;
 import io.camunda.gateway.protocol.model.JobUpdateRequest;
 import java.util.List;
@@ -55,6 +57,25 @@ public final class JobRequestValidator {
           // errorCode can't be null or empty
           if (errorRequest.getErrorCode() == null || errorRequest.getErrorCode().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("errorCode"));
+          }
+        });
+  }
+
+  public static Optional<ProblemDetail> validateJobCompletionRequest(
+      final JobCompletionRequest completionRequest) {
+    return validate(
+        violations -> {
+          if (completionRequest == null) {
+            return;
+          }
+          final String businessId = completionRequest.getBusinessId();
+          if (businessId == null) {
+            return;
+          }
+          if (businessId.isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("businessId"));
+          } else {
+            validateBusinessId(businessId, violations);
           }
         });
   }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -550,7 +550,7 @@ class RequestMapperTest {
       final var result = RequestMapper.toJobCompletionRequest(request, 1L);
 
       // then
-      assertThat(result.leaseToken()).isEqualTo("lease-1");
+      assertThat(result.get().leaseToken()).isEqualTo("lease-1");
     }
 
     @Test
@@ -562,7 +562,61 @@ class RequestMapperTest {
       final var result = RequestMapper.toJobCompletionRequest(request, 1L);
 
       // then
-      assertThat(result.leaseToken()).isNull();
+      assertThat(result.get().leaseToken()).isNull();
+    }
+
+    @Test
+    void shouldMapBusinessIdOnJobCompletion() {
+      // given
+      final var request = JobCompletionRequest.Builder.create().businessId("biz-1").build();
+
+      // when
+      final var result = RequestMapper.toJobCompletionRequest(request, 1L);
+
+      // then
+      assertThat(result.get().businessId()).isEqualTo("biz-1");
+    }
+
+    @Test
+    void shouldMapAbsentBusinessIdOnJobCompletion() {
+      // given
+      final var request = JobCompletionRequest.Builder.create().build();
+
+      // when
+      final var result = RequestMapper.toJobCompletionRequest(request, 1L);
+
+      // then
+      assertThat(result.get().businessId()).isNull();
+    }
+
+    @Test
+    void shouldRejectEmptyBusinessIdOnJobCompletion() {
+      // given
+      final var request = JobCompletionRequest.Builder.create().businessId("").build();
+
+      // when
+      final var result = RequestMapper.toJobCompletionRequest(request, 1L);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("businessId");
+    }
+
+    @Test
+    void shouldRejectBlankBusinessIdOnJobCompletion() {
+      // given
+      final var request = JobCompletionRequest.Builder.create().businessId("   ").build();
+
+      // when
+      final var result = RequestMapper.toJobCompletionRequest(request, 1L);
+
+      // then
+      assertThat(result.isLeft()).isTrue();
+      final var problemDetail = result.getLeft();
+      assertThat(problemDetail.getStatus()).isEqualTo(400);
+      assertThat(problemDetail.getDetail()).contains("businessId");
     }
 
     @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CompleteJobBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CompleteJobBusinessIdAssignmentIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.waitForProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Verifies late Business ID assignment via {@code CompleteJob} end to end over both client
+ * transports (ADR 0006, D11/D12): the happy path with propagation to secondary storage, that
+ * re-assigning an already-assigned instance is rejected, and that a failed assignment rejects the
+ * whole completion atomically, leaving the job open and the previously assigned business id
+ * untouched.
+ *
+ * <p>Each test uses its own process/job type so that {@code activateNextJob} never steals a job
+ * from a concurrently running test's instance — which would otherwise assign the business id to the
+ * wrong instance.
+ */
+@MultiDbTest
+class CompleteJobBusinessIdAssignmentIT {
+
+  private static final int MAX_BUSINESS_ID_LENGTH = 256;
+
+  private static CamundaClient camundaClient;
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldAssignBusinessIdWhenCompletingJob(final boolean useRest) {
+    // given - a running process instance that currently has no business id
+    final var jobType = jobType("complete-assign", useRest);
+    final long processInstanceKey = startProcessInstance(jobType);
+    final var businessId = "order-" + transport(useRest) + "-98765";
+
+    // when - the first job is completed with a business id to assign
+    completeNextJob(jobType, businessId, useRest);
+
+    // then - the assignment propagates to secondary storage
+    awaitBusinessId(processInstanceKey, businessId);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldRejectReassigningBusinessIdOnCompletion(final boolean useRest) {
+    // given - a process instance that already has a business id assigned via job completion
+    final var jobType = jobType("complete-reassign", useRest);
+    final long processInstanceKey = startProcessInstance(jobType);
+    completeNextJob(jobType, "order-original", useRest);
+    awaitBusinessId(processInstanceKey, "order-original");
+
+    // when / then - completing a job while assigning a different business id is rejected, leaving
+    // the job open (the whole completion is atomic)
+    final var job = activateNextJob(jobType);
+    assertThatThrownBy(() -> completeJob(job, "order-different", useRest))
+        .describedAs(
+            "assigning a different business id while completing a job is rejected over %s",
+            transport(useRest))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("it already has a business id assigned");
+
+    // and - re-sending the identical business id is likewise rejected, again leaving the job open
+    assertThatThrownBy(() -> completeJob(job, "order-original", useRest))
+        .describedAs(
+            "re-sending the identical business id while completing a job is rejected over %s",
+            transport(useRest))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("it already has a business id assigned");
+
+    // and - the job is still open and can be completed normally, keeping the original business id
+    assertThatNoException()
+        .describedAs("the rejected completions left the job open")
+        .isThrownBy(() -> completeJob(job, null, useRest));
+    awaitBusinessId(processInstanceKey, "order-original");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldRejectBusinessIdExceedingMaxLengthOnCompletion(final boolean useRest) {
+    // given - a running process instance with no business id
+    final var jobType = jobType("complete-too-long", useRest);
+    final long processInstanceKey = startProcessInstance(jobType);
+    final var tooLong = "b".repeat(MAX_BUSINESS_ID_LENGTH + 1);
+
+    // when / then - completing a job with an over-long business id is rejected atomically
+    final var job = activateNextJob(jobType);
+    assertThatThrownBy(() -> completeJob(job, tooLong, useRest))
+        .describedAs(
+            "assigning an over-long business id while completing a job is rejected over %s",
+            transport(useRest))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("exceeds the limit of 256 characters");
+
+    // and - the job is still open and can be completed normally, with no business id assigned
+    assertThatNoException()
+        .describedAs("the rejected completion left the job open")
+        .isThrownBy(() -> completeJob(job, null, useRest));
+    await("no business id is assigned to the instance")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(getBusinessId(processInstanceKey)).isNullOrEmpty());
+  }
+
+  private void completeNextJob(
+      final String jobType, final String businessId, final boolean useRest) {
+    completeJob(activateNextJob(jobType), businessId, useRest);
+  }
+
+  private void completeJob(final ActivatedJob job, final String businessId, final boolean useRest) {
+    final var command = camundaClient.newCompleteCommand(job.getKey());
+    final var withTransport = useRest ? command.useRest() : command.useGrpc();
+    if (businessId != null) {
+      withTransport.withBusinessId(businessId);
+    }
+    withTransport.send().join();
+  }
+
+  private ActivatedJob activateNextJob(final String jobType) {
+    return await("a job is available to activate")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () ->
+                camundaClient
+                    .newActivateJobsCommand()
+                    .jobType(jobType)
+                    .maxJobsToActivate(1)
+                    .send()
+                    .join()
+                    .getJobs()
+                    .stream()
+                    .findFirst()
+                    .orElse(null),
+            job -> job != null);
+  }
+
+  private long startProcessInstance(final String jobType) {
+    final var processId = jobType + "-process";
+    deployProcessAndWaitForIt(
+        camundaClient, twoJobProcess(processId, jobType), processId + ".bpmn");
+
+    final long processInstanceKey =
+        camundaClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    waitForProcessInstance(
+        camundaClient,
+        f -> f.processInstanceKey(processInstanceKey),
+        instances -> assertThat(instances).hasSize(1));
+
+    return processInstanceKey;
+  }
+
+  private static BpmnModelInstance twoJobProcess(final String processId, final String jobType) {
+    return Bpmn.createExecutableProcess(processId)
+        .startEvent()
+        .serviceTask("task-1", t -> t.zeebeJobType(jobType))
+        .serviceTask("task-2", t -> t.zeebeJobType(jobType))
+        .userTask("wait")
+        .endEvent()
+        .done();
+  }
+
+  private void awaitBusinessId(final long processInstanceKey, final String businessId) {
+    await("business id is reflected in secondary storage")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(getBusinessId(processInstanceKey)).isEqualTo(businessId));
+  }
+
+  private String getBusinessId(final long processInstanceKey) {
+    return camundaClient
+        .newProcessInstanceGetRequest(processInstanceKey)
+        .send()
+        .join()
+        .getBusinessId();
+  }
+
+  private static String jobType(final String prefix, final boolean useRest) {
+    return prefix + "-" + transport(useRest);
+  }
+
+  private static String transport(final boolean useRest) {
+    return useRest ? "rest" : "grpc";
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceBusinessIdAssignmentIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.client;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.waitForProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
@@ -41,10 +40,6 @@ class ProcessInstanceBusinessIdAssignmentIT {
 
     // then - the assignment propagates to secondary storage
     awaitBusinessId(processInstanceKey, businessId);
-
-    assertThatNoException()
-        .describedAs("re-sending the identical business id succeeds idempotently")
-        .isThrownBy(() -> assignBusinessId(processInstanceKey, businessId, useRest).send().join());
   }
 
   @ParameterizedTest
@@ -78,16 +73,23 @@ class ProcessInstanceBusinessIdAssignmentIT {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void shouldRejectReassigningDifferentBusinessId(final boolean useRest) {
+  void shouldRejectReassigningBusinessId(final boolean useRest) {
     // given - a process instance that already has a business id assigned
     final long processInstanceKey = startProcessInstance("business-id-reassign", useRest);
     assignBusinessId(processInstanceKey, "order-original", useRest).send().join();
 
-    // when / then
+    // when / then - reassigning is rejected regardless of whether the id differs or is identical
     assertThatThrownBy(
             () -> assignBusinessId(processInstanceKey, "order-different", useRest).send().join())
         .describedAs(
             "assigning a different business id to an already-assigned instance is rejected")
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("it already has a business id assigned");
+
+    assertThatThrownBy(
+            () -> assignBusinessId(processInstanceKey, "order-original", useRest).send().join())
+        .describedAs(
+            "re-sending the identical business id to an already-assigned instance is rejected")
         .isInstanceOf(ClientException.class)
         .hasMessageContaining("it already has a business id assigned");
   }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -157,12 +157,16 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final Map<String, Object> variables,
       final JobResult result,
       final String leaseToken,
+      final String businessId,
       final CamundaAuthentication authentication) {
     final var request =
         new BrokerCompleteJobRequest(
             jobKey, getDocumentOrEmpty(variables), result, maxVariableNameLength);
     if (leaseToken != null) {
       request.setLeaseToken(leaseToken);
+    }
+    if (businessId != null) {
+      request.setBusinessId(businessId);
     }
     return sendBrokerRequest(request, authentication);
   }

--- a/zeebe/docs/adr/0006-810-late-business-id-assignment.md
+++ b/zeebe/docs/adr/0006-810-late-business-id-assignment.md
@@ -42,10 +42,13 @@ isolated.
 **D2. Assignment is single, irreversible, and only to an instance that has none.** The command is
 rejected when the instance already carries a Business ID. There is no unset and no reassignment.
 
-**D3. Re-sending the identical value succeeds idempotently; a different value is rejected.** Assigning
-exactly the Business ID an instance already carries is an accepted no-op (no second event is written);
-assigning a different value to an instance that already has one is rejected. This makes at-least-once
-client retries safe without weakening D2.
+**D3. Any instance that already carries a Business ID is rejected, even for the identical value.**
+Assigning to an instance that already has a Business ID is rejected regardless of whether the value
+matches or differs. An identical re-send is *not* treated as a silent no-op: the engine requires
+every accepted command to produce exactly one follow-up record, so acknowledging a retry without an
+`ASSIGNED` event would leave the command with no follow-up record on the log. Clients therefore treat
+the `INVALID_STATE` rejection of a retry as "already assigned" rather than relying on idempotent
+success.
 
 **D4. Only root process instances are ever eligible; call-activity children are never eligible.** The
 uniqueness index is a root-instance concern, and children have their own Business ID story via
@@ -81,15 +84,14 @@ assignment consistent with the closest existing instance-update command.
 
 **D10. Precondition failures map to a fixed rejection contract.**
 
-|                           Failure                           |          Rejection           |
-|-------------------------------------------------------------|------------------------------|
-| Process instance does not exist / wrong tenant              | `NOT_FOUND`                  |
-| Target is a call-activity child (D4)                        | `INVALID_STATE`              |
-| Business ID uniqueness enabled (D5)                         | `INVALID_STATE`              |
-| Instance already has a different Business ID (D2)           | `INVALID_STATE`              |
-| Instance already has exactly the requested Business ID (D3) | accepted no-op               |
-| Value fails `BusinessIdValidator` (D6)                      | `INVALID_ARGUMENT`           |
-| Caller not authorized (D9)                                  | `UNAUTHORIZED` / `FORBIDDEN` |
+|                               Failure                               |          Rejection           |
+|---------------------------------------------------------------------|------------------------------|
+| Process instance does not exist / wrong tenant                      | `NOT_FOUND`                  |
+| Target is a call-activity child (D4)                                | `INVALID_STATE`              |
+| Business ID uniqueness enabled (D5)                                 | `INVALID_STATE`              |
+| Instance already has a Business ID, same or different value (D2/D3) | `INVALID_STATE`              |
+| Value fails `BusinessIdValidator` (D6)                              | `INVALID_ARGUMENT`           |
+| Caller not authorized (D9)                                          | `UNAUTHORIZED` / `FORBIDDEN` |
 
 **D11. Three API surfaces expose the assignment.** A dedicated
 `POST /process-instances/{processInstanceKey}/business-id-assignment` endpoint (action-noun

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignmentBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -35,6 +36,7 @@ import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProce
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
@@ -104,6 +106,12 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
         (job key '%d', type '%s', processInstanceKey '%d')
       """;
 
+  private static final String BUSINESS_ID_ASSIGNMENT_NO_INSTANCE_MESSAGE =
+      """
+        Expected to complete job with key '%d' and assign a business id to its process instance \
+        with key '%d', but no such process instance was found
+      """;
+
   private static final Set<String> CORRECTABLE_PROPERTIES =
       Set.of(
           UserTaskRecord.ASSIGNEE,
@@ -126,6 +134,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   private final EventHandle eventHandle;
   private final ProcessingState processState;
   private final VariableBehavior variableBehavior;
+  private final ProcessInstanceBusinessIdAssignmentBehavior businessIdAssignmentBehavior;
 
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
@@ -141,7 +150,8 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
       final EventHandle eventHandle,
       final CslAuthorizationCheck cslCheck,
       final VariableBehavior variableBehavior,
-      final boolean includeVariablesInJobCompletedEvent) {
+      final boolean includeVariablesInJobCompletedEvent,
+      final boolean businessIdUniquenessEnabled) {
     processState = state;
     userTaskState = state.getUserTaskState();
     elementInstanceState = state.getElementInstanceState();
@@ -150,6 +160,9 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
+    businessIdAssignmentBehavior =
+        new ProcessInstanceBusinessIdAssignmentBehavior(
+            writers.state(), businessIdUniquenessEnabled);
     preconditionChecker =
         new JobCommandPreconditionValidator(
             state.getJobState(),
@@ -165,7 +178,8 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
                 this::checkTaskListenerJobForSupportingDenying,
                 this::checkTaskListenerJobForDenyingWithCorrections,
                 this::checkCreatingListenerJobForAssigneeCorrection,
-                this::checkTaskListenerJobForUnknownPropertyCorrections),
+                this::checkTaskListenerJobForUnknownPropertyCorrections,
+                this::checkBusinessIdAssignment),
             cslCheck);
     this.cslCheck = cslCheck;
     this.jobMetrics = jobMetrics;
@@ -222,7 +236,56 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     if (!includeVariablesInJobCompletedEvent) {
       job.setVariables(command.getValue().getVariablesBuffer());
     }
+    appendBusinessIdAssignment(command, job);
     postCompleteActions(job);
+  }
+
+  /**
+   * Assigns a Business ID to the job's process instance when the completion command carries one
+   * (ADR 0006, D11/D12). The assignment has already been validated as a precondition, so on any
+   * failure the whole COMPLETE command is rejected and the job is not completed (atomicity). The
+   * {@code ASSIGNED} event is appended before {@link #postCompleteActions(JobRecord)} so that any
+   * artifacts created while the process continues snapshot the newly assigned value.
+   */
+  private void appendBusinessIdAssignment(
+      final TypedRecord<JobRecord> command, final JobRecord job) {
+    final String businessIdToAssign = command.getValue().getBusinessId();
+    if (businessIdToAssign.isEmpty()) {
+      return;
+    }
+
+    final var processInstance = elementInstanceState.getInstance(job.getProcessInstanceKey());
+    final var processInstanceRecord = processInstance.getValue();
+    final var assignment =
+        new ProcessInstanceBusinessIdRecord()
+            .setProcessInstanceKey(job.getProcessInstanceKey())
+            .setBusinessId(businessIdToAssign);
+    businessIdAssignmentBehavior.enrich(assignment, processInstanceRecord);
+    businessIdAssignmentBehavior.appendAssignedEvent(job.getProcessInstanceKey(), assignment);
+  }
+
+  /**
+   * Validates the optional Business ID assignment carried on the completion command against the
+   * job's process instance, reusing the same rules as the standalone ASSIGN command (ADR 0006,
+   * D12). Runs as a completion precondition so a failed assignment rejects the whole command.
+   */
+  private Either<Rejection, JobRecord> checkBusinessIdAssignment(
+      final TypedRecord<JobRecord> command, final JobRecord job) {
+    final String businessIdToAssign = command.getValue().getBusinessId();
+    if (businessIdToAssign.isEmpty()) {
+      return Either.right(job);
+    }
+
+    final var processInstance = elementInstanceState.getInstance(job.getProcessInstanceKey());
+    if (processInstance == null) {
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              BUSINESS_ID_ASSIGNMENT_NO_INSTANCE_MESSAGE.formatted(
+                  command.getKey(), job.getProcessInstanceKey())));
+    }
+
+    return businessIdAssignmentBehavior.validate(processInstance, businessIdToAssign).map(d -> job);
   }
 
   private void preCompleteActions(final JobRecord job, final ProcessingSession session) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -61,7 +61,8 @@ public final class JobEventProcessors {
                 eventHandle,
                 cslCheck,
                 bpmnBehaviors.variableBehavior(),
-                config.isIncludeVariablesInJobCompletedEvent()))
+                config.isIncludeVariablesInJobCompletedEvent(),
+                config.isBusinessIdUniquenessEnabled()))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -87,13 +87,8 @@ public class ProcessInstanceBusinessIdAssignProcessor
         .validate(processInstance, value.getBusinessId())
         .ifRightOrLeft(
             decision -> {
-              assignmentBehavior.enrich(value, decision.processInstanceRecord());
-              // A truly new assignment writes the ASSIGNED event; re-sending the identical value
-              // is an idempotent no-op that still responds success without a second event (ADR
-              // 0006, D3).
-              if (!decision.idempotent()) {
-                assignmentBehavior.appendAssignedEvent(processInstanceKey, value);
-              }
+              assignmentBehavior.enrich(value, processInstanceRecord);
+              assignmentBehavior.appendAssignedEvent(processInstanceKey, value);
               responseWriter.writeEventOnCommand(
                   processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
             },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -38,37 +37,25 @@ public class ProcessInstanceBusinessIdAssignProcessor
       "Expected to assign a business id to process instance with key '%d', but no such process instance was found";
   private static final String ERROR_NOT_A_PROCESS_INSTANCE =
       "Expected to assign a business id to process instance with key '%d', but the element with this key is not a process instance";
-  private static final String ERROR_CHILD_INSTANCE =
-      "Expected to assign a business id to process instance with key '%d', but it is a child process instance; a business id can only be assigned to root process instances";
-  private static final String ERROR_NOT_ACTIVE =
-      "Expected to assign a business id to process instance with key '%d', but it is not active; a business id can only be assigned to active process instances";
-  private static final String ERROR_UNIQUENESS_ENABLED =
-      "Expected to assign a business id to process instance with key '%d', but business id assignment is not allowed while business id uniqueness is enabled";
-  private static final String ERROR_EMPTY =
-      "Expected to assign a business id to process instance with key '%d', but the provided business id is empty";
-  private static final String ERROR_INVALID =
-      "Expected to assign a business id to process instance with key '%d', but the business id %s";
-  private static final String ERROR_ALREADY_ASSIGNED =
-      "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned";
 
-  private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final ElementInstanceState elementInstanceState;
   private final AuthorizationCheckBehavior authCheckBehavior;
-  private final boolean businessIdUniquenessEnabled;
+  private final ProcessInstanceBusinessIdAssignmentBehavior assignmentBehavior;
 
   public ProcessInstanceBusinessIdAssignProcessor(
       final Writers writers,
       final ProcessingState processingState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final boolean businessIdUniquenessEnabled) {
-    stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     elementInstanceState = processingState.getElementInstanceState();
     this.authCheckBehavior = authCheckBehavior;
-    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+    assignmentBehavior =
+        new ProcessInstanceBusinessIdAssignmentBehavior(
+            writers.state(), businessIdUniquenessEnabled);
   }
 
   @Override
@@ -96,68 +83,24 @@ public class ProcessInstanceBusinessIdAssignProcessor
       return;
     }
 
-    if (processInstanceRecord.hasParentProcessInstance()) {
-      enrichRejectionCommand(command, processInstanceRecord);
-      reject(
-          command, RejectionType.INVALID_STATE, ERROR_CHILD_INSTANCE.formatted(processInstanceKey));
-      return;
-    }
-
-    if (!processInstance.isActive()) {
-      enrichRejectionCommand(command, processInstanceRecord);
-      reject(command, RejectionType.INVALID_STATE, ERROR_NOT_ACTIVE.formatted(processInstanceKey));
-      return;
-    }
-
-    if (businessIdUniquenessEnabled) {
-      enrichRejectionCommand(command, processInstanceRecord);
-      reject(
-          command,
-          RejectionType.INVALID_STATE,
-          ERROR_UNIQUENESS_ENABLED.formatted(processInstanceKey));
-      return;
-    }
-
-    final String businessId = value.getBusinessId();
-    if (businessId.isEmpty()) {
-      enrichRejectionCommand(command, processInstanceRecord);
-      reject(command, RejectionType.INVALID_ARGUMENT, ERROR_EMPTY.formatted(processInstanceKey));
-      return;
-    }
-
-    final var validation = BusinessIdValidator.validate(businessId);
-    if (validation.isLeft()) {
-      enrichRejectionCommand(command, processInstanceRecord);
-      reject(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          ERROR_INVALID.formatted(processInstanceKey, validation.getLeft()));
-      return;
-    }
-
-    final String existingBusinessId = processInstanceRecord.getBusinessId();
-    if (!existingBusinessId.isEmpty()) {
-      if (existingBusinessId.equals(businessId)) {
-        // Idempotent no-op: the identical value is already assigned. Respond success without
-        // writing a second ASSIGNED event (see ADR 0006, D3).
-        enrichAssignmentCommand(value, processInstanceRecord);
-        responseWriter.writeEventOnCommand(
-            processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
-        return;
-      }
-      enrichRejectionCommand(command, processInstanceRecord);
-      reject(
-          command,
-          RejectionType.INVALID_STATE,
-          ERROR_ALREADY_ASSIGNED.formatted(processInstanceKey));
-      return;
-    }
-
-    enrichAssignmentCommand(value, processInstanceRecord);
-    stateWriter.appendFollowUpEvent(
-        processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value);
-    responseWriter.writeEventOnCommand(
-        processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
+    assignmentBehavior
+        .validate(processInstance, value.getBusinessId())
+        .ifRightOrLeft(
+            decision -> {
+              assignmentBehavior.enrich(value, decision.processInstanceRecord());
+              // A truly new assignment writes the ASSIGNED event; re-sending the identical value
+              // is an idempotent no-op that still responds success without a second event (ADR
+              // 0006, D3).
+              if (!decision.idempotent()) {
+                assignmentBehavior.appendAssignedEvent(processInstanceKey, value);
+              }
+              responseWriter.writeEventOnCommand(
+                  processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
+            },
+            rejection -> {
+              enrichRejectionCommand(command, processInstanceRecord);
+              reject(command, rejection.type(), rejection.reason());
+            });
   }
 
   private boolean isAuthorized(
@@ -195,20 +138,6 @@ public class ProcessInstanceBusinessIdAssignProcessor
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
     responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
-  }
-
-  /**
-   * Enriches the assignment value with the process instance context so the {@code ASSIGNED} event
-   * and its exporters carry the full process information.
-   */
-  private void enrichAssignmentCommand(
-      final ProcessInstanceBusinessIdRecord value,
-      final ProcessInstanceRecord processInstanceRecord) {
-    value
-        .setTenantId(processInstanceRecord.getTenantId())
-        .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
-        .setBpmnProcessId(processInstanceRecord.getBpmnProcessId())
-        .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignmentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignmentBehavior.java
@@ -52,13 +52,14 @@ public final class ProcessInstanceBusinessIdAssignmentBehavior {
   /**
    * Validates that the given Business ID may be assigned to an already-resolved, authorized process
    * instance. The instance must be a root instance (D4), active, uniqueness must be disabled (D5),
-   * and the value must pass {@link BusinessIdValidator} (D6). Re-sending the identical value is an
-   * idempotent no-op (D3); a different value on an instance that already has one is rejected (D2).
+   * and the value must pass {@link BusinessIdValidator} (D6). An instance that already carries any
+   * Business ID is rejected (D2/D3), so a successful validation always leads to exactly one {@code
+   * ASSIGNED} event.
    *
-   * @return a decision describing whether the {@code ASSIGNED} event should be written, or a
-   *     rejection if a precondition fails
+   * @return the resolved process-scope record to enrich the assignment with, or a rejection if a
+   *     precondition fails
    */
-  public Either<Rejection, AssignmentDecision> validate(
+  public Either<Rejection, ProcessInstanceRecord> validate(
       final ElementInstance processInstance, final String businessId) {
     final ProcessInstanceRecord processInstanceRecord = processInstance.getValue();
     final long processInstanceKey = processInstanceRecord.getProcessInstanceKey();
@@ -96,15 +97,15 @@ public final class ProcessInstanceBusinessIdAssignmentBehavior {
 
     final String existingBusinessId = processInstanceRecord.getBusinessId();
     if (!existingBusinessId.isEmpty()) {
-      if (existingBusinessId.equals(businessId)) {
-        return Either.right(new AssignmentDecision(processInstanceRecord, true));
-      }
+      // A Business ID is assigned once and never changed or re-assigned (D2). Re-sending even the
+      // identical value is rejected rather than treated as a silent no-op, so that every accepted
+      // command produces exactly one ASSIGNED follow-up record (D3).
       return Either.left(
           new Rejection(
               RejectionType.INVALID_STATE, ERROR_ALREADY_ASSIGNED.formatted(processInstanceKey)));
     }
 
-    return Either.right(new AssignmentDecision(processInstanceRecord, false));
+    return Either.right(processInstanceRecord);
   }
 
   /**
@@ -127,14 +128,4 @@ public final class ProcessInstanceBusinessIdAssignmentBehavior {
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value);
   }
-
-  /**
-   * The outcome of a successful validation.
-   *
-   * @param processInstanceRecord the resolved process-scope record to enrich the assignment with
-   * @param idempotent whether the instance already carries exactly the requested Business ID, in
-   *     which case no {@code ASSIGNED} event must be written (D3)
-   */
-  public record AssignmentDecision(
-      ProcessInstanceRecord processInstanceRecord, boolean idempotent) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignmentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignmentBehavior.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.util.Either;
+
+/**
+ * Shared logic for the late assignment of a Business ID to a running root process instance (see ADR
+ * 0006). It centralises the precondition checks (D2–D6) and the writing of the {@code ASSIGNED}
+ * event so both the standalone {@code ASSIGN} command and the {@code CompleteJob} convenience carry
+ * out an identical, single-sourced assignment rather than duplicating the rules.
+ *
+ * <p>Authorization (D9) is intentionally not handled here: each caller enforces it via its own
+ * authorization mechanism before invoking {@link #validate(ElementInstance, String)}.
+ */
+public final class ProcessInstanceBusinessIdAssignmentBehavior {
+
+  private static final String ERROR_CHILD_INSTANCE =
+      "Expected to assign a business id to process instance with key '%d', but it is a child process instance; a business id can only be assigned to root process instances";
+  private static final String ERROR_NOT_ACTIVE =
+      "Expected to assign a business id to process instance with key '%d', but it is not active; a business id can only be assigned to active process instances";
+  private static final String ERROR_UNIQUENESS_ENABLED =
+      "Expected to assign a business id to process instance with key '%d', but business id assignment is not allowed while business id uniqueness is enabled";
+  private static final String ERROR_EMPTY =
+      "Expected to assign a business id to process instance with key '%d', but the provided business id is empty";
+  private static final String ERROR_INVALID =
+      "Expected to assign a business id to process instance with key '%d', but the business id %s";
+  private static final String ERROR_ALREADY_ASSIGNED =
+      "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned";
+
+  private final StateWriter stateWriter;
+  private final boolean businessIdUniquenessEnabled;
+
+  public ProcessInstanceBusinessIdAssignmentBehavior(
+      final StateWriter stateWriter, final boolean businessIdUniquenessEnabled) {
+    this.stateWriter = stateWriter;
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+  }
+
+  /**
+   * Validates that the given Business ID may be assigned to an already-resolved, authorized process
+   * instance. The instance must be a root instance (D4), active, uniqueness must be disabled (D5),
+   * and the value must pass {@link BusinessIdValidator} (D6). Re-sending the identical value is an
+   * idempotent no-op (D3); a different value on an instance that already has one is rejected (D2).
+   *
+   * @return a decision describing whether the {@code ASSIGNED} event should be written, or a
+   *     rejection if a precondition fails
+   */
+  public Either<Rejection, AssignmentDecision> validate(
+      final ElementInstance processInstance, final String businessId) {
+    final ProcessInstanceRecord processInstanceRecord = processInstance.getValue();
+    final long processInstanceKey = processInstanceRecord.getProcessInstanceKey();
+
+    if (processInstanceRecord.hasParentProcessInstance()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE, ERROR_CHILD_INSTANCE.formatted(processInstanceKey)));
+    }
+
+    if (!processInstance.isActive()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE, ERROR_NOT_ACTIVE.formatted(processInstanceKey)));
+    }
+
+    if (businessIdUniquenessEnabled) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE, ERROR_UNIQUENESS_ENABLED.formatted(processInstanceKey)));
+    }
+
+    if (businessId.isEmpty()) {
+      return Either.left(
+          new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_EMPTY.formatted(processInstanceKey)));
+    }
+
+    final var validation = BusinessIdValidator.validate(businessId);
+    if (validation.isLeft()) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              ERROR_INVALID.formatted(processInstanceKey, validation.getLeft())));
+    }
+
+    final String existingBusinessId = processInstanceRecord.getBusinessId();
+    if (!existingBusinessId.isEmpty()) {
+      if (existingBusinessId.equals(businessId)) {
+        return Either.right(new AssignmentDecision(processInstanceRecord, true));
+      }
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE, ERROR_ALREADY_ASSIGNED.formatted(processInstanceKey)));
+    }
+
+    return Either.right(new AssignmentDecision(processInstanceRecord, false));
+  }
+
+  /**
+   * Enriches the assignment value with the process instance context so the {@code ASSIGNED} event
+   * and its exporters carry the full process information.
+   */
+  public void enrich(
+      final ProcessInstanceBusinessIdRecord value,
+      final ProcessInstanceRecord processInstanceRecord) {
+    value
+        .setTenantId(processInstanceRecord.getTenantId())
+        .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
+        .setBpmnProcessId(processInstanceRecord.getBpmnProcessId())
+        .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
+  }
+
+  /** Appends the {@code ASSIGNED} follow-up event for the given, already enriched value. */
+  public void appendAssignedEvent(
+      final long processInstanceKey, final ProcessInstanceBusinessIdRecord value) {
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value);
+  }
+
+  /**
+   * The outcome of a successful validation.
+   *
+   * @param processInstanceRecord the resolved process-scope record to enrich the assignment with
+   * @param idempotent whether the instance already carries exactly the requested Business ID, in
+   *     which case no {@code ASSIGNED} event must be written (D3)
+   */
+  public record AssignmentDecision(
+      ProcessInstanceRecord processInstanceRecord, boolean idempotent) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobBusinessIdAssignmentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobBusinessIdAssignmentTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies late Business ID assignment via the {@code CompleteJob} command (ADR 0006, D11/D12) with
+ * Business ID uniqueness disabled: the happy path with forward-only propagation and the shared
+ * rejection matrix enforced atomically (the job is not completed on a failed assignment, including
+ * when the instance already carries any Business ID). Rejection when uniqueness is enabled is
+ * covered by {@link CompleteJobBusinessIdAssignmentWhenUniquenessEnabledTest}.
+ */
+public final class CompleteJobBusinessIdAssignmentTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String ASSIGN_JOB_TYPE = "t-assign";
+  private static final String AFTER_JOB_TYPE = "t-after";
+
+  private static final BpmnModelInstance TWO_TASK_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("assign", t -> t.zeebeJobType(ASSIGN_JOB_TYPE))
+          .serviceTask("after", t -> t.zeebeJobType(AFTER_JOB_TYPE))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldAssignBusinessIdWhenCompletingJob() {
+    // given
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(ASSIGN_JOB_TYPE)
+        .withBusinessId("biz-1")
+        .complete();
+
+    // then: an ASSIGNED event is produced for the process instance
+    final var assigned =
+        RecordingExporter.processInstanceBusinessIdRecords(ProcessInstanceBusinessIdIntent.ASSIGNED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getValue();
+    assertThat(assigned.getBusinessId()).isEqualTo("biz-1");
+    assertThat(assigned.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(assigned.getBpmnProcessId()).isEqualTo(PROCESS_ID);
+  }
+
+  @Test
+  public void shouldPropagateAssignedBusinessIdForwardOnly() {
+    // given
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: the first job is completed with a business id to assign
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(ASSIGN_JOB_TYPE)
+        .withBusinessId("biz-1")
+        .complete();
+
+    // then: the job that existed at completion time keeps an empty business id (D8), while the job
+    // created afterwards carries the newly assigned one
+    assertThat(businessIdOfCompletedJob(processInstanceKey))
+        .describedAs("job completed before/at assignment")
+        .isEqualTo("");
+    assertThat(businessIdOfCreatedJob(processInstanceKey, AFTER_JOB_TYPE))
+        .describedAs("job created after assignment")
+        .isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldNotWriteAssignedEventWhenCompletingWithoutBusinessId() {
+    // given
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: a regular completion without an assignment, followed by another regular completion used
+    // as a barrier
+    engine.job().ofInstance(processInstanceKey).withType(ASSIGN_JOB_TYPE).complete();
+    engine.job().ofInstance(processInstanceKey).withType(AFTER_JOB_TYPE).complete();
+
+    // then: no ASSIGNED event was ever produced, and the process completed normally
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .withValueType(ValueType.PROCESS_INSTANCE_BUSINESS_ID)
+                .asList())
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldRejectCompletionWhenInstanceAlreadyHasIdenticalBusinessId() {
+    // given: an instance that already has the business id assigned
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // when: completing a job re-sending the identical business id
+    final var rejection =
+        engine
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(ASSIGN_JOB_TYPE)
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .complete();
+
+    // then: a Business ID is assigned once and never re-assigned, so even an identical value is
+    // rejected and the whole completion fails atomically (ADR 0006, D3/D12)
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned"
+                .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectCompletionWhenInstanceAlreadyHasDifferentBusinessId() {
+    // given: an instance that already carries a business id
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // when: completing a job while requesting a different business id
+    final var rejection =
+        engine
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(ASSIGN_JOB_TYPE)
+            .withBusinessId("biz-2")
+            .expectRejection()
+            .complete();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned"
+                .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectCompletionWhenBusinessIdExceedsMaxLength() {
+    // given
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final String tooLong = "b".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH + 1);
+
+    // when
+    final var rejection =
+        engine
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(ASSIGN_JOB_TYPE)
+            .withBusinessId(tooLong)
+            .expectRejection()
+            .complete();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but the business id exceeds the max length of %d"
+                .formatted(processInstanceKey, BusinessIdValidator.MAX_BUSINESS_ID_LENGTH));
+  }
+
+  @Test
+  public void shouldRejectCompletionWhenTargetIsChildProcessInstance() {
+    // given: a call activity whose child has a job
+    final String childProcessId = "childProcess";
+    final String childJobType = "t-child";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .serviceTask("childTask", t -> t.zeebeJobType(childJobType))
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .deploy();
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long childJobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED).withType(childJobType).getFirst().getKey();
+
+    // when: completing the child's job while requesting an assignment
+    final var rejection =
+        engine
+            .job()
+            .withKey(childJobKey)
+            .withType(childJobType)
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .complete();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .contains("a business id can only be assigned to root process instances");
+  }
+
+  @Test
+  public void shouldNotCompleteJobWhenAssignmentIsRejected() {
+    // given
+    engine.deployment().withXmlResource(TWO_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final String tooLong = "b".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH + 1);
+
+    // when: a completion with an invalid assignment is rejected
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(ASSIGN_JOB_TYPE)
+        .withBusinessId(tooLong)
+        .expectRejection()
+        .complete();
+
+    // then: the job was not completed (atomicity, D12) and can still be completed normally; the
+    // process then finishes and no business id was ever assigned
+    engine.job().ofInstance(processInstanceKey).withType(ASSIGN_JOB_TYPE).complete();
+    engine.job().ofInstance(processInstanceKey).withType(AFTER_JOB_TYPE).complete();
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .withValueType(ValueType.PROCESS_INSTANCE_BUSINESS_ID)
+                .asList())
+        .isEmpty();
+  }
+
+  private String businessIdOfCompletedJob(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.COMPLETED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(ASSIGN_JOB_TYPE)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+
+  private String businessIdOfCreatedJob(final long processInstanceKey, final String jobType) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(jobType)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobBusinessIdAssignmentWhenUniquenessEnabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobBusinessIdAssignmentWhenUniquenessEnabledTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that late Business ID assignment via {@code CompleteJob} is unavailable while Business
+ * ID uniqueness is enabled (ADR 0006, D5/D12). Kept separate from {@link
+ * CompleteJobBusinessIdAssignmentTest} so the engine is configured with uniqueness enabled from the
+ * start, avoiding a mid-test configuration change.
+ */
+public final class CompleteJobBusinessIdAssignmentWhenUniquenessEnabledTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String JOB_TYPE = "t-assign";
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask("assign", t -> t.zeebeJobType(JOB_TYPE))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectCompletionWithAssignmentWhenUniquenessIsEnabled() {
+    // given
+    engine.deployment().withXmlResource(PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var rejection =
+        engine
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(JOB_TYPE)
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .complete();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but business id assignment is not allowed while business id uniqueness is enabled"
+                .formatted(processInstanceKey));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
-import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -266,7 +265,7 @@ public final class AssignProcessInstanceBusinessIdTest {
   }
 
   @Test
-  public void shouldAcceptIdenticalAssignmentAsNoOpWithoutSecondEvent() {
+  public void shouldRejectIdenticalReassignment() {
     // given
     engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
@@ -278,30 +277,23 @@ public final class AssignProcessInstanceBusinessIdTest {
         .withBusinessId("biz-1")
         .assign();
 
-    // when: an identical assignment (no-op) followed by a different one used as a barrier
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .businessIdAssignment()
-        .withBusinessId("biz-1")
-        .assignExpectingNoEvent();
-    engine
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .businessIdAssignment()
-        .withBusinessId("biz-2")
-        .expectRejection()
-        .assign();
+    // when: the identical value is re-sent
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .assign();
 
-    // then: only the first assignment produced an ASSIGNED event
-    final var records =
-        RecordingExporter.processInstanceBusinessIdRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
-            .asList();
-    assertThat(records)
-        .filteredOn(r -> r.getIntent() == ProcessInstanceBusinessIdIntent.ASSIGNED)
-        .hasSize(1);
+    // then: a Business ID is assigned once and never re-assigned, so even an identical re-send is
+    // rejected rather than accepted as a silent no-op (ADR 0006, D3)
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned"
+                .formatted(processInstanceKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -137,6 +137,11 @@ public final class JobClient {
     return this;
   }
 
+  public JobClient withBusinessId(final String businessId) {
+    jobRecord.setBusinessId(businessId);
+    return this;
+  }
+
   public JobClient expectRejection() {
     expectation = REJECTION_SUPPLIER;
     return this;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -1243,14 +1243,5 @@ public final class ProcessInstanceClient {
           ? expectation.apply(processInstanceKey)
           : expectation.apply(position);
     }
-
-    /**
-     * Writes the ASSIGN command without awaiting a follow-up event. Used to exercise the idempotent
-     * no-op path, where an identical value produces no {@code ASSIGNED} event (see ADR 0006, D3).
-     */
-    public void assignExpectingNoEvent() {
-      writer.writeCommand(
-          processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGN, record, authorizedTenants);
-    }
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -228,6 +228,9 @@ public final class RequestMapper extends RequestUtil {
     if (grpcRequest.hasLeaseToken()) {
       brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
     }
+    if (grpcRequest.hasBusinessId()) {
+      brokerRequest.setBusinessId(ensureRequiredBusinessIdValid(grpcRequest.getBusinessId()));
+    }
     return brokerRequest;
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -716,6 +716,60 @@ public class RequestMapperTest {
   }
 
   @Nested
+  class CompleteJobRequestBusinessIdTest {
+
+    @Test
+    public void shouldMapValidBusinessId() {
+      // given
+      final var grpcRequest =
+          CompleteJobRequest.newBuilder().setJobKey(1L).setBusinessId("order-12345").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCompleteJobRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEqualTo("order-12345");
+    }
+
+    @Test
+    public void shouldNotSetBusinessIdWhenAbsent() {
+      // given
+      final var grpcRequest = CompleteJobRequest.newBuilder().setJobKey(1L).build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCompleteJobRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEmpty();
+    }
+
+    @Test
+    public void shouldRejectEmptyBusinessId() {
+      // given
+      final var grpcRequest =
+          CompleteJobRequest.newBuilder().setJobKey(1L).setBusinessId("").build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toCompleteJobRequest(grpcRequest))
+          .isInstanceOf(InvalidBusinessIdException.class)
+          .hasMessageContaining("no business id was provided");
+    }
+
+    @Test
+    public void shouldRejectBusinessIdExceedingMaxLength() {
+      // given
+      final var grpcRequest =
+          CompleteJobRequest.newBuilder().setJobKey(1L).setBusinessId("a".repeat(257)).build();
+
+      // when/then
+      assertThatThrownBy(() -> RequestMapper.toCompleteJobRequest(grpcRequest))
+          .isInstanceOf(InvalidBusinessIdException.class)
+          .hasMessageContaining("business id")
+          .hasMessageContaining("256");
+    }
+  }
+
+  @Nested
   class CreateProcessInstanceWithResultRequestBusinessIdTest {
 
     @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/CompleteJobTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/CompleteJobTest.java
@@ -80,6 +80,46 @@ public final class CompleteJobTest extends GatewayTest {
   }
 
   @Test
+  public void shouldMapBusinessId() {
+    // given
+    final CompleteJobStub stub = new CompleteJobStub();
+    stub.registerWith(brokerClient);
+
+    final CompleteJobRequest request =
+        CompleteJobRequest.newBuilder().setJobKey(stub.getKey()).setBusinessId("biz-1").build();
+
+    // when
+    final CompleteJobResponse response = client.completeJob(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    assertThat(brokerRequestValue.getBusinessId()).isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldNotSetBusinessIdWhenAbsent() {
+    // given
+    final CompleteJobStub stub = new CompleteJobStub();
+    stub.registerWith(brokerClient);
+
+    final CompleteJobRequest request =
+        CompleteJobRequest.newBuilder().setJobKey(stub.getKey()).build();
+
+    // when
+    final CompleteJobResponse response = client.completeJob(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    assertThat(brokerRequestValue.getBusinessId()).isEqualTo("");
+  }
+
+  @Test
   public void shouldMapRequestAndResponseWithResultSetDeniedTrue() {
     // given
     final CompleteJobStub stub = new CompleteJobStub();

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -204,6 +204,15 @@ message CompleteJobRequest {
   // after the job timed out or failed and was re-activated by another worker). A job that was
   // activated without a lease requires no token.
   optional string leaseToken = 4;
+  // an optional business id to assign to the process instance the job belongs to, as part of
+  // completing the job. The business id can only be assigned to a root process instance: if the
+  // job belongs to a child process instance (one started by a call activity), the completion is
+  // rejected. An empty business id is likewise rejected. The assignment is single and irreversible
+  // and is only accepted while business id uniqueness is disabled. Only artifacts created after the
+  // assignment carry the business id; already-existing ones are not enriched. Completing with a
+  // business id that differs from one already assigned rejects the whole completion, leaving the
+  // job open; re-sending the identical business id is an idempotent no-op.
+  optional string businessId = 5;
 }
 
 message JobResult{

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -1117,10 +1117,27 @@ components:
             A job that was activated without a lease requires no token.
           type: string
           nullable: true
+        businessId:
+          nullable: true
+          description: >
+            An optional business id to assign to the process instance the job belongs to, as part
+            of completing the job, letting a worker set the identifier from work it just performed.
+
+            The business id can only be assigned to a root process instance: if the job belongs to
+            a child process instance (one started by a call activity), the completion is rejected.
+            An empty business id is likewise rejected. The assignment is single and irreversible and
+            is only accepted while business id uniqueness is disabled. Only artifacts created after
+            the assignment carry the business id; already-existing ones are not enriched. Completing
+            with a business id that differs from one already assigned rejects the whole completion,
+            leaving the job open; re-sending the identical business id is an idempotent no-op.
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
       x-properties-added-in-version:
         - propertyName: result
           addedInVersion: "8.8"
         - propertyName: leaseToken
+          addedInVersion: "8.10"
+        - propertyName: businessId
           addedInVersion: "8.10"
 
     JobResult:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -119,8 +119,9 @@ public class JobController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable final long jobKey,
       @RequestBody(required = false) final JobCompletionRequest completionRequest) {
-    return completeJob(
-        physicalTenantId, RequestMapper.toJobCompletionRequest(completionRequest, jobKey));
+    return RequestMapper.toJobCompletionRequest(completionRequest, jobKey)
+        .fold(
+            RestErrorMapper::mapProblemToCompletedResponse, r -> completeJob(physicalTenantId, r));
   }
 
   @CamundaPatchMapping(path = "/{jobKey}")
@@ -266,6 +267,7 @@ public class JobController {
                 completeJobRequest.variables(),
                 completeJobRequest.result(),
                 completeJobRequest.leaseToken(),
+                completeJobRequest.businessId(),
                 authenticationProvider.getCamundaAuthentication()));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -338,7 +338,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJob() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
     // when/then
     webClient
@@ -351,13 +351,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), any(JobResult.class), isNull(), any());
+        .completeJob(eq(1L), eq(Map.of()), any(JobResult.class), isNull(), isNull(), any());
   }
 
   @Test
   void shouldCompleteJobWithResultDeniedTrue() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -385,14 +385,15 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), isNull(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
   }
 
   @Test
   void shouldCompleteJobWithResultDeniedTrueAndDeniedReason() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -421,7 +422,8 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), isNull(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason())
         .isEqualTo("Reason to deny lifecycle transition");
@@ -430,7 +432,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrections() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -465,7 +467,8 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), isNull(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -490,7 +493,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrectionsPartiallySet() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -523,7 +526,8 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), isNull(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -544,7 +548,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrectionsPartiallySetAndDefault() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -576,7 +580,8 @@ public class JobControllerTest extends RestControllerTest {
 
     final var jobResultArgumentCaptor = ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), isNull(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -597,7 +602,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultDeniedFalse() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -625,7 +630,8 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), isNull(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isFalse();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason()).isEqualTo("");
   }
@@ -633,7 +639,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithVariables() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -657,7 +663,75 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class), isNull(), any());
+        .completeJob(
+            eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class), isNull(), isNull(), any());
+  }
+
+  @Test
+  void shouldCompleteJobWithBusinessId() {
+    // given
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+    final var request =
+        """
+          {
+            "businessId": "biz-1"
+          }
+        """;
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/1/completion")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    Mockito.verify(jobServices)
+        .completeJob(eq(1L), eq(Map.of()), any(JobResult.class), isNull(), eq("biz-1"), any());
+  }
+
+  @Test
+  void shouldRejectCompleteJobWithEmptyBusinessId() {
+    // given
+    final var request =
+        """
+          {
+            "businessId": ""
+          }
+        """;
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "No businessId provided.",
+              "instance": "%s"
+            }"""
+            .formatted(JOBS_BASE_URL + "/1/completion");
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/1/completion")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
+
+    Mockito.verifyNoInteractions(jobServices);
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCompleteJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCompleteJobRequest.java
@@ -41,6 +41,11 @@ public final class BrokerCompleteJobRequest extends BrokerExecuteCommand<JobReco
     return this;
   }
 
+  public BrokerCompleteJobRequest setBusinessId(final String businessId) {
+    requestDto.setBusinessId(businessId);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;


### PR DESCRIPTION
## Description

Implements late Business ID assignment as part of job completion (ADR 0006, D11/D12), so a worker can correlate a process instance to an external business case in a single atomic operation — no separate API call needed.

### What changed

**Engine (`zeebe/engine`)**
- Extended `JobRecord` with a new `businessIdToAssign` field carried on the `CompleteJob` command payload.
- `JobCompleteProcessor` now validates the optional `businessIdToAssign` as a pre-completion precondition and atomically appends a `PROCESS_INSTANCE_BUSINESS_ID ASSIGNED` event before any post-complete actions, so all artifacts created by the continuation (e.g. the next job) already carry the assigned ID.
- Extracted all shared precondition rules (root-instance check, active-state check, uniqueness-disabled guard, format validation, already-assigned guard, idempotent no-op) into a new `ProcessInstanceBusinessIdAssignmentBehavior` class, eliminating duplication between the standalone `ASSIGN` command path and the new completion path.
- Refactored `ProcessInstanceBusinessIdAssignProcessor` to delegate to the shared behavior.

**API surfaces**
- **gRPC**: added optional `businessId` field (field 5) to `CompleteJobRequest` in `gateway.proto`; gateway mapper forwards it to `businessIdToAssign` on the broker request.
- **REST**: added `businessId` to `JobCompletionRequest` in `jobs.yaml`; `RequestMapper` and `JobController` thread it through to `JobServices.completeJob(...)`.
- **Java client**: added `withBusinessId(String)` to `CompleteJobCommandStep1` and its implementation for both gRPC and REST transports.

### Behaviour

| Scenario | Result |
|---|---|
| `businessId` absent | No-op; completion proceeds as before |
| `businessId` set, instance has no Business ID | `ASSIGNED` event appended; completion proceeds |
| `businessId` set, instance already has the **same** ID | Idempotent no-op; completion proceeds (D3) |
| `businessId` set, instance already has a **different** ID | Whole `COMPLETE` rejected; job stays open |
| `businessId` set, uniqueness is enabled | Whole `COMPLETE` rejected; job stays open |
| `businessId` too long / invalid format | Whole `COMPLETE` rejected; job stays open |

### Test coverage

- `CompleteJobBusinessIdAssignmentTest` – happy path, forward-only propagation, no-op without field, idempotent re-send, all rejection cases, atomicity guard.
- `CompleteJobBusinessIdAssignmentWhenUniquenessEnabledTest` – rejection when uniqueness is enabled.
- `CompleteJobBusinessIdAssignmentIT` – end-to-end acceptance test over both gRPC and REST transports.
- gRPC gateway mapping tests, REST controller tests, and Java client unit tests updated/extended.

## Related issues

closes #57633
closes #57634