### PR TITLE
feat: validate AWS Secrets Manager connectivity at startup

### DIFF
--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
@@ -76,8 +76,10 @@ public final class AwsSecretsManagerSecretStore
   }
 
   /**
-   * Builds a store from configuration, eagerly constructing the underlying client. Building the
-   * client validates the region and endpoint at startup, failing fast on misconfiguration.
+   * Builds a store from configuration, eagerly constructing the underlying client and validating
+   * connectivity/credentials with a minimal AWS call. Failing fast here means a bad region,
+   * unreachable endpoint, or invalid/missing credentials surfaces immediately at startup instead of
+   * being deferred to the first real {@link #resolve} or {@link #list} call.
    */
   public static AwsSecretsManagerSecretStore fromConfig(final AwsSecretsManagerStoreConfig config) {
     final var builder =
@@ -104,7 +106,25 @@ public final class AwsSecretsManagerSecretStore
       throw new SecretStoreUnavailableException(
           "Failed to initialize AWS Secrets Manager client: " + e.getMessage(), e);
     }
+    validateConnectivity(client);
     return new AwsSecretsManagerSecretStore(client, config.pathPrefix());
+  }
+
+  /**
+   * Proves the client can authenticate and reach AWS Secrets Manager with a minimal call. Closes
+   * the client and fails fast on any error, rather than leaving misconfiguration (bad
+   * region/credentials/network) to surface on the first real {@link #resolve} or {@link #list}.
+   */
+  private static void validateConnectivity(final SecretsManagerClient client) {
+    try {
+      client.listSecrets(ListSecretsRequest.builder().maxResults(1).build());
+    } catch (final RuntimeException e) {
+      client.close();
+      throw new SecretStoreUnavailableException(
+          "Failed to validate AWS Secrets Manager connectivity/credentials at startup: "
+              + e.getMessage(),
+          e);
+    }
   }
 
   @Override

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreIT.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreIT.java
@@ -8,10 +8,12 @@
 package io.camunda.secretstore.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
 import java.net.URI;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
@@ -137,7 +139,8 @@ class AwsSecretsManagerSecretStoreIT {
   @Test
   void shouldResolveViaFromConfigIdentityPath() {
     // given — exercise the production build path (DefaultCredentialsProvider) with
-    // credentials supplied via system properties, mirroring how a pod identity injects them
+    // credentials supplied via system properties, mirroring how a pod identity injects them.
+    // fromConfig() succeeding at all already proves its startup connectivity validation passed.
     System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
     System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
     try {
@@ -159,6 +162,30 @@ class AwsSecretsManagerSecretStoreIT {
             .extracting(r -> ((Resolved) r).value())
             .isEqualTo("tok3n");
       }
+    } finally {
+      System.clearProperty("aws.accessKeyId");
+      System.clearProperty("aws.secretAccessKey");
+    }
+  }
+
+  @Test
+  void shouldFailFastOnUnreachableEndpoint() {
+    // given — an endpoint nothing listens on, mimicking a network/DNS misconfiguration
+    System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
+    System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
+    try {
+      final var config =
+          new AwsSecretsManagerStoreConfig(
+              LOCALSTACK.getRegion(),
+              "camunda/",
+              URI.create("http://127.0.0.1:1"),
+              // fail fast, don't waste the test retrying an already-deterministic connection
+              // refusal
+              0);
+
+      // when / then — fromConfig() itself must fail, not the first resolve()/list() call
+      assertThatThrownBy(() -> AwsSecretsManagerSecretStore.fromConfig(config))
+          .isInstanceOf(SecretStoreUnavailableException.class);
     } finally {
       System.clearProperty("aws.accessKeyId");
       System.clearProperty("aws.secretAccessKey");


### PR DESCRIPTION
## Summary
- `fromConfig()` previously only built the SDK client, which never actually touches AWS — bad credentials, a wrong region, or an unreachable endpoint only surfaced on the first real `resolve()`/`list()` call.
- Adds a minimal `ListSecrets` call right after client construction so misconfiguration fails fast at startup instead, closing the client on failure to avoid leaking it.
- Region/path-prefix remain optional by design (SDK resolves region from env when omitted, matching the `Document` store convention) — no new required config fields; fail-fast comes entirely from this connectivity check.

Stacked on #58015 (implementation).

## Test plan
- [x] `AwsSecretsManagerSecretStoreIT` — `fromConfig()` fails fast (throws `SecretStoreUnavailableException` from `fromConfig()` itself, not deferred) when pointed at an unreachable endpoint
- [x] Existing `shouldResolveViaFromConfigIdentityPath` IT continues to pass, proving the happy path isn't affected
- [x] SpotBugs review profile clean

Note: a bad-credentials variant of the fail-fast test isn't included — LocalStack doesn't enforce credential validity by default, so that assertion would be flaky there. The unreachable-endpoint case exercises the same catch-and-fail-fast path in `validateConnectivity()`, which doesn't discriminate by error type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)