### PR TITLE
test: cover expired document in variables document list modal

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
@@ -293,4 +293,63 @@ describe('<ViewDocumentListButton />', () => {
     expect(fileNameEl.textContent).not.toContain('original-middle');
     expect(fileNameEl.textContent).not.toBe(longFileName);
   });
+
+  it('should mark an expired document row and disable its preview and download buttons', async () => {
+    const documentsWithExpired: DocumentInfo[] = [
+      {
+        link: '/v2/documents/active',
+        fileName: 'active.png',
+        type: 'image',
+        contentType: 'image/png',
+        size: 1024,
+        isExpired: false,
+      },
+      {
+        link: '/v2/documents/expired',
+        fileName: 'expired.png',
+        type: 'image',
+        contentType: 'image/png',
+        size: 2048,
+        isExpired: true,
+      },
+    ];
+
+    const {user} = render(
+      <ViewDocumentListButton
+        documents={documentsWithExpired}
+        isLowerBound={false}
+        variableKey={VARIABLE_KEY}
+        variableName="files"
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await user.click(
+      screen.getByLabelText('View documents for variable files'),
+    );
+
+    const dialog = within(screen.getByRole('dialog'));
+
+    const expiredItem = within(
+      dialog.getByRole('listitem', {name: 'expired.png'}),
+    );
+    expect(expiredItem.getByText('Expired')).toBeInTheDocument();
+    expect(
+      expiredItem.getByLabelText('Preview document for variable files'),
+    ).toBeDisabled();
+    expect(
+      expiredItem.getByLabelText('Download document for variable files'),
+    ).toBeDisabled();
+
+    const activeItem = within(
+      dialog.getByRole('listitem', {name: 'active.png'}),
+    );
+    expect(activeItem.queryByText('Expired')).not.toBeInTheDocument();
+    expect(
+      activeItem.getByLabelText('Preview document for variable files'),
+    ).toBeEnabled();
+    expect(
+      activeItem.getByLabelText('Download document for variable files'),
+    ).toBeEnabled();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentList/ViewDocumentListButton.test.tsx
@@ -348,8 +348,11 @@ describe('<ViewDocumentListButton />', () => {
     expect(
       activeItem.getByLabelText('Preview document for variable files'),
     ).toBeEnabled();
-    expect(
-      activeItem.getByLabelText('Download document for variable files'),
-    ).toBeEnabled();
+    const activeDownloadLink = activeItem.getByLabelText(
+      'Download document for variable files',
+    );
+    expect(activeDownloadLink).toBeEnabled();
+    expect(activeDownloadLink).toHaveAttribute('href', '/v2/documents/active');
+    expect(activeDownloadLink).toHaveAttribute('download', 'active.png');
   });
 });


### PR DESCRIPTION
## Why

Part of closing automated-test gaps for epic [`Visualize Reference Documents in Operate`](https://github.com/camunda/product-hub/issues/3465).

The multi-document list modal (`DocumentListModal`) renders an `Expired` tag per row and disables the preview/download actions for expired documents, but this behavior was not covered by any test. The single-document path and standalone preview/download buttons already test expiry; only the list-modal row was missing.

## What

Adds one test to `ViewDocumentListButton.test.tsx` that opens the list modal with a mix of an active and an expired document and asserts:

- the expired row shows the `Expired` tag; the active row does not
- the expired row's preview and download buttons are disabled
- the active row's preview and download buttons are enabled

## Scope

- Test-only. No production code changes.
- Follows the existing `ViewDocumentListButton.test.tsx` patterns (per-row `within(listitem)` queries, aria-label lookups).

## Validation

```
npx vitest run --project=unit .../DocumentList/ViewDocumentListButton.test.tsx  # 8 passed
```

Relates to camunda/product-hub#3465


Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17028&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=678356

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview