### PR TITLE
fix: ship complete sources jar for camunda-spring-boot-4-starter

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -140,6 +140,23 @@
         </configuration>
       </plugin>
 
+      <!-- Build this module's own sources jar before the package phase, so the shade plugin
+           (createSourcesJar) can merge it with the base module sources. Reuses the release
+           parent's "attach-sources" execution id to move it from package to prepare-package. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Shade plugin to include and relocate classes from camunda-spring-boot-starter -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -153,6 +170,9 @@
             <phase>package</phase>
             <configuration>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Also shade the sources jar so it carries the base module sources plus our
+                   overrides, instead of only this module's few files (see #48090). -->
+              <createSourcesJar>true</createSourcesJar>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
@@ -170,6 +190,13 @@
                     <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.class</exclude>
+                    <!-- The same overrides in the shaded sources jar (createSourcesJar). Filters
+                         match by literal path, so the .class excludes above don't cover .java. -->
+                    <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java</exclude>
                     <!-- Exclude META-INF services that we override -->
                     <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
                   </excludes>


### PR DESCRIPTION
## Description

The `camunda-spring-boot-4-starter` `-sources.jar` on Maven Central contains only this module's handful of override files (~4 sources) instead of the full ~150, making it useless for consumers.

Root cause: the shade plugin rewrites classes into the main jar but never touches the sources jar. The `maven-source-plugin` (bound to `package` by the release parent's `central-sonatype-publish` profile) builds the sources jar from this module's own sources alone — so the shaded base-module sources are never included. I confirmed the release path (`-P central-sonatype-publish`) produces exactly the broken jar.

## Fix

- Enable the shade plugin's `createSourcesJar` so the sources jar is shaded like the classes: base-module sources + our overrides.
- Move `attach-sources` to `prepare-package` (reusing the release parent's execution id, so it overrides rather than duplicates) so this module's own sources jar exists when shade runs — otherwise shade silently drops the override sources.
- Add `.java` twins of the `.class` override excludes, since shade filters match by literal path.

Verified under `-P central-sonatype-publish`: sources jar now has **122** `.java` files, all SB4 overrides present (byte-identical to the module's override sources, not the base versions), no duplicates, single attached `-sources` artifact.

The same breakage exists on `main`/`stable/8.9` where shading flips to `camunda-spring-boot-3-starter` — handled in a separate PR against `main`.

Closes #48090