### PR TITLE
fix: ship complete sources jar for camunda-spring-boot-3-starter

### DIFF
--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -151,6 +151,23 @@
         </configuration>
       </plugin>
 
+      <!-- Build this module's own sources jar before the package phase, so the shade plugin
+           (createSourcesJar) can merge it with the base module sources. Reuses the release
+           parent's "attach-sources" execution id to move it from package to prepare-package. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Shade plugin to include and relocate classes from camunda-spring-boot-starter -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -163,6 +180,9 @@
             <phase>package</phase>
             <configuration>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Also shade the sources jar so it carries the base module sources plus our
+                   overrides, instead of only this module's few files (see #48090). -->
+              <createSourcesJar>true</createSourcesJar>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
@@ -179,6 +199,12 @@
                     <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.class</exclude>
+                    <!-- The same overrides in the shaded sources jar (createSourcesJar). Filters
+                         match by literal path, so the .class excludes above don't cover .java. -->
+                    <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaClientAllAutoConfiguration.java</exclude>
                     <!-- Exclude META-INF services that we override -->
                     <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
                   </excludes>


### PR DESCRIPTION
## Description

On `main`/`stable/8.9` the shaded starter flips to `camunda-spring-boot-3-starter`, so the same broken `-sources.jar` bug reported for `camunda-spring-boot-4-starter` now affects the 3-starter: the published sources jar contains only this module's few override files instead of the full base-module sources.

Root cause: the shade plugin rewrites classes into the main jar but never touches the sources jar. The `maven-source-plugin` (bound to `package` by the release parent's `central-sonatype-publish` profile) builds the sources jar from this module's own sources alone.

## Fix

- Enable the shade plugin's `createSourcesJar` so the sources jar is shaded like the classes: base-module sources + our overrides.
- Move `attach-sources` to `prepare-package` (reusing the release parent's execution id, so it overrides rather than duplicates) so this module's own sources jar exists when shade runs — otherwise shade silently drops the override sources.
- Add `.java` twins of the `.class` override excludes, since shade filters match by literal path.

Verified under `-P central-sonatype-publish`: sources jar now has **140** `.java` files, all SB3 overrides present (byte-identical to the module's override sources, not the base versions), no duplicates, single attached `-sources` artifact.

Companion fix for the 4-starter on `stable/8.8` (where shading still lives): #58018.

Relates to #48090