### PR TITLE
test: add e2e coverage for document reference variables in operate

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/documentVariables.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/documentVariables.spec.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {buildUrl, defaultHeaders} from 'utils/http';
+import {CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA} from 'utils/beans/requestBeans';
+import {generateUniqueId} from 'utils/constants';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+
+const VARIABLE_NAME = 'reference_document';
+const PROCESS_ID = 'Job_Worker_Process';
+
+type DocumentReference = {
+  'camunda.document.type': string;
+  storeId: string;
+  documentId: string;
+  contentHash: string;
+  metadata: {
+    fileName: string;
+    contentType: string;
+    size: number;
+  };
+};
+
+let processInstanceKey: string;
+let documentReference: DocumentReference;
+
+test.beforeAll(async ({request}) => {
+  await deploy(['./resources/Job_Worker_Process.bpmn']);
+
+  const fileName = generateUniqueId();
+  const response = await request.post(buildUrl('/documents'), {
+    headers: defaultHeaders(),
+    multipart: CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA(
+      fileName,
+      PROCESS_ID,
+    ),
+  });
+  expect(response.status()).toBe(201);
+  documentReference = await response.json();
+
+  const instance = await createSingleInstance(PROCESS_ID, 1, {
+    [VARIABLE_NAME]: documentReference,
+  });
+  processInstanceKey = String(instance.processInstanceKey);
+});
+
+test.describe('Process Instance Document Variables', () => {
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('View and download a document reference variable', async ({
+    page,
+    operateProcessInstancePage,
+  }) => {
+    test.slow();
+
+    const documentRow = operateProcessInstancePage.variablesList.getByTestId(
+      `variable-${VARIABLE_NAME}`,
+    );
+    const previewButton = documentRow.getByRole('button', {name: 'Preview'});
+    const downloadButton = documentRow.getByRole('link', {name: 'Download'});
+
+    await test.step('Open the process instance and its variables', async () => {
+      await expect(async () => {
+        await operateProcessInstancePage.gotoProcessInstancePage({
+          id: processInstanceKey,
+        });
+        await expect(operateProcessInstancePage.instanceHeader).toBeVisible({
+          timeout: 15000,
+        });
+      }).toPass({timeout: 90000});
+
+      await operateProcessInstancePage.variablesTabButton.click();
+      await expect(operateProcessInstancePage.variablesList).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step('Verify the reference is rendered as a document cell', async () => {
+      await expect(documentRow).toBeVisible({timeout: 60000});
+      await expect(
+        documentRow.getByTitle(documentReference.metadata.fileName),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify preview is unavailable for a text document while download is enabled', async () => {
+      await expect(previewButton).toBeDisabled();
+      await expect(downloadButton).toBeEnabled();
+    });
+
+    await test.step('Download the document', async () => {
+      const downloadPromise = page.waitForEvent('download');
+      await downloadButton.click();
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toBe(
+        documentReference.metadata.fileName,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Why

Part of closing automated-test gaps for epic [`Visualize Reference Documents in Operate`](https://github.com/camunda/product-hub/issues/3465).

The document-visualization feature had **no end-to-end coverage against a live cluster**. Existing coverage was either component-level (Vitest, mocked) or visual (Playwright, mocked). This adds a real end-to-end test in the orchestration-cluster e2e suite that exercises the whole path: a document created via the REST API → referenced from a process-instance variable → rendered and downloadable in the Operate UI.

## What

Adds `tests/operate/documentVariables.spec.ts` which:

1. deploys `Job_Worker_Process` (stays active on a user task so variables remain visible)
2. creates a document via `POST /v2/documents` (existing `CREATE_ON_FLY_DOCUMENT_REQUEST_BODY_WITH_METADATA` bean)
3. starts a process instance whose variable value is the returned document reference
4. opens the instance in Operate, switches to the Variables tab, and asserts:
   - the variable renders as a document cell showing the file name
   - preview is disabled for a `text/plain` document while download is enabled
   - clicking download triggers a browser download with the expected filename

Reuses the suite's existing helpers (`deploy`, `createSingleInstance`, `buildUrl`, `defaultHeaders`, request beans, `gotoProcessInstancePage`) — no new shared utilities or production changes.

## Validation

- Type-checked and Prettier-formatted.
- **Not run against a live cluster from my environment** — this spec requires the full orchestration cluster (Zeebe + Operate + secondary storage). It needs one CI/local cluster run before marking ready; minor locator/timing adjustments may be needed. Kept as draft for that reason.

## Follow-ups noted for the DRI (feature gaps, not test gaps)

- Release notes mention **plain-text preview** and a **creation-date** metadata field; neither is currently implemented in the UI. Out of scope here.

## Scope

- Test-only. No production code changes.

Relates to camunda/product-hub#3465
