### PR TITLE
fix: force Docker manifest-list media type for multi-arch image pushes

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -149,6 +149,7 @@ runs:
         push: ${{ inputs.push }}
         platforms: ${{ inputs.platforms }}
         provenance: false
+        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false' || '' }}
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -146,10 +146,10 @@ runs:
         file: ${{ inputs.dockerfile }}
         tags: ${{ steps.get-image.outputs.tags }}
         load: ${{ inputs.push != 'true' }}
-        push: ${{ inputs.push }}
+        push: false
         platforms: ${{ inputs.platforms }}
         provenance: false
-        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false' || '' }}
+        outputs: ${{ inputs.push == 'true' && 'type=image,oci-mediatypes=false,push=true' || '' }}
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}

--- a/.github/actions/execute-healthcheck-and-push-image/action.yml
+++ b/.github/actions/execute-healthcheck-and-push-image/action.yml
@@ -41,6 +41,6 @@ runs:
           --platform linux/amd64,linux/arm64 \
           --file optimize.Dockerfile \
           --provenance false \
-          --push \
+          --output type=image,oci-mediatypes=false,push=true \
           .
       shell: bash

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -313,9 +313,9 @@ jobs:
           context: ./build-repo
           file: ./build-repo/${{ matrix.component == 'zeebe' && 'Dockerfile' || format('{0}.Dockerfile', matrix.component) }}
           platforms: ${{ env.PLATFORMS }}
-          push: true
+          push: false
           provenance: false
-          outputs: type=image,oci-mediatypes=false
+          outputs: type=image,oci-mediatypes=false,push=true
           build-args: ${{ steps.build-args.outputs.args }}
           tags: |
             ${{ env.HOTFIX_REGISTRY }}/${{ matrix.component }}:${{ steps.set-version.outputs.hotfix-version }}

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -315,6 +315,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           push: true
           provenance: false
+          outputs: type=image,oci-mediatypes=false
           build-args: ${{ steps.build-args.outputs.args }}
           tags: |
             ${{ env.HOTFIX_REGISTRY }}/${{ matrix.component }}:${{ steps.set-version.outputs.hotfix-version }}


### PR DESCRIPTION
## Summary
- Docker Engine bumps on GitHub-hosted runners pulled in BuildKit v0.31.0, which made OCI mediatypes the consistent default whenever attestations are involved in a build ([moby/buildkit#6094](https://github.com/moby/buildkit/issues/6094)). `--provenance=false` alone no longer prevents multi-platform pushes from being exported as an OCI image index instead of the expected Docker manifest list, which broke `.ci/docker/test/verify.sh`'s media-type check ([INC-6578](https://github.com/camunda/camunda/actions/runs/29518114743/job/87688280159)).
- Reproduced locally against the same BuildKit line (Docker Engine 29.6.1, matching GitHub-hosted `ubuntu-latest` runners):

  | Build flags | Resulting manifest `mediaType` |
  |---|---|
  | `--provenance=false` only (before) | `application/vnd.oci.image.index.v1+json` ❌ |
  | `--provenance=false` + `oci-mediatypes=false` (after) | `application/vnd.docker.distribution.manifest.list.v2+json` ✅ |

- Fixed all three sites in the repo that do a multi-platform `docker buildx build` + push with `provenance: false`, not just the one guarded by `verify.sh`:
  - `.github/actions/build-platform-docker/action.yml` (camunda/zeebe images — the one causing INC-6578)
  - `.github/actions/execute-healthcheck-and-push-image/action.yml` (Optimize release push to Docker Hub/Harbor — no manifest-type check existed here, so this path could have silently shipped the wrong format to customers)
  - `.github/workflows/create-urgent-hotfix-img.yml` (hotfix images — also no manifest-type check)


**A note on the `push: false` + `outputs: ...,push=true` switch:**

In `build-platform-docker/action.yml` and `create-urgent-hotfix-img.yml`, `docker/build-push-action`'s `push:` input is set to `false` while the actual push still happens — this isn't a contradiction. `push:` there is only a convenience switch: when `true`, the action appends the buildx CLI shorthand `--push` (which itself expands to `--output=type=registry,unpack=false`). It's not an independent "push or don't push" gate.

Once we need an explicit `--output type=image,...` anyway (to set `oci-mediatypes=false`), adding the shorthand `--push` on top means asking buildx to merge two separately-specified export targets (`type=registry` from the shorthand, `type=image` from ours) into one push - behavior the buildx docs don't document as a supported combination. It happened to work fine when tested locally (same buildx/BuildKit line as the CI runners), but relying on that merge holding across buildx versions is exactly the kind of implicit-version-behavior risk that caused this incident in the first place.

So instead: `push:` is turned off as a mechanism, and `push=true` is written directly into the `outputs` string instead. The image still gets pushed — just through one explicit, unambiguous export spec rather than two flags whose interaction isn't guaranteed.

## Test plan
- [x] Reproduced the bug and validated the fix locally with a scratch multi-arch build against a local registry (Docker 29.6.1 / BuildKit 0.31.x, matching GitHub-hosted `ubuntu-latest` runners)
- [x] Validated that `push: false` + `outputs: type=image,...,push=true` pushes correctly (same digest/manifest as the shorthand `--push`) — see [review discussion](https://github.com/camunda/camunda/pull/58023#discussion_r3598567632)
- [x] `docker-checks` job in CI passes on this PR (currently the failing check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
