### PR TITLE
feat: store and query metadata for cluster variables in RDBMS exporter

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -618,11 +618,14 @@
     </preConditions>
     <createTable tableName="${prefix}CLUSTER_VARIABLE_METADATA">
       <column name="CLUSTER_VARIABLE_ID" type="NVARCHAR(${userCharColumnSize})">
-        <constraints foreignKeyName="${prefix}FK_CLUSTER_VARIABLE_METADATA_CLUSTER_VARIABLE"
+        <constraints primaryKey="true"
+          foreignKeyName="${prefix}FK_CLUSTER_VARIABLE_METADATA_CLUSTER_VARIABLE"
           referencedTableName="${prefix}CLUSTER_VARIABLE" referencedColumnNames="CLUSTER_VARIABLE_ID"
           deleteCascade="true"/>
       </column>
-      <column name="METADATA_KEY" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="METADATA_KEY" type="NVARCHAR(${userCharColumnSize})">
+        <constraints primaryKey="true"/>
+      </column>
       <column name="METADATA_VALUE" type="VARCHAR(8192)"/>
       <column name="METADATA_VALUE_NUMBER" type="DOUBLE"/>
     </createTable>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -610,4 +610,40 @@
     </modifySql>
   </changeSet>
 
+  <changeSet id="create_cluster_variable_metadata_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}CLUSTER_VARIABLE_METADATA"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}CLUSTER_VARIABLE_METADATA">
+      <column name="CLUSTER_VARIABLE_ID" type="NVARCHAR(${userCharColumnSize})">
+        <constraints foreignKeyName="${prefix}FK_CLUSTER_VARIABLE_METADATA_CLUSTER_VARIABLE"
+          referencedTableName="${prefix}CLUSTER_VARIABLE" referencedColumnNames="CLUSTER_VARIABLE_ID"
+          deleteCascade="true"/>
+      </column>
+      <column name="METADATA_KEY" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="METADATA_VALUE" type="VARCHAR(8192)"/>
+      <column name="METADATA_VALUE_NUMBER" type="DOUBLE"/>
+    </createTable>
+
+    <modifySql dbms="oracle">
+      <!-- Oracle only supports a size 4000 characters in varchar2 -->
+      <replace replace="VARCHAR2(8192)" with="VARCHAR2(4000)"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_cluster_variable_metadata_cluster_variable_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_CLUSTER_VARIABLE_METADATA_CLUSTER_VARIABLE_ID"
+          tableName="${prefix}CLUSTER_VARIABLE_METADATA"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}CLUSTER_VARIABLE_METADATA"
+      indexName="${prefix}IDX_CLUSTER_VARIABLE_METADATA_CLUSTER_VARIABLE_ID">
+      <column name="CLUSTER_VARIABLE_ID"/>
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -35,6 +35,7 @@ public final class RdbmsTableNames {
           "CANDIDATE_GROUP",
           "CANDIDATE_USER",
           "CLUSTER_VARIABLE",
+          "CLUSTER_VARIABLE_METADATA",
           "CORRELATED_MESSAGE_SUBSCRIPTION",
           "DECISION_DEFINITION",
           "DECISION_INSTANCE_INPUT",

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableDbQuery.java
@@ -24,6 +24,10 @@ public record ClusterVariableDbQuery(
     DbQuerySorting<ClusterVariableEntity> sort,
     DbQueryPage page) {
 
+  public List<ClusterVariableMetadataSearchFilter> metadataSearchFilters() {
+    return ClusterVariableMetadataSearchFilter.from(filter.metadataOperations());
+  }
+
   public static ClusterVariableDbQuery of(
       final Function<ClusterVariableDbQuery.Builder, ObjectBuilder<ClusterVariableDbQuery>> fn) {
     return fn.apply(new ClusterVariableDbQuery.Builder()).build();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableMetadataSearchFilter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ClusterVariableMetadataSearchFilter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.filter.MetadataValueFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.filter.UntypedOperation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * RDBMS-friendly shape of a {@link MetadataValueFilter}. MyBatis XML cannot branch on {@link
+ * UntypedOperation#type()}, so the string-vs-numeric routing is precomputed here, mirroring {@code
+ * ClusterVariableFilterTransformer#toMetadataValueQueries} to keep RDBMS and ES/OS filter semantics
+ * in parity.
+ */
+public record ClusterVariableMetadataSearchFilter(
+    String key,
+    boolean notExists,
+    List<Operation<String>> stringOperations,
+    List<Operation<Double>> numericOperations) {
+
+  public static List<ClusterVariableMetadataSearchFilter> from(
+      final List<MetadataValueFilter> filters) {
+    if (filters == null || filters.isEmpty()) {
+      return List.of();
+    }
+    return filters.stream().map(ClusterVariableMetadataSearchFilter::from).toList();
+  }
+
+  private static ClusterVariableMetadataSearchFilter from(final MetadataValueFilter filter) {
+    final var valueOperations = filter.valueOperations();
+    if (valueOperations == null || valueOperations.isEmpty()) {
+      return new ClusterVariableMetadataSearchFilter(filter.key(), false, List.of(), List.of());
+    }
+
+    final var negated =
+        valueOperations.stream().anyMatch(op -> op.operator() == Operator.NOT_EXISTS);
+    if (negated) {
+      if (valueOperations.size() > 1) {
+        throw new IllegalArgumentException(
+            "NOT_EXISTS cannot be combined with other operations for the same metadata key: "
+                + filter.key());
+      }
+      return new ClusterVariableMetadataSearchFilter(filter.key(), true, List.of(), List.of());
+    }
+
+    final var stringOperations = new ArrayList<Operation<String>>();
+    final var numericOperations = new ArrayList<Operation<Double>>();
+    for (final var operation : valueOperations) {
+      switch (operation.type()) {
+        case LONG, DOUBLE -> numericOperations.add(toDoubleOperation(operation));
+        default -> stringOperations.add(toStringOperation(operation));
+      }
+    }
+    return new ClusterVariableMetadataSearchFilter(
+        filter.key(), false, stringOperations, numericOperations);
+  }
+
+  private static Operation<String> toStringOperation(final UntypedOperation operation) {
+    return toOperation(operation, Object::toString);
+  }
+
+  private static Operation<Double> toDoubleOperation(final UntypedOperation operation) {
+    return toOperation(operation, v -> ((Number) v).doubleValue());
+  }
+
+  private static <T> Operation<T> toOperation(
+      final UntypedOperation operation, final Function<Object, T> valueMapper) {
+    final var values =
+        operation.values() == null
+            ? null
+            : operation.values().stream()
+                .map(v -> v == null ? null : valueMapper.apply(v))
+                .toList();
+    return new Operation<>(operation.operator(), values);
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -108,18 +108,21 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
             .collect(Collectors.groupingBy(ClusterVariableMetadataDbModel::clusterVariableId));
 
     entities.forEach(
-        entity ->
-            entity
-                .metadata()
-                .addAll(
-                    metadataByClusterVariableId.getOrDefault(entity.id(), List.of()).stream()
-                        .map(m -> new MetadataEntry(m.key(), m.value(), m.valueNumber()))
-                        .toList()));
+        entity -> {
+          final var metadata = entity.metadata();
+          if (metadata != null) {
+            metadata.addAll(
+                metadataByClusterVariableId.getOrDefault(entity.id(), List.of()).stream()
+                    .map(m -> new MetadataEntry(m.key(), m.value(), m.valueNumber()))
+                    .toList());
+          }
+        });
 
     return entities;
   }
 
-  private ClusterVariableEntity hydrateMetadata(final ClusterVariableEntity entity) {
+  private @Nullable ClusterVariableEntity hydrateMetadata(
+      final @Nullable ClusterVariableEntity entity) {
     if (entity == null) {
       return null;
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ClusterVariableDbReader.java
@@ -11,8 +11,10 @@ import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery;
 import io.camunda.db.rdbms.sql.ClusterVariableMapper;
 import io.camunda.db.rdbms.sql.columns.ClusterVariableSearchColumn;
+import io.camunda.db.rdbms.write.domain.ClusterVariableMetadataDbModel;
 import io.camunda.search.clients.reader.ClusterVariableReader;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -20,6 +22,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.util.ClusterVariableUtil;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +68,7 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
     LOG.trace("[RDBMS DB] Search for cluster variables with filter {}", query);
     return executePagedQuery(
         () -> clusterVariableMapper.count(dbQuery),
-        () -> clusterVariableMapper.search(dbQuery),
+        () -> hydrateMetadata(clusterVariableMapper.search(dbQuery)),
         dbPage,
         dbSort);
   }
@@ -77,15 +80,50 @@ public class ClusterVariableDbReader extends AbstractEntityReader<ClusterVariabl
   @Override
   public @Nullable ClusterVariableEntity getTenantScopedClusterVariable(
       final String name, final String tenant, final ResourceAccessChecks resourceAccessChecks) {
-    return clusterVariableMapper.get(
-        ClusterVariableUtil.generateID(name, tenant, ClusterVariableScope.TENANT));
+    return hydrateMetadata(
+        clusterVariableMapper.get(
+            ClusterVariableUtil.generateID(name, tenant, ClusterVariableScope.TENANT)));
   }
 
   @Override
   public @Nullable ClusterVariableEntity getGloballyScopedClusterVariable(
       final String name, final ResourceAccessChecks resourceAccessChecks) {
-    return clusterVariableMapper.get(
-        ClusterVariableUtil.generateID(name, null, ClusterVariableScope.GLOBAL));
+    return hydrateMetadata(
+        clusterVariableMapper.get(
+            ClusterVariableUtil.generateID(name, null, ClusterVariableScope.GLOBAL)));
+  }
+
+  /**
+   * Fetches metadata for the given cluster variables in a single batched query and attaches it to
+   * each entity.
+   */
+  private List<ClusterVariableEntity> hydrateMetadata(final List<ClusterVariableEntity> entities) {
+    if (entities.isEmpty()) {
+      return entities;
+    }
+
+    final var ids = entities.stream().map(ClusterVariableEntity::id).toList();
+    final var metadataByClusterVariableId =
+        clusterVariableMapper.findMetadataByClusterVariableIds(ids).stream()
+            .collect(Collectors.groupingBy(ClusterVariableMetadataDbModel::clusterVariableId));
+
+    entities.forEach(
+        entity ->
+            entity
+                .metadata()
+                .addAll(
+                    metadataByClusterVariableId.getOrDefault(entity.id(), List.of()).stream()
+                        .map(m -> new MetadataEntry(m.key(), m.value(), m.valueNumber()))
+                        .toList()));
+
+    return entities;
+  }
+
+  private ClusterVariableEntity hydrateMetadata(final ClusterVariableEntity entity) {
+    if (entity == null) {
+      return null;
+    }
+    return hydrateMetadata(List.of(entity)).getFirst();
   }
 
   @Override

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ClusterVariableMapper.java
@@ -9,8 +9,10 @@ package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.ClusterVariableDbQuery;
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.domain.ClusterVariableMetadataDbModel;
 import io.camunda.search.entities.ClusterVariableEntity;
 import java.util.List;
+import org.apache.ibatis.annotations.Param;
 
 public interface ClusterVariableMapper {
 
@@ -18,9 +20,16 @@ public interface ClusterVariableMapper {
 
   void insert(ClusterVariableDbModel variable);
 
+  void insertMetadata(ClusterVariableDbModel variable);
+
+  void deleteMetadata(String id);
+
   void delete(ClusterVariableDbModel variable);
 
   Long count(ClusterVariableDbQuery filter);
 
   List<ClusterVariableEntity> search(ClusterVariableDbQuery filter);
+
+  List<ClusterVariableMetadataDbModel> findMetadataByClusterVariableIds(
+      @Param("ids") List<String> ids);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -82,7 +82,7 @@ public record ClusterVariableDbModel(
   // the METADATA_VALUE column rather than failing the insert.
   private List<MetadataEntry> truncateMetadata(final int sizeLimit, final Integer byteLimit) {
     if (metadata == null || metadata.isEmpty()) {
-      return metadata;
+      return List.of();
     }
     return metadata.stream()
         .map(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -75,7 +75,25 @@ public record ClusterVariableDbModel(
         isPreview,
         tenantId,
         scope,
-        metadata);
+        truncateMetadata(sizeLimit, byteLimit));
+  }
+
+  // Metadata values have no full-value fallback column, so oversized values are truncated to fit
+  // the METADATA_VALUE column rather than failing the insert.
+  private List<MetadataEntry> truncateMetadata(final int sizeLimit, final Integer byteLimit) {
+    if (metadata == null || metadata.isEmpty()) {
+      return metadata;
+    }
+    return metadata.stream()
+        .map(
+            entry ->
+                entry.value() == null
+                    ? entry
+                    : new MetadataEntry(
+                        entry.key(),
+                        TruncateUtil.truncateValue(entry.value(), sizeLimit, byteLimit),
+                        entry.valueNumber()))
+        .toList();
   }
 
   public static class ClusterVariableDbModelBuilder

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModel.java
@@ -12,11 +12,13 @@ import static io.camunda.util.ValueTypeUtil.mapDouble;
 import static io.camunda.util.ValueTypeUtil.mapLong;
 
 import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.util.ValueTypeUtil;
+import java.util.List;
 import java.util.function.Function;
 
 public record ClusterVariableDbModel(
@@ -29,7 +31,8 @@ public record ClusterVariableDbModel(
     String fullValue,
     boolean isPreview,
     String tenantId,
-    ClusterVariableScope scope)
+    ClusterVariableScope scope,
+    List<MetadataEntry> metadata)
     implements Copyable<ClusterVariableDbModel> {
 
   @Override
@@ -42,7 +45,8 @@ public record ClusterVariableDbModel(
                 .name(name)
                 .value(value)
                 .tenantId(tenantId)
-                .scope(scope))
+                .scope(scope)
+                .metadata(metadata))
         .build();
   }
 
@@ -70,7 +74,8 @@ public record ClusterVariableDbModel(
         fullValue,
         isPreview,
         tenantId,
-        scope);
+        scope,
+        metadata);
   }
 
   public static class ClusterVariableDbModelBuilder
@@ -79,6 +84,7 @@ public record ClusterVariableDbModel(
     private String value;
     private String tenantId;
     private ClusterVariableScope scope;
+    private List<MetadataEntry> metadata = List.of();
 
     public ClusterVariableDbModelBuilder name(final String name) {
       this.name = name;
@@ -97,6 +103,11 @@ public record ClusterVariableDbModel(
 
     public ClusterVariableDbModelBuilder tenantId(final String tenantId) {
       this.tenantId = tenantId;
+      return this;
+    }
+
+    public ClusterVariableDbModelBuilder metadata(final List<MetadataEntry> metadata) {
+      this.metadata = metadata == null ? List.of() : metadata;
       return this;
     }
 
@@ -122,7 +133,8 @@ public record ClusterVariableDbModel(
           null,
           false,
           tenantId,
-          scope);
+          scope,
+          metadata);
     }
 
     private String getCompositeId() {
@@ -131,7 +143,17 @@ public record ClusterVariableDbModel(
 
     private ClusterVariableDbModel getModel(final ValueTypeEnum valueTypeEnum, final String value) {
       return new ClusterVariableDbModel(
-          getCompositeId(), name, valueTypeEnum, null, null, value, null, false, tenantId, scope);
+          getCompositeId(),
+          name,
+          valueTypeEnum,
+          null,
+          null,
+          value,
+          null,
+          false,
+          tenantId,
+          scope,
+          metadata);
     }
 
     private ClusterVariableDbModel getDoubleModel() {
@@ -145,7 +167,8 @@ public record ClusterVariableDbModel(
           null,
           false,
           tenantId,
-          scope);
+          scope,
+          metadata);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableMetadataDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableMetadataDbModel.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import org.jspecify.annotations.Nullable;
+
+public record ClusterVariableMetadataDbModel(
+    String clusterVariableId, String key, @Nullable String value, @Nullable Double valueNumber) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableMetadataDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ClusterVariableMetadataDbModel.java
@@ -7,7 +7,5 @@
  */
 package io.camunda.db.rdbms.write.domain;
 
-import org.jspecify.annotations.Nullable;
-
 public record ClusterVariableMetadataDbModel(
-    String clusterVariableId, String key, @Nullable String value, @Nullable Double valueNumber) {}
+    String clusterVariableId, String key, String value, Double valueNumber) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -42,7 +42,9 @@ public enum ContextType {
   USER_TASK(true),
   VARIABLE(false),
   WAIT_STATE(false),
-  CLUSTER_VARIABLE(false),
+  // delete+insert is used for CLUSTER_VARIABLE_METADATA child rows, so order must be preserved
+  // to ensure DELETE runs before INSERT
+  CLUSTER_VARIABLE(true),
   PROCESS_DEF_VAR_NAME_LOOKUP(false),
   // for global listeners, event types are updated through delete+insert, so order needs to be
   // preserved

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ClusterVariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ClusterVariableWriter.java
@@ -27,30 +27,33 @@ public class ClusterVariableWriter implements RdbmsWriter {
   }
 
   public void create(final ClusterVariableDbModel clusterVariable) {
+    final var truncated = truncate(clusterVariable);
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.CLUSTER_VARIABLE,
             WriteStatementType.INSERT,
             clusterVariable.id(),
             "io.camunda.db.rdbms.sql.ClusterVariableMapper.insert",
-            clusterVariable.truncateValue(
-                vendorDatabaseProperties.variableValuePreviewSize(),
-                vendorDatabaseProperties.charColumnMaxBytes())));
+            truncated));
+    enqueueMetadataInsert(clusterVariable.id(), truncated);
   }
 
   public void update(final ClusterVariableDbModel clusterVariable) {
+    final var truncated = truncate(clusterVariable);
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.CLUSTER_VARIABLE,
             WriteStatementType.UPDATE,
             clusterVariable.id(),
             "io.camunda.db.rdbms.sql.ClusterVariableMapper.update",
-            clusterVariable.truncateValue(
-                vendorDatabaseProperties.variableValuePreviewSize(),
-                vendorDatabaseProperties.charColumnMaxBytes())));
+            truncated));
+    // metadata is replaced via delete+insert, so the prior rows are always cleared first
+    enqueueMetadataDelete(clusterVariable.id());
+    enqueueMetadataInsert(clusterVariable.id(), truncated);
   }
 
   public void delete(final ClusterVariableDbModel clusterVariable) {
+    enqueueMetadataDelete(clusterVariable.id());
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.CLUSTER_VARIABLE,
@@ -58,5 +61,34 @@ public class ClusterVariableWriter implements RdbmsWriter {
             clusterVariable.id(),
             "io.camunda.db.rdbms.sql.ClusterVariableMapper.delete",
             clusterVariable));
+  }
+
+  private ClusterVariableDbModel truncate(final ClusterVariableDbModel clusterVariable) {
+    return clusterVariable.truncateValue(
+        vendorDatabaseProperties.variableValuePreviewSize(),
+        vendorDatabaseProperties.charColumnMaxBytes());
+  }
+
+  private void enqueueMetadataInsert(final String id, final ClusterVariableDbModel truncated) {
+    if (truncated.metadata().isEmpty()) {
+      return;
+    }
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.CLUSTER_VARIABLE,
+            WriteStatementType.INSERT,
+            id,
+            "io.camunda.db.rdbms.sql.ClusterVariableMapper.insertMetadata",
+            truncated));
+  }
+
+  private void enqueueMetadataDelete(final String id) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.CLUSTER_VARIABLE,
+            WriteStatementType.DELETE,
+            id,
+            "io.camunda.db.rdbms.sql.ClusterVariableMapper.deleteMetadata",
+            id));
   }
 }

--- a/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ClusterVariableMapper.xml
@@ -21,17 +21,23 @@
       <arg column="IS_PREVIEW" javaType="boolean"/>
       <arg column="SCOPE" javaType="io.camunda.search.entities.ClusterVariableScope"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
-      <!-- no METADATA column yet; queries select a literal NULL and the entity defaults it to an
-       empty list. We use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
-      <arg column="METADATA" javaType="java.util.List"
-        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+    </constructor>
+  </resultMap>
+
+  <resultMap id="clusterVariableMetadataResultMap"
+    type="io.camunda.db.rdbms.write.domain.ClusterVariableMetadataDbModel">
+    <constructor>
+      <idArg column="CLUSTER_VARIABLE_ID" javaType="java.lang.String"/>
+      <arg column="METADATA_KEY" javaType="java.lang.String"/>
+      <arg column="METADATA_VALUE" javaType="java.lang.String"/>
+      <arg column="METADATA_VALUE_NUMBER" javaType="java.lang.Double"/>
     </constructor>
   </resultMap>
 
   <select id="count" resultType="java.lang.Long">
     SELECT COUNT(*) FROM (
       SELECT 1 as col
-      FROM ${prefix}CLUSTER_VARIABLE
+      FROM ${prefix}CLUSTER_VARIABLE cv
       <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
       ${count.limit}
     ) t
@@ -47,16 +53,14 @@
     VAR_FULL_VALUE,
     TENANT_ID,
     SCOPE,
-    IS_PREVIEW,
-    NULL AS METADATA
-    FROM ${prefix}CLUSTER_VARIABLE
+    IS_PREVIEW
+    FROM ${prefix}CLUSTER_VARIABLE cv
     <include refid="io.camunda.db.rdbms.sql.ClusterVariableMapper.searchFilter"/>
-    ) t
+    ) filtered
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
-
 
   <select id="get" parameterType="java.lang.String"
     resultMap="io.camunda.db.rdbms.sql.ClusterVariableMapper.clusterVariableResultMap">
@@ -67,10 +71,23 @@
     VAR_FULL_VALUE,
     TENANT_ID,
     SCOPE,
-    IS_PREVIEW,
-    NULL AS METADATA
-    FROM ${prefix}CLUSTER_VARIABLE
-    WHERE CLUSTER_VARIABLE_ID = #{id}
+    IS_PREVIEW
+    FROM ${prefix}CLUSTER_VARIABLE cv
+    WHERE cv.CLUSTER_VARIABLE_ID = #{id}
+  </select>
+
+  <select id="findMetadataByClusterVariableIds"
+    resultMap="io.camunda.db.rdbms.sql.ClusterVariableMapper.clusterVariableMetadataResultMap">
+    SELECT
+    CLUSTER_VARIABLE_ID,
+    METADATA_KEY,
+    METADATA_VALUE,
+    METADATA_VALUE_NUMBER
+    FROM ${prefix}CLUSTER_VARIABLE_METADATA
+    WHERE CLUSTER_VARIABLE_ID IN
+    <foreach collection="ids" item="id" open="(" separator="," close=")">
+      #{id}
+    </foreach>
   </select>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
@@ -83,6 +100,33 @@
             #{value},
             #{fullValue}, #{isPreview}, #{tenantId}, #{scope})
   </insert>
+
+  <insert id="insertMetadata" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
+    INSERT INTO ${prefix}CLUSTER_VARIABLE_METADATA (CLUSTER_VARIABLE_ID, METADATA_KEY, METADATA_VALUE,
+                                                     METADATA_VALUE_NUMBER)
+    VALUES
+    <foreach collection="metadata" item="entry" separator=", ">
+      (#{id}, #{entry.key}, #{entry.value}, #{entry.valueNumber, jdbcType=DOUBLE})
+    </foreach>
+  </insert>
+
+  <!-- Oracle requires INSERT ALL syntax for multi-row inserts -->
+  <insert id="insertMetadata" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel"
+    databaseId="oracle">
+    INSERT ALL
+    <foreach collection="metadata" item="entry">
+      INTO ${prefix}CLUSTER_VARIABLE_METADATA (CLUSTER_VARIABLE_ID, METADATA_KEY, METADATA_VALUE,
+                                                METADATA_VALUE_NUMBER)
+      VALUES (#{id}, #{entry.key}, #{entry.value}, #{entry.valueNumber, jdbcType=DOUBLE})
+    </foreach>
+    SELECT 1 FROM DUAL
+  </insert>
+
+  <delete id="deleteMetadata" parameterType="java.lang.String">
+    DELETE
+    FROM ${prefix}CLUSTER_VARIABLE_METADATA
+    WHERE CLUSTER_VARIABLE_ID = #{id}
+  </delete>
 
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.ClusterVariableDbModel">
     DELETE
@@ -158,6 +202,36 @@
 
       <if test="filter.isTruncated != null">
         AND IS_PREVIEW = #{filter.isTruncated}
+      </if>
+
+      <!-- metadata filters -->
+      <if test="metadataSearchFilters != null and !metadataSearchFilters.isEmpty()">
+        <foreach collection="metadataSearchFilters" item="metadataFilter">
+          <choose>
+            <when test="metadataFilter.notExists">
+              AND NOT EXISTS (
+              SELECT 1 FROM ${prefix}CLUSTER_VARIABLE_METADATA cvm
+              WHERE cvm.CLUSTER_VARIABLE_ID = cv.CLUSTER_VARIABLE_ID
+              AND cvm.METADATA_KEY = #{metadataFilter.key}
+              )
+            </when>
+            <otherwise>
+              AND EXISTS (
+              SELECT 1 FROM ${prefix}CLUSTER_VARIABLE_METADATA cvm
+              WHERE cvm.CLUSTER_VARIABLE_ID = cv.CLUSTER_VARIABLE_ID
+              AND cvm.METADATA_KEY = #{metadataFilter.key}
+              <foreach collection="metadataFilter.stringOperations" item="operation">
+                AND cvm.METADATA_VALUE
+                <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+              </foreach>
+              <foreach collection="metadataFilter.numericOperations" item="operation">
+                AND cvm.METADATA_VALUE_NUMBER
+                <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+              </foreach>
+              )
+            </otherwise>
+          </choose>
+        </foreach>
       </if>
     </where>
   </sql>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModelTest.java
@@ -37,6 +37,7 @@ public class ClusterVariableDbModelTest {
     assertThat(model.doubleValue()).isNull();
     assertThat(model.longValue()).isNull();
     assertThat(model.value()).isEqualTo("null");
+    assertThat(model.metadata()).isEmpty();
   }
 
   @Test
@@ -62,26 +63,7 @@ public class ClusterVariableDbModelTest {
   }
 
   @Test
-  public void shouldDefaultMetadataToEmptyList() {
-    // given
-    final ClusterVariableDbModel.ClusterVariableDbModelBuilder builder =
-        new ClusterVariableDbModel.ClusterVariableDbModelBuilder();
-
-    // when
-    final ClusterVariableDbModel model =
-        builder
-            .name("test")
-            .value("someValue")
-            .tenantId("tenant1")
-            .scope(ClusterVariableScope.GLOBAL)
-            .build();
-
-    // then
-    assertThat(model.metadata()).isEmpty();
-  }
-
-  @Test
-  public void shouldCarryMetadataThroughBuildAndCopy() {
+  public void shouldCopyClusterVariable() {
     // given
     final List<MetadataEntry> metadata =
         List.of(
@@ -105,26 +87,10 @@ public class ClusterVariableDbModelTest {
 
     // and copy() preserves metadata unless overridden
     final ClusterVariableDbModel copied = model.copy(b -> b);
+    assertThat(copied.name()).isEqualTo("test");
+    assertThat(copied.value()).isEqualTo("someValue");
+    assertThat(copied.tenantId()).isEqualTo("tenant1");
+    assertThat(copied.scope()).isEqualTo(ClusterVariableScope.GLOBAL);
     assertThat(copied.metadata()).isEqualTo(metadata);
-  }
-
-  @Test
-  public void shouldCarryMetadataThroughTruncateValue() {
-    // given
-    final List<MetadataEntry> metadata = List.of(new MetadataEntry("kind", "CREDENTIAL", null));
-    final ClusterVariableDbModel model =
-        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
-            .name("test")
-            .value("someValue")
-            .tenantId("tenant1")
-            .scope(ClusterVariableScope.GLOBAL)
-            .metadata(metadata)
-            .build();
-
-    // when
-    final ClusterVariableDbModel truncated = model.truncateValue(1000, 4000);
-
-    // then
-    assertThat(truncated.metadata()).isEqualTo(metadata);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/ClusterVariableDbModelTest.java
@@ -9,8 +9,10 @@ package io.camunda.db.rdbms.write.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.ValueTypeEnum;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class ClusterVariableDbModelTest {
@@ -57,5 +59,72 @@ public class ClusterVariableDbModelTest {
     assertThat(model.doubleValue()).isNull();
     assertThat(model.longValue()).isEqualTo(123456L);
     assertThat(model.value()).isEqualTo("123456");
+  }
+
+  @Test
+  public void shouldDefaultMetadataToEmptyList() {
+    // given
+    final ClusterVariableDbModel.ClusterVariableDbModelBuilder builder =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder();
+
+    // when
+    final ClusterVariableDbModel model =
+        builder
+            .name("test")
+            .value("someValue")
+            .tenantId("tenant1")
+            .scope(ClusterVariableScope.GLOBAL)
+            .build();
+
+    // then
+    assertThat(model.metadata()).isEmpty();
+  }
+
+  @Test
+  public void shouldCarryMetadataThroughBuildAndCopy() {
+    // given
+    final List<MetadataEntry> metadata =
+        List.of(
+            new MetadataEntry("kind", "CREDENTIAL", null),
+            new MetadataEntry("schemaVersion", "2", 2.0));
+    final ClusterVariableDbModel.ClusterVariableDbModelBuilder builder =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder();
+
+    // when
+    final ClusterVariableDbModel model =
+        builder
+            .name("test")
+            .value("someValue")
+            .tenantId("tenant1")
+            .scope(ClusterVariableScope.GLOBAL)
+            .metadata(metadata)
+            .build();
+
+    // then
+    assertThat(model.metadata()).isEqualTo(metadata);
+
+    // and copy() preserves metadata unless overridden
+    final ClusterVariableDbModel copied = model.copy(b -> b);
+    assertThat(copied.metadata()).isEqualTo(metadata);
+  }
+
+  @Test
+  public void shouldCarryMetadataThroughTruncateValue() {
+    // given
+    final List<MetadataEntry> metadata = List.of(new MetadataEntry("kind", "CREDENTIAL", null));
+    final ClusterVariableDbModel model =
+        new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
+            .name("test")
+            .value("someValue")
+            .tenantId("tenant1")
+            .scope(ClusterVariableScope.GLOBAL)
+            .metadata(metadata)
+            .build();
+
+    // when
+    final ClusterVariableDbModel truncated = model.truncateValue(1000, 4000);
+
+    // then
+    assertThat(truncated.metadata()).isEqualTo(metadata);
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ClusterVariableWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ClusterVariableWriterTest.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.service;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +20,8 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ClusterVariableWriterTest {
@@ -38,6 +41,7 @@ class ClusterVariableWriterTest {
     final var truncatedModel = mock(ClusterVariableDbModel.class);
     when(model.truncateValue(anyInt(), anyInt())).thenReturn(truncatedModel);
     when(model.id()).thenReturn("var1");
+    when(truncatedModel.metadata()).thenReturn(List.of());
 
     writer.create(model);
 
@@ -50,6 +54,48 @@ class ClusterVariableWriterTest {
                     "var1",
                     "io.camunda.db.rdbms.sql.ClusterVariableMapper.insert",
                     truncatedModel)));
+    verify(executionQueue, never())
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.INSERT,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.insertMetadata",
+                    truncatedModel)));
+  }
+
+  @Test
+  void shouldCreateClusterVariableWithMetadata() {
+    when(vendorDatabaseProperties.variableValuePreviewSize()).thenReturn(1000);
+    when(vendorDatabaseProperties.charColumnMaxBytes()).thenReturn(4000);
+
+    final var model = mock(ClusterVariableDbModel.class);
+    final var truncatedModel = mock(ClusterVariableDbModel.class);
+    when(model.truncateValue(anyInt(), anyInt())).thenReturn(truncatedModel);
+    when(model.id()).thenReturn("var1");
+    when(truncatedModel.metadata()).thenReturn(List.of(new MetadataEntry("kind", "X", null)));
+
+    writer.create(model);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.INSERT,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.insert",
+                    truncatedModel)));
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.INSERT,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.insertMetadata",
+                    truncatedModel)));
   }
 
   @Test
@@ -59,6 +105,15 @@ class ClusterVariableWriterTest {
 
     writer.delete(model);
 
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.DELETE,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.deleteMetadata",
+                    "var1")));
     verify(executionQueue)
         .executeInQueue(
             eq(
@@ -79,6 +134,7 @@ class ClusterVariableWriterTest {
     final var truncatedModel = mock(ClusterVariableDbModel.class);
     when(model.truncateValue(anyInt(), anyInt())).thenReturn(truncatedModel);
     when(model.id()).thenReturn("var1");
+    when(truncatedModel.metadata()).thenReturn(List.of());
 
     writer.update(model);
 
@@ -90,6 +146,57 @@ class ClusterVariableWriterTest {
                     WriteStatementType.UPDATE,
                     "var1",
                     "io.camunda.db.rdbms.sql.ClusterVariableMapper.update",
+                    truncatedModel)));
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.DELETE,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.deleteMetadata",
+                    "var1")));
+    verify(executionQueue, never())
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.INSERT,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.insertMetadata",
+                    truncatedModel)));
+  }
+
+  @Test
+  void shouldUpdateClusterVariableReplacesMetadata() {
+    when(vendorDatabaseProperties.variableValuePreviewSize()).thenReturn(1000);
+    when(vendorDatabaseProperties.charColumnMaxBytes()).thenReturn(4000);
+
+    final var model = mock(ClusterVariableDbModel.class);
+    final var truncatedModel = mock(ClusterVariableDbModel.class);
+    when(model.truncateValue(anyInt(), anyInt())).thenReturn(truncatedModel);
+    when(model.id()).thenReturn("var1");
+    when(truncatedModel.metadata()).thenReturn(List.of(new MetadataEntry("kind", "X", null)));
+
+    writer.update(model);
+
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.DELETE,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.deleteMetadata",
+                    "var1")));
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.CLUSTER_VARIABLE,
+                    WriteStatementType.INSERT,
+                    "var1",
+                    "io.camunda.db.rdbms.sql.ClusterVariableMapper.insertMetadata",
                     truncatedModel)));
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableIT.java
@@ -23,6 +23,7 @@ import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ClusterVariableEntity;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.filter.ClusterVariableFilter;
 import io.camunda.search.page.SearchQueryPage;
@@ -30,6 +31,7 @@ import io.camunda.search.query.ClusterVariableQuery;
 import io.camunda.search.sort.ClusterVariableSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -372,6 +374,66 @@ public class ClusterVariableIT {
   }
 
   @TestTemplate
+  public void shouldSaveAndFindTenantClusterVariableWithMetadata(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
+
+    final List<MetadataEntry> metadata =
+        List.of(
+            new MetadataEntry("kind", "CREDENTIAL", null),
+            new MetadataEntry("schemaVersion", "2", 2.0));
+    final ClusterVariableDbModel clusterVariable =
+        ClusterVariableFixtures.createRandomTenantClusterVariable(generateRandomString(50))
+            .copy(b -> ((ClusterVariableDbModelBuilder) b).metadata(metadata));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var instance =
+        clusterVariableReader.getTenantScopedClusterVariable(
+            clusterVariable.name(),
+            clusterVariable.tenantId(),
+            CommonFixtures.resourceAccessChecksFromResourceIds(
+                AuthorizationResourceType.CLUSTER_VARIABLE, clusterVariable.name()));
+
+    assertThat(instance).isNotNull();
+    assertVariableDbModelEqualToEntity(clusterVariable, instance);
+  }
+
+  @TestTemplate
+  public void shouldUpdateClusterVariableReplacesMetadata(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final ClusterVariableDbReader clusterVariableReader = rdbmsService.getClusterVariableReader();
+
+    final ClusterVariableDbModel clusterVariable =
+        ClusterVariableFixtures.createRandomTenantClusterVariable(generateRandomString(50))
+            .copy(
+                b ->
+                    ((ClusterVariableDbModelBuilder) b)
+                        .metadata(List.of(new MetadataEntry("kind", "CREDENTIAL", null))));
+    rdbmsWriters.getClusterVariableWriter().create(clusterVariable);
+    rdbmsWriters.flush();
+
+    final List<MetadataEntry> updatedMetadata =
+        List.of(new MetadataEntry("schemaVersion", "3", 3.0));
+    final ClusterVariableDbModel updatedClusterVariable =
+        clusterVariable.copy(b -> ((ClusterVariableDbModelBuilder) b).metadata(updatedMetadata));
+    rdbmsWriters.getClusterVariableWriter().update(updatedClusterVariable);
+    rdbmsWriters.flush();
+
+    final var instance =
+        clusterVariableReader.getTenantScopedClusterVariable(
+            clusterVariable.name(),
+            clusterVariable.tenantId(),
+            CommonFixtures.resourceAccessChecksFromResourceIds(
+                AuthorizationResourceType.CLUSTER_VARIABLE, clusterVariable.name()));
+
+    assertThat(instance).isNotNull();
+    assertVariableDbModelEqualToEntity(updatedClusterVariable, instance);
+  }
+
+  @TestTemplate
   public void shouldDeleteTenantClusterVariable(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
@@ -443,7 +505,7 @@ public class ClusterVariableIT {
 
   private void assertVariableDbModelEqualToEntity(
       final ClusterVariableDbModel dbModel, final ClusterVariableEntity entity) {
-    // metadata is not yet persisted in ClusterVariableDbModel, so it has no equivalent to compare
-    assertThat(entity).usingRecursiveComparison().ignoringFields("metadata").isEqualTo(dbModel);
+    // the metadata JOIN has no ORDER BY, so row order across metadata entries is not guaranteed
+    assertThat(entity).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(dbModel);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableMetadataFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableMetadataFilterIT.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.clustervariables;
+
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createAndSaveVariables;
+import static io.camunda.it.rdbms.db.fixtures.ClusterVariableFixtures.createRandomTenantClusterVariable;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel.ClusterVariableDbModelBuilder;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.search.entities.ClusterVariableScope;
+import io.camunda.search.filter.ClusterVariableFilter;
+import io.camunda.search.filter.MetadataValueFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UntypedOperation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ClusterVariableQuery;
+import io.camunda.search.sort.ClusterVariableSort;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class ClusterVariableMetadataFilterIT {
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataEqFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("kind", "CREDENTIAL", null));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.eq("CREDENTIAL")));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataNeqFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("kind", "CREDENTIAL", null));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.neq("OTHER")));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataGtFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("schemaVersion", "2", 2.0));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("schemaVersion")
+            .valueOperation(UntypedOperation.of(Operation.gt(1.0)));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataGteFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("schemaVersion", "2", 2.0));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("schemaVersion")
+            .valueOperation(UntypedOperation.of(Operation.gte(2.0)));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataLtFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("schemaVersion", "2", 2.0));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("schemaVersion")
+            .valueOperation(UntypedOperation.of(Operation.lt(3.0)));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataLteFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("schemaVersion", "2", 2.0));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("schemaVersion")
+            .valueOperation(UntypedOperation.of(Operation.lte(2.0)));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataInFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("kind", "CREDENTIAL", null));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.in("CREDENTIAL", "OTHER")));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataLikeFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName,
+            tenantId,
+            new MetadataEntry("schemaRef", "io.camunda.connector.slack:1", null));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("schemaRef")
+            .valueOperation(UntypedOperation.of(Operation.like("*slack*")));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataExistsFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("kind", "CREDENTIAL", null));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.exists(true)));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataNotExistsFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        createRandomTenantClusterVariable(generateRandomString(50))
+            .copy(
+                b ->
+                    ((ClusterVariableDbModelBuilder) b)
+                        .name(varName)
+                        .tenantId(tenantId)
+                        .scope(ClusterVariableScope.TENANT));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.exists(false)));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldExcludeClusterVariableNotMatchingMetadataFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("kind", "PLAIN", null));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.eq("CREDENTIAL")));
+
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder()
+                        .scopes(ClusterVariableScope.TENANT.name())
+                        .tenantIds(tenantId)
+                        .names(varName)
+                        .metadataOperations(metadataFilter.build())
+                        .build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isZero();
+    assertThat(searchResult.items()).isEmpty();
+  }
+
+  private static ClusterVariableDbModel givenClusterVariableWithMetadata(
+      final String varName, final String tenantId, final MetadataEntry... metadata) {
+    return createRandomTenantClusterVariable(generateRandomString(50))
+        .copy(
+            b ->
+                ((ClusterVariableDbModelBuilder) b)
+                    .name(varName)
+                    .tenantId(tenantId)
+                    .scope(ClusterVariableScope.TENANT)
+                    .metadata(List.of(metadata)));
+  }
+
+  private static void searchAndAssertMetadataFilter(
+      final RdbmsService rdbmsService,
+      final String varName,
+      final String tenantId,
+      final MetadataValueFilter.Builder metadataFilter) {
+    final var searchResult =
+        rdbmsService
+            .getClusterVariableReader()
+            .search(
+                new ClusterVariableQuery(
+                    new ClusterVariableFilter.Builder()
+                        .scopes(ClusterVariableScope.TENANT.name())
+                        .tenantIds(tenantId)
+                        .names(varName)
+                        .metadataOperations(metadataFilter.build())
+                        .build(),
+                    ClusterVariableSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().name()).isEqualTo(varName);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableMetadataFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/clustervariables/ClusterVariableMetadataFilterIT.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class ClusterVariableMetadataFilterIT {
 
   @TestTemplate
-  public void shouldFindClusterVariableWithMetadataEqFilter(
+  public void shouldFindClusterVariableWithMetadataStringEqFilter(
       final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String tenantId = nextStringId();
@@ -51,6 +51,25 @@ public class ClusterVariableMetadataFilterIT {
         new MetadataValueFilter.Builder()
             .key("kind")
             .valueOperation(UntypedOperation.of(Operation.eq("CREDENTIAL")));
+
+    searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
+  }
+
+  @TestTemplate
+  public void shouldFindClusterVariableWithMetadataNumberEqFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final String tenantId = nextStringId();
+    final String varName = "var-name-" + nextStringId();
+    final ClusterVariableDbModel clusterVariable =
+        givenClusterVariableWithMetadata(
+            varName, tenantId, new MetadataEntry("kind", "10.0", 10.0));
+    createAndSaveVariables(rdbmsService, clusterVariable);
+
+    final var metadataFilter =
+        new MetadataValueFilter.Builder()
+            .key("kind")
+            .valueOperation(UntypedOperation.of(Operation.eq(10L)));
 
     searchAndAssertMetadataFilter(rdbmsService, varName, tenantId, metadataFilter);
   }

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
@@ -55,8 +55,10 @@ class RdbmsDbModelCoverageArchTest {
           "UsageMetricTUStatisticsDbModel", // TU statistics variant; covered by UsageMetricIT
           "UsageMetricTenantStatisticsDbModel", // tenant statistics variant; covered by
           // UsageMetricIT
-          "UsageMetricTUTenantStatisticsDbModel"); // TU tenant statistics variant; covered by
-  // UsageMetricIT
+          "UsageMetricTUTenantStatisticsDbModel", // TU tenant statistics variant; covered by
+          // UsageMetricIT
+          "ClusterVariableMetadataDbModel"); // metadata sub-entity of ClusterVariable; covered by
+  // ClusterVariableIT
 
   // IT class simple names scanned from test-jars once at class-load time.
   static final Set<String> IT_SIMPLE_NAMES =

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
@@ -54,6 +54,7 @@ class RdbmsDbModelSortITCoverageArchTest {
           "GroupMemberDbModel", // member sub-entity; no GroupMemberSortIT
           "TenantMemberDbModel", // member sub-entity; no TenantMemberSortIT
           "RoleMemberDbModel", // member sub-entity; no RoleMemberSortIT
+          "ClusterVariableMetadataDbModel", // metadata sub-entity; covered by ClusterVariableIT
           "ProcessDefinitionVariableNameLookupDbModel", // variable-name cache; has an IT but no
           // sort fields
           "BatchOperationErrorDbModel", // error sub-entity of BatchOperation; no sort fields

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ClusterVariableEntity.java
@@ -33,6 +33,19 @@ public record ClusterVariableEntity(
     metadata = metadata != null ? new ArrayList<>(metadata) : new ArrayList<>();
   }
 
+  // Used by the RDBMS resultMap's <constructor>, whose args mirror this signature; the
+  // <collection> for metadata is mapped separately and hydrated onto the mutable list below.
+  public ClusterVariableEntity(
+      final String id,
+      final String name,
+      final String value,
+      final String fullValue,
+      final Boolean isPreview,
+      final ClusterVariableScope scope,
+      final String tenantId) {
+    this(id, name, value, fullValue, isPreview, scope, tenantId, new ArrayList<>());
+  }
+
   @Override
   public boolean hasTenantScope() {
     return ClusterVariableScope.TENANT.equals(scope);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -12,11 +12,14 @@ import static io.camunda.zeebe.protocol.record.value.ClusterVariableScope.GLOBAL
 import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
 import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
+import java.util.List;
+import java.util.Map;
 
 public class ClusterVariableExportHandler
     implements RdbmsExportHandler<ClusterVariableRecordValue> {
@@ -51,12 +54,28 @@ public class ClusterVariableExportHandler
     final var builder =
         new ClusterVariableDbModel.ClusterVariableDbModelBuilder()
             .name(value.getName())
-            .value(value.getValue());
+            .value(value.getValue())
+            .metadata(mapMetadata(value.getMetadata()));
     if (value.getScope() == GLOBAL) {
       builder.scope(ClusterVariableScope.GLOBAL).tenantId(null);
     } else {
       builder.scope(ClusterVariableScope.TENANT).tenantId(value.getTenantId());
     }
     return builder.build();
+  }
+
+  private List<MetadataEntry> mapMetadata(final Map<String, Object> metadata) {
+    if (metadata == null || metadata.isEmpty()) {
+      return List.of();
+    }
+    return metadata.entrySet().stream()
+        .map(
+            entry -> {
+              final var metadataValue = entry.getValue();
+              final var numericValue =
+                  metadataValue instanceof Number number ? number.doubleValue() : null;
+              return new MetadataEntry(entry.getKey(), String.valueOf(metadataValue), numericValue);
+            })
+        .toList();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandler.java
@@ -69,6 +69,7 @@ public class ClusterVariableExportHandler
       return List.of();
     }
     return metadata.entrySet().stream()
+        .filter(entry -> entry.getValue() != null)
         .map(
             entry -> {
               final var metadataValue = entry.getValue();

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
@@ -74,6 +74,33 @@ class ClusterVariableExportHandlerTest {
   }
 
   @Test
+  void shouldFilterOutMetadataEntriesWithNullValues() {
+    // given
+    final Map<String, Object> metadata = new java.util.HashMap<>();
+    metadata.put("kind", "CREDENTIAL");
+    metadata.put("empty", null);
+    final var recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .withName("myVariable")
+            .withValue("myValue")
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withMetadata(metadata)
+            .build();
+    final Record<io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().metadata())
+        .containsExactly(new MetadataEntry("kind", "CREDENTIAL", null));
+  }
+
+  @Test
   void shouldMapEmptyMetadataToEmptyList() {
     // given
     final var recordValue =

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ClusterVariableExportHandlerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.ClusterVariableDbModel;
+import io.camunda.db.rdbms.write.service.ClusterVariableWriter;
+import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
+import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterVariableExportHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private ClusterVariableWriter writer;
+  @Captor private ArgumentCaptor<ClusterVariableDbModel> modelCaptor;
+
+  private ClusterVariableExportHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new ClusterVariableExportHandler(writer);
+  }
+
+  @Test
+  void shouldMapMetadataStringAndNumericValues() {
+    // given
+    final var recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .withName("myVariable")
+            .withValue("myValue")
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withMetadata(Map.of("kind", "CREDENTIAL", "schemaVersion", 2L))
+            .build();
+    final Record<io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var metadata = modelCaptor.getValue().metadata();
+    assertThat(metadata).hasSize(2);
+    assertThat(metadata)
+        .filteredOn(entry -> entry.key().equals("kind"))
+        .containsExactly(new MetadataEntry("kind", "CREDENTIAL", null));
+    assertThat(metadata)
+        .filteredOn(entry -> entry.key().equals("schemaVersion"))
+        .containsExactly(new MetadataEntry("schemaVersion", "2", 2.0));
+  }
+
+  @Test
+  void shouldMapEmptyMetadataToEmptyList() {
+    // given
+    final var recordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .withName("myVariable")
+            .withValue("myValue")
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withMetadata(Map.of())
+            .build();
+    final Record<io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue> record =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(ClusterVariableIntent.CREATED).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().metadata()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

Adds arbitrary key/value metadata to cluster variables in the RDBMS exporter, alongside the existing name/value/scope fields.

- Introduces a `CLUSTER_VARIABLE_METADATA` table with read/write support.
- Adds search filtering by metadata key with string and numeric operations.
- Metadata is read via a separate batched query keyed by cluster variable id (not a `LEFT JOIN`), avoiding duplication of the large `VAR_VALUE` / `VAR_FULL_VALUE` columns across metadata rows.
- On write, metadata is replaced via delete+insert; the `CLUSTER_VARIABLE` context now preserves queue order so `DELETE` runs before `INSERT`.
- String-vs-numeric routing is precomputed in `ClusterVariableMetadataSearchFilter` (MyBatis XML cannot branch on an untyped operation), mirroring `ClusterVariableFilterTransformer#toMetadataValueQueries` to keep RDBMS and ES/OS filter semantics in parity.

## Map semantics & coverage

Follow-up changes addressing review findings:

- Added a composite primary key `(CLUSTER_VARIABLE_ID, METADATA_KEY)` to `CLUSTER_VARIABLE_METADATA` so duplicate keys cannot be persisted and the rows faithfully represent a key/value map. Mirrors the existing `PROCESS_INSTANCE_TAG` child-table pattern. The changeset is unreleased, so it is edited in place rather than via a follow-up changeset.
- Oversized metadata values are truncated to fit the `METADATA_VALUE` column (there is no full-value fallback column), so an oversized value no longer fails the insert and stalls the exporter.
- Registered `CLUSTER_VARIABLE_METADATA` in `RdbmsTableNames` so the purger truncates it (fixes `PurgerCompletenessIT`).
- Exempted `ClusterVariableMetadataDbModel` from the DbModel and SortIT coverage arch rules: it is a read-side sub-entity covered by `ClusterVariableIT`, with no standalone IT or user-facing sort fields.

## Related issues

Closes #55093
