### PR TITLE
feat: add contention ratio in zeebe grafana dashboard

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -10110,7 +10110,7 @@
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
-          "description": "Quantiles of time spent waiting to acquire the sequencer lock, by who is waiting",
+          "description": "Quantiles of time spent waiting to acquire the sequencer lock, by who is waiting. The metric is only recorded when a thread actually had to wait for the lock — if the lock was acquired immediately, no observation is recorded. Contention ratio (right axis) is the rate of lock waits divided by the rate of lock holds, i.e. the fraction of writes that had to wait.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -10165,7 +10165,30 @@
               },
               "unit": "s"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^contention ratio.*/"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "custom.scaleDistribution",
+                    "value": {
+                      "type": "linear"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 7,
@@ -10236,6 +10259,18 @@
               "interval": "30s",
               "legendFormat": "p50 {{waiter}}",
               "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(zeebe_sequencer_lock_wait_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (waiter) / on(waiter) label_replace(sum(rate(zeebe_sequencer_lock_hold_time_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\", pod=~\"$pod\"}[$__rate_interval])) by (writer), \"waiter\", \"$1\", \"writer\", \"(.*)\")",
+              "format": "time_series",
+              "interval": "30s",
+              "legendFormat": "contention ratio {{waiter}}",
+              "refId": "E"
             }
           ],
           "title": "Sequencer Lock Wait Time Quantiles",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -48,7 +48,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 4,
+  "id": null,
   "links": [],
   "panels": [
     {


### PR DESCRIPTION
## Description
Adds the percentage of times a thread had to wait for another thread before grabbing the lock in a secondary axis. 
The metric was not measured when there was no lock to grab, so it was giving a false indication on the time spent waiting on a lock.
<img width="916" height="278" alt="image" src="https://github.com/user-attachments/assets/00e7ab62-32ad-4797-a8be-0c6925cf91f8" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #49717
