### PR TITLE
pg/56674-partition-recovering-state

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -377,6 +377,7 @@ final class ClusterApiUtils {
       case JOINING -> PartitionStateCode.JOINING;
       case ACTIVE -> PartitionStateCode.ACTIVE;
       case LEAVING -> PartitionStateCode.LEAVING;
+      case RECOVERING -> PartitionStateCode.RECOVERING;
       // TODO: Define state code for BootStrapping
       case BOOTSTRAPPING, UNKNOWN -> PartitionStateCode.UNKNOWN;
     };

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -495,6 +495,7 @@ schemas:
       - JOINING
       - ACTIVE
       - LEAVING
+      - RECOVERING
 
   TopologyVersion:
     title: TopologyVersion

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -203,6 +203,30 @@ final class ClusterApiUtilsTest {
         .containsExactlyInAnyOrder("0", "1");
   }
 
+  @Test
+  void shouldMapRecoveringPartitionState() {
+    // given
+    final var config =
+        ClusterConfiguration.init()
+            .addMember(
+                MemberId.from("0"),
+                MemberState.initializeAsActive(
+                    Map.of(
+                        1,
+                        PartitionState.active(1, DynamicPartitionConfig.init()).toRecovering())));
+
+    // when
+    final var response = ClusterApiUtils.mapClusterTopologyResponse(Either.right(config));
+
+    // then
+    final var body = (GetTopologyResponse) response.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.getBrokers())
+        .flatExtracting(BrokerState::getPartitions)
+        .extracting(io.camunda.zeebe.management.cluster.PartitionState::getState)
+        .containsExactly(io.camunda.zeebe.management.cluster.PartitionStateCode.RECOVERING);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"ZONE_AWARE", "FIXED", "ROUND_ROBIN"})
   void shouldIncludePartitionDistributorConfig(final String type) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandler.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -312,6 +313,15 @@ public final class PartitionModeHandler implements ModeChangeExecutor, AsyncClos
                       .filter(
                           partitionId -> health.get(partitionId) == PartitionHealthStatus.HEALTHY)
                       .collect(Collectors.toSet());
+              if (healthyPartitions.size() < expectedPartitions.size()) {
+                final var unhealthyPartitions = new HashSet<>(expectedPartitions);
+                unhealthyPartitions.removeAll(healthyPartitions);
+                LOG.warn(
+                    "Partition group {}: partitions {} are not healthy during recovery transition - {}",
+                    partitionGroup,
+                    unhealthyPartitions,
+                    health);
+              }
               result.complete(healthyPartitions);
             });
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandler.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.protocol.record.PartitionRole;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
@@ -138,9 +139,9 @@ public final class PartitionModeHandler implements ModeChangeExecutor, AsyncClos
    * operation fails immediately.
    */
   @Override
-  public ActorFuture<Void> awaitModeApplied(final Mode mode) {
+  public ActorFuture<Set<Integer>> awaitModeApplied(final Mode mode) {
     final var concurrencyControl = concurrencyControl();
-    final var result = concurrencyControl.<Void>createFuture();
+    final var result = concurrencyControl.<Set<Integer>>createFuture();
     concurrencyControl.run(
         () -> {
           final var expectedRecovering = mode == Mode.RECOVERING;
@@ -153,10 +154,10 @@ public final class PartitionModeHandler implements ModeChangeExecutor, AsyncClos
           }
           final var expectedPartitions = expectedLocalPartitionIds();
           if (expectedPartitions.isEmpty()) {
-            result.complete(null);
+            result.complete(Set.of());
             return;
           }
-          pollPartitionsReady(expectedPartitions, readyRolesFor(mode), result);
+          pollPartitionsReady(expectedPartitions, mode, result);
         });
     return result;
   }
@@ -255,28 +256,63 @@ public final class PartitionModeHandler implements ModeChangeExecutor, AsyncClos
 
   private void pollPartitionsReady(
       final Set<Integer> expectedPartitions,
-      final Set<PartitionRole> targetRoles,
-      final ActorFuture<Void> result) {
+      final Mode mode,
+      final ActorFuture<Set<Integer>> result) {
+    final var targetRoles = readyRolesFor(mode);
     concurrencyControl()
         .runOnCompletion(
             topologyManager.getLocalPartitionRoles(),
-            (roles, error) -> {
-              if (error != null) {
-                result.completeExceptionally(error);
+            (roles, rolesError) -> {
+              if (rolesError != null) {
+                result.completeExceptionally(rolesError);
                 return;
               }
               final var pendingRolePartitions =
                   expectedPartitions.stream()
                       .filter(partitionId -> !targetRoles.contains(roles.get(partitionId)))
                       .toList();
-              if (pendingRolePartitions.isEmpty()) {
-                result.complete(null);
-              } else {
+              if (!pendingRolePartitions.isEmpty()) {
                 result.completeExceptionally(
                     new IllegalStateException(
                         "Partition group %s: partitions %s have not yet reached roles %s (current roles: %s); the operation will be retried"
                             .formatted(partitionGroup, pendingRolePartitions, targetRoles, roles)));
+                return;
               }
+              if (mode != Mode.RECOVERING) {
+                result.complete(expectedPartitions);
+                return;
+              }
+              pollHealthAndComplete(expectedPartitions, result);
+            });
+  }
+
+  private void pollHealthAndComplete(
+      final Set<Integer> expectedPartitions, final ActorFuture<Set<Integer>> result) {
+    concurrencyControl()
+        .runOnCompletion(
+            topologyManager.getLocalPartitionHealth(),
+            (health, healthError) -> {
+              if (healthError != null) {
+                result.completeExceptionally(healthError);
+                return;
+              }
+              final var pendingHealthPartitions =
+                  expectedPartitions.stream()
+                      .filter(partitionId -> !health.containsKey(partitionId))
+                      .toList();
+              if (!pendingHealthPartitions.isEmpty()) {
+                result.completeExceptionally(
+                    new IllegalStateException(
+                        "Partition group %s: partitions %s have not yet reported health; the operation will be retried"
+                            .formatted(partitionGroup, pendingHealthPartitions)));
+                return;
+              }
+              final var healthyPartitions =
+                  expectedPartitions.stream()
+                      .filter(
+                          partitionId -> health.get(partitionId) == PartitionHealthStatus.HEALTHY)
+                      .collect(Collectors.toSet());
+              result.complete(healthyPartitions);
             });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManager.java
@@ -181,6 +181,10 @@ public final class RecoveryPartitionManager
               (ignoredDeactivate, deactivateError) -> {
                 // reported once the partition is registered as INACTIVE above, since
                 // onHealthChanged is a no-op for a partition the topology doesn't know about yet
+                recoveryPartitions.forEach(
+                    p ->
+                        topologyManager.onHealthChanged(
+                            p.partitionId().number(), HealthStatus.HEALTHY));
                 failedPartitionIds.forEach(
                     id -> topologyManager.onHealthChanged(id, HealthStatus.DEAD));
                 if (recoveryPartitions.isEmpty()) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.protocol.record.PartitionRole;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -100,6 +101,11 @@ public final class TopologyManagerImpl extends Actor
   /** Returns a snapshot of this broker's local partition roles for this partition group */
   public ActorFuture<Map<Integer, PartitionRole>> getLocalPartitionRoles() {
     return actor.call(() -> Map.copyOf(localPartitionGroupInfo.getPartitionRoles()));
+  }
+
+  /** Returns a snapshot of this broker's local partition health for this partition group */
+  public ActorFuture<Map<Integer, PartitionHealthStatus>> getLocalPartitionHealth() {
+    return actor.call(() -> Map.copyOf(localPartitionGroupInfo.getPartitionHealthStatuses()));
   }
 
   public ActorFuture<Void> setInactive(final int partitionId) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerAwaitModeChangeApplierTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerAwaitModeChangeApplierTest.java
@@ -122,12 +122,6 @@ final class PartitionModeHandlerAwaitModeChangeApplierTest {
     scheduler.workUntilDone();
   }
 
-  private static final class ControlActor extends Actor {
-    ActorControl getActorControl() {
-      return actor;
-    }
-  }
-
   @Test
   void shouldWriteRecoveringOnlyForHealthyPartitionsAcrossBothCollaborators() {
     // given - partition 1 recovers healthily, partition 2 reaches INACTIVE but is DEAD
@@ -177,5 +171,11 @@ final class PartitionModeHandlerAwaitModeChangeApplierTest {
     // then - the applier propagates the failure so the cluster change is retried, rather than
     // writing any partition state prematurely
     assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+
+  private static final class ControlActor extends Actor {
+    ActorControl getActorControl() {
+      return actor;
+    }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerAwaitModeChangeApplierTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerAwaitModeChangeApplierTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
+import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
+import io.camunda.zeebe.dynamic.config.changes.AwaitModeChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import io.camunda.zeebe.protocol.record.PartitionRole;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Wires the real {@link PartitionModeHandler} together with a real {@link AwaitModeChangeApplier} -
+ * the two collaborators, split across the broker and dynamic-config modules, that jointly decide
+ * which partitions get confirmed as {@link PartitionState.State#RECOVERING}. Each is otherwise
+ * tested in isolation with the other mocked out, so this proves the composition: a partition
+ * reported unhealthy is excluded from the confirmed set and keeps its prior {@link PartitionState},
+ * while a healthy sibling is written as {@code RECOVERING}.
+ */
+final class PartitionModeHandlerAwaitModeChangeApplierTest {
+
+  private static final String GROUP = PartitionManagerImpl.DEFAULT_GROUP_NAME;
+  private static final MemberId LOCAL_MEMBER = MemberId.from("0");
+
+  @RegisterExtension
+  private final ControlledActorSchedulerExtension scheduler =
+      new ControlledActorSchedulerExtension();
+
+  private final ControlActor controlActor = new ControlActor();
+
+  private ClusterConfigurationService clusterConfigurationService;
+  private TopologyManagerImpl topologyManager;
+  private PartitionModeHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler.submitActor(controlActor);
+    scheduler.workUntilDone();
+
+    clusterConfigurationService = mock(ClusterConfigurationService.class);
+    topologyManager = mock(TopologyManagerImpl.class);
+
+    final var brokerStartupContext = mock(BrokerStartupContext.class);
+    when(brokerStartupContext.getConcurrencyControl()).thenReturn(controlActor.getActorControl());
+    when(brokerStartupContext.getClusterConfigurationService())
+        .thenReturn(clusterConfigurationService);
+    final Map<String, PartitionManager> partitionManagers = new HashMap<>();
+    partitionManagers.put(GROUP, mock(RecoveryPartitionManager.class));
+    when(brokerStartupContext.getPartitionManagers()).thenReturn(partitionManagers);
+
+    final var clusterServices = mock(ClusterServicesImpl.class);
+    final var membershipService = mock(ClusterMembershipService.class);
+    final var localMember = mock(Member.class);
+    when(localMember.id()).thenReturn(LOCAL_MEMBER);
+    when(membershipService.getLocalMember()).thenReturn(localMember);
+    when(clusterServices.getMembershipService()).thenReturn(membershipService);
+    when(brokerStartupContext.getClusterServices()).thenReturn(clusterServices);
+
+    handler = new PartitionModeHandler(brokerStartupContext, GROUP, topologyManager);
+  }
+
+  private void givenLocalPartitions(final Integer... partitionIds) {
+    final Set<PartitionMetadata> metadata =
+        Arrays.stream(partitionIds)
+            .map(
+                id ->
+                    new PartitionMetadata(
+                        new PartitionId(GROUP, id),
+                        Set.of(LOCAL_MEMBER),
+                        Map.of(LOCAL_MEMBER, 1),
+                        1,
+                        LOCAL_MEMBER))
+            .collect(Collectors.toSet());
+    when(clusterConfigurationService.getPartitionDistribution())
+        .thenReturn(new PartitionDistribution(metadata));
+  }
+
+  private void givenPartitionRoles(final Map<Integer, PartitionRole> roles) {
+    when(topologyManager.getLocalPartitionRoles())
+        .thenReturn(CompletableActorFuture.completed(Map.copyOf(roles)));
+  }
+
+  private void givenPartitionHealth(final Map<Integer, PartitionHealthStatus> health) {
+    when(topologyManager.getLocalPartitionHealth())
+        .thenReturn(CompletableActorFuture.completed(Map.copyOf(health)));
+  }
+
+  private void progress() {
+    scheduler.workUntilDone();
+  }
+
+  private static final class ControlActor extends Actor {
+    ActorControl getActorControl() {
+      return actor;
+    }
+  }
+
+  @Test
+  void shouldWriteRecoveringOnlyForHealthyPartitionsAcrossBothCollaborators() {
+    // given - partition 1 recovers healthily, partition 2 reaches INACTIVE but is DEAD
+    givenLocalPartitions(1, 2);
+    givenPartitionRoles(Map.of(1, PartitionRole.INACTIVE, 2, PartitionRole.INACTIVE));
+    givenPartitionHealth(Map.of(1, PartitionHealthStatus.HEALTHY, 2, PartitionHealthStatus.DEAD));
+
+    final var partitionConfig = DynamicPartitionConfig.init();
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                LOCAL_MEMBER,
+                MemberState.initializeAsActive(
+                    Map.of(
+                        1, PartitionState.active(1, partitionConfig),
+                        2, PartitionState.active(1, partitionConfig))));
+    final var applier = new AwaitModeChangeApplier(LOCAL_MEMBER, Mode.RECOVERING, handler);
+
+    // when
+    final var result = applier.apply();
+    progress();
+
+    // then - only the confirmed, healthy partition (1) is written as RECOVERING; the dead
+    // partition (2) keeps its prior state instead of being silently marked as recovered
+    assertThat(result.isCompletedExceptionally()).isFalse();
+    final var updated = result.join().apply(clusterConfiguration);
+    assertThat(updated.getMember(LOCAL_MEMBER).getPartition(1).state())
+        .isEqualTo(PartitionState.State.RECOVERING);
+    assertThat(updated.getMember(LOCAL_MEMBER).getPartition(2).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+  }
+
+  @Test
+  void shouldFailWithoutWritingAnyStateWhenHealthNotYetReported() {
+    // given - role reached INACTIVE, but health hasn't been reported yet (the race the design
+    // closes: RecoveryPartitionManager sets role and health in two separate steps)
+    givenLocalPartitions(1);
+    givenPartitionRoles(Map.of(1, PartitionRole.INACTIVE));
+    givenPartitionHealth(Map.of());
+
+    final var applier = new AwaitModeChangeApplier(LOCAL_MEMBER, Mode.RECOVERING, handler);
+
+    // when
+    final var result = applier.apply();
+    progress();
+
+    // then - the applier propagates the failure so the cluster change is retried, rather than
+    // writing any partition state prematurely
+    assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
@@ -79,6 +79,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
   private static final String GROUP = PartitionManagerImpl.DEFAULT_GROUP_NAME;
   private static final int PARTITION_ID = 1;
   private static final int PARTITION_ID_2 = 2;
+  private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(30);
 
   private ActorScheduler actorScheduler;
   private Actor controlActor;
@@ -203,7 +204,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
     final var enterResult = handler.enterRecovery();
 
     // then - the operation completes without waiting for the recovery manager to fully start
-    assertThat(enterResult).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(enterResult).succeedsWithin(AWAIT_TIMEOUT);
 
     // and - partition 1 recovers healthily, partition 2 reaches INACTIVE but never recovers so
     // it is reported DEAD
@@ -212,33 +213,26 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
             () -> {
               final var publishedInfos = BrokerInfo.allFromProperties(localMember.properties());
               assertThat(publishedInfos)
-                  .anySatisfy(
-                      info ->
-                          assertThat(info.getPartitionRoles())
-                              .containsEntry(PARTITION_ID, PartitionRole.INACTIVE)
-                              .containsEntry(PARTITION_ID_2, PartitionRole.INACTIVE));
-            });
-    await()
-        .untilAsserted(
-            () -> {
-              final var publishedInfos = BrokerInfo.allFromProperties(localMember.properties());
-              assertThat(publishedInfos)
-                  .anySatisfy(
-                      info ->
-                          assertThat(info.getPartitionHealthStatuses())
-                              .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
-                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD));
+                  .allSatisfy(
+                      info -> {
+                        assertThat(info.getPartitionRoles())
+                            .containsEntry(PARTITION_ID, PartitionRole.INACTIVE)
+                            .containsEntry(PARTITION_ID_2, PartitionRole.INACTIVE);
+                        assertThat(info.getPartitionHealthStatuses())
+                            .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
+                            .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD);
+                      });
             });
 
     // and - confirming and writing recovery state excludes the dead partition but still completes
     final var recoveringConfirmed = handler.awaitModeApplied(Mode.RECOVERING);
-    assertThat(recoveringConfirmed).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(recoveringConfirmed).succeedsWithin(AWAIT_TIMEOUT);
     assertThat(recoveringConfirmed.join()).containsExactly(PARTITION_ID);
 
     final var recoveringApplier =
         new AwaitModeChangeApplier(localMemberId, Mode.RECOVERING, handler);
     final var recoveringApplyResult = recoveringApplier.apply();
-    assertThat(recoveringApplyResult).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(recoveringApplyResult).succeedsWithin(AWAIT_TIMEOUT);
     clusterConfiguration = recoveringApplyResult.join().apply(clusterConfiguration);
 
     assertThat(clusterConfiguration.getMember(localMemberId).getPartition(PARTITION_ID).state())
@@ -249,7 +243,7 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
     // and - exiting recovery replaces the recovery manager (including its partial failure) with a
     // brand-new partition manager
     final var exitResult = handler.exitRecovery();
-    assertThat(exitResult).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(exitResult).succeedsWithin(AWAIT_TIMEOUT);
 
     // and - the new manager brings both partitions to a processing role, including the one that
     // was DEAD during recovery
@@ -267,13 +261,13 @@ final class PartitionModeHandlerRecoveryRoundTripTest {
 
     // and - confirming exit is role-only: partition 2's earlier DEAD health status must not matter
     final var processingConfirmed = handler.awaitModeApplied(Mode.PROCESSING);
-    assertThat(processingConfirmed).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(processingConfirmed).succeedsWithin(AWAIT_TIMEOUT);
     assertThat(processingConfirmed.join()).containsExactlyInAnyOrder(PARTITION_ID, PARTITION_ID_2);
 
     final var processingApplier =
         new AwaitModeChangeApplier(localMemberId, Mode.PROCESSING, handler);
     final var processingApplyResult = processingApplier.apply();
-    assertThat(processingApplyResult).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(processingApplyResult).succeedsWithin(AWAIT_TIMEOUT);
     clusterConfiguration = processingApplyResult.join().apply(clusterConfiguration);
 
     // then - the whole group converges cleanly back to ACTIVE, unaffected by the earlier partial

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerRecoveryRoundTripTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberConfig;
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.partition.RaftPartition;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
+import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.partitioning.PartitionModeHandler.PartitionManagerFactory;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
+import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
+import io.camunda.zeebe.dynamic.config.changes.AwaitModeChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import io.camunda.zeebe.protocol.record.PartitionRole;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.SchedulingHints;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves the full round trip through recovery mode with a partial failure: one partition fails to
+ * recover (reported {@code DEAD}) while its sibling recovers cleanly, the group still confirms and
+ * writes {@code RECOVERING} only for the healthy partition, and - crucially - exiting recovery
+ * afterward is not blocked or corrupted by that earlier partial failure. The exit path
+ * (`PartitionModeHandler#exitRecovery`/`awaitModeApplied(PROCESSING)`) gates purely on Raft role,
+ * not health, and starts a brand-new partition manager from scratch, so the group must converge
+ * cleanly back to {@code PROCESSING}/{@code ACTIVE} regardless of what happened to partition 2
+ * during recovery.
+ *
+ * <p>Every collaborator is real except the "exit" partition manager: a real Raft-based {@link
+ * PartitionManagerImpl} would require a running Raft cluster, so a lightweight fake that marks its
+ * local partitions {@code LEADER} on the real {@link TopologyManagerImpl} stands in for it - the
+ * same level of fidelity {@link PartitionModeHandlerTest}'s {@code ExitRecovery} tests use with a
+ * mocked {@code normalManager}.
+ */
+final class PartitionModeHandlerRecoveryRoundTripTest {
+
+  private static final String GROUP = PartitionManagerImpl.DEFAULT_GROUP_NAME;
+  private static final int PARTITION_ID = 1;
+  private static final int PARTITION_ID_2 = 2;
+
+  private ActorScheduler actorScheduler;
+  private Actor controlActor;
+  private Member localMember;
+  private MemberId localMemberId;
+  private TopologyManagerImpl topologyManager;
+  private PartitionModeHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    actorScheduler = ActorScheduler.newActorScheduler().build();
+    actorScheduler.start();
+
+    controlActor = new Actor() {};
+    actorScheduler.submitActor(controlActor).join();
+
+    localMember = new Member(new MemberConfig());
+    localMemberId = localMember.id();
+
+    final var membershipService = mock(ClusterMembershipService.class);
+    when(membershipService.getLocalMember()).thenReturn(localMember);
+
+    final var metadata1 = localPartitionMetadata(PARTITION_ID);
+    final var metadata2 = localPartitionMetadata(PARTITION_ID_2);
+    final var clusterConfigurationService = mock(ClusterConfigurationService.class);
+    when(clusterConfigurationService.getPartitionDistribution())
+        .thenReturn(new PartitionDistribution(Set.of(metadata1, metadata2)));
+
+    final var brokerInfo = new BrokerInfo(0, null, "localhost:26501").setPartitionGroup(GROUP);
+    topologyManager = new TopologyManagerImpl(membershipService, brokerInfo);
+    actorScheduler.submitActor(topologyManager).join();
+
+    final var transport = mock(AtomixServerTransport.class);
+    when(transport.subscribe(any(), any(), any()))
+        .thenReturn(CompletableActorFuture.completed(null));
+    when(transport.unsubscribe(any(), any())).thenReturn(CompletableActorFuture.completed(null));
+
+    final Map<String, PartitionManager> partitionManagers = new HashMap<>();
+    final var initialManager = mock(PartitionManager.class);
+    when(initialManager.stop()).thenReturn(CompletableActorFuture.completed(null));
+    partitionManagers.put(GROUP, initialManager);
+
+    final var brokerStartupContext = mock(BrokerStartupContext.class);
+    when(brokerStartupContext.getConcurrencyControl()).thenReturn(controlActor);
+    when(brokerStartupContext.getClusterConfigurationService())
+        .thenReturn(clusterConfigurationService);
+    when(brokerStartupContext.getPartitionManagers()).thenReturn(partitionManagers);
+    // publish the new manager into the resolved map so currentManager()/isRecovering() reflect the
+    // transition, mirroring what the production BrokerStartupContext does
+    doAnswer(
+            invocation -> {
+              partitionManagers.put(invocation.getArgument(0), invocation.getArgument(1));
+              return null;
+            })
+        .when(brokerStartupContext)
+        .addPartitionManager(any(), any());
+
+    final var clusterServices = mock(ClusterServicesImpl.class);
+    when(clusterServices.getMembershipService()).thenReturn(membershipService);
+    when(brokerStartupContext.getClusterServices()).thenReturn(clusterServices);
+
+    // recovery manager: real, driven by the real actor scheduler, with partition 2's recovery
+    // steps rigged to fail so only partition 1 actually recovers
+    final var recoveryManager =
+        new RecoveryPartitionManager(
+            GROUP,
+            new BrokerCfg(),
+            brokerInfo,
+            controlActor,
+            clusterConfigurationService,
+            membershipService,
+            new FailingActorSchedulingService(actorScheduler, PARTITION_ID_2),
+            new SimpleMeterRegistry(),
+            transport,
+            topologyManager);
+
+    // exit manager: a lightweight fake standing in for a real Raft-based PartitionManagerImpl -
+    // it just marks both local partitions LEADER on start, matching what PartitionModeHandlerTest
+    // does with a mocked normalManager
+    final var exitManager =
+        new LeaderPartitionManager(controlActor, topologyManager, PARTITION_ID, PARTITION_ID_2);
+
+    final PartitionManagerFactory partitionManagerFactory =
+        mode -> mode == Mode.RECOVERING ? recoveryManager : exitManager;
+
+    handler =
+        new PartitionModeHandler(
+            brokerStartupContext, GROUP, topologyManager, partitionManagerFactory);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (controlActor != null) {
+      controlActor.closeAsync().join();
+    }
+    actorScheduler.stop();
+  }
+
+  private PartitionMetadata localPartitionMetadata(final int partitionId) {
+    return new PartitionMetadata(
+        new PartitionId(GROUP, partitionId),
+        Set.of(localMemberId),
+        Map.of(localMemberId, 1),
+        1,
+        localMemberId);
+  }
+
+  @Test
+  void shouldConvergeToProcessingAfterRecoveryWithPartialFailure() {
+    // given - both partitions start out ACTIVE in cluster configuration
+    final var partitionConfig = DynamicPartitionConfig.init();
+    var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(
+                        PARTITION_ID, PartitionState.active(1, partitionConfig),
+                        PARTITION_ID_2, PartitionState.active(1, partitionConfig))));
+
+    // when - entering recovery, partition 2's recovery steps fail to schedule
+    final var enterResult = handler.enterRecovery();
+
+    // then - the operation completes without waiting for the recovery manager to fully start
+    assertThat(enterResult).succeedsWithin(Duration.ofSeconds(10));
+
+    // and - partition 1 recovers healthily, partition 2 reaches INACTIVE but never recovers so
+    // it is reported DEAD
+    await()
+        .untilAsserted(
+            () -> {
+              final var publishedInfos = BrokerInfo.allFromProperties(localMember.properties());
+              assertThat(publishedInfos)
+                  .anySatisfy(
+                      info ->
+                          assertThat(info.getPartitionRoles())
+                              .containsEntry(PARTITION_ID, PartitionRole.INACTIVE)
+                              .containsEntry(PARTITION_ID_2, PartitionRole.INACTIVE));
+            });
+    await()
+        .untilAsserted(
+            () -> {
+              final var publishedInfos = BrokerInfo.allFromProperties(localMember.properties());
+              assertThat(publishedInfos)
+                  .anySatisfy(
+                      info ->
+                          assertThat(info.getPartitionHealthStatuses())
+                              .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
+                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD));
+            });
+
+    // and - confirming and writing recovery state excludes the dead partition but still completes
+    final var recoveringConfirmed = handler.awaitModeApplied(Mode.RECOVERING);
+    assertThat(recoveringConfirmed).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(recoveringConfirmed.join()).containsExactly(PARTITION_ID);
+
+    final var recoveringApplier =
+        new AwaitModeChangeApplier(localMemberId, Mode.RECOVERING, handler);
+    final var recoveringApplyResult = recoveringApplier.apply();
+    assertThat(recoveringApplyResult).succeedsWithin(Duration.ofSeconds(10));
+    clusterConfiguration = recoveringApplyResult.join().apply(clusterConfiguration);
+
+    assertThat(clusterConfiguration.getMember(localMemberId).getPartition(PARTITION_ID).state())
+        .isEqualTo(PartitionState.State.RECOVERING);
+    assertThat(clusterConfiguration.getMember(localMemberId).getPartition(PARTITION_ID_2).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+
+    // and - exiting recovery replaces the recovery manager (including its partial failure) with a
+    // brand-new partition manager
+    final var exitResult = handler.exitRecovery();
+    assertThat(exitResult).succeedsWithin(Duration.ofSeconds(10));
+
+    // and - the new manager brings both partitions to a processing role, including the one that
+    // was DEAD during recovery
+    await()
+        .untilAsserted(
+            () -> {
+              final var publishedInfos = BrokerInfo.allFromProperties(localMember.properties());
+              assertThat(publishedInfos)
+                  .anySatisfy(
+                      info ->
+                          assertThat(info.getPartitionRoles())
+                              .containsEntry(PARTITION_ID, PartitionRole.LEADER)
+                              .containsEntry(PARTITION_ID_2, PartitionRole.LEADER));
+            });
+
+    // and - confirming exit is role-only: partition 2's earlier DEAD health status must not matter
+    final var processingConfirmed = handler.awaitModeApplied(Mode.PROCESSING);
+    assertThat(processingConfirmed).succeedsWithin(Duration.ofSeconds(10));
+    assertThat(processingConfirmed.join()).containsExactlyInAnyOrder(PARTITION_ID, PARTITION_ID_2);
+
+    final var processingApplier =
+        new AwaitModeChangeApplier(localMemberId, Mode.PROCESSING, handler);
+    final var processingApplyResult = processingApplier.apply();
+    assertThat(processingApplyResult).succeedsWithin(Duration.ofSeconds(10));
+    clusterConfiguration = processingApplyResult.join().apply(clusterConfiguration);
+
+    // then - the whole group converges cleanly back to ACTIVE, unaffected by the earlier partial
+    // recovery failure
+    assertThat(clusterConfiguration.getMember(localMemberId).getPartition(PARTITION_ID).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+    assertThat(clusterConfiguration.getMember(localMemberId).getPartition(PARTITION_ID_2).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+  }
+
+  /** Fails scheduling of actors for the given partition id(s), leaving others unaffected. */
+  private static final class FailingActorSchedulingService implements ActorSchedulingService {
+    private final ActorSchedulingService delegate;
+    private final Set<Integer> failingPartitionIds;
+
+    private FailingActorSchedulingService(
+        final ActorSchedulingService delegate, final Integer... failingPartitionIds) {
+      this.delegate = delegate;
+      this.failingPartitionIds = Set.of(failingPartitionIds);
+    }
+
+    @Override
+    public ActorFuture<Void> submitActor(final Actor actor) {
+      return shouldFail(actor) ? failure() : delegate.submitActor(actor);
+    }
+
+    @Override
+    public ActorFuture<Void> submitActor(final Actor actor, final SchedulingHints schedulingHints) {
+      return shouldFail(actor) ? failure() : delegate.submitActor(actor, schedulingHints);
+    }
+
+    private boolean shouldFail(final Actor actor) {
+      return failingPartitionIds.stream().anyMatch(id -> actor.getName().endsWith("-" + id));
+    }
+
+    private ActorFuture<Void> failure() {
+      return CompletableActorFuture.completedExceptionally(
+          new RuntimeException("Injected failure for partition(s) " + failingPartitionIds));
+    }
+  }
+
+  /**
+   * Stands in for a real Raft-based {@link PartitionManagerImpl}: on {@link #start()} it marks all
+   * of its given partitions {@code LEADER} on the real {@link TopologyManagerImpl}, then completes
+   * - the same level of fidelity {@link PartitionModeHandlerTest}'s {@code ExitRecovery} tests use
+   * with a mocked {@code normalManager}.
+   */
+  private static final class LeaderPartitionManager implements PartitionManager {
+    private final ConcurrencyControl concurrencyControl;
+    private final TopologyManagerImpl topologyManager;
+    private final int[] partitionIds;
+
+    private LeaderPartitionManager(
+        final ConcurrencyControl concurrencyControl,
+        final TopologyManagerImpl topologyManager,
+        final int... partitionIds) {
+      this.concurrencyControl = concurrencyControl;
+      this.topologyManager = topologyManager;
+      this.partitionIds = partitionIds;
+    }
+
+    @Override
+    public RaftPartition getRaftPartition(final int partitionId) {
+      return null;
+    }
+
+    @Override
+    public Collection<RaftPartition> getRaftPartitions() {
+      return List.of();
+    }
+
+    @Override
+    public Collection<ZeebePartition> getZeebePartitions() {
+      return List.of();
+    }
+
+    @Override
+    public ActorFuture<Void> start() {
+      final var result = concurrencyControl.<Void>createFuture();
+      final var leaderFutures =
+          Arrays.stream(partitionIds).mapToObj(id -> topologyManager.setLeader(1, id)).toList();
+      concurrencyControl.runOnCompletion(
+          leaderFutures,
+          error -> {
+            if (error != null) {
+              result.completeExceptionally(error);
+            } else {
+              result.complete(null);
+            }
+          });
+      return result;
+    }
+
+    @Override
+    public ActorFuture<Void> stop() {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionModeHandlerTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.protocol.record.PartitionRole;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorControl;
@@ -141,6 +142,11 @@ final class PartitionModeHandlerTest {
   private void givenPartitionRoles(final Map<Integer, PartitionRole> roles) {
     when(topologyManager.getLocalPartitionRoles())
         .thenReturn(CompletableActorFuture.completed(Map.copyOf(roles)));
+  }
+
+  private void givenPartitionHealth(final Map<Integer, PartitionHealthStatus> health) {
+    when(topologyManager.getLocalPartitionHealth())
+        .thenReturn(CompletableActorFuture.completed(Map.copyOf(health)));
   }
 
   private void progress() {
@@ -371,7 +377,7 @@ final class PartitionModeHandlerTest {
     void shouldFailWhenNotInExpectedMode() {
       // given - the member is in processing mode but a recovery transition is awaited
       // when
-      final ActorFuture<Void> await = handler.awaitModeApplied(Mode.RECOVERING);
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.RECOVERING);
       progress();
 
       // then
@@ -379,48 +385,86 @@ final class PartitionModeHandlerTest {
     }
 
     @Test
-    void shouldCompleteWhenNoLocalPartitions() {
+    void shouldCompleteWithEmptySetWhenNoLocalPartitions() {
       // given - this member replicates no partitions of the group
       givenLocalPartitions();
 
       // when
-      final ActorFuture<Void> await = handler.awaitModeApplied(Mode.PROCESSING);
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.PROCESSING);
       progress();
 
       // then
-      assertThat(await.isDone()).isTrue();
       assertThat(await.isCompletedExceptionally()).isFalse();
+      assertThat(await.join()).isEmpty();
     }
 
     @Test
-    void shouldCompleteWhenAllPartitionsReachedProcessingRoles() {
+    void shouldCompleteWithAllPartitionsWhenProcessingRolesReached() {
       // given
       givenLocalPartitions(1, 2);
       givenPartitionRoles(Map.of(1, PartitionRole.LEADER, 2, PartitionRole.FOLLOWER));
 
       // when
-      final ActorFuture<Void> await = handler.awaitModeApplied(Mode.PROCESSING);
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.PROCESSING);
       progress();
 
-      // then - the first poll already sees ready roles
-      assertThat(await.isDone()).isTrue();
+      // then - processing readiness is role-only, no health gating
       assertThat(await.isCompletedExceptionally()).isFalse();
+      assertThat(await.join()).containsExactlyInAnyOrder(1, 2);
     }
 
     @Test
-    void shouldCompleteForRecoveryWhenPartitionsInactive() {
-      // given - in recovery mode, the partitions are expected to be deactivated
+    void shouldCompleteWithHealthyPartitionsWhenRecovering() {
+      // given
       givenCurrentManager(GROUP, recoveryManager);
       givenLocalPartitions(1, 2);
       givenPartitionRoles(Map.of(1, PartitionRole.INACTIVE, 2, PartitionRole.INACTIVE));
+      givenPartitionHealth(
+          Map.of(1, PartitionHealthStatus.HEALTHY, 2, PartitionHealthStatus.HEALTHY));
 
       // when
-      final ActorFuture<Void> await = handler.awaitModeApplied(Mode.RECOVERING);
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.RECOVERING);
       progress();
 
       // then
-      assertThat(await.isDone()).isTrue();
       assertThat(await.isCompletedExceptionally()).isFalse();
+      assertThat(await.join()).containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    void shouldExcludeDeadPartitionsFromConfirmedSetButStillComplete() {
+      // given - partition 2 reached INACTIVE but never recovered, so it's DEAD
+      givenCurrentManager(GROUP, recoveryManager);
+      givenLocalPartitions(1, 2);
+      givenPartitionRoles(Map.of(1, PartitionRole.INACTIVE, 2, PartitionRole.INACTIVE));
+      givenPartitionHealth(Map.of(1, PartitionHealthStatus.HEALTHY, 2, PartitionHealthStatus.DEAD));
+
+      // when
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.RECOVERING);
+      progress();
+
+      // then - the operation still completes (a dead partition must not stall the cluster
+      // change), but only the healthy partition is in the confirmed set
+      assertThat(await.isCompletedExceptionally()).isFalse();
+      assertThat(await.join()).containsExactly(1);
+    }
+
+    @Test
+    void shouldRetryWhenHealthNotYetReported() {
+      // given - role reached INACTIVE, but health hasn't been reported yet (a race between
+      // RecoveryPartitionManager's role batch and its health batch)
+      givenCurrentManager(GROUP, recoveryManager);
+      givenLocalPartitions(1);
+      givenPartitionRoles(Map.of(1, PartitionRole.INACTIVE));
+      givenPartitionHealth(Map.of());
+
+      // when
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.RECOVERING);
+      progress();
+
+      // then - the operation fails so the cluster change can be retried, same as an
+      // unready role
+      assertThat(await.isCompletedExceptionally()).isTrue();
     }
 
     @Test
@@ -430,7 +474,7 @@ final class PartitionModeHandlerTest {
       givenPartitionRoles(Map.of(1, PartitionRole.INACTIVE));
 
       // when
-      final ActorFuture<Void> await = handler.awaitModeApplied(Mode.PROCESSING);
+      final ActorFuture<Set<Integer>> await = handler.awaitModeApplied(Mode.PROCESSING);
       progress();
 
       // then - the operation fails so the cluster change can be retried

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RecoveryPartitionManagerTest.java
@@ -205,7 +205,8 @@ final class RecoveryPartitionManagerTest {
             });
 
     // and: only the partition that failed to start is reported as DEAD, since it never
-    // recovered and nothing is left running to ever bring it back
+    // recovered and nothing is left running to ever bring it back; the one that succeeded is
+    // reported HEALTHY
     await()
         .untilAsserted(
             () -> {
@@ -214,8 +215,27 @@ final class RecoveryPartitionManagerTest {
                   .anySatisfy(
                       info ->
                           assertThat(info.getPartitionHealthStatuses())
-                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD)
-                              .doesNotContainKey(PARTITION_ID));
+                              .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
+                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.DEAD));
+            });
+  }
+
+  @Test
+  void shouldReportHealthyForSuccessfullyRecoveredPartitions() {
+    // when
+    controlActor.run(() -> partitionManager.start());
+
+    // then - both partitions started successfully, so both are reported healthy
+    await()
+        .untilAsserted(
+            () -> {
+              final var publishedInfos = BrokerInfo.allFromProperties(localMember.properties());
+              assertThat(publishedInfos)
+                  .anySatisfy(
+                      info ->
+                          assertThat(info.getPartitionHealthStatuses())
+                              .containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY)
+                              .containsEntry(PARTITION_ID_2, PartitionHealthStatus.HEALTHY));
             });
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Duration;
@@ -85,6 +86,21 @@ final class TopologyManagerImplTest {
             () -> {
               assertThat(brokerInfo.getPartitionRoles()).doesNotContainKey(PARTITION_ID);
               assertThat(brokerInfo.getPartitionHealthStatuses()).doesNotContainKey(PARTITION_ID);
+            });
+  }
+
+  @Test
+  void shouldReturnLocalPartitionHealth() {
+    // given
+    topologyManager.onHealthChanged(PARTITION_ID, HealthStatus.HEALTHY);
+
+    // when / then
+    Awaitility.await()
+        .atMost(TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var health = topologyManager.getLocalPartitionHealth().join();
+              assertThat(health).containsEntry(PARTITION_ID, PartitionHealthStatus.HEALTHY);
             });
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
@@ -72,12 +72,12 @@ public class AwaitModeChangeApplier implements ClusterOperationApplier {
     return clusterConfiguration ->
         clusterConfiguration.updateMember(
             memberId,
-            memberState ->
-                confirmedPartitions.stream()
-                    .reduce(
-                        memberState,
-                        (state, partitionId) ->
-                            state.updatePartition(partitionId, partitionStateUpdater),
-                        (first, second) -> second));
+            memberState -> {
+              var updatedState = memberState;
+              for (final var partitionId : confirmedPartitions) {
+                updatedState = updatedState.updatePartition(partitionId, partitionStateUpdater);
+              }
+              return updatedState;
+            });
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
@@ -7,27 +7,35 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 /**
  * Waits for a member's partition manager to finish starting in the target {@link Mode}. Emitted
  * after the per-member {@code ModeChangeOperation}s so that the cluster change only completes once
- * every member's partitions are actually up. It changes no cluster configuration state; it only
- * gates the change plan until the local transition has settled.
+ * every member's partitions are actually up. Writes {@link PartitionState.State#RECOVERING} or
+ * {@link PartitionState.State#ACTIVE} for the subset of this member's partitions that {@link
+ * ModeChangeExecutor#awaitModeApplied(Mode)} confirms transitioned; partitions outside that subset
+ * (e.g. unhealthy ones) keep their prior state.
  */
 public class AwaitModeChangeApplier implements ClusterOperationApplier {
 
+  private final MemberId memberId;
   private final Mode mode;
   private final ModeChangeExecutor modeChangeExecutor;
 
-  public AwaitModeChangeApplier(final Mode mode, final ModeChangeExecutor modeChangeExecutor) {
+  public AwaitModeChangeApplier(
+      final MemberId memberId, final Mode mode, final ModeChangeExecutor modeChangeExecutor) {
+    this.memberId = Objects.requireNonNull(memberId);
     this.mode = Objects.requireNonNull(mode);
     this.modeChangeExecutor = Objects.requireNonNull(modeChangeExecutor);
   }
@@ -44,13 +52,32 @@ public class AwaitModeChangeApplier implements ClusterOperationApplier {
     modeChangeExecutor
         .awaitModeApplied(mode)
         .onComplete(
-            (ignored, error) -> {
+            (confirmedPartitions, error) -> {
               if (error != null) {
                 result.completeExceptionally(error);
               } else {
-                result.complete(UnaryOperator.identity());
+                result.complete(writeConfirmedPartitions(confirmedPartitions));
               }
             });
     return result;
+  }
+
+  private UnaryOperator<ClusterConfiguration> writeConfirmedPartitions(
+      final Set<Integer> confirmedPartitions) {
+    if (confirmedPartitions.isEmpty()) {
+      return UnaryOperator.identity();
+    }
+    final UnaryOperator<PartitionState> partitionStateUpdater =
+        mode == Mode.RECOVERING ? PartitionState::toRecovering : PartitionState::toActive;
+    return clusterConfiguration ->
+        clusterConfiguration.updateMember(
+            memberId,
+            memberState ->
+                confirmedPartitions.stream()
+                    .reduce(
+                        memberState,
+                        (state, partitionId) ->
+                            state.updatePartition(partitionId, partitionStateUpdater),
+                        (first, second) -> second));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -147,7 +147,10 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
                 new ExitRecoveryApplier(modeChangeOperation.memberId(), modeChangeExecutor);
           };
       case final AwaitModeChangeOperation awaitModeChangeOperation ->
-          new AwaitModeChangeApplier(awaitModeChangeOperation.mode(), modeChangeExecutor);
+          new AwaitModeChangeApplier(
+              awaitModeChangeOperation.memberId(),
+              awaitModeChangeOperation.mode(),
+              modeChangeExecutor);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ModeChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ModeChangeExecutor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.changes;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Set;
 
 /**
  * Performs the local, broker-side switch of a member's partition manager between normal processing
@@ -37,11 +38,18 @@ public interface ModeChangeExecutor {
   ActorFuture<Void> exitRecovery();
 
   /**
-   * Completes once the partition manager started by the most recent transition into {@code mode}
-   * has finished starting. Completes immediately if no transition is in flight (e.g. the member was
-   * already in {@code mode}). A failed start is propagated so the cluster change can be retried.
+   * Completes once every local partition has reached the role expected for {@code mode} - and, when
+   * entering recovery, once health has been reported for each (closing a race between
+   * RecoveryPartitionManager's role and health reporting). Completes immediately if no transition
+   * is in flight (e.g. the member was already in {@code mode}). A failed check is propagated so the
+   * cluster change can be retried.
+   *
+   * @return the subset of local partitions confirmed ready for {@code mode}: for {@code
+   *     PROCESSING}, every role-confirmed partition; for {@code RECOVERING}, only those also
+   *     reported healthy (a partition reported DEAD still lets the operation complete but is
+   *     excluded from this set).
    */
-  ActorFuture<Void> awaitModeApplied(Mode mode);
+  ActorFuture<Set<Integer>> awaitModeApplied(Mode mode);
 
   final class NoopModeChangeExecutor implements ModeChangeExecutor {
     @Override
@@ -55,8 +63,8 @@ public interface ModeChangeExecutor {
     }
 
     @Override
-    public ActorFuture<Void> awaitModeApplied(final Mode mode) {
-      return CompletableActorFuture.completed(null);
+    public ActorFuture<Set<Integer>> awaitModeApplied(final Mode mode) {
+      return CompletableActorFuture.completed(Set.of());
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -390,11 +390,12 @@ public class ProtoBufSerializer
 
   private PartitionState.State toPartitionState(final Topology.State state) {
     return switch (state) {
-      case UNRECOGNIZED, UNKNOWN, LEFT, RECOVERING -> PartitionState.State.UNKNOWN;
+      case UNRECOGNIZED, UNKNOWN, LEFT -> PartitionState.State.UNKNOWN;
       case ACTIVE -> PartitionState.State.ACTIVE;
       case JOINING -> PartitionState.State.JOINING;
       case LEAVING -> PartitionState.State.LEAVING;
       case BOOTSTRAPPING -> PartitionState.State.BOOTSTRAPPING;
+      case RECOVERING -> PartitionState.State.RECOVERING;
     };
   }
 
@@ -405,6 +406,7 @@ public class ProtoBufSerializer
       case JOINING -> Topology.State.JOINING;
       case LEAVING -> Topology.State.LEAVING;
       case BOOTSTRAPPING -> Topology.State.BOOTSTRAPPING;
+      case RECOVERING -> Topology.State.RECOVERING;
     };
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
@@ -37,6 +37,10 @@ public record PartitionState(State state, int priority, DynamicPartitionConfig c
     return new PartitionState(State.LEAVING, priority, config);
   }
 
+  public PartitionState toRecovering() {
+    return new PartitionState(State.RECOVERING, priority, config);
+  }
+
   public PartitionState updateConfig(final DynamicPartitionConfig config) {
     return new PartitionState(state, priority, config);
   }
@@ -58,6 +62,7 @@ public record PartitionState(State state, int priority, DynamicPartitionConfig c
     JOINING,
     ACTIVE,
     LEAVING,
-    BOOTSTRAPPING
+    BOOTSTRAPPING,
+    RECOVERING
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -75,8 +75,10 @@ public final class ConfigurationUtil {
                 final Integer partitionId = entry.getKey();
                 final PartitionState partitionState = entry.getValue();
                 if (partitionState.state().equals(State.ACTIVE)
-                    || partitionState.state().equals(State.LEAVING)) {
-                  // only add active and leaving partitions because only those has to be started
+                    || partitionState.state().equals(State.LEAVING)
+                    || partitionState.state().equals(State.RECOVERING)) {
+                  // only add active, leaving, and recovering partitions because only those has to
+                  // be started
                   memberPriorityByPartition
                       .computeIfAbsent(partitionId, k -> new HashMap<>())
                       .put(memberId, partitionState.priority());

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplierTest.java
@@ -11,43 +11,103 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 final class AwaitModeChangeApplierTest {
 
+  private static final MemberId MEMBER_ID = MemberId.from("1");
   private final ModeChangeExecutor executor = mock(ModeChangeExecutor.class);
 
   @Test
   void shouldInitWithoutChangingConfiguration() {
     // given
-    final var applier = new AwaitModeChangeApplier(Mode.RECOVERING, executor);
+    final var applier = new AwaitModeChangeApplier(MEMBER_ID, Mode.RECOVERING, executor);
     final var config = ClusterConfiguration.init();
 
     // when
     final var result = applier.init(config);
 
-    // then - the await operation does not change cluster configuration state
+    // then - the await operation does not change cluster configuration state on init
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get().apply(config)).isEqualTo(config);
   }
 
   @Test
-  void shouldCompleteWhenModeApplied() {
+  void shouldWriteRecoveringForConfirmedPartitionsOnly() {
     // given
+    final var partitionConfig = DynamicPartitionConfig.init();
+    final var config =
+        ClusterConfiguration.init()
+            .addMember(
+                MEMBER_ID,
+                MemberState.initializeAsActive(
+                    Map.of(
+                        1, PartitionState.active(1, partitionConfig),
+                        2, PartitionState.active(1, partitionConfig))));
     when(executor.awaitModeApplied(Mode.RECOVERING))
-        .thenReturn(CompletableActorFuture.completed(null));
-    final var applier = new AwaitModeChangeApplier(Mode.RECOVERING, executor);
+        .thenReturn(CompletableActorFuture.completed(Set.of(1)));
+    final var applier = new AwaitModeChangeApplier(MEMBER_ID, Mode.RECOVERING, executor);
 
     // when
     final var result = applier.apply();
 
-    // then - completes with an identity transformer (the await changes no configuration state)
+    // then - only the confirmed partition (1) is marked RECOVERING; partition 2 (e.g. dead) is
+    // left untouched
     assertThat(result.isCompletedExceptionally()).isFalse();
+    final var updated = result.join().apply(config);
+    assertThat(updated.getMember(MEMBER_ID).getPartition(1).state())
+        .isEqualTo(PartitionState.State.RECOVERING);
+    assertThat(updated.getMember(MEMBER_ID).getPartition(2).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+  }
+
+  @Test
+  void shouldWriteActiveForConfirmedPartitionsWhenExitingRecovery() {
+    // given
+    final var partitionConfig = DynamicPartitionConfig.init();
+    final var config =
+        ClusterConfiguration.init()
+            .addMember(
+                MEMBER_ID,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig).toRecovering())));
+    when(executor.awaitModeApplied(Mode.PROCESSING))
+        .thenReturn(CompletableActorFuture.completed(Set.of(1)));
+    final var applier = new AwaitModeChangeApplier(MEMBER_ID, Mode.PROCESSING, executor);
+
+    // when
+    final var result = applier.apply();
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
+    final var updated = result.join().apply(config);
+    assertThat(updated.getMember(MEMBER_ID).getPartition(1).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+  }
+
+  @Test
+  void shouldNotChangeConfigurationWhenNoPartitionsConfirmed() {
+    // given - e.g. the only local partition ended up DEAD
     final var config = ClusterConfiguration.init();
+    when(executor.awaitModeApplied(Mode.RECOVERING))
+        .thenReturn(CompletableActorFuture.completed(Set.of()));
+    final var applier = new AwaitModeChangeApplier(MEMBER_ID, Mode.RECOVERING, executor);
+
+    // when
+    final var result = applier.apply();
+
+    // then
+    assertThat(result.isCompletedExceptionally()).isFalse();
     assertThat(result.join().apply(config)).isEqualTo(config);
   }
 
@@ -57,7 +117,7 @@ final class AwaitModeChangeApplierTest {
     when(executor.awaitModeApplied(Mode.PROCESSING))
         .thenReturn(
             CompletableActorFuture.completedExceptionally(new RuntimeException("not started")));
-    final var applier = new AwaitModeChangeApplier(Mode.PROCESSING, executor);
+    final var applier = new AwaitModeChangeApplier(MEMBER_ID, Mode.PROCESSING, executor);
 
     // when
     final var result = applier.apply();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/EnterRecoveryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/EnterRecoveryApplierTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ final class EnterRecoveryApplierTest {
         }
 
         @Override
-        public CompletableActorFuture<Void> awaitModeApplied(final Mode mode) {
+        public CompletableActorFuture<Set<Integer>> awaitModeApplied(final Mode mode) {
           return CompletableActorFuture.completedExceptionally(
               new RuntimeException("Force failure"));
         }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ExitRecoveryApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ExitRecoveryApplierTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ final class ExitRecoveryApplierTest {
         }
 
         @Override
-        public CompletableActorFuture<Void> awaitModeApplied(final Mode mode) {
+        public CompletableActorFuture<Set<Integer>> awaitModeApplied(final Mode mode) {
           return CompletableActorFuture.completedExceptionally(
               new RuntimeException("Force failure"));
         }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -24,11 +24,14 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.ExporterStateEnum;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
@@ -36,6 +39,7 @@ import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.util.List;
 import java.util.Map;
@@ -293,5 +297,25 @@ final class ProtoBufSerializerTest {
 
     // then
     assertThat(deserialized.state()).isEqualTo(ExportingState.UNKNOWN);
+  }
+
+  @Test
+  void shouldEncodeAndDecodePartitionStateRecovering() {
+    // given
+    final var partitionConfig = DynamicPartitionConfig.init();
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                MemberId.from("1"),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig).toRecovering())));
+    final var gossipState = new ClusterConfigurationGossipState();
+    gossipState.setClusterConfiguration(clusterConfiguration);
+
+    // when
+    final var decoded = protoBufSerializer.decode(protoBufSerializer.encode(gossipState));
+
+    // then
+    assertThat(decoded.getClusterConfiguration()).isEqualTo(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionStateTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionStateTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class PartitionStateTest {
+
+  @Test
+  void shouldTransitionToRecovering() {
+    // given
+    final var config = DynamicPartitionConfig.init();
+    final var partitionState = PartitionState.active(3, config);
+
+    // when
+    final var recovering = partitionState.toRecovering();
+
+    // then
+    assertThat(recovering.state()).isEqualTo(PartitionState.State.RECOVERING);
+    assertThat(recovering.priority()).isEqualTo(3);
+    assertThat(recovering.config()).isEqualTo(config);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -259,6 +259,28 @@ class ConfigurationUtilTest {
         .correlatesMessagesToPartitions(2);
   }
 
+  @Test
+  void shouldIncludeRecoveringPartitionsInDistribution() {
+    // given
+    final PartitionMetadata partitionOne =
+        new PartitionMetadata(
+            new PartitionId(GROUP_NAME, 1), Set.of(member(0)), Map.of(member(0), 1), 1, member(0));
+
+    final ClusterConfiguration topology =
+        ClusterConfiguration.init()
+            .addMember(
+                member(0),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig).toRecovering())));
+
+    // when
+    final var partitionDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+
+    // then
+    assertThat(partitionDistribution).containsExactly(partitionOne);
+  }
+
   private MemberId member(final int id) {
     return MemberId.from(String.valueOf(id));
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
@@ -85,6 +85,22 @@ final class ModeChangeAcceptanceIT {
           .timeout(Duration.ofSeconds(30))
           .untilAsserted(() -> assertAllCreateInstanceAttemptsFail(processId));
 
+      // and - every local partition reports RECOVERING via the cluster topology actuator
+      Awaitility.await("All local partitions report RECOVERING (iteration " + i + ")")
+          .timeout(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var topology = actuator.getTopology();
+                assertThat(topology.getBrokers())
+                    .flatExtracting(io.camunda.zeebe.management.cluster.BrokerState::getPartitions)
+                    .extracting(io.camunda.zeebe.management.cluster.PartitionState::getState)
+                    .allMatch(
+                        state ->
+                            state
+                                == io.camunda.zeebe.management.cluster.PartitionStateCode
+                                    .RECOVERING);
+              });
+
       // when - transition back to PROCESSING
       final var toProcessing = triggerModeChange(trigger, actuator, "PROCESSING");
       Awaitility.await("Cluster transitions to PROCESSING (iteration " + i + ")")
@@ -105,6 +121,20 @@ final class ModeChangeAcceptanceIT {
               PARTITIONS_COUNT, i)
           .containsExactlyInAnyOrderElementsOf(
               IntStream.rangeClosed(1, PARTITIONS_COUNT).boxed().collect(Collectors.toList()));
+
+      // and - every local partition reports ACTIVE again via the cluster topology actuator
+      Awaitility.await("All local partitions report ACTIVE (iteration " + i + ")")
+          .timeout(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var topology = actuator.getTopology();
+                assertThat(topology.getBrokers())
+                    .flatExtracting(io.camunda.zeebe.management.cluster.BrokerState::getPartitions)
+                    .extracting(io.camunda.zeebe.management.cluster.PartitionState::getState)
+                    .allMatch(
+                        state ->
+                            state == io.camunda.zeebe.management.cluster.PartitionStateCode.ACTIVE);
+              });
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce the `RECOVERING` PartitionState in distribution for clarity discerning between a partition being in recovery mode or not. 

Also, refactor the AwaitModeChange to report back what partitions successfully transitioned and not to provide an accurate state. Partitions that failed to transition to recovery are reported as `ACTIVE` but with a `DEAD` health status. For such cases, the expected resolution is to repeat the process by jumping back to `PROCESSING` and `RECOVERING` transition again. That should be an edge case, as for the time being there are not that many dependencies that could block a partition from starting in the `RECOVERY` mode

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56674
