### PR TITLE
docs: add Claude skill to analyize zeebe flamegraphs

### DIFF
--- a/.claude/skills/zeebe-flamegraph-diff/SKILL.md
+++ b/.claude/skills/zeebe-flamegraph-diff/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: zeebe-flamegraph-diff
+description: Parse and compare async-profiler CPU flamegraphs from Camunda/Zeebe brokers — benchmark nodes or production. Use when investigating a CPU regression or outlier with .html flamegraphs (e.g. from dashboard.benchmark.camunda.cloud daily runs, or pulled from a live cluster/customer incident) — attribute a node's CPU to Zeebe subsystems and diff a suspect run against a healthy baseline.
+---
+
+# Zeebe flamegraph diff
+
+Tooling to read async-profiler HTML flamegraphs from Camunda 8 / Zeebe brokers
+and answer: **"where is this node burning CPU, and what changed vs a healthy
+run?"** Works on any pair of comparable flamegraphs — daily load-test captures
+(per-node, per-protocol) from `dashboard.benchmark.camunda.cloud`, or ad-hoc
+captures pulled from a production/customer cluster during an incident.
+
+## When to use
+
+- A benchmark/load-test run, or a production node/pod, is flagged problematic
+  (backpressure, dropped requests, low throughput, high CPU) and you have
+  per-node `.html` flamegraphs.
+- One node/broker is a CPU outlier vs its peers.
+- Confirming whether a CPU/throughput regression is a code change, a config/
+  sizing change, or just load — on a benchmark run or in production.
+
+If you don't have a profile yet: benchmark nodes emit one automatically per
+daily run; on production you need `async-profiler` attached to the JVM (or an
+equivalent continuous-profiling agent) and must capture one yourself — this
+skill only covers reading and diffing `.html` output, not attaching/capturing.
+
+Pair with Grafana (`prometheus` datasource) for the metrics half of the story —
+the flamegraph tells you *where* CPU goes; metrics tell you *whether it
+matters* (see step 4). For benchmark runs, also pair with the `load-test-ops`
+skill (triggering/monitoring runs).
+
+## Critical gotchas (read first)
+
+1. **Never diff a gRPC profile against a REST profile.** Each daily run emits
+   TWO flamegraphs per node — one while the gateway serves gRPC, one for REST.
+   Their request-handling stacks are completely different (REST = Tomcat/coyote +
+   Spring Security filter chain + `BearerTokenAuthenticationFilter`; gRPC = Netty
+   event loop, no Tomcat). Diffing across protocols produces garbage. Filenames
+   do NOT say which is which — detect it (step 1).
+2. **Sample counts are not comparable across files.** Different capture windows →
+   different totals. Only compare **percentages** (all scripts output %).
+3. **Lambda/proxy names and native `.so` files carry per-run random ids**
+   (`$$Lambda.0x…7b91000.run`, `librocksdbjni<random>.so`). Raw they look like
+   huge diffs for identical code. `fg_diff.py` normalizes these; `grep` over the
+   raw HTML will also miss compressed names — always parse, don't grep.
+
+## Workflow
+
+All scripts live in `scripts/` and share `fg_common.py`. Run them from that dir
+(or `cd` there) so the import resolves.
+
+### 1. Identify each file's protocol (gRPC vs REST)
+
+```bash
+cd scripts
+python3 fg_top.py <file.html> 40 | grep -iE "coyote|tomcat|BearerToken|SingleThreadIoEventLoop|FrameworkServlet"
+```
+
+Tomcat/coyote/`FrameworkServlet`/`BearerToken` present → **REST**. Only Netty
+(`SingleThreadIoEventLoop`) with no Tomcat → **gRPC**. Pick matching protocols on
+both sides of a diff.
+
+### 2. Attribute one node's CPU to subsystems
+
+```bash
+python3 fg_subsystems.py <file.html>
+```
+
+Leaf-based split across Zeebe subsystems (exporter, replay, processing,
+rocksdb-state, journal-flush, raft-netty, grpc, gc). ~70-75% coverage is normal
+(native/syscall scatter → `other`). See
+[`references/zeebe-contributors.md`](references/zeebe-contributors.md) for what
+each subsystem is and which frames feed it.
+
+### 3. Diff suspect vs healthy baseline
+
+```bash
+python3 fg_diff.py <baseline.html> <candidate.html> [min_delta_pct]
+```
+
+Inclusive-% diff, volatile ids normalized. "Grew in candidate" = where the
+regressed run spends more; "Shrank" = where the healthy run spent more. Ignore
+generic roots that move together (`thread_native_entry`, `start_thread`,
+`Thread::call_run`, `Executors$RunnableAdapter.call`, the renamed `.so`) — they
+are attribution shuffles, not signal. Focus on named Camunda/RocksDB/journal
+frames.
+
+### 4. Confirm with metrics — the efficiency lens (don't stop at the flamegraph)
+
+A flamegraph shows CPU *distribution*, not efficiency. Two runs can have an almost
+identical profile shape yet very different throughput. Pull the metrics half from
+Grafana (`prometheus` datasource). Namespace/datasource depends on where the
+profile came from: daily benchmarks live under
+`c8-medic-daily-<date>-<hash>-test`; a production or customer cluster will be on
+a different namespace/datasource — confirm you can actually reach it (customer
+envs are often not scrapeable from the same Grafana) before assuming the
+metric half is available at all.
+
+Metric cheat-sheet (all rate/histogram over the steady window):
+
+| question | metric |
+|---|---|
+| CPU per pod / saturated? / outlier? | `container_cpu_usage_seconds_total` |
+| backpressure / shed load | `zeebe_dropped_request_count_total`, `zeebe_backpressure_*` |
+| processing throughput | `zeebe_stream_processor_records_total{action="processed"}` |
+| bytes persisted / append rate | `atomix_journal_append_data_rate_total`, `atomix_journal_append_rate_total` |
+| flush count + latency | `atomix_journal_flush_time_seconds_{count,sum,bucket}` |
+| per-record cost by type | `zeebe_stream_processor_processing_duration_seconds_bucket` (group by `valueType,intent`) |
+| state size (rule out data growth) | `zeebe_rocksdb_live_estimate_live_data_size`, `_num_keys`, `zeebe_rocksdb_sst_total_sst_files_size` |
+| GC | `jvm_gc_pause_seconds_*` (STW) vs the `gc` flamegraph bucket (concurrent, off-pause) |
+
+**The key derived signal is work-per-core.** Compute CPU/record and CPU/MB-persisted
+on both runs. Interpreting the combination:
+
+- **CPU pinned at the request/limit** → node is *saturated*; a regression then shows
+  up as **lower throughput at flat CPU**, NOT higher CPU. Don't expect the CPU line
+  to move — divide it by throughput.
+- **Flat CPU + throughput down + a subsystem grew in the diff** → *efficiency*
+  regression (more CPU per unit work), not more load.
+- **Processing-duration median flat but p99 tail up** → usually a *saturation
+  queueing* symptom, not a per-record slowdown; and the extra CPU lives *outside*
+  `processCommand` (replay/commit/flush/state access, which that metric excludes).
+  Break the histogram down by `valueType,intent` to see if one record type
+  regressed vs a uniform shift.
+
+### 5. Decide: is it even a hot-path *code* regression?
+
+Before blaming a commit, separate "code got slower" from "code runs more often" from
+"config/infra changed":
+
+- `git log -1 --format=%ad -- <path/to/hot/file>` for the top grown frames. **If the
+  hot file hasn't changed in the regression window, the code didn't get slower — it's
+  being *called more per record*, or a config/flag/sizing changed.** Chase the caller
+  or the config, not the frame.
+- Rule out data growth: compare RocksDB state size / num_keys. Flat state + more
+  state-access CPU = more ops per record, not more data.
+- Narrow the window cheaply: for daily benchmarks, one build/day means you can
+  **binary-search across days** (is the run between healthy and broken already
+  broken?) to shrink the commit range before diffing 100s of commits. For
+  production, narrow by deploy history instead — which version/config was live
+  at each past-good vs first-bad capture.
+
+## CPU-mode profiling gotchas (async-profiler `-e cpu`)
+
+These bite every flamegraph read, not just regressions:
+
+- **On-CPU only.** CPU-mode samples running threads; **off-CPU time is invisible**
+  (blocked on disk, lock, socket, park). So a slower disk / slower ES backend does
+  **not** raise CPU samples — it shows as lower throughput with threads parked. Never
+  infer "X got slower" from more CPU in X; infer "X did more on-CPU work".
+- **Syscall CPU folds onto a userland stub.** Without kernel stacks (needs
+  perf_events + `perf_event_paranoid<=1` + kernel symbols), kernel time (e.g.
+  `msync`/`fsync` dirty-page scan, socket writes) is attributed to the glibc syscall
+  trampoline (`__syscall_cancel_arch`) or the JNI leaf. You then can't split user vs
+  kernel from that file — re-profile with kernel stacks, or add a wall-clock/off-CPU
+  profile, to see the real split.
+- **Concurrent GC ≠ pause.** The `gc` bucket (G1 concurrent marking) burns CPU on GC
+  threads without showing as STW pause; cross-check `jvm_gc_pause_seconds`.
+
+## Reading the diff → hypothesis (generic patterns)
+
+| Diff signature | Likely direction |
+|---|---|
+| `rocksdb-state` / `TransactionalColumnFamily` up, state size flat | more state ops per record (caller change / config), not bigger data |
+| `journal-flush` / `msync` up, flush-rate flat or down, p99 flat | heavier work per flush (larger scanned region / segment sizing), not disk stalls |
+| `exporter-es-client` up, ES health degraded | exporter blocked/retrying on a slow backend |
+| `gc` up, allocation metrics up | allocation-pressure regression |
+| whole profile shape ~unchanged, throughput down at flat CPU | efficiency regression — find it by ratio, not by eye |
+| one `valueType,intent` tail explodes, others flat | a specific processor/path, not a global slowdown |

--- a/.claude/skills/zeebe-flamegraph-diff/references/zeebe-contributors.md
+++ b/.claude/skills/zeebe-flamegraph-diff/references/zeebe-contributors.md
@@ -1,0 +1,104 @@
+# Biggest CPU contributors in a Zeebe broker flamegraph
+
+Reference for interpreting `fg_subsystems.py` output and `fg_diff.py` frame names.
+These are the subsystems that dominate a Camunda 8 broker CPU profile under load,
+what they mean, the marker frames that identify them, and what a *rise* usually
+implies. Percentages are rough steady-state shares seen on the daily ES-exporter
+benchmark (gRPC profile, single broker node) — treat as ballpark, not SLO.
+
+All engine work runs on the Zeebe **actor scheduler**, so nearly everything sits
+under `io/camunda/zeebe/scheduler/ActorJob.invoke` /
+`AtomixThreadFactory.lambda$newThread$0`. Those two are near the root of almost
+every stack — high % there is expected and not itself a finding; look deeper.
+
+## Subsystems (as split by `fg_subsystems.py`)
+
+### exporter-es-client  (~15-16%)
+Marker frames: `org/apache/http/impl/nio/*` (`produceOutput`, `outputReady`),
+`co/elastic/clients/json/ObjectDeserializer.deserialize`,
+`io/camunda/zeebe/broker/exporter/stream/*` (`ExporterContainer`,
+`ExporterDirector`, `RecordExporter.export`), `sun/nio/ch/SocketChannel*.write`.
+- The Elasticsearch/Camunda exporter serializing records and driving the async
+  HTTP client to bulk-index into ES. Absent entirely with `exporter: none`.
+- **Rises** if ES is slow (client blocks/retries), bulk size/rate grew, or record
+  volume per flush increased. Cross-check with ES cluster health metrics.
+
+### processing  (~12-13%)
+Marker frames: `ProcessingStateMachine` (`batchProcessing`, `processCommand`),
+`TypedRecordProcessor.processRecord`, `processing/bpmn/*`, `EventAppliers.applyState`,
+`ResultBuilderBackedEventApplyingStateWriter`.
+- The actual command→event engine work: executing BPMN, applying state changes.
+  This is the "useful work" bucket — you *want* CPU here.
+- **Falling** processing share while total CPU is flat is a red flag: the node is
+  doing less real work per core (something else crowded it out).
+
+### replay  (~9-12%)
+Marker frames: `ReplayStateMachine` (`tryToReplayBatch`, `lambda$tryToReplayBatch$5`),
+`Engine.replay`.
+- Rebuilding state from the log. Followers replay continuously; leaders replay on
+  transition/restart. High replay on a node = it follows busy partitions or just
+  went through a leader change / restart / snapshot install.
+- A large `Engine.replay` spike (→10%+ from ~0) usually means the capture caught a
+  catch-up burst, not steady state.
+
+### rocksdb-state  (small in `other`/native, but watch the named frames)
+Marker frames: `TransactionalColumnFamily` (`.get`, `.forEach`, `.ensureInOpen`,
+its `$$Lambda.run`), `ColumnFamilyContext.withPrefixKey`, `ZeebeTransaction`,
+native `rocksdb::*` / `librocksdbjni.so`.
+- Reading/iterating/writing engine state in RocksDB. Note much RocksDB time is in
+  native code and lands in `other` in the subsystem split — the *named* Java
+  frames in the diff are the reliable signal.
+- **Rises** with larger state (more/longer prefix scans, bigger LSM → more read
+  amplification), more key lookups per record, or compaction pressure. A big jump
+  in `TransactionalColumnFamily$$Lambda.run` / `forEach` / `withPrefixKey` points
+  at state-access cost per record going up.
+
+### journal-flush  (~3-6%)
+Marker frames: `io/camunda/zeebe/journal/file/*` (`SegmentedJournal.flush`,
+`SegmentedJournalWriter.flush`), `RaftLogFlusher`, `PassiveRole.flush`,
+`java/nio/MappedMemoryUtils.force` (msync), `Sequencer.tryWrite`.
+- Appending to and fsync-ing the Raft log (durability). `MappedMemoryUtils.force`
+  is the mmap msync; its on-CPU cost is kernel dirty-page scan + writeback setup
+  (proportional to region scanned and dirty-page count), NOT the disk transfer.
+- **CPU-mode caveat:** a *slower disk* does NOT raise this bucket — disk wait is
+  off-CPU and invisible to CPU sampling. More flush CPU means more flush *work*:
+  more frequent flushes, or a larger mapped region scanned per `msync` (e.g. bigger
+  journal segments), or more append contention (`Sequencer.tryWrite` climbing).
+  Confirm with `atomix_journal_flush_time_seconds_{count,sum}`: distinguish "more
+  flushes" (count up) from "heavier flushes" (avg latency up, p99 flat) from "disk
+  stalls" (p99 up) — only the first two show as CPU.
+
+### raft-netty  (~14-15%)
+Marker frames: `io/atomix/raft/*` (`ActiveRole.onAppend`, `PassiveRole.appendEntries`,
+`RaftContext`, `RaftServerCommunicator.sendAndReceive`), `io/netty/*`
+(`SingleThreadIoEventLoop`, `epoll`), `sun/nio/ch/SocketChannel`.
+- Raft replication: leaders send AppendEntries, followers receive/ack, all over
+  Netty. Scales with write throughput and cluster chatter.
+
+### grpc  (~2%)
+Marker frames: `io/grpc/*` (`ServerInterceptors`, `SerializingExecutor`),
+`MetricCollectingServerInterceptor`, `NimbusJwtDecoder.createJwt` (auth). REST
+equivalent lives under Tomcat/Spring instead.
+
+### gc  (~8-9%)
+Marker frames: `G1CMTask::do_marking_step`, `G1*`, `CMTask`, GC thread roots.
+- G1 concurrent marking runs on dedicated GC threads and burns CPU **without**
+  showing as stop-the-world pause time. So a high `gc` bucket here can coexist with
+  a tiny `jvm_gc_pause_seconds` — it indicates allocation pressure / churn, not
+  necessarily pause problems. Cross-check `jvm_gc_pause_seconds_*` vs
+  `jvm_gc_memory_allocated_bytes_total`.
+
+### scheduler-idle
+`ActorThread.waitOnRunnable`, `Unsafe.park` — idle actor/park time. High idle means
+the node is NOT CPU-bound on that path; treat as headroom, not work.
+
+## Frames to ignore in diffs (attribution noise, not regressions)
+
+- `thread_native_entry`, `start_thread`, `Thread::call_run`,
+  `Executors$RunnableAdapter.call`, `ForkJoinTask*` — generic thread roots; they
+  swing when the profiler attributes native/unknown differently between runs.
+- `librocksdbjni<random>.so`, `libnetty_*<random>.so` — per-run temp filenames;
+  `fg_common.normalize` collapses them but residual +/- on the raw name is noise.
+- `$$Lambda.0x…run` — the address differs every JVM run; only meaningful after
+  normalization (which `fg_diff.py` does) and only when the *owning class* is a
+  real Camunda/engine type.

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_common.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_common.py
@@ -39,7 +39,8 @@ def load_frames(path):
         if fn == "f":
             key = a[0]
             lvl = a[1]
-            width = a[2] if len(a) > 2 and a[2] != 0 else width0
+            # f(key, level, left, width): a[2] is `left`, a[3] is width.
+            width = a[3] if len(a) > 3 and a[3] != 0 else width0
         elif fn == "u":
             lvl += 1
             key = a[0]

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_common.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_common.py
@@ -1,0 +1,67 @@
+"""Shared async-profiler HTML flamegraph parser for Zeebe/Camunda benchmark profiles.
+
+async-profiler emits frames as a sequence of f()/u()/n() JS calls over a
+prefix-compressed `cpool` string array. This module unpacks the cpool and walks
+the call sequence into (level, title, width) frames. Width is in sample units;
+the level-0 frame width is the total sample count.
+
+Frame call semantics (from the generated HTML):
+  f(key, level, left, width)  -> frame at absolute `level`, sets width0=width
+  u(key, width)               -> child: level0+1, inherits width0 if width omitted/0
+  n(key, width)               -> sibling: same level0, inherits width0 if omitted/0
+`key >>> 3` indexes into the unpacked cpool to get the frame title.
+"""
+import re
+
+
+def load_frames(path):
+    """Return (total_samples, [(level, title, width), ...]) for a flamegraph HTML."""
+    txt = open(path, encoding="utf-8").read()
+    m = re.search(r"const cpool = \[(.*?)\];", txt, re.S)
+    items = re.findall(r"'((?:[^'\\]|\\.)*)'", m.group(1))
+    # prefix decompression: first char of each entry encodes shared-prefix length
+    cp = [items[0]]
+    for i in range(1, len(items)):
+        s = items[i]
+        cp.append(cp[i - 1][: ord(s[0]) - 32] + s[1:])
+    body = txt[txt.rindex("unpack(cpool);"):]
+    frames = []
+    total = 0
+    width0 = 0
+    lvl = 0
+    for line in body.splitlines():
+        line = line.strip()
+        mm = re.match(r"([fun])\(([\d,\-]+)\)", line)
+        if not mm:
+            continue
+        fn = mm.group(1)
+        a = [int(x) for x in mm.group(2).split(",")]
+        if fn == "f":
+            key = a[0]
+            lvl = a[1]
+            width = a[2] if len(a) > 2 and a[2] != 0 else width0
+        elif fn == "u":
+            lvl += 1
+            key = a[0]
+            width = a[1] if len(a) > 1 and a[1] != 0 else width0
+        else:  # n
+            key = a[0]
+            width = a[1] if len(a) > 1 and a[1] != 0 else width0
+        width0 = width
+        title = cp[key >> 3]
+        if lvl == 0:
+            total = width
+        frames.append((lvl, title, width))
+    return total, frames
+
+
+def normalize(title):
+    """Collapse per-JVM-run volatile identifiers so two runs are comparable.
+
+    JIT lambda/proxy class names embed a per-run address (…$$Lambda.0x00000000abc.run)
+    and native .so temp files embed a random suffix (librocksdbjni<random>.so). These
+    differ every run for identical code, so strip them before diffing."""
+    t = re.sub(r"0x[0-9a-f]+", "0xLAMBDA", title)
+    t = re.sub(r"librocksdbjni\d+\.so", "librocksdbjni.so", t)
+    t = re.sub(r"libnetty_[a-z_0-9]+\.so", "libnetty.so", t)
+    return t

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_diff.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_diff.py
@@ -1,0 +1,45 @@
+"""Diff two async-profiler flamegraphs by INCLUSIVE per-function %.
+
+Inclusive % = share of total samples whose stack contains the function anywhere.
+Per-run volatile identifiers (lambda addresses, native .so temp names) are
+normalized (see fg_common.normalize) so the diff reflects real code, not noise.
+
+Prints functions that grew the most in FILE_B (e.g. today / regressed) and those
+that shrank vs FILE_A (e.g. baseline / healthy).
+
+Usage: python3 fg_diff.py <baseline.html> <candidate.html> [min_delta_pct]
+
+IMPORTANT for comparability: only diff like-for-like profiles. In the Camunda
+daily benchmark each run produces BOTH a gRPC and a REST flamegraph for the same
+node — never diff gRPC against REST (the whole request-handling stack differs).
+Identify which is which first (see SKILL.md).
+"""
+import sys
+from fg_common import load_frames, normalize
+
+
+def inclusive_pct(path):
+    total, frames = load_frames(path)
+    incl = {}
+    for _, title, width in frames:
+        k = normalize(title)
+        incl[k] = incl.get(k, 0) + width
+    return {k: 100 * v / total for k, v in incl.items()}
+
+
+if __name__ == "__main__":
+    a = inclusive_pct(sys.argv[1])
+    b = inclusive_pct(sys.argv[2])
+    thr = float(sys.argv[3]) if len(sys.argv) > 3 else 1.5
+    keys = set(a) | set(b)
+    d = sorted(((b.get(k, 0) - a.get(k, 0), k) for k in keys), reverse=True)
+    print(f"### Grew in {sys.argv[2].split('/')[-1][:30]} (candidate):")
+    for v, k in d:
+        if v < thr:
+            break
+        print(f"  +{v:6.2f}  (base {a.get(k, 0):6.2f} -> cand {b.get(k, 0):6.2f})  {k[:76]}")
+    print(f"### Shrank vs {sys.argv[1].split('/')[-1][:30]} (baseline):")
+    for v, k in d[::-1]:
+        if -v < thr:
+            break
+        print(f"  {v:7.2f}  (base {a.get(k, 0):6.2f} -> cand {b.get(k, 0):6.2f})  {k[:76]}")

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_subsystems.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_subsystems.py
@@ -1,0 +1,56 @@
+"""Attribute one Zeebe flamegraph's CPU to Camunda subsystems (leaf-based).
+
+Each leaf sample is assigned to the FIRST matching subsystem found while walking
+its stack from root to leaf, using the ordered SUBSYSTEMS table below. Order
+matters: more-specific / outer-owner categories come first. Leaves matching
+nothing land in 'other'. Native/syscall scatter means coverage is typically
+~70-75%, which is fine for a directional split.
+
+Usage: python3 fg_subsystems.py <flamegraph.html>
+"""
+import re
+import sys
+from fg_common import load_frames
+
+# Ordered (name, regex-over-joined-stack). See references/zeebe-contributors.md
+# for what each subsystem means and why it shows up. Tuned for Zeebe broker
+# profiles with the Elasticsearch/Camunda exporter enabled.
+SUBSYSTEMS = [
+    ("exporter-es-client", r"org/apache/http|broker/exporter|co/elastic/clients|elasticsearch|RestClient"),
+    ("replay",             r"ReplayStateMachine|Engine\.replay"),
+    ("processing",         r"ProcessingStateMachine|TypedRecordProcessor|processing/bpmn|EventAppliers|ResultBuilderBacked"),
+    ("rocksdb-state",      r"rocksdb|TransactionalColumnFamily|ZeebeTransaction|ColumnFamilyContext"),
+    ("journal-flush",      r"journal/file|RaftLogFlusher|MappedMemoryUtils\.force|Sequencer"),
+    ("raft-netty",         r"io/atomix/raft|io/netty|SocketChannel|epoll"),
+    ("grpc",               r"io/grpc"),
+    ("gc",                 r"G1|GCTask|CMTask|CollectedHeap|markOop|ConcurrentGC"),
+    ("scheduler-idle",     r"ActorThread\.waitOnRunnable|Unsafe\.park|park\b"),
+]
+
+
+def attribute(path):
+    total, frames = load_frames(path)
+    pathstack = {}
+    agg = {name: 0 for name, _ in SUBSYSTEMS}
+    agg["other"] = 0
+    n = len(frames)
+    for i, (lvl, title, w) in enumerate(frames):
+        pathstack[lvl] = title
+        is_leaf = (i + 1 >= n) or (frames[i + 1][0] <= lvl)
+        if not is_leaf:
+            continue
+        joined = " ".join(pathstack[l] for l in range(0, lvl + 1) if l in pathstack)
+        for name, pat in SUBSYSTEMS:
+            if re.search(pat, joined):
+                agg[name] += w
+                break
+        else:
+            agg["other"] += w
+    return total, agg
+
+
+if __name__ == "__main__":
+    total, agg = attribute(sys.argv[1])
+    print(f"total samples: {total}")
+    for k, v in sorted(agg.items(), key=lambda x: -x[1]):
+        print(f"  {100 * v / total:6.2f}%  {k}")

--- a/.claude/skills/zeebe-flamegraph-diff/scripts/fg_top.py
+++ b/.claude/skills/zeebe-flamegraph-diff/scripts/fg_top.py
@@ -1,0 +1,31 @@
+"""Per-function SELF-time top list for one async-profiler flamegraph.
+
+Self time = a frame's width minus the width of its direct children, aggregated by
+title across the whole tree. Good first look at "what is this node burning CPU on".
+
+Usage: python3 fg_top.py <flamegraph.html> [topN]
+"""
+import sys
+from fg_common import load_frames
+
+
+def self_times(path):
+    total, frames = load_frames(path)
+    stack = {}
+    self_by = {}
+    for lvl, title, width in frames:
+        stack[lvl] = title
+        self_by[title] = self_by.get(title, 0) + width
+        if lvl > 0 and stack.get(lvl - 1) is not None:
+            self_by[stack[lvl - 1]] = self_by.get(stack[lvl - 1], 0) - width
+    return total, self_by
+
+
+if __name__ == "__main__":
+    top = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+    total, s = self_times(sys.argv[1])
+    print(f"total samples: {total}")
+    for t, v in sorted(s.items(), key=lambda x: -x[1])[:top]:
+        if v <= 0:
+            continue
+        print(f"  {100 * v / total:6.2f}%  {t[:90]}")

--- a/.claude/skills/zeebe-flamegraph-diff/tests/fixture.html
+++ b/.claude/skills/zeebe-flamegraph-diff/tests/fixture.html
@@ -1,0 +1,21 @@
+<!-- Minimal async-profiler flamegraph fixture for parser tests.
+     Mirrors the real f()/u()/n() emission scheme:
+       f(key, level, left, width): absolute level; left0 += left; width0 = width || width0
+       u(key, width): child   -> f(key, level0+1, 0, width)
+       n(key, width): sibling -> f(key, level0, width0, width)
+     title = cpool[key >>> 3]; cpool is prefix-compressed (first char = shared-prefix len + 32). -->
+<script>
+	const cpool = [
+'all',
+' root',
+' aa',
+' bb'
+];
+	function unpack(cpool) {}
+unpack(cpool);
+
+n(0,100)
+u(8,60)
+f(16,1,30,40)
+n(24,10)
+</script>

--- a/.claude/skills/zeebe-flamegraph-diff/tests/test_fg_common.py
+++ b/.claude/skills/zeebe-flamegraph-diff/tests/test_fg_common.py
@@ -1,0 +1,30 @@
+"""Golden test for the async-profiler HTML parser in fg_common.load_frames.
+
+Regression guard for the f()-frame width bug: async-profiler emits
+`f(key, level, left, width)`, so width is the 4th arg. Reading the 3rd (`left`)
+instead silently corrupts every f-frame width (and any u/n frames that inherit
+width0 from it). Runnable standalone: `python3 test_fg_common.py`.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import fg_common  # noqa: E402
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixture.html")
+
+
+def test_load_frames():
+    total, frames = fg_common.load_frames(FIXTURE)
+    assert total == 100, total
+    assert frames == [
+        (0, "all", 100),
+        (1, "root", 60),
+        (1, "aa", 40),  # from f(16,1,30,40): width is a[3]=40, NOT left a[2]=30
+        (1, "bb", 10),
+    ], frames
+
+
+if __name__ == "__main__":
+    test_load_frames()
+    print("ok")

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ docs/superpowers/
 
 # Load test
 load-tests/setup/c8-*
+
+
+# python caches from scripts in skills
+**/__pycache__/**


### PR DESCRIPTION
## Description
The skill contains some useful scripts to make two different flamegraphs comparable.
A sample of expected contributors is included in the skill so that each subsystem is already known.

It also contains some pointers on how to corroborate the flamegraphs with the grafana metrics.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
