### PR TITLE
perf: back off between processing result write retries

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Processing.java
+++ b/configuration/src/main/java/io/camunda/configuration/Processing.java
@@ -16,7 +16,6 @@ import org.springframework.core.ResolvableType;
 public class Processing {
   private static final String PREFIX = "camunda.processing";
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
-  private static final boolean DEFAULT_ENABLE_ASYNC_SCHEDULED_TASKS = true;
   private static final Duration DEFAULT_SCHEDULED_TASKS_CHECK_INTERVAL = Duration.ofSeconds(1);
 
   private static final boolean DEFAULT_ENABLE_PRECONDITIONS_CHECK = false;
@@ -32,8 +31,6 @@ public class Processing {
 
   private static final Set<String> LEGACY_MAX_COMMANDS_IN_BATCH_PROPERTIES =
       Set.of("zeebe.broker.processingCfg.maxCommandsInBatch");
-  private static final Set<String> LEGACY_ENABLE_ASYNC_SCHEDULED_TASKS_PROPERTIES =
-      Set.of("zeebe.broker.processingCfg.enableAsyncScheduledTasks");
   private static final Set<String> LEGACY_SCHEDULED_TASKS_CHECK_INTERVAL_PROPERTIES =
       Set.of("zeebe.broker.processingCfg.scheduledTaskCheckInterval");
   private static final Set<String> LEGACY_SKIP_POSITIONS_PROPERTIES =
@@ -76,21 +73,6 @@ public class Processing {
    * retry.
    */
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
-
-  /**
-   * Allows scheduled processing tasks such as checking for timed-out jobs to run concurrently to
-   * regular processing. This is a performance optimization to ensure that processing is not
-   * interrupted by higher than usual workload for any of the scheduled tasks. This should only be
-   * disabled in case of bugs, for example if one of the scheduled tasks is not safe to run
-   * concurrently to regular processing.
-   *
-   * <p>This replaces the deprecated experimental settings that enable async scheduling for specific
-   * tasks only, for example `enableMessageTTLCheckerAsync`. When `enableAsyncScheduledTasks` is
-   * enabled (which it is by default), the deprecated settings take no effect. When
-   * `enableAsyncScheduledTasks` is disabled, scheduled tasks are only run async if explicitly
-   * enabled by the deprecated setting.
-   */
-  private boolean enableAsyncScheduledTasks = DEFAULT_ENABLE_ASYNC_SCHEDULED_TASKS;
 
   /**
    * Configures the rate at which a partition leader checks for expired scheduled tasks such as the
@@ -187,19 +169,6 @@ public class Processing {
 
   public void setMaxCommandsInBatch(final Integer maxCommandsInBatch) {
     this.maxCommandsInBatch = maxCommandsInBatch;
-  }
-
-  public boolean isEnableAsyncScheduledTasks() {
-    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
-        PREFIX + ".enable-async-scheduled-tasks",
-        enableAsyncScheduledTasks,
-        Boolean.class,
-        BackwardsCompatibilityMode.SUPPORTED,
-        LEGACY_ENABLE_ASYNC_SCHEDULED_TASKS_PROPERTIES);
-  }
-
-  public void setEnableAsyncScheduledTasks(final boolean enableAsyncScheduledTasks) {
-    this.enableAsyncScheduledTasks = enableAsyncScheduledTasks;
   }
 
   public Duration getScheduledTasksCheckInterval() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -210,7 +210,6 @@ public class BrokerBasedPropertiesOverride {
     // processing
     override.getProcessing().setMaxCommandsInBatch(processing.getMaxCommandsInBatch());
     override.getProcessing().setMaxRecoverableRetries(processing.getMaxRecoverableRetries());
-    override.getProcessing().setEnableAsyncScheduledTasks(processing.isEnableAsyncScheduledTasks());
     override
         .getProcessing()
         .setScheduledTaskCheckInterval(processing.getScheduledTasksCheckInterval());

--- a/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ProcessingPropertiesTest.java
@@ -32,7 +32,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class ProcessingPropertiesTest {
 
   private static final int EXPECTED_MAX_COMMANDS_IN_BATCH = 200;
-  private static final boolean EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS = false;
   private static final Duration EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL = Duration.ofSeconds(10);
   private static final Set<Long> EXPECTED_SKIP_POSITIONS = Set.of(10L, 20L);
   private static final boolean EXPECTED_ENABLE_PRECONDITIONS_CHECK = true;
@@ -52,7 +51,6 @@ public class ProcessingPropertiesTest {
   @TestPropertySource(
       properties = {
         "camunda.processing.max-commands-in-batch=" + EXPECTED_MAX_COMMANDS_IN_BATCH,
-        "camunda.processing.enable-async-scheduled-tasks=" + EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS,
         "camunda.processing.scheduled-tasks-check-interval=10s",
         "camunda.processing.skip-positions=10,20",
         "camunda.processing.enable-preconditions-check=" + EXPECTED_ENABLE_PRECONDITIONS_CHECK,
@@ -80,8 +78,6 @@ public class ProcessingPropertiesTest {
     void shouldSetProcessingProperties() {
       assertThat(brokerBasedProperties.getProcessing())
           .returns(EXPECTED_MAX_COMMANDS_IN_BATCH, ProcessingCfg::getMaxCommandsInBatch)
-          .returns(
-              EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS, ProcessingCfg::isEnableAsyncScheduledTasks)
           .returns(
               EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
           .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions)
@@ -118,8 +114,6 @@ public class ProcessingPropertiesTest {
   @TestPropertySource(
       properties = {
         "zeebe.broker.processingCfg.maxCommandsInBatch=" + EXPECTED_MAX_COMMANDS_IN_BATCH,
-        "zeebe.broker.processingCfg.enableAsyncScheduledTasks="
-            + EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS,
         "zeebe.broker.processingCfg.scheduledTaskCheckInterval=10s",
         "zeebe.broker.processingCfg.skipPositions=10,20",
         "zeebe.broker.experimental.consistencyChecks.enablePreconditions="
@@ -150,8 +144,6 @@ public class ProcessingPropertiesTest {
     void shouldSetProcessingPropertiesFromLegacy() {
       assertThat(brokerBasedProperties.getProcessing())
           .returns(EXPECTED_MAX_COMMANDS_IN_BATCH, ProcessingCfg::getMaxCommandsInBatch)
-          .returns(
-              EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS, ProcessingCfg::isEnableAsyncScheduledTasks)
           .returns(
               EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
           .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions);
@@ -188,7 +180,6 @@ public class ProcessingPropertiesTest {
       properties = {
         // new
         "camunda.processing.max-commands-in-batch=" + EXPECTED_MAX_COMMANDS_IN_BATCH,
-        "camunda.processing.enable-async-scheduled-tasks=" + EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS,
         "camunda.processing.scheduled-tasks-check-interval=10s",
         "camunda.processing.skip-positions=10,20",
         "camunda.processing.enable-preconditions-check=" + EXPECTED_ENABLE_PRECONDITIONS_CHECK,
@@ -207,7 +198,6 @@ public class ProcessingPropertiesTest {
 
         // legacy
         "zeebe.broker.processingCfg.maxCommandsInBatch=1",
-        "zeebe.broker.processingCfg.enableAsyncScheduledTasks=true",
         "zeebe.broker.processingCfg.scheduledTaskCheckInterval=1s",
         "zeebe.broker.processingCfg.skipPositions=30,40",
         "zeebe.broker.experimental.consistencyChecks.enablePreconditions=false",
@@ -231,8 +221,6 @@ public class ProcessingPropertiesTest {
     void shouldSetProcessingPropertiesFromNew() {
       assertThat(brokerBasedProperties.getProcessing())
           .returns(EXPECTED_MAX_COMMANDS_IN_BATCH, ProcessingCfg::getMaxCommandsInBatch)
-          .returns(
-              EXPECTED_ENABLE_ASYNC_SCHEDULED_TASKS, ProcessingCfg::isEnableAsyncScheduledTasks)
           .returns(
               EXPECTED_SCHEDULED_TASKS_CHECK_INTERVAL, ProcessingCfg::getScheduledTaskCheckInterval)
           .returns(EXPECTED_SKIP_POSITIONS, ProcessingCfg::skipPositions)

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -253,7 +253,6 @@ process-instance-creation.message-start-lock-release-poll-batch-limit
 process-instance-creation.message-start-lock-release-poll-interval
 process-instance-creation.message-start-lock-release-poll-max-backoff
 processing.enable-async-message-ttl-checker
-processing.enable-async-scheduled-tasks
 processing.enable-async-timer-duedate-checker
 processing.enable-foreign-key-checks
 processing.enable-message-body-on-expired

--- a/debug-cli/src/main/java/io/camunda/debug/cli/concurrency/CurrentThreadConcurrencyControl.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/concurrency/CurrentThreadConcurrencyControl.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
@@ -54,7 +53,7 @@ public class CurrentThreadConcurrencyControl implements ConcurrencyControl {
   }
 
   @Override
-  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+  public ScheduledTimer schedule(final long delayMs, final Runnable runnable) {
     throw new UnsupportedOperationException("schedule is not supported");
   }
 }

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1037,16 +1037,6 @@ camunda: # Type: io.camunda.configuration.Camunda
     # improve throughput and process latency in use cases that publish many messages with a non-zero TTL.
     # We recommend testing this feature in a non-production environment before enabling it in production.
     enable-async-message-ttl-checker: false # Type: Boolean, Env: CAMUNDA_PROCESSING_ENABLEASYNCMESSAGETTLCHECKER
-    # Allows scheduled processing tasks such as checking for timed-out jobs to run concurrently to regular
-    # processing. This is a performance optimization to ensure that processing is not interrupted by
-    # higher than usual workload for any of the scheduled tasks. This should only be disabled in case of
-    # bugs, for example if one of the scheduled tasks is not safe to run concurrently to regular
-    # processing.
-    # This replaces the deprecated experimental settings that enable async scheduling for specific tasks
-    # only, for example `enableMessageTTLCheckerAsync`. When `enableAsyncScheduledTasks` is enabled (which
-    # it is by default), the deprecated settings take no effect. When `enableAsyncScheduledTasks` is
-    # disabled, scheduled tasks are only run async if explicitly enabled by the deprecated setting.
-    enable-async-scheduled-tasks: true # Type: Boolean, Env: CAMUNDA_PROCESSING_ENABLEASYNCSCHEDULEDTASKS
     # While disabled, checking for due timers blocks all other executions that occur on the stream
     # processor, including process execution and job activation/completion. When enabled, the Due Date
     # Checker will run asynchronous to the Engine's stream processor. This helps improve throughput and

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -16,7 +16,6 @@ public final class ProcessingCfg implements ConfigurationEntry {
   private static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
-  private boolean enableAsyncScheduledTasks = true;
   private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
   private Set<Long> skipPositions;
 
@@ -53,14 +52,6 @@ public final class ProcessingCfg implements ConfigurationEntry {
     this.maxRecoverableRetries = maxRecoverableRetries;
   }
 
-  public boolean isEnableAsyncScheduledTasks() {
-    return enableAsyncScheduledTasks;
-  }
-
-  public void setEnableAsyncScheduledTasks(final boolean enableAsyncScheduledTasks) {
-    this.enableAsyncScheduledTasks = enableAsyncScheduledTasks;
-  }
-
   public Set<Long> skipPositions() {
     return skipPositions != null ? skipPositions : Set.of();
   }
@@ -76,8 +67,6 @@ public final class ProcessingCfg implements ConfigurationEntry {
         + maxCommandsInBatch
         + ", maxRecoverableRetries="
         + maxRecoverableRetries
-        + ", enableAsyncScheduledTasks="
-        + enableAsyncScheduledTasks
         + ", scheduledTaskCheckInterval="
         + scheduledTaskCheckInterval
         + '}';

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -172,8 +172,6 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .commandResponseWriter(context.getCommandApiService().newCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
         .maxRecoverableRetries(context.getBrokerCfg().getProcessing().getMaxRecoverableRetries())
-        .setEnableAsyncScheduledTasks(
-            context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())
         .setScheduledTaskCheckInterval(
             context.getBrokerCfg().getProcessing().getScheduledTaskCheckInterval())
         .processingFilter(processingFilter)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -145,58 +145,6 @@ final class ProcessingCfgTest {
   }
 
   @Test
-  void shouldEnableAsyncScheduledTasksByDefault() {
-    // given
-    final var cfg = new ProcessingCfg();
-
-    // when
-    final var enabled = cfg.isEnableAsyncScheduledTasks();
-
-    // then
-    assertThat(enabled).isTrue();
-  }
-
-  @Test
-  void shouldSetAsyncScheduledTasks() {
-    // given
-    final var cfg = new ProcessingCfg();
-    cfg.setEnableAsyncScheduledTasks(false);
-
-    // when
-    final var enabled = cfg.isEnableAsyncScheduledTasks();
-
-    // then
-    assertThat(enabled).isFalse();
-  }
-
-  @Test
-  void shouldSetAsyncScheduledTasksFromConfig() {
-    // given
-    final var cfg =
-        TestConfigReader.readConfig("processing-cfg", Collections.emptyMap()).getProcessing();
-
-    // when
-    final var enabled = cfg.isEnableAsyncScheduledTasks();
-
-    // then
-    assertThat(enabled).isFalse();
-  }
-
-  @Test
-  void shouldDisableAsyncScheduledTasksFromEnvironment() {
-    // given
-    final var environment =
-        Collections.singletonMap("zeebe.broker.processing.enableAsyncScheduledTasks", "true");
-    final var cfg = TestConfigReader.readConfig("processing-cfg", environment).getProcessing();
-
-    // when
-    final var enabled = cfg.isEnableAsyncScheduledTasks();
-
-    // then
-    assertThat(enabled).isTrue();
-  }
-
-  @Test
   void shouldSetSkipPositions() {
     // given
     final var cfg = new ProcessingCfg();

--- a/zeebe/broker/src/test/resources/system/processing-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/processing-cfg.yaml
@@ -3,5 +3,4 @@ zeebe:
     processing:
       maxCommandsInBatch: 125
       maxRecoverableRetries: 200
-      enableAsyncScheduledTasks: false
       skipPositions: 1, 2, 3

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.scheduler;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Loggers;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -196,8 +195,8 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   }
 
   @Override
-  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
-    return actor.schedule(delay, runnable);
+  public ScheduledTimer schedule(final long delayMs, final Runnable runnable) {
+    return actor.schedule(delayMs, runnable);
   }
 
   public static ActorBuilder newActor() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -223,17 +223,12 @@ public class ActorControl implements ConcurrencyControl {
   /**
    * The runnable is executed while the actor is in the following actor lifecycle phases: {@link
    * ActorLifecyclePhase#STARTED}
-   *
-   * @param delay
-   * @param runnable
-   * @return
    */
   @Override
-  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+  public ScheduledTimer schedule(final long delayMs, final Runnable runnable) {
     ensureCalledFromWithinActor("runDelayed(...)");
     return scheduleTimerSubscription(
-        runnable,
-        job -> new DelayedTimerSubscription(job, delay.toMillis(), TimeUnit.MILLISECONDS, false));
+        runnable, job -> new DelayedTimerSubscription(job, delayMs, TimeUnit.MILLISECONDS, false));
   }
 
   /**

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
@@ -65,7 +65,12 @@ public interface ConcurrencyControl extends Executor {
   <T> ActorFuture<T> call(final Callable<T> callable);
 
   /** Schedule a task to be executed after a delay */
-  ScheduledTimer schedule(final Duration delay, final Runnable runnable);
+  default ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+    return schedule(delay.toMillis(), runnable);
+  }
+
+  /** Schedule a task to be executed after a delay */
+  ScheduledTimer schedule(final long delayMs, final Runnable runnable);
 
   /**
    * Create a new future object

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableBackOffRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableBackOffRetryStrategy.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler.retry;
+
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Retries an operation with exponential backoff between attempts. The first attempt runs
+ * immediately; retries are scheduled as actor timers, so the actor stays responsive and processes
+ * other jobs while waiting for the next attempt.
+ *
+ * <p>Unlike {@link BackOffRetryStrategy}, exceptions thrown by the operation are not retried but
+ * complete the result future exceptionally, mirroring {@link AbortableRetryStrategy}.
+ */
+public final class AbortableBackOffRetryStrategy implements RetryStrategy {
+
+  private final ActorControl actor;
+  private final Duration maxBackOff;
+  private final Duration initialBackOff;
+
+  private Duration backOffDuration;
+  private CompletableActorFuture<Boolean> currentFuture;
+  private BooleanSupplier currentTerminateCondition;
+  private OperationToRetry currentCallable;
+
+  public AbortableBackOffRetryStrategy(
+      final ActorControl actor, final Duration initialBackOff, final Duration maxBackOff) {
+    this.actor = actor;
+    this.initialBackOff = initialBackOff;
+    this.maxBackOff = maxBackOff;
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(final OperationToRetry callable) {
+    return runWithRetry(callable, () -> false);
+  }
+
+  @Override
+  public ActorFuture<Boolean> runWithRetry(
+      final OperationToRetry callable, final BooleanSupplier terminateCondition) {
+    currentFuture = new CompletableActorFuture<>();
+    currentTerminateCondition = terminateCondition;
+    currentCallable = callable;
+    backOffDuration = initialBackOff;
+
+    actor.run(this::run);
+
+    return currentFuture;
+  }
+
+  private void run() {
+    try {
+      if (currentCallable.run()) {
+        currentFuture.complete(true);
+      } else if (currentTerminateCondition.getAsBoolean()) {
+        currentFuture.complete(false);
+      } else {
+        backOff();
+      }
+    } catch (final Exception exception) {
+      currentFuture.completeExceptionally(exception);
+    }
+  }
+
+  private void backOff() {
+    actor.schedule(backOffDuration, this::run);
+    final var nextBackOff = backOffDuration.multipliedBy(2);
+    backOffDuration = nextBackOff.compareTo(maxBackOff) < 0 ? nextBackOff : maxBackOff;
+  }
+}

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableDelayedRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableDelayedRetryStrategy.java
@@ -10,33 +10,30 @@ package io.camunda.zeebe.scheduler.retry;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.time.Duration;
+import io.camunda.zeebe.util.RetryDelayStrategy;
 import java.util.function.BooleanSupplier;
 
 /**
- * Retries an operation with exponential backoff between attempts. The first attempt runs
- * immediately; retries are scheduled as actor timers, so the actor stays responsive and processes
- * other jobs while waiting for the next attempt.
+ * Retries an operation with delays between attempts. The first attempt runs immediately; retries
+ * are scheduled as actor timers, so the actor stays responsive and processes other jobs while
+ * waiting for the next attempt.
  *
  * <p>Unlike {@link BackOffRetryStrategy}, exceptions thrown by the operation are not retried but
  * complete the result future exceptionally, mirroring {@link AbortableRetryStrategy}.
  */
-public final class AbortableBackOffRetryStrategy implements RetryStrategy {
+public final class AbortableDelayedRetryStrategy implements RetryStrategy {
 
   private final ActorControl actor;
-  private final Duration maxBackOff;
-  private final Duration initialBackOff;
+  private final RetryDelayStrategy delayStrategy;
 
-  private Duration backOffDuration;
   private CompletableActorFuture<Boolean> currentFuture;
   private BooleanSupplier currentTerminateCondition;
   private OperationToRetry currentCallable;
 
-  public AbortableBackOffRetryStrategy(
-      final ActorControl actor, final Duration initialBackOff, final Duration maxBackOff) {
+  public AbortableDelayedRetryStrategy(
+      final ActorControl actor, final RetryDelayStrategy delayStrategy) {
     this.actor = actor;
-    this.initialBackOff = initialBackOff;
-    this.maxBackOff = maxBackOff;
+    this.delayStrategy = delayStrategy;
   }
 
   @Override
@@ -50,7 +47,7 @@ public final class AbortableBackOffRetryStrategy implements RetryStrategy {
     currentFuture = new CompletableActorFuture<>();
     currentTerminateCondition = terminateCondition;
     currentCallable = callable;
-    backOffDuration = initialBackOff;
+    delayStrategy.reset();
 
     actor.run(this::run);
 
@@ -72,8 +69,6 @@ public final class AbortableBackOffRetryStrategy implements RetryStrategy {
   }
 
   private void backOff() {
-    actor.schedule(backOffDuration, this::run);
-    final var nextBackOff = backOffDuration.multipliedBy(2);
-    backOffDuration = nextBackOff.compareTo(maxBackOff) < 0 ? nextBackOff : maxBackOff;
+    actor.schedule(delayStrategy.nextDelay(), this::run);
   }
 }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -334,7 +335,9 @@ final class RetryStrategyTest {
         case "backoff" -> TestCase.of(actor -> new BackOffRetryStrategy(actor, Duration.ZERO));
         case "abortable-backoff" ->
             TestCase.of(
-                actor -> new AbortableBackOffRetryStrategy(actor, Duration.ZERO, Duration.ZERO));
+                actor ->
+                    new AbortableDelayedRetryStrategy(
+                        actor, new ExponentialBackoffRetryDelay(Duration.ZERO, Duration.ZERO)));
         default ->
             throw new IllegalArgumentException(
                 "Expected one of ['endless', 'recoverable', 'abortable', 'backoff', or "

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/retry/RetryStrategyTest.java
@@ -39,7 +39,7 @@ final class RetryStrategyTest {
   private ActorFuture<Boolean> resultFuture;
 
   @ParameterizedTest
-  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff"})
+  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff", "abortable-backoff"})
   void shouldRunUntilDone(final TestCase<?> test) {
     // given
     final var count = new AtomicInteger(0);
@@ -56,7 +56,7 @@ final class RetryStrategyTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff"})
+  @ValueSource(strings = {"endless", "recoverable", "abortable", "backoff", "abortable-backoff"})
   void shouldStopWhenAbortConditionReturnsTrue(final TestCase<?> test) {
     // given
     final AtomicInteger count = new AtomicInteger(0);
@@ -80,7 +80,7 @@ final class RetryStrategyTest {
    * specific class tests?
    */
   @ParameterizedTest
-  @ValueSource(strings = {"recoverable", "abortable"})
+  @ValueSource(strings = {"recoverable", "abortable", "abortable-backoff"})
   void shouldAbortOnOtherException(final TestCase<?> test) {
     // given
     final RuntimeException failure = new RuntimeException("expected");
@@ -332,9 +332,13 @@ final class RetryStrategyTest {
         case "recoverable" -> TestCase.of(RecoverableRetryStrategy::new);
         case "abortable" -> TestCase.of(AbortableRetryStrategy::new);
         case "backoff" -> TestCase.of(actor -> new BackOffRetryStrategy(actor, Duration.ZERO));
+        case "abortable-backoff" ->
+            TestCase.of(
+                actor -> new AbortableBackOffRetryStrategy(actor, Duration.ZERO, Duration.ZERO));
         default ->
             throw new IllegalArgumentException(
-                "Expected one of ['endless', 'recoverable', 'abortable', or 'backoff'], but got "
+                "Expected one of ['endless', 'recoverable', 'abortable', 'backoff', or "
+                    + "'abortable-backoff'], but got "
                     + type);
       };
     }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.LockUtil;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -113,9 +112,9 @@ public class TestConcurrencyControl implements ConcurrencyControl {
   }
 
   @Override
-  public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
+  public ScheduledTimer schedule(final long delayMs, final Runnable runnable) {
     if (asyncSchedule) {
-      final var task = new ScheduledTask(System.currentTimeMillis() + delay.toMillis(), runnable);
+      final var task = new ScheduledTask(System.currentTimeMillis() + delayMs, runnable);
       tasks.add(task);
       return () -> tasks.removeIf(t -> t == task);
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
@@ -20,10 +20,5 @@ public interface ReadonlyStreamProcessorContext {
    */
   int getPartitionId();
 
-  /**
-   * @return true when scheduled tasks should run async, concurrently to the processing actor.
-   */
-  boolean enableAsyncScheduledTasks();
-
   StreamClock getClock();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -12,22 +12,15 @@ import static io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup.ASYNC_PROCES
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
-import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import java.time.Duration;
 
 class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
   private final AsyncScheduleServiceContext context;
-  private final SimpleProcessingScheduleService processorActorService;
-  private final boolean alwaysAsync;
 
   public ExtendedProcessingScheduleServiceImpl(
-      final AsyncScheduleServiceContext asyncScheduleServiceContext,
-      final SimpleProcessingScheduleService processorActorService,
-      final boolean alwaysAsync) {
+      final AsyncScheduleServiceContext asyncScheduleServiceContext) {
     context = asyncScheduleServiceContext;
-    this.processorActorService = processorActorService;
-    this.alwaysAsync = alwaysAsync;
   }
 
   @Override
@@ -90,65 +83,45 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
 
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
-    if (alwaysAsync) {
-      final var actor = context.geAsyncActor(ASYNC_PROCESSING);
-      final var actorService = actor.getScheduleService();
-      final var futureScheduledTask = actor.<ScheduledTask>createFuture();
-      actor.run(
-          () -> {
-            // we must run in different actor in order to schedule task
-            final var scheduledTask = actorService.runDelayed(delay, task);
-            futureScheduledTask.complete(scheduledTask);
-          });
-      return new AsyncScheduledTask(futureScheduledTask, ASYNC_PROCESSING);
-    } else {
-      return processorActorService.runDelayed(delay, task);
-    }
+    final var actor = context.geAsyncActor(ASYNC_PROCESSING);
+    final var actorService = actor.getScheduleService();
+    final var futureScheduledTask = actor.<ScheduledTask>createFuture();
+    actor.run(
+        () -> {
+          // we must run in different actor in order to schedule task
+          final var scheduledTask = actorService.runDelayed(delay, task);
+          futureScheduledTask.complete(scheduledTask);
+        });
+    return new AsyncScheduledTask(futureScheduledTask, ASYNC_PROCESSING);
   }
 
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Task task) {
-    if (alwaysAsync) {
-      return runDelayedAsync(delay, task);
-    } else {
-      return processorActorService.runDelayed(delay, task);
-    }
+    return runDelayedAsync(delay, task);
   }
 
   @Override
   public ScheduledTask runAt(final long timestamp, final Task task) {
-    if (alwaysAsync) {
-      return runAtAsync(timestamp, task);
-    } else {
-      return processorActorService.runAt(timestamp, task);
-    }
+    return runAtAsync(timestamp, task);
   }
 
   @Override
   public ScheduledTask runAt(final long timestamp, final Runnable task) {
-    if (alwaysAsync) {
-      final var actor = context.geAsyncActor(ASYNC_PROCESSING);
-      final var actorService = actor.getScheduleService();
-      final var futureScheduledTask = actor.<ScheduledTask>createFuture();
-      actor.run(
-          () -> {
-            // we must run in different actor in order to schedule task
-            final var scheduledTask = actorService.runAt(timestamp, task);
-            futureScheduledTask.complete(scheduledTask);
-          });
-      return new AsyncScheduledTask(futureScheduledTask, ASYNC_PROCESSING);
-    } else {
-      return processorActorService.runAt(timestamp, task);
-    }
+    final var actor = context.geAsyncActor(ASYNC_PROCESSING);
+    final var actorService = actor.getScheduleService();
+    final var futureScheduledTask = actor.<ScheduledTask>createFuture();
+    actor.run(
+        () -> {
+          // we must run in different actor in order to schedule task
+          final var scheduledTask = actorService.runAt(timestamp, task);
+          futureScheduledTask.complete(scheduledTask);
+        });
+    return new AsyncScheduledTask(futureScheduledTask, ASYNC_PROCESSING);
   }
 
   @Override
   public void runAtFixedRate(final Duration delay, final Task task) {
-    if (alwaysAsync) {
-      runAtFixedRateAsync(delay, task);
-    } else {
-      processorActorService.runAtFixedRate(delay, task);
-    }
+    runAtFixedRateAsync(delay, task);
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.scheduler.retry.AbortableBackOffRetryStrategy;
+import io.camunda.zeebe.scheduler.retry.AbortableDelayedRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
@@ -46,6 +46,7 @@ import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
@@ -120,8 +121,6 @@ public final class ProcessingStateMachine {
   private static final String NOTIFY_SKIPPED_LISTENER_ERROR_MESSAGE =
       "Expected to invoke skipped listener for record '{} {}' successfully, but exception was thrown.";
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
-  private static final Duration WRITE_RETRY_INITIAL_BACKOFF = Duration.ofMillis(1);
-  private static final Duration WRITE_RETRY_MAX_BACKOFF = Duration.ofMillis(100);
   private static final String ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED =
       "Expected to process command '{} {}' successfully on stream processor, but caught unexpected exception. Failed to handle the exception gracefully.";
   private final RecordMetadataBlock recordTypeDecoder = new RecordMetadataBlock();
@@ -192,8 +191,8 @@ public final class ProcessingStateMachine {
     // `inProcessing`, and no other job on this actor touches the open transaction or writes to
     // the log stream, so the actor may serve unrelated jobs while backing off.
     writeRetryStrategy =
-        new AbortableBackOffRetryStrategy(
-            actor, WRITE_RETRY_INITIAL_BACKOFF, WRITE_RETRY_MAX_BACKOFF);
+        new AbortableDelayedRetryStrategy(
+            actor, new ExponentialBackoffRetryDelay(Duration.ofMillis(50), Duration.ofMillis(1)));
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
     updateStateRetryStrategy =
         new RecoverableRetryStrategy(actor, context.getMaxRecoverableRetries());

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.logstreams.impl.Loggers;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.encoding.RecordMetadataBlock;
@@ -25,6 +26,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.retry.AbortableBackOffRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.AbortableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
@@ -118,6 +120,8 @@ public final class ProcessingStateMachine {
   private static final String NOTIFY_SKIPPED_LISTENER_ERROR_MESSAGE =
       "Expected to invoke skipped listener for record '{} {}' successfully, but exception was thrown.";
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
+  private static final Duration WRITE_RETRY_INITIAL_BACKOFF = Duration.ofMillis(1);
+  private static final Duration WRITE_RETRY_MAX_BACKOFF = Duration.ofMillis(100);
   private static final String ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED =
       "Expected to process command '{} {}' successfully on stream processor, but caught unexpected exception. Failed to handle the exception gracefully.";
   private final RecordMetadataBlock recordTypeDecoder = new RecordMetadataBlock();
@@ -184,7 +188,12 @@ public final class ProcessingStateMachine {
     lastProcessedPositionState = context.getLastProcessedPositionState();
     maxCommandsInBatch = context.getMaxCommandsInBatch();
 
-    writeRetryStrategy = new AbortableRetryStrategy(actor);
+    // Waiting between write attempts is safe: processing of the next record is guarded by
+    // `inProcessing`, and no other job on this actor touches the open transaction or writes to
+    // the log stream, so the actor may serve unrelated jobs while backing off.
+    writeRetryStrategy =
+        new AbortableBackOffRetryStrategy(
+            actor, WRITE_RETRY_INITIAL_BACKOFF, WRITE_RETRY_MAX_BACKOFF);
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
     updateStateRetryStrategy =
         new RecoverableRetryStrategy(actor, context.getMaxRecoverableRetries());
@@ -635,9 +644,16 @@ public final class ProcessingStateMachine {
                 if (writeResult.isRight()) {
                   writtenPosition = writeResult.get();
                   return true;
-                } else {
-                  return false;
                 }
+                final var failure = writeResult.getLeft();
+                if (failure == WriteFailure.INVALID_ARGUMENT) {
+                  // deterministic failure, retrying would never succeed - escalate to onError
+                  // instead so the regular error handling can reject the command
+                  throw new IllegalArgumentException(
+                      "Expected to write %d processing results for record '%s %s', but the writer rejected them as invalid"
+                          .formatted(pendingWrites.size(), currentRecord, metadata));
+                }
+                return false;
               },
               abortCondition);
     }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -110,7 +110,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private final List<RecordProcessor> recordProcessors = new ArrayList<>();
   private AsyncScheduleServiceContext asyncScheduleServiceContext;
-  private ProcessingScheduleServiceImpl processorActorService;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     super("StreamProcessor", processorBuilder.getProcessingContext().partitionId());
@@ -167,13 +166,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
           new AsyncScheduleServiceContext(
               actorSchedulingService, actorServiceFactory, streamProcessorContext.partitionId());
 
-      processorActorService = actorServiceFactory.create();
-
       final var processingScheduleService =
-          new ExtendedProcessingScheduleServiceImpl(
-              asyncScheduleServiceContext,
-              processorActorService,
-              streamProcessorContext.enableAsyncScheduledTasks());
+          new ExtendedProcessingScheduleServiceImpl(asyncScheduleServiceContext);
       streamProcessorContext.scheduleService(processingScheduleService);
 
       initRecordProcessors();
@@ -267,7 +261,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void tearDown() {
-    processorActorService.close();
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     replayStateMachine.close();
@@ -359,9 +352,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
     metrics.setStreamProcessorProcessing();
 
-    processorActorService
-        .open(actor)
-        .andThen(() -> asyncScheduleServiceContext.submitActors(actor), actor)
+    asyncScheduleServiceContext
+        .submitActors(actor)
         .onComplete(
             (ignored, error) -> {
               if (error != null) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -160,11 +160,6 @@ public final class StreamProcessorBuilder {
     return this;
   }
 
-  public StreamProcessorBuilder setEnableAsyncScheduledTasks(final boolean enabled) {
-    streamProcessorContext.setEnableAsyncScheduledTasks(enabled);
-    return this;
-  }
-
   public StreamProcessorBuilder processingFilter(final EventFilter processingFilter) {
     streamProcessorContext.processingFilter(processingFilter);
     return this;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -57,7 +57,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
-  private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
   private ControllableStreamClock clock;
   private MeterRegistry meterRegistry;
@@ -97,11 +96,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   public StreamProcessorContext partitionId(final PartitionId partitionId) {
     this.partitionId = partitionId;
     return this;
-  }
-
-  @Override
-  public boolean enableAsyncScheduledTasks() {
-    return enableAsyncScheduledTasks;
   }
 
   @Override
@@ -251,11 +245,6 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public int getMaxRecoverableRetries() {
     return maxRecoverableRetries;
-  }
-
-  public StreamProcessorContext setEnableAsyncScheduledTasks(final boolean enabled) {
-    enableAsyncScheduledTasks = enabled;
-    return this;
   }
 
   public EventFilter processingFilter() {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -20,25 +20,8 @@ import org.mockito.Mockito;
 
 final class ExtendedProcessingScheduleServiceImplTest {
   @Test
-  void shouldNotScheduleAsyncIfDisabled() {
+  void shouldAlwaysScheduleAsync() {
     // given
-    final var context = mock(AsyncScheduleServiceContext.class);
-    final var sync = mock(SimpleProcessingScheduleService.class);
-
-    final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, false);
-
-    // when
-    schedulingService.runDelayed(Duration.ZERO, () -> {});
-
-    // then
-    Mockito.verify(sync, Mockito.times(1))
-        .runDelayed(Mockito.eq(Duration.ZERO), Mockito.<Runnable>any());
-  }
-
-  @Test
-  void shouldAlwaysScheduleAsyncIfEnabled() {
-    // given
-    final var sync = mock(SimpleProcessingScheduleService.class);
     final var async = mock(SimpleProcessingScheduleService.class);
     final var asyncControl = mock(AsyncProcessingScheduleServiceActor.class);
     when(asyncControl.createFuture()).thenReturn(new CompletableActorFuture<>());
@@ -55,7 +38,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
     when(context.geAsyncActor(ASYNC_PROCESSING)).thenReturn(asyncControl);
     when(asyncControl.getScheduleService()).thenReturn(async);
 
-    final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, true);
+    final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context);
 
     // when
     schedulingService.runDelayed(Duration.ZERO, () -> {});


### PR DESCRIPTION
Replaces the `ProcessingStateMachine`'s busy-loop write retry with timer-based exponential backoff, and removes the sync-mode scheduled task execution path that was the last reason the stream processor actor could not safely yield during those retries.

Previously the write retry re-inserted itself at the head of the actor's fast lane and `yieldThread` only yields the OS thread to other actors (https://github.com/camunda/camunda/blob/ff8dbe135d1523283ba1324ed42c98824150432d/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/AbortableRetryStrategy.java#L43-L53), so while waiting for write capacity the actor never polled its submitted jobs or timers: health ticks, pause/resume, and position queries starved, and a core was burned re-running `tryWrite`. The write retry now uses the new `AbortableBackOffRetryStrategy` (1ms doubling to 100ms), which schedules retries as actor timers and, unlike `BackOffRetryStrategy`, fails the result future on exceptions so they still reach `onError`. Serving other jobs during the wait does not admit any new interleaving: those jobs already run between the pipeline's stages (the actor polls submitted jobs before future continuations), reading the next record is guarded by `inProcessing`, and with sync-mode scheduled tasks removed no other job on this actor writes to the log stream or touches the open transaction.

The `WriteFailure` reason is no longer discarded: `INVALID_ARGUMENT` is deterministic (empty or oversized batch), so it now escalates to the regular error handling, which can reject the command, instead of being retried forever (https://github.com/camunda/camunda/blob/7af52a2e8a7d862c068845623c1ab358f6f8bbd6/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java#L640-L658).

Two deliberate behavior changes to be aware of: the `camunda.processing.enable-async-scheduled-tasks` property (legacy `zeebe.broker.processingCfg.enableAsyncScheduledTasks`) is removed and ignored if still set, since scheduled tasks now always run on their dedicated actors; and a stream processor waiting for write capacity no longer reports as "actor appears blocked" in health checks because the actor stays responsive — sustained backpressure remains observable via the flow control metrics. The endless-error-loop unhealthiness detection via `isMakingProgress` is unaffected.

This is the first increment of untangling the `ProcessingStateMachine`'s busy-loop retries; the side-effect and rollback/commit retries still use the fast-lane strategies and can follow separately.