### PR TITLE
test: multi-client integration tests for the Physical-Tenant Java client & Spring starter

### DIFF
--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -151,11 +151,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/clients/camunda-spring-boot-starter/pom.xml
+++ b/clients/camunda-spring-boot-starter/pom.xml
@@ -151,6 +151,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiClientJobWorkerFanOutTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiClientJobWorkerFanOutTest.java
@@ -26,10 +26,11 @@ import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -72,21 +73,39 @@ class MultiClientJobWorkerFanOutTest {
         .run(
             context ->
                 // then both clients poll their own physical-tenant-scoped activation endpoint
-                Awaitility.await()
-                    .atMost(Duration.ofSeconds(15))
-                    .untilAsserted(
-                        () -> {
-                          final Set<String> activationPaths =
-                              WM.getAllServeEvents().stream()
-                                  .map(event -> event.getRequest().getUrl())
-                                  .filter(Objects::nonNull)
-                                  .filter(url -> url.endsWith("/jobs/activation"))
-                                  .collect(Collectors.toSet());
-                          assertThat(activationPaths)
-                              .contains(
-                                  "/physical-tenants/finance/v2/jobs/activation",
-                                  "/physical-tenants/risk/v2/jobs/activation");
-                        }));
+                assertThat(
+                        awaitActivationPaths(
+                            List.of(
+                                "/physical-tenants/finance/v2/jobs/activation",
+                                "/physical-tenants/risk/v2/jobs/activation"),
+                            Duration.ofSeconds(15)))
+                    .contains(
+                        "/physical-tenants/finance/v2/jobs/activation",
+                        "/physical-tenants/risk/v2/jobs/activation"));
+  }
+
+  /**
+   * Polls WireMock's request journal until every expected job-activation path has been seen or the
+   * timeout elapses, returning the paths seen. Uses a plain deadline loop (no {@code Thread.sleep})
+   * so no extra test dependency is required.
+   */
+  private static Set<String> awaitActivationPaths(
+      final List<String> expected, final Duration timeout) {
+    final long deadline = System.nanoTime() + timeout.toNanos();
+    Set<String> activationPaths = Set.of();
+    while (System.nanoTime() < deadline) {
+      activationPaths =
+          WM.getAllServeEvents().stream()
+              .map(event -> event.getRequest().getUrl())
+              .filter(Objects::nonNull)
+              .filter(url -> url.endsWith("/jobs/activation"))
+              .collect(Collectors.toSet());
+      if (activationPaths.containsAll(expected)) {
+        break;
+      }
+      LockSupport.parkNanos(Duration.ofMillis(100).toNanos());
+    }
+    return activationPaths;
   }
 
   @Configuration

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiClientJobWorkerFanOutTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiClientJobWorkerFanOutTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.api.response.ActivatedJob;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Verifies that a single {@code @JobWorker} fans out across every configured client: with two
+ * clients configured, both start polling their own (physical-tenant-scoped) job-activation
+ * endpoint. This exercises the multi-client lifecycle producer, the per-client event fan-out and
+ * the composite-keyed job-worker registration end-to-end over REST.
+ */
+class MultiClientJobWorkerFanOutTest {
+
+  @RegisterExtension
+  static final WireMockExtension WM =
+      WireMockExtension.newInstance().options(new WireMockConfiguration().dynamicPort()).build();
+
+  @Test
+  void shouldRegisterTheJobWorkerOnEveryConfiguredClient() {
+    // given two clients scoped to their own physical tenants, both polling WireMock over REST
+    WM.stubFor(post(urlPathMatching(".*/jobs/activation")).willReturn(okJson("{\"jobs\":[]}")));
+
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(CamundaAutoConfiguration.class))
+        .withUserConfiguration(WorkerConfiguration.class)
+        // the actuator config activates on the test classpath and wires a micrometer metrics
+        // recorder used by the workers, so provide a MeterRegistry (as a real app would)
+        .withBean(SimpleMeterRegistry.class)
+        .withPropertyValues(
+            "camunda.client.rest-address=http://localhost:" + WM.getPort(),
+            "camunda.client.prefer-rest-over-grpc=true",
+            // force REST polling (not the job stream) so activation calls hit WireMock
+            "camunda.client.worker.defaults.stream-enabled=false",
+            "camunda.clients.finance.physical-tenant-id=finance",
+            "camunda.clients.finance.prefix-physical-tenant-path=true",
+            "camunda.clients.risk.physical-tenant-id=risk",
+            "camunda.clients.risk.prefix-physical-tenant-path=true")
+        .run(
+            context ->
+                // then both clients poll their own physical-tenant-scoped activation endpoint
+                Awaitility.await()
+                    .atMost(Duration.ofSeconds(15))
+                    .untilAsserted(
+                        () -> {
+                          final Set<String> activationPaths =
+                              WM.getAllServeEvents().stream()
+                                  .map(event -> event.getRequest().getUrl())
+                                  .filter(Objects::nonNull)
+                                  .filter(url -> url.endsWith("/jobs/activation"))
+                                  .collect(Collectors.toSet());
+                          assertThat(activationPaths)
+                              .contains(
+                                  "/physical-tenants/finance/v2/jobs/activation",
+                                  "/physical-tenants/risk/v2/jobs/activation");
+                        }));
+  }
+
+  @Configuration
+  static class WorkerConfiguration {
+    @Bean
+    public FanOutWorker fanOutWorker() {
+      return new FanOutWorker();
+    }
+  }
+
+  static class FanOutWorker {
+    @JobWorker(type = "fan-out-type", autoComplete = false)
+    public void handle(final ActivatedJob job) {
+      // no-op: the test only asserts that each client polls for this worker's jobs
+    }
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiClientRestBaseUrlTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiClientRestBaseUrlTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Verifies the two REST base-URL modes per client: a client with a {@code physical-tenant-id} and
+ * {@code prefix-physical-tenant-path=true} auto-prefixes its REST path with {@code
+ * /physical-tenants/<id>}, while a client without prefixing sends bare {@code /v2} requests to its
+ * configured {@code rest-address}. Both point at the same WireMock so the requested paths are
+ * compared directly.
+ */
+class MultiClientRestBaseUrlTest {
+
+  @RegisterExtension
+  static final WireMockExtension WM =
+      WireMockExtension.newInstance().options(new WireMockConfiguration().dynamicPort()).build();
+
+  private static void sendTopology(final CamundaClient client) {
+    try {
+      client.newTopologyRequest().send().join();
+    } catch (final Exception ignored) {
+      // only the outgoing request path is under test; the response is irrelevant
+    }
+  }
+
+  @Test
+  void shouldAutoPrefixPhysicalTenantPathForPrefixedClientOnly() {
+    // given a shared REST base pointing at WireMock, one auto-prefixing client and one bare client
+    WM.stubFor(WireMock.any(anyUrl()).willReturn(ok()));
+
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(CamundaAutoConfiguration.class))
+        .withPropertyValues(
+            "camunda.client.rest-address=http://localhost:" + WM.getPort(),
+            "camunda.client.prefer-rest-over-grpc=true",
+            // finance targets its physical tenant via the auto-prefixed REST path
+            "camunda.clients.finance.physical-tenant-id=finance",
+            "camunda.clients.finance.prefix-physical-tenant-path=true",
+            // risk uses the bare base URL verbatim (no physical-tenant path prefixing)
+            "camunda.clients.risk.prefix-physical-tenant-path=false")
+        .run(
+            context -> {
+              final CamundaClientRegistry registry = context.getBean(CamundaClientRegistry.class);
+
+              // when each client issues a REST request
+              sendTopology(registry.get("finance"));
+              sendTopology(registry.get("risk"));
+
+              // then finance is scoped under /physical-tenants/finance and risk is not
+              final Set<String> paths =
+                  WM.getAllServeEvents().stream()
+                      .map(event -> event.getRequest().getUrl())
+                      .filter(Objects::nonNull)
+                      .collect(Collectors.toSet());
+              assertThat(paths).contains("/physical-tenants/finance/v2/topology", "/v2/topology");
+              assertThat(paths).noneMatch(path -> path.contains("physical-tenants/risk"));
+            });
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/MultiClientPhysicalTenantGrpcHeaderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/MultiClientPhysicalTenantGrpcHeaderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.util.RecordingGatewayService;
+import io.camunda.zeebe.gateway.protocol.GrpcHeaders;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.netty.NettyServerBuilder;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that, when multiple {@link CamundaClient}s are each configured with their own {@code
+ * physicalTenantId} and gRPC is used (not REST), every client attaches its own {@code
+ * Camunda-Physical-Tenant} gRPC metadata header (via {@code PhysicalTenantInterceptor}) to its
+ * outgoing calls against a shared gateway.
+ *
+ * <p>Complements the REST-only multi-client coverage in {@code camunda-spring-boot-starter}
+ * (per-client REST path prefixing, {@code @JobWorker} fan-out) by exercising the real gRPC routing
+ * path left untested there.
+ */
+final class MultiClientPhysicalTenantGrpcHeaderTest {
+
+  private final RecordingGatewayService gatewayService = new RecordingGatewayService();
+  private final Set<String> capturedPhysicalTenantHeaders = new CopyOnWriteArraySet<>();
+  private final ServerInterceptor capturingInterceptor =
+      new ServerInterceptor() {
+        @Override
+        public <ReqT, RespT> Listener<ReqT> interceptCall(
+            final ServerCall<ReqT, RespT> call,
+            final Metadata headers,
+            final ServerCallHandler<ReqT, RespT> next) {
+          final String physicalTenant = headers.get(GrpcHeaders.PHYSICAL_TENANT);
+          if (physicalTenant != null) {
+            capturedPhysicalTenantHeaders.add(physicalTenant);
+          }
+          return next.startCall(call, headers);
+        }
+      };
+  private final Server grpcServer =
+      NettyServerBuilder.forPort(0)
+          .addService(ServerInterceptors.intercept(gatewayService, capturingInterceptor))
+          .build();
+
+  private CamundaClient financeClient;
+  private CamundaClient riskClient;
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    grpcServer.start();
+  }
+
+  @AfterEach
+  void afterEach() {
+    if (financeClient != null) {
+      financeClient.close();
+    }
+    if (riskClient != null) {
+      riskClient.close();
+    }
+    grpcServer.shutdownNow();
+  }
+
+  @Test
+  void shouldSendDistinctPhysicalTenantHeaderPerClientOverGrpc() throws URISyntaxException {
+    // given two clients, each scoped to its own physical tenant, both talking gRPC to the same
+    // gateway (prefer-rest-over-grpc=false is the default)
+    financeClient = clientBuilder("finance").build();
+    riskClient = clientBuilder("risk").build();
+
+    // when each client sends a request over gRPC
+    sendTopology(financeClient);
+    sendTopology(riskClient);
+
+    // then each call carried its own client's physical-tenant header
+    assertThat(capturedPhysicalTenantHeaders).containsExactlyInAnyOrder("finance", "risk");
+  }
+
+  private static void sendTopology(final CamundaClient client) {
+    try {
+      client.newTopologyRequest().send().join();
+    } catch (final Exception ignored) {
+      // only the outgoing request headers are under test; the response is irrelevant
+    }
+  }
+
+  private CamundaClientBuilder clientBuilder(final String physicalTenantId)
+      throws URISyntaxException {
+    return CamundaClient.newClientBuilder()
+        .grpcAddress(new URI("http://localhost:" + grpcServer.getPort()))
+        .preferRestOverGrpc(false)
+        .physicalTenantId(physicalTenantId);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantClientHappyPathIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantClientHappyPathIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.auth;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -64,24 +66,35 @@ final class MultiPhysicalTenantClientHappyPathIT {
     final CamundaClient tenantB = ptClients.admin(TENANT_B);
     final String processA = Strings.newRandomValidBpmnId();
     final String processB = Strings.newRandomValidBpmnId();
-    final String jobTypeA = "job-" + processA;
-    final String jobTypeB = "job-" + processB;
+    // deliberately the SAME job type in both tenants: each client requests this shared type, so a
+    // routing leak would surface as one client activating the other tenant's job
+    final String jobType = "shared-job-" + Strings.newRandomValidBpmnId();
 
-    // given — each client deploys its own process and creates an instance (commands)
-    deployServiceTaskProcess(tenantA, processA, jobTypeA);
-    deployServiceTaskProcess(tenantB, processB, jobTypeB);
+    // given — each client deploys its own process (same job type) and creates an instance
+    // (commands)
+    deployServiceTaskProcess(tenantA, processA, jobType);
+    deployServiceTaskProcess(tenantB, processB, jobType);
     tenantA.newCreateInstanceCommand().bpmnProcessId(processA).latestVersion().send().join();
     tenantB.newCreateInstanceCommand().bpmnProcessId(processB).latestVersion().send().join();
 
-    // then — each client activates only its own physical tenant's job (jobs)
-    Awaitility.await("tenantA activates its own job")
+    // then — requesting the shared job type, each client activates only its own tenant's job and
+    // never the other tenant's, proving job routing is isolated per physical tenant (jobs)
+    Awaitility.await("tenantA activates only its own tenant's jobs for the shared type")
         .atMost(PROPAGATION_TIMEOUT)
         .ignoreExceptions()
-        .untilAsserted(() -> assertThat(activateJobType(tenantA, jobTypeA)).isEqualTo(1));
-    Awaitility.await("tenantB activates its own job")
+        .untilAsserted(
+            () -> {
+              final List<String> processes = activatedJobProcesses(tenantA, jobType);
+              assertThat(processes).containsExactly(processA);
+            });
+    Awaitility.await("tenantB activates only its own tenant's jobs for the shared type")
         .atMost(PROPAGATION_TIMEOUT)
         .ignoreExceptions()
-        .untilAsserted(() -> assertThat(activateJobType(tenantB, jobTypeB)).isEqualTo(1));
+        .untilAsserted(
+            () -> {
+              final List<String> processes = activatedJobProcesses(tenantB, jobType);
+              assertThat(processes).containsExactly(processB);
+            });
 
     // and — each client sees only its own instance via search (queries)
     Awaitility.await("each client sees only its own process instance")
@@ -116,15 +129,23 @@ final class MultiPhysicalTenantClientHappyPathIT {
     client.newDeployResourceCommand().addProcessModel(model, processId + ".bpmn").send().join();
   }
 
-  private static int activateJobType(final CamundaClient client, final String jobType) {
+  /**
+   * Activates up to a handful of jobs of the given type and returns the BPMN process ids they came
+   * from. A high {@code maxJobsToActivate} ensures a routing leak (the other tenant's job) would be
+   * included rather than silently missed.
+   */
+  private static List<String> activatedJobProcesses(
+      final CamundaClient client, final String jobType) {
     return client
         .newActivateJobsCommand()
         .jobType(jobType)
-        .maxJobsToActivate(1)
+        .maxJobsToActivate(10)
         .send()
         .join()
         .getJobs()
-        .size();
+        .stream()
+        .map(ActivatedJob::getBpmnProcessId)
+        .toList();
   }
 
   private static long activeInstanceCount(final CamundaClient client, final String processId) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantClientHappyPathIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/MultiPhysicalTenantClientHappyPathIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.ProcessInstanceState;
+import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.qa.util.multidb.MultiPhysicalTenantClients;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Multi-client happy path over a real runtime: two clients, each scoped to its own physical tenant,
+ * run commands (deploy, create instance), jobs (activate) and queries (search) independently and
+ * see only their own physical tenant's data.
+ *
+ * <p>Complements the client-side WireMock integration tests in {@code camunda-spring-boot-starter}
+ * (per-client REST routing, base-URL modes, {@code @JobWorker} fan-out) with an end-to-end check
+ * against a running broker.
+ *
+ * <p>RDBMS only — physical-tenant secondary storage is RDBMS-only, matching the other
+ * physical-tenant acceptance tests.
+ */
+@MultiDbTest
+@MultiDbPhysicalTenants({"tenanta", "tenantb"})
+@EnabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
+final class MultiPhysicalTenantClientHappyPathIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+
+  static MultiPhysicalTenantClients ptClients;
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  @Test
+  void shouldRunCommandsJobsAndQueriesPerPhysicalTenantClient() {
+    final CamundaClient tenantA = ptClients.admin(TENANT_A);
+    final CamundaClient tenantB = ptClients.admin(TENANT_B);
+    final String processA = Strings.newRandomValidBpmnId();
+    final String processB = Strings.newRandomValidBpmnId();
+    final String jobTypeA = "job-" + processA;
+    final String jobTypeB = "job-" + processB;
+
+    // given — each client deploys its own process and creates an instance (commands)
+    deployServiceTaskProcess(tenantA, processA, jobTypeA);
+    deployServiceTaskProcess(tenantB, processB, jobTypeB);
+    tenantA.newCreateInstanceCommand().bpmnProcessId(processA).latestVersion().send().join();
+    tenantB.newCreateInstanceCommand().bpmnProcessId(processB).latestVersion().send().join();
+
+    // then — each client activates only its own physical tenant's job (jobs)
+    Awaitility.await("tenantA activates its own job")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(activateJobType(tenantA, jobTypeA)).isEqualTo(1));
+    Awaitility.await("tenantB activates its own job")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(activateJobType(tenantB, jobTypeB)).isEqualTo(1));
+
+    // and — each client sees only its own instance via search (queries)
+    Awaitility.await("each client sees only its own process instance")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertThat(activeInstanceCount(tenantA, processA)).isEqualTo(1);
+              assertThat(activeInstanceCount(tenantB, processB)).isEqualTo(1);
+            });
+
+    // and — the physical-tenant boundary holds: neither client sees the other physical tenant's
+    // instance, continuously over a window so a late-arriving leak still fails
+    Awaitility.await("physical-tenant instance data does not leak across clients")
+        .during(PROPAGATION_TIMEOUT.dividedBy(6))
+        .atMost(PROPAGATION_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              assertThat(activeInstanceCount(tenantA, processB)).isZero();
+              assertThat(activeInstanceCount(tenantB, processA)).isZero();
+            });
+  }
+
+  private static void deployServiceTaskProcess(
+      final CamundaClient client, final String processId, final String jobType) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    client.newDeployResourceCommand().addProcessModel(model, processId + ".bpmn").send().join();
+  }
+
+  private static int activateJobType(final CamundaClient client, final String jobType) {
+    return client
+        .newActivateJobsCommand()
+        .jobType(jobType)
+        .maxJobsToActivate(1)
+        .send()
+        .join()
+        .getJobs()
+        .size();
+  }
+
+  private static long activeInstanceCount(final CamundaClient client, final String processId) {
+    return client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.processDefinitionId(processId).state(ProcessInstanceState.ACTIVE))
+        .send()
+        .join()
+        .items()
+        .size();
+  }
+}


### PR DESCRIPTION
## Description

Adds regression coverage for the multi-client Java client & Spring Boot starter feature — both client-side (WireMock) integration tests in the starter and an end-to-end acceptance test against a real broker.

## Related issues

related to #56727 
