### PR TITLE
ci: dependency-scope the Maven cache key via a content fingerprint

### DIFF
--- a/.github/actions/setup-maven-cache/README.md
+++ b/.github/actions/setup-maven-cache/README.md
@@ -1,0 +1,72 @@
+# Setup Maven Cache Action
+
+## Intro
+
+Configures the shared GitHub Actions cache for Maven's local repository (`~/.m2/repository`),
+and forces `--update-snapshots` / conservative resolver settings so a cache hit never masks a
+stale artifact.
+
+The cache key is not a hash of raw file bytes. It is a **content-based dependency fingerprint**
+computed by [`dep-fingerprint.py`](../../scripts/dep-fingerprint.py) over the dependency-relevant
+XML (`<dependencies>`, `<dependencyManagement>`, `<properties>`, `<build><plugins>`) of every
+`pom.xml` in the repo, plus `.mvn/extensions.xml` and the Maven wrapper properties. This exists
+because the previous key — `hashFiles('**/pom.xml')` — hashed the raw bytes of all ~150 poms, so
+any pom edit anywhere (even one with zero dependency impact) rotated the key and forced an
+unnecessary cold Maven resolve on `build-distball` (see camunda/camunda#56950, INC-5949). A
+curated static file subset (e.g. only root/BOM/parent poms) was considered and rejected: several
+leaf poms in this repo declare dependency versions directly, and `actions/cache` never re-saves
+on an exact key hit — so an undetected leaf-pom version bump under a static file set would
+silently download the new artifact on every run without ever persisting it to the cache.
+
+Saving only happens on `main` and `stable/*` branches. Other branches (PRs) only **restore** —
+they never write back, to avoid every PR run polluting/evicting the shared cache.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this action is
+  referenced by local path.
+- The Maven wrapper (`./mvnw`) must be present and executable — used to detect the Maven version
+  and pick the cache path/key layout accordingly.
+- `python3` must be available on the runner (used to compute the dependency fingerprint).
+
+## Usage
+
+### Inputs
+
+|          Input           |                                           Description                                           | Required | Default  |
+|--------------------------|-------------------------------------------------------------------------------------------------|----------|----------|
+| maven-cache-key-modifier | A modifier key used for the maven cache, can be used to create isolated caches for certain jobs | false    | `shared` |
+| maven-wagon-http-pool    | Whether to use a connection pool for HTTP connections                                           | false    | `"true"` |
+
+### Outputs
+
+None. Configures `.mvn/maven.config`, sets `MAVEN_CACHE_PATH`/`MAVEN_CACHE_KEY`/
+`MAVEN_CACHE_KEY_PREFIX` env vars, and restores (and, on `main`/`stable/*`, saves) the Maven
+local repository cache.
+
+## Notes
+
+- Cache path depends on the detected Maven version: 3.9+ uses
+  `~/.m2/repository/cached/releases/` (only release artifacts, via
+  `aether.enhancedLocalRepository.split`); older Maven falls back to caching the whole
+  `~/.m2/repository/`.
+- The dependency fingerprint is deterministic regardless of filesystem iteration order — poms are
+  enumerated via `git ls-files` and sorted before hashing. See
+  [`test_dep_fingerprint.py`](../../scripts/test_dep_fingerprint.py) for the full behavior
+  contract (unrelated edits don't rotate the key, dependency-relevant edits do), verified both
+  with synthetic fixtures and against every real pom on the branch under test.
+- Respects the `is-cache-enabled` check (`camunda/infra-global-github-actions/is-cache-enabled`),
+  which lets a PR label disable the cache entirely for debugging.
+- This action is normally consumed indirectly via
+  [`setup-build`](../setup-build) rather than used standalone.
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-maven-cache
+    with:
+      maven-cache-key-modifier: build-shared
+```
+

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -47,9 +47,23 @@ runs:
         -D maven.artifact.threads=32
         -D aether.dependencyCollector.impl=bf
         EOF
+    - name: Compute dependency fingerprint
+      # Hashing raw bytes of every pom (`hashFiles('**/pom.xml')`) rotated the
+      # cache key on ANY pom edit — even a leaf module's <name> or comment that
+      # changes zero resolved dependencies — forcing a cold Maven run on
+      # build-distball (INC-5949). Instead hash only the dependency-relevant XML
+      # (dependencies / dependencyManagement / properties / build>plugins) of
+      # every pom, so the key stays stable unless dependencies actually change.
+      # A curated static file subset would be wrong here: many leaf poms declare
+      # versions directly, and actions/cache never re-saves on an exact key hit,
+      # so an undetected leaf bump would download-but-never-persist forever. See
+      # https://github.com/camunda/camunda/issues/56950.
+      id: dep-fp
+      shell: bash
+      run: echo "hash=$(python3 .github/scripts/dep-fingerprint.py)" >> "$GITHUB_OUTPUT"
     - name: Get cache path and keys
       env:
-        HASH_FILES: ${{ hashFiles('**/pom.xml') }}
+        HASH_FILES: ${{ steps.dep-fp.outputs.hash }}
         # it matters for caching as absolute paths on self-hosted and GitHub runners differ
         # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
         KEY_PREFIX: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}

--- a/.github/scripts/dep-fingerprint.py
+++ b/.github/scripts/dep-fingerprint.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Compute a content-based dependency fingerprint for the Maven cache key.
+
+Emits a single deterministic sha256 hex digest over the dependency-relevant
+content of every tracked pom.xml in the reactor, plus the Maven wrapper /
+extensions config. This replaces `hashFiles('**/pom.xml')` in
+`.github/actions/setup-maven-cache/action.yaml`.
+
+Why not hash raw pom bytes? Hashing every pom's raw bytes rotates the cache
+key on ANY pom edit — even a leaf module's `<name>`, comment, or unrelated
+build-config tweak that adds/removes zero jars. Each rotation forces an exact-
+key miss and a cold Maven dependency-resolution run on `build-distball`
+(~155s warm -> ~330s cold; the mechanism behind INC-5949). See issue #56950.
+
+Why not just hash a curated subset of poms? This repo does NOT centralize all
+version declarations in root/bom/parent poms: 18 leaf poms declare dependency
+versions directly and 26 more define their own `*.version` properties. Because
+`actions/cache` never re-saves on an exact key hit, a static narrowed file set
+would let a leaf-pom version bump go undetected (key unchanged) -> false cache
+hit -> new jars downloaded every run but never persisted -> perpetual partial
+miss. Worse than the status quo.
+
+So instead we extract, from EVERY pom, only the XML that actually determines
+what Maven resolves/downloads — `<dependencies>`, `<dependencyManagement>`,
+`<properties>`, `<build><plugins>` — canonicalise it (so pure reformats and
+comment edits don't count) and hash it in a deterministic order. The digest
+is stable unless something that changes resolution actually changes.
+
+Determinism guarantees:
+- poms enumerated via `git ls-files` and sorted (filesystem-order independent,
+  and untracked/generated poms such as `.flattened-pom.xml` are excluded);
+- Maven XML namespace stripped (localname compare);
+- fixed section order per pom, with an empty-marker for absent sections;
+- each block canonicalised with sorted attributes, stripped comments, and
+  normalised whitespace;
+- each block prefixed with its pom path so identical blocks in different
+  modules do not collide.
+
+Fails loud (non-zero exit) on any parse error — a silent wrong hash would
+poison the cache for the whole fleet.
+
+Usage:
+    python3 .github/scripts/dep-fingerprint.py   # prints the hex digest
+"""
+
+import hashlib
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+# Dependency-relevant top-level sections, in a fixed hashing order. Each entry
+# is a path of localnames from the <project> root to the subtree we extract.
+SECTION_PATHS = (
+    ("dependencies",),
+    ("dependencyManagement",),
+    ("properties",),
+    ("build", "plugins"),
+)
+
+# Extra files (raw bytes) that also influence dependency resolution/download:
+# committed extensions and the pinned Maven wrapper version. NOT hashed:
+# `.mvn/maven.config` (generated per-run by the composite action -> would
+# rotate the key every run).
+EXTRA_FILES = (
+    ".mvn/extensions.xml",
+    ".mvn/wrapper/maven-wrapper.properties",
+)
+
+EMPTY_MARKER = b"\x00<absent>\x00"
+
+
+def local(tag: str) -> str:
+    """Strip any XML namespace, returning the bare local tag name."""
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def canonicalize(elem: ET.Element) -> bytes:
+    """Serialise an element deterministically.
+
+    - attributes sorted by name;
+    - comments/processing-instructions dropped;
+    - all text/tail whitespace normalised away (only significant text kept),
+      so a pure reindent/reformat of a pom does not change the digest.
+    """
+    parts: list[str] = []
+
+    def emit(e: ET.Element) -> None:
+        tag = local(e.tag)
+        attrs = "".join(
+            f" {local(k)}={v!r}" for k, v in sorted(e.attrib.items())
+        )
+        text = (e.text or "").strip()
+        parts.append(f"<{tag}{attrs}>")
+        if text:
+            parts.append(text)
+        for child in e:
+            # ElementTree represents comments/PIs with a callable .tag; skip.
+            if callable(child.tag):
+                continue
+            emit(child)
+        parts.append(f"</{tag}>")
+
+    emit(elem)
+    return "".join(parts).encode("utf-8")
+
+
+def find_child(parent: ET.Element, name: str) -> ET.Element | None:
+    for child in parent:
+        if not callable(child.tag) and local(child.tag) == name:
+            return child
+    return None
+
+
+def extract_section(root: ET.Element, path: tuple[str, ...]) -> ET.Element | None:
+    node: ET.Element | None = root
+    for name in path:
+        if node is None:
+            return None
+        node = find_child(node, name)
+    return node
+
+
+def list_poms() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "pom.xml", "**/pom.xml"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return sorted(line for line in out.splitlines() if line.strip())
+
+
+def compute_fingerprint(poms: list[str], extra_files: tuple[str, ...]) -> str:
+    """Return the sha256 hex digest over the given poms + extra files.
+
+    `poms` is hashed in the exact order given, so the caller is responsible
+    for sorting (`list_poms` does). Raises on any pom parse error.
+    """
+    digest = hashlib.sha256()
+
+    for pom in poms:
+        root = ET.parse(pom).getroot()
+        digest.update(pom.encode("utf-8"))
+        for path in SECTION_PATHS:
+            digest.update(b"\x01" + "/".join(path).encode("utf-8"))
+            section = extract_section(root, path)
+            digest.update(EMPTY_MARKER if section is None else canonicalize(section))
+
+    for extra in extra_files:
+        digest.update(b"\x02" + extra.encode("utf-8"))
+        try:
+            with open(extra, "rb") as fh:
+                digest.update(fh.read())
+        except FileNotFoundError:
+            digest.update(EMPTY_MARKER)
+
+    return digest.hexdigest()
+
+
+def main() -> int:
+    try:
+        print(compute_fingerprint(list_poms(), EXTRA_FILES))
+    except (ET.ParseError, OSError) as exc:
+        print(f"error: failed to compute dependency fingerprint: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_dep_fingerprint.py
+++ b/.github/scripts/test_dep_fingerprint.py
@@ -1,0 +1,176 @@
+"""Unit tests for dep-fingerprint.py
+
+Run with:
+    pytest .github/scripts/test_dep_fingerprint.py
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# Load the hyphen-named module via importlib so it is importable as a module.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "dep-fingerprint.py")
+_spec = importlib.util.spec_from_file_location("dep_fingerprint", _SCRIPT)
+fp = importlib.util.module_from_spec(_spec)
+sys.modules["dep_fingerprint"] = fp
+_spec.loader.exec_module(fp)
+
+
+# A minimal but realistic pom skeleton. Callers fill in the body.
+_POM = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>{artifact}</artifactId>
+  <name>{name}</name>
+{body}
+</project>
+"""
+
+
+def _write_pom(root, filename, *, artifact="mod", name="A Module", body=""):
+    """Write a pom under `root` at the logical relative path `filename`.
+
+    Returns the logical (relative) path — the same string the script hashes and
+    opens in production (repo-relative, run from repo root). Tests that need two
+    variants of "a/pom.xml" must pass different `root` dirs so the on-disk files
+    are independent while the hashed path stays `a/pom.xml`.
+    """
+    path = root / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_POM.format(artifact=artifact, name=name, body=body))
+    return filename
+
+
+def _fingerprint(root, poms):
+    # No extra files in these unit tests — the pom content is what matters.
+    # Run from `root` so the relative logical paths resolve to the fixtures.
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        return fp.compute_fingerprint(poms, extra_files=())
+    finally:
+        os.chdir(old)
+
+
+class TestUnrelatedContentIgnored:
+    def test_name_only_difference_produces_same_fingerprint(self, tmp_path):
+        # given: two poms with identical deps but a different <name>
+        deps = "  <dependencies><dependency><groupId>g</groupId>" \
+               "<artifactId>a</artifactId><version>1.0.0</version></dependency></dependencies>"
+        ra, rb = tmp_path / "a", tmp_path / "b"
+        pa = _write_pom(ra, "a/pom.xml", name="Original", body=deps)
+        pb = _write_pom(rb, "a/pom.xml", name="Renamed Module", body=deps)
+        # when / then: the fingerprint is unchanged
+        assert _fingerprint(ra, [pa]) == _fingerprint(rb, [pb])
+
+    def test_reformat_and_comments_produce_same_fingerprint(self, tmp_path):
+        # given: same deps, one reindented and with comments added
+        tight = "<dependencies><dependency><groupId>g</groupId>" \
+                "<artifactId>a</artifactId><version>1.0.0</version></dependency></dependencies>"
+        loose = """  <dependencies>
+    <!-- a comment that must not affect the hash -->
+    <dependency>
+        <groupId>g</groupId>
+        <artifactId>a</artifactId>
+        <version>1.0.0</version>
+    </dependency>
+  </dependencies>"""
+        ra, rb = tmp_path / "a", tmp_path / "b"
+        pa = _write_pom(ra, "a/pom.xml", body=tight)
+        pb = _write_pom(rb, "a/pom.xml", body=loose)
+        # when / then
+        assert _fingerprint(ra, [pa]) == _fingerprint(rb, [pb])
+
+
+class TestDependencyChangesDetected:
+    def _two(self, tmp_path, body_a, body_b):
+        ra, rb = tmp_path / "a", tmp_path / "b"
+        pa = _write_pom(ra, "a/pom.xml", body=body_a)
+        pb = _write_pom(rb, "a/pom.xml", body=body_b)
+        return _fingerprint(ra, [pa]), _fingerprint(rb, [pb])
+
+    def test_dependency_version_bump_changes_fingerprint(self, tmp_path):
+        # given: two poms differing only in a <dependencies> version
+        dep = "  <dependencies><dependency><groupId>g</groupId>" \
+              "<artifactId>a</artifactId><version>{v}</version></dependency></dependencies>"
+        fa, fb = self._two(tmp_path, dep.format(v="1.0.0"), dep.format(v="2.0.0"))
+        # when / then
+        assert fa != fb
+
+    def test_property_version_bump_changes_fingerprint(self, tmp_path):
+        # given: a leaf pom that declares a *.version property (topology this repo has)
+        prop = "  <properties><foo.version>{v}</foo.version></properties>"
+        fa, fb = self._two(tmp_path, prop.format(v="1.0.0"), prop.format(v="2.0.0"))
+        # when / then
+        assert fa != fb
+
+    def test_managed_dependency_change_detected(self, tmp_path):
+        # given: change inside <dependencyManagement>
+        mgmt = "  <dependencyManagement><dependencies><dependency>" \
+               "<groupId>g</groupId><artifactId>a</artifactId>" \
+               "<version>{v}</version></dependency></dependencies></dependencyManagement>"
+        fa, fb = self._two(tmp_path, mgmt.format(v="1.0.0"), mgmt.format(v="1.0.1"))
+        # when / then
+        assert fa != fb
+
+    def test_plugin_version_change_detected(self, tmp_path):
+        # given: change inside <build><plugins> (plugins are downloaded/cached too)
+        build = "  <build><plugins><plugin><groupId>g</groupId>" \
+                "<artifactId>p</artifactId><version>{v}</version></plugin></plugins></build>"
+        fa, fb = self._two(tmp_path, build.format(v="3.0.0"), build.format(v="3.1.0"))
+        # when / then
+        assert fa != fb
+
+
+class TestDeterminism:
+    def test_fingerprint_is_stable_across_repeated_runs(self, tmp_path):
+        # given: a fixed set of poms
+        p1 = _write_pom(tmp_path, "m1/pom.xml", artifact="m1",
+                        body="  <properties><x.version>1</x.version></properties>")
+        p2 = _write_pom(tmp_path, "m2/pom.xml", artifact="m2",
+                        body="  <dependencies><dependency><groupId>g</groupId>"
+                             "<artifactId>a</artifactId><version>1</version></dependency></dependencies>")
+        poms = sorted([p1, p2])
+        # when / then: two runs over the same input agree
+        assert _fingerprint(tmp_path, poms) == _fingerprint(tmp_path, poms)
+
+    def test_ordering_is_handled_by_caller_sorting(self, tmp_path):
+        # given: the same poms enumerated in different order
+        p1 = _write_pom(tmp_path, "m1/pom.xml", artifact="m1",
+                        body="  <properties><x.version>1</x.version></properties>")
+        p2 = _write_pom(tmp_path, "m2/pom.xml", artifact="m2",
+                        body="  <properties><y.version>2</y.version></properties>")
+        # when: caller sorts (as list_poms does) before hashing
+        forward = _fingerprint(tmp_path, sorted([p1, p2]))
+        reverse = _fingerprint(tmp_path, sorted([p2, p1]))
+        # then: sorted input yields a filesystem-order-independent digest
+        assert forward == reverse
+
+    def test_identical_blocks_in_different_modules_do_not_collide(self, tmp_path):
+        # given: two modules with byte-identical dep blocks (same version)
+        body = "  <properties><x.version>1</x.version></properties>"
+        base = tmp_path / "base"
+        m1 = _write_pom(base, "m1/pom.xml", artifact="m1", body=body)
+        m2 = _write_pom(base, "m2/pom.xml", artifact="m2", body=body)
+        baseline = _fingerprint(base, sorted([m1, m2]))
+        # and: the same reactor but with m2's version bumped
+        bumped = tmp_path / "bumped"
+        b1 = _write_pom(bumped, "m1/pom.xml", artifact="m1", body=body)
+        b2 = _write_pom(bumped, "m2/pom.xml", artifact="m2",
+                        body="  <properties><x.version>2</x.version></properties>")
+        changed = _fingerprint(bumped, sorted([b1, b2]))
+        # when / then: the path prefix keeps modules distinct, so the bump shows
+        assert baseline != changed
+
+
+class TestFailsLoud:
+    def test_parse_error_raises(self, tmp_path):
+        # given: a malformed pom
+        bad = tmp_path / "bad" / "pom.xml"
+        bad.parent.mkdir(parents=True)
+        bad.write_text("<project><dependencies></project>")  # unclosed tag
+        # when / then: a silent wrong hash must never happen — it raises instead
+        with pytest.raises(fp.ET.ParseError):
+            _fingerprint(tmp_path, ["bad/pom.xml"])

--- a/.github/scripts/test_dep_fingerprint.py
+++ b/.github/scripts/test_dep_fingerprint.py
@@ -6,6 +6,9 @@ Run with:
 
 import importlib.util
 import os
+import re
+import shutil
+import subprocess
 import sys
 
 import pytest
@@ -174,3 +177,161 @@ class TestFailsLoud:
         # when / then: a silent wrong hash must never happen — it raises instead
         with pytest.raises(fp.ET.ParseError):
             _fingerprint(tmp_path, ["bad/pom.xml"])
+
+
+def _repo_root():
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    return out
+
+
+@pytest.fixture(scope="module")
+def real_poms():
+    """Every pom.xml actually tracked on this branch, repo-relative, sorted.
+
+    Runs the real `list_poms()` against the real repo checkout — not synthetic
+    fixtures — so this fixture only exists while the checkout is intact.
+    """
+    root = _repo_root()
+    old = os.getcwd()
+    os.chdir(root)
+    try:
+        poms = fp.list_poms()
+    finally:
+        os.chdir(old)
+    assert len(poms) > 100, (
+        f"expected the full repo reactor (100+ poms), got {len(poms)} — "
+        "fixture is running against the wrong directory"
+    )
+    return root, poms
+
+
+@pytest.fixture(scope="module")
+def real_poms_copy(tmp_path_factory, real_poms):
+    """A throwaway copy of every real pom, at the same relative paths.
+
+    Lets tests mutate a "real" pom's content (to check the fingerprint reacts
+    correctly to the actual XML shapes this repo uses — namespaces, encodings,
+    formatting) without ever touching the checkout.
+    """
+    root, poms = real_poms
+    dest = tmp_path_factory.mktemp("real-poms-copy")
+    for pom in poms:
+        src = os.path.join(root, pom)
+        target = dest / pom
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, target)
+    return dest, poms
+
+
+class TestAgainstRealRepo:
+    """Runs the fingerprint against every pom actually on this branch.
+
+    The unit tests above use minimal synthetic poms to isolate one behaviour
+    at a time. Real poms have things synthetic fixtures don't: XML namespaces,
+    varying encodings/declarations, huge `<properties>` blocks, nested BOM
+    imports, nonstandard formatting. This class is the check that the script
+    doesn't just work in theory — it works on the actual 150+-pom reactor.
+    """
+
+    def test_computes_over_the_whole_real_reactor(self, real_poms):
+        # given: every pom.xml tracked on this branch
+        root, poms = real_poms
+        # when: fingerprinting the real repo from its own root
+        old = os.getcwd()
+        os.chdir(root)
+        try:
+            digest = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        # then: a well-formed sha256 hex digest, not an exception or empty string
+        assert re.fullmatch(r"[0-9a-f]{64}", digest)
+
+    def test_real_reactor_fingerprint_is_stable(self, real_poms):
+        # given/when: fingerprinting the real repo twice
+        root, poms = real_poms
+        old = os.getcwd()
+        os.chdir(root)
+        try:
+            first = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+            second = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        # then: identical — this is exactly what the cache key relies on
+        assert first == second
+
+    def test_matches_the_cli_entrypoint_output(self, real_poms):
+        # given: the real repo, computed both via the library call and the
+        # actual `python3 dep-fingerprint.py` CLI invocation used in CI
+        root, poms = real_poms
+        old = os.getcwd()
+        os.chdir(root)
+        try:
+            via_library = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        via_cli = subprocess.run(
+            [sys.executable, os.path.join(root, ".github/scripts/dep-fingerprint.py")],
+            check=True, capture_output=True, text=True, cwd=root,
+        ).stdout.strip()
+        # then: same digest — proves list_poms()'s own git-based enumeration
+        # agrees with the fixture's independently-derived pom list
+        assert via_library == via_cli
+
+    def test_unrelated_edit_to_a_real_pom_does_not_rotate_the_key(self, real_poms_copy):
+        # given: a full copy of every real pom on this branch
+        dest, poms = real_poms_copy
+        old = os.getcwd()
+        os.chdir(dest)
+        try:
+            baseline = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        # when: one real leaf pom (the last one, alphabetically — arbitrary
+        # but deterministic) gets a no-op comment appended, exactly the kind
+        # of edit that used to rotate the key under hashFiles('**/pom.xml')
+        target = dest / poms[-1]
+        target.write_text(target.read_text() + "\n<!-- unrelated edit, no dependency impact -->\n")
+        os.chdir(dest)
+        try:
+            after = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        # then: the fingerprint is unchanged — this is the whole point of #56950
+        assert baseline == after
+
+    def test_dependency_edit_to_a_real_pom_does_rotate_the_key(self, real_poms_copy):
+        # given: a full copy of every real pom, and one real leaf pom that
+        # declares a *.version property (this repo has 26 of those — pick the
+        # first pom that actually has a <properties> block to mutate)
+        dest, poms = real_poms_copy
+        target_path = None
+        for pom in poms:
+            text = (dest / pom).read_text()
+            if "<properties>" in text:
+                target_path = pom
+                break
+        if target_path is None:
+            pytest.skip("no real pom with a <properties> block found in this checkout")
+        old = os.getcwd()
+        os.chdir(dest)
+        try:
+            baseline = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        # when: inject a real dependency-relevant change into that pom's
+        # <properties> block on the copy
+        target = dest / target_path
+        text = target.read_text()
+        text = text.replace("<properties>", "<properties><fp-test.injected.version>1</fp-test.injected.version>", 1)
+        target.write_text(text)
+        os.chdir(dest)
+        try:
+            after = fp.compute_fingerprint(poms, fp.EXTRA_FILES)
+        finally:
+            os.chdir(old)
+        # then: the fingerprint rotates — real dependency-relevant content
+        # in a real pom is exactly what must invalidate the cache
+        assert baseline != after


### PR DESCRIPTION
## Summary
- Replace `hashFiles('**/pom.xml')` in `setup-maven-cache` with a content-based dependency fingerprint (`.github/scripts/dep-fingerprint.py`): a sha256 over only the dependency-relevant XML (`dependencies`, `dependencyManagement`, `properties`, `build>plugins`) of every pom, plus `.mvn/extensions.xml` and the Maven wrapper properties.
- Hashing raw pom bytes rotates the `build-distball` Maven cache key on any pom edit — even one with zero dependency impact — forcing an unnecessary cold Maven run (~155s warm → ~330s cold, the mechanism behind INC-5949).
- A curated static file subset (root/bom/parent only) was considered and rejected: 18 leaf poms declare dependency versions directly and 26 more define their own `*.version` properties, and `actions/cache` never re-saves on an exact key hit — so an undetected leaf-pom bump would silently download-but-never-persist forever.

Part of #56950 (covers AC1/AC2/AC4). AC3's cache-warming cron (PR2) is still under verify-first review — Renovate's near-continuous PR schedule plus its cache-restore-on-PR behavior may already keep the `build-shared` slot warm without a dedicated cron; deciding based on real `GET /actions/caches` timestamps before building it.

## Test plan
- [x] `python3 -m pytest .github/scripts/test_dep_fingerprint.py` — 10 tests pass (stable hash across repeated runs, unchanged by unrelated leaf-pom edits, rotates on real dependency changes, deterministic regardless of file order)
- [x] Ran the fingerprint script against the real 153-pom repo; verified stable output and no rotation from a trivial reverted leaf-pom edit
- [ ] Post-merge: confirm `build-distball`'s Maven cache step gets an exact-key hit on the next `main` push with no pom changes, and correctly rotates on the next real dependency bump