### PR TITLE
refactor: add jspecify to zeebe/dynamic-config

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -259,14 +260,14 @@ public interface ClusterConfigurationInitializer {
     private final ActorFuture<ClusterConfiguration> initialized;
     private final List<MemberId> knownMembersToSync;
     private final ConcurrencyControl executor;
-    private final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester;
+    private final Function<MemberId, ActorFuture<@Nullable ClusterConfiguration>> syncRequester;
 
     public SyncInitializer(
         final Duration syncDelay,
         final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
         final List<MemberId> knownMembersToSync,
         final ConcurrencyControl executor,
-        final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester) {
+        final Function<MemberId, ActorFuture<@Nullable ClusterConfiguration>> syncRequester) {
       this.syncDelay = syncDelay;
       this.clusterConfigurationUpdateNotifier = clusterConfigurationUpdateNotifier;
       this.knownMembersToSync = knownMembersToSync;
@@ -320,7 +321,7 @@ public interface ClusterConfigurationInitializer {
               });
     }
 
-    private ActorFuture<ClusterConfiguration> requestSync(final MemberId memberId) {
+    private ActorFuture<@Nullable ClusterConfiguration> requestSync(final MemberId memberId) {
       return syncRequester.apply(memberId);
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.dynamic.config;
 
 import static io.camunda.zeebe.util.Unit.unit;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
@@ -26,6 +28,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,10 +60,10 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(1);
   private final ConcurrencyControl executor;
   private final PersistedClusterConfiguration persistedClusterConfiguration;
-  private Consumer<ClusterConfiguration> configurationGossiper;
+  private @Nullable Consumer<ClusterConfiguration> configurationGossiper;
   private final ActorFuture<Void> startFuture;
-  private ConfigurationChangeAppliers changeAppliers;
-  private InconsistentConfigurationListener onInconsistentConfigurationDetected;
+  private @Nullable ConfigurationChangeAppliers changeAppliers;
+  private @Nullable InconsistentConfigurationListener onInconsistentConfigurationDetected;
   private final MemberId localMemberId;
   // Indicates whether there is a configuration change operation in progress on this member.
   private boolean onGoingConfigurationChangeOperation = false;
@@ -168,7 +171,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                   LOG.debug(
                       "Initialized cluster configuration '{}'",
                       persistedClusterConfiguration.getConfiguration());
-                  configurationGossiper.accept(persistedClusterConfiguration.getConfiguration());
+                  requireNonNull(configurationGossiper)
+                      .accept(persistedClusterConfiguration.getConfiguration());
                   setStarted();
                 } catch (final IOException e) {
                   startFuture.completeExceptionally(
@@ -194,7 +198,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                 receivedConfiguration);
             // When not started, do not update the local configuration. This is to avoid any race
             // condition between FileInitializer and concurrently received configuration via gossip.
-            configurationGossiper.accept(receivedConfiguration);
+            requireNonNull(configurationGossiper).accept(receivedConfiguration);
             return;
           }
           try {
@@ -220,7 +224,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                       mergedConfiguration, oldConfiguration);
                 }
 
-                configurationGossiper.accept(mergedConfiguration);
+                requireNonNull(configurationGossiper).accept(mergedConfiguration);
                 applyConfigurationChangeOperation(mergedConfiguration);
               }
             }
@@ -237,7 +241,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
       final ClusterConfiguration mergedConfiguration, final ClusterConfiguration oldConfiguration) {
     if (!mergedConfiguration.hasMember(localMemberId)
         && oldConfiguration.hasMember(localMemberId)
-        && oldConfiguration.getMember(localMemberId).state() == State.LEFT) {
+        && requireNonNull(oldConfiguration.getMember(localMemberId)).state() == State.LEFT) {
       // If the member has left, it's state will be removed from the configuration by another
       // member. See ClusterConfiguration#advance()
       return false;
@@ -272,7 +276,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     final var operation = mergedConfiguration.pendingChangesFor(localMemberId).orElseThrow();
     final var observer = topologyMetrics.observeOperation(operation);
     LOG.info("Applying configuration change operation {}", operation);
-    final var operationApplier = changeAppliers.getApplier(operation);
+    final var operationApplier = requireNonNull(changeAppliers).getApplier(operation);
     final var operationInitialized =
         operationApplier
             .init(mergedConfiguration)
@@ -362,7 +366,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     }
     try {
       persistedClusterConfiguration.update(configuration);
-      configurationGossiper.accept(configuration);
+      requireNonNull(configurationGossiper).accept(configuration);
       return Either.right(configuration);
     } catch (final Exception e) {
       return Either.left(e);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
@@ -179,7 +181,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private void setStarted() {
     if (!startFuture.isDone()) {
       initialized = true;
-      startFuture.complete(null);
+      startFuture.complete(unit());
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -45,8 +45,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
 public final class ClusterConfigurationManagerService
     implements ClusterConfigurationUpdateNotifier, AsyncClosable {
@@ -64,7 +64,7 @@ public final class ClusterConfigurationManagerService
   private final TopologyMetrics topologyMetrics;
   private final TopologyManagerMetrics topologyManagerMetrics;
   private final MemberId localMemberId;
-  private ModeChangeExecutor modeChangeExecutor;
+  private @Nullable ModeChangeExecutor modeChangeExecutor;
 
   public ClusterConfigurationManagerService(
       final Path dataRootDirectory,
@@ -142,7 +142,9 @@ public final class ClusterConfigurationManagerService
                 managerActor))
         .andThen(
             new ExporterStateInitializer(
-                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                requireNonNull(staticConfiguration.partitionConfig().exporting())
+                    .exporters()
+                    .keySet(),
                 staticConfiguration.localMemberId(),
                 managerActor,
                 false))
@@ -172,7 +174,9 @@ public final class ClusterConfigurationManagerService
         .orThen(new StaticInitializer(staticConfiguration))
         .andThen(
             new ExporterStateInitializer(
-                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                requireNonNull(staticConfiguration.partitionConfig().exporting())
+                    .exporters()
+                    .keySet(),
                 staticConfiguration.localMemberId(),
                 managerActor,
                 true))

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
@@ -250,7 +252,7 @@ public final class ClusterConfigurationManagerService
       final PartitionScalingChangeExecutor partitionScalingChangeExecutor) {
     managerActor.run(
         () -> {
-          Objects.requireNonNull(
+          requireNonNull(
               modeChangeExecutor,
               "ModeChangeExecutor not set before registering topology appliers.");
           clusterConfigurationManager.registerTopologyChangeAppliers(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.Collection;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * After the configuration is initialized, we can use a {@link ClusterConfigurationModifier} to
@@ -38,7 +39,7 @@ public interface ClusterConfigurationModifier {
    */
   ActorFuture<ClusterConfiguration> modify(ClusterConfiguration configuration);
 
-  record ExecutionFilter(boolean coordinatorOnly, MemberId localMemberId) {
+  record ExecutionFilter(boolean coordinatorOnly, @Nullable MemberId localMemberId) {
     public boolean canRunInitializer(final Collection<MemberId> clusterMembers) {
       if (!coordinatorOnly) {
         return true;
@@ -46,7 +47,7 @@ public interface ClusterConfigurationModifier {
       final var coordinator =
           ClusterConfigurationCoordinatorSupplier.ofMembers(Set.copyOf(clusterMembers))
               .getDefaultCoordinator();
-      return coordinator.equals(localMemberId);
+      return localMemberId != null && coordinator.equals(localMemberId);
     }
 
     public boolean canRunInitializer(final ClusterConfiguration configuration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
+import static java.util.Objects.requireNonNull;
 import static org.slf4j.LoggerFactory.*;
 
 import io.atomix.cluster.MemberId;
@@ -65,7 +66,9 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
         result.complete(configuration);
       }
     } else {
-      result.complete(configuration.updateMember(localMemberId, this::updateExporterState));
+      result.complete(
+          configuration.updateMember(
+              localMemberId, member -> updateExporterState(requireNonNull(member))));
     }
     return result;
   }
@@ -74,7 +77,8 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
       final ClusterConfiguration configuration) {
     ClusterConfiguration updated = configuration;
     for (final var memberId : configuration.members().keySet()) {
-      updated = updated.updateMember(memberId, this::updateExporterState);
+      updated =
+          updated.updateMember(memberId, member -> updateExporterState(requireNonNull(member)));
     }
     return updated;
   }
@@ -101,7 +105,8 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
             ? partitionState
             : new PartitionState(
                 partitionState.state(), partitionState.priority(), DynamicPartitionConfig.init());
-    final var exportersInConfig = initializedPartitionState.config().exporting().exporters();
+    final var exportersInConfig =
+        requireNonNull(initializedPartitionState.config().exporting()).exporters();
 
     final var newlyAddedExporters =
         configuredExporters.stream().filter(id -> !exportersInConfig.containsKey(id)).toList();
@@ -127,9 +132,16 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
             .toList();
 
     return initializedPartitionState
-        .updateConfig(c -> c.updateExporting(e -> e.withConfigNotFoundFor(configRemovedExporters)))
-        .updateConfig(c -> c.updateExporting(e -> reEnableExporters(e, configReaddedExporters)))
-        .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
+        .updateConfig(
+            c ->
+                c.updateExporting(
+                    e -> requireNonNull(e).withConfigNotFoundFor(configRemovedExporters)))
+        .updateConfig(
+            c ->
+                c.updateExporting(
+                    e -> reEnableExporters(requireNonNull(e), configReaddedExporters)))
+        .updateConfig(
+            c -> c.updateExporting(e -> requireNonNull(e).addExporters(newlyAddedExporters)));
   }
 
   private ExportingConfig reEnableExporters(
@@ -138,8 +150,9 @@ public class ExporterStateInitializer implements ClusterConfigurationModifier {
 
     ExportingConfig updating = exportingConfig;
     for (final var entry : configReaddedExporters) {
-      final var exporterName = entry.getKey();
-      final var exporterState = entry.getValue();
+      final var nonNullEntry = requireNonNull(entry);
+      final var exporterName = nonNullEntry.getKey();
+      final var exporterState = requireNonNull(nonNullEntry.getValue());
       // reuse the metadata version and initializedFrom from the existing exporter state
       updating =
           updating.enableExporter(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestFailedException.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestFailedException.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import org.jspecify.annotations.Nullable;
+
 public sealed interface ClusterConfigurationRequestFailedException {
 
   final class InvalidRequest extends RuntimeException
       implements ClusterConfigurationRequestFailedException {
-    public InvalidRequest(final String message) {
+    public InvalidRequest(final @Nullable String message) {
       super(message);
     }
 
@@ -22,14 +24,14 @@ public sealed interface ClusterConfigurationRequestFailedException {
 
   final class OperationNotAllowed extends RuntimeException
       implements ClusterConfigurationRequestFailedException {
-    public OperationNotAllowed(final String message) {
+    public OperationNotAllowed(final @Nullable String message) {
       super(message);
     }
   }
 
   final class ConcurrentModificationException extends RuntimeException
       implements ClusterConfigurationRequestFailedException {
-    public ConcurrentModificationException(final String message) {
+    public ConcurrentModificationException(final @Nullable String message) {
       super(message);
     }
   }
@@ -40,7 +42,7 @@ public sealed interface ClusterConfigurationRequestFailedException {
       super(cause);
     }
 
-    public InternalError(final String message) {
+    public InternalError(final @Nullable String message) {
       super(message);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -281,6 +281,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
           Either.left(
               new ErrorResponse(
                   ErrorCode.CONCURRENT_MODIFICATION, concurrentModificationException.getMessage()));
+      case null -> Either.left(new ErrorResponse(ErrorCode.INTERNAL_ERROR, throwable.getMessage()));
       default -> Either.left(new ErrorResponse(ErrorCode.INTERNAL_ERROR, throwable.getMessage()));
     };
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import io.atomix.cluster.MemberId;
@@ -137,7 +139,8 @@ public class ForceScaleDownRequestTransformer implements ConfigurationChangeRequ
     for (final var partitionId : partitions) {
       partitionToMembersMap.put(partitionId, new TreeSet<>());
       for (final var member : membersToRetain) {
-        if (currentTopology.getMember(member).hasPartition(partitionId)) {
+        final var memberState = requireNonNull(currentTopology.getMember(member));
+        if (memberState.hasPartition(partitionId)) {
           partitionToMembersMap.computeIfPresent(
               partitionId,
               (ignore, members) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
@@ -134,8 +136,8 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
             .collect(Collectors.toMap(PartitionMetadata::id, p -> p));
 
     for (final PartitionId partition : oldPartitions) {
-      final var newMetadata = newDistribution.get(partition);
-      final var oldMetadata = oldDistribution.get(partition);
+      final var newMetadata = requireNonNull(newDistribution.get(partition));
+      final var oldMetadata = requireNonNull(oldDistribution.get(partition));
       operations.addAll(movePartition(oldMetadata, newMetadata));
     }
     final var hasNewPartitions = !newPartitions.isEmpty();
@@ -143,7 +145,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     if (hasNewPartitions) {
       operations.add(new StartPartitionScaleUp(coordinatorNodeId, newPartitionCount.get()));
       for (final PartitionId partition : newPartitions) {
-        final var newMetadata = newDistribution.get(partition);
+        final var newMetadata = requireNonNull(newDistribution.get(partition));
         operations.addAll(addPartition(newMetadata));
       }
       operations.addAll(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -52,7 +54,7 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
         final var partitionId = partitions.getKey();
         operations.add(new PartitionLeaveOperation(memberId, partitionId, 0));
 
-        final var primaryForPartition = primaries.get(partitionId);
+        final var primaryForPartition = requireNonNull(primaries.get(partitionId));
 
         if (!primaryForPartition.memberId().equals(memberId)) {
           followers

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.cluster.ZoneLayout;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
@@ -155,7 +157,7 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
                   zoneName, zones.size())));
     }
 
-    return Either.right(null);
+    return Either.right(unit());
   }
 
   private int expectedNextZoneIndex(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
+@NullMarked
 package io.camunda.zeebe.dynamic.config.api;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
-import io.atomix.cluster.MemberId;
 import static java.util.Objects.requireNonNull;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
@@ -74,7 +74,7 @@ public class AwaitModeChangeApplier implements ClusterOperationApplier {
         clusterConfiguration.updateMember(
             memberId,
             memberState -> {
-              var updatedState = memberState;
+              var updatedState = requireNonNull(memberState);
               for (final var partitionId : confirmedPartitions) {
                 updatedState = updatedState.updatePartition(partitionId, partitionStateUpdater);
               }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitModeChangeApplier.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import io.atomix.cluster.MemberId;
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
@@ -15,7 +17,6 @@ import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
@@ -35,9 +36,9 @@ public class AwaitModeChangeApplier implements ClusterOperationApplier {
 
   public AwaitModeChangeApplier(
       final MemberId memberId, final Mode mode, final ModeChangeExecutor modeChangeExecutor) {
-    this.memberId = Objects.requireNonNull(memberId);
-    this.mode = Objects.requireNonNull(mode);
-    this.modeChangeExecutor = Objects.requireNonNull(modeChangeExecutor);
+    this.memberId = requireNonNull(memberId);
+    this.mode = requireNonNull(mode);
+    this.modeChangeExecutor = requireNonNull(modeChangeExecutor);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRedistributionCompletionApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRedistributionCompletion;
@@ -16,7 +18,6 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPar
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
-import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 public class AwaitRedistributionCompletionApplier implements ClusterOperationApplier {
@@ -27,8 +28,8 @@ public class AwaitRedistributionCompletionApplier implements ClusterOperationApp
   public AwaitRedistributionCompletionApplier(
       final PartitionScalingChangeExecutor executor,
       final AwaitRedistributionCompletion operation) {
-    this.executor = Objects.requireNonNull(executor);
-    this.operation = Objects.requireNonNull(operation);
+    this.executor = requireNonNull(executor);
+    this.operation = requireNonNull(operation);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRelocationCompletionApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/AwaitRelocationCompletionApplier.java
@@ -7,13 +7,14 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOperation.AwaitRelocationCompletion;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
-import java.util.Objects;
 import java.util.function.UnaryOperator;
 
 public class AwaitRelocationCompletionApplier implements ClusterOperationApplier {
@@ -23,8 +24,8 @@ public class AwaitRelocationCompletionApplier implements ClusterOperationApplier
 
   public AwaitRelocationCompletionApplier(
       final PartitionScalingChangeExecutor executor, final AwaitRelocationCompletion operation) {
-    this.executor = Objects.requireNonNull(executor);
-    this.operation = Objects.requireNonNull(operation);
+    this.executor = requireNonNull(executor);
+    this.operation = requireNonNull(operation);
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ClusterChangeExecutor.java
@@ -53,18 +53,18 @@ public interface ClusterChangeExecutor {
   final class NoopClusterChangeExecutor implements ClusterChangeExecutor {
     @Override
     public ActorFuture<Void> deleteHistory() {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
     }
 
     @Override
     public ActorFuture<Void> preScaling(
         final int currentClusterSize, final Set<MemberId> clusterMembers) {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
     }
 
     @Override
     public ActorFuture<Void> postScaling(final Set<MemberId> clusterMembers) {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliers.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliers.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -64,7 +66,12 @@ public interface ConfigurationChangeAppliers {
     default Either<Exception, UnaryOperator<ClusterConfiguration>> init(
         final ClusterConfiguration currentClusterConfiguration) {
       return initMemberState(currentClusterConfiguration)
-          .map(transformer -> cluster -> cluster.updateMember(memberId(), transformer));
+          .map(
+              transformer ->
+                  cluster ->
+                      cluster.updateMember(
+                          memberId(),
+                          memberState -> transformer.apply(requireNonNull(memberState))));
     }
 
     @Override
@@ -74,7 +81,11 @@ public interface ConfigurationChangeAppliers {
           .onComplete(
               (transformer, error) -> {
                 if (error == null) {
-                  future.complete(cluster -> cluster.updateMember(memberId(), transformer));
+                  future.complete(
+                      cluster ->
+                          cluster.updateMember(
+                              memberId(),
+                              memberState -> transformer.apply(requireNonNull(memberState))));
                 } else {
                   future.completeExceptionally(error);
                 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -334,7 +334,9 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
   private boolean isCoordinator(final ClusterConfiguration clusterConfiguration) {
     // coordinator is usually the broker with the lowest member id
     // return false if there are currently no known members, which means it will be uninitialized.
-    return localMemberId.equals(
-        clusterConfiguration.members().keySet().stream().min(MemberId::compareTo).orElse(null));
+    return clusterConfiguration.members().keySet().stream()
+        .min(MemberId::compareTo)
+        .map(localMemberId::equals)
+        .orElse(false);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/EnterRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/EnterRecoveryApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -42,7 +44,7 @@ public class EnterRecoveryApplier implements MemberOperationApplier {
           new IllegalStateException(String.format(TRANSITION_ERROR_MESSAGE, memberId)));
     }
 
-    final var memberState = currentClusterConfiguration.getMember(memberId).state();
+    final var memberState = requireNonNull(currentClusterConfiguration.getMember(memberId)).state();
 
     if (State.RECOVERING.equals(memberState)) {
       return Either.right(UnaryOperator.identity());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ExitRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ExitRecoveryApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -42,7 +44,7 @@ public class ExitRecoveryApplier implements MemberOperationApplier {
           new IllegalStateException(String.format(TRANSITION_ERROR_MESSAGE, memberId)));
     }
 
-    final var memberState = currentClusterConfiguration.getMember(memberId).state();
+    final var memberState = requireNonNull(currentClusterConfiguration.getMember(memberId)).state();
 
     if (State.ACTIVE.equals(memberState)) {
       return Either.right(UnaryOperator.identity());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/MemberJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/MemberJoinApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -31,6 +33,17 @@ final class MemberJoinApplier implements MemberOperationApplier {
   }
 
   @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    if (!currentClusterConfiguration.hasMember(memberId)) {
+      return Either.right(
+          configuration ->
+              configuration.addMember(memberId, MemberState.uninitialized().toJoining()));
+    }
+    return MemberOperationApplier.super.init(currentClusterConfiguration);
+  }
+
+  @Override
   public MemberId memberId() {
     return memberId;
   }
@@ -39,7 +52,9 @@ final class MemberJoinApplier implements MemberOperationApplier {
   public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterConfiguration currentClusterConfiguration) {
     if (currentClusterConfiguration.hasMember(memberId)
-        && !currentClusterConfiguration.getMember(memberId).state().equals(State.JOINING)) {
+        && !requireNonNull(currentClusterConfiguration.getMember(memberId))
+            .state()
+            .equals(State.JOINING)) {
       return Either.left(
           new IllegalStateException(
               String.format(
@@ -48,7 +63,9 @@ final class MemberJoinApplier implements MemberOperationApplier {
     }
 
     if (currentClusterConfiguration.hasMember(memberId)
-        && currentClusterConfiguration.getMember(memberId).state().equals(State.JOINING)) {
+        && requireNonNull(currentClusterConfiguration.getMember(memberId))
+            .state()
+            .equals(State.JOINING)) {
       // If member is already joining, then we don't need to set it again. This can happen if the
       // node restarted while applying the join operation. To ensure that the topology change can
       // make progress, we do not treat this as an error.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/MemberLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/MemberLeaveApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -45,16 +47,17 @@ public class MemberLeaveApplier implements MemberOperationApplier {
     }
 
     final boolean hasPartitions =
-        !currentClusterConfiguration.getMember(memberId).partitions().isEmpty();
+        !requireNonNull(currentClusterConfiguration.getMember(memberId)).partitions().isEmpty();
     if (hasPartitions) {
       return Either.left(
           new IllegalStateException(
               String.format(
                   "Expected to remove member %s, but the member still has partitions assigned. Partitions: [%s]",
-                  memberId, currentClusterConfiguration.getMember(memberId).partitions())));
+                  memberId,
+                  requireNonNull(currentClusterConfiguration.getMember(memberId)).partitions())));
     }
 
-    return Either.right(MemberState::toLeaving);
+    return Either.right(memberState -> requireNonNull(memberState).toLeaving());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ModeChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ModeChangeExecutor.java
@@ -54,12 +54,12 @@ public interface ModeChangeExecutor {
   final class NoopModeChangeExecutor implements ModeChangeExecutor {
     @Override
     public ActorFuture<Void> enterRecovery() {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
     }
 
     @Override
     public ActorFuture<Void> exitRecovery() {
-      return CompletableActorFuture.completed(null);
+      return CompletableActorFuture.completed();
     }
 
     @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopClusterMembershipChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopClusterMembershipChangeExecutor.java
@@ -15,11 +15,11 @@ public class NoopClusterMembershipChangeExecutor implements ClusterMembershipCha
 
   @Override
   public ActorFuture<Void> addBroker(final MemberId memberId) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
   public ActorFuture<Void> removeBroker(final MemberId memberId) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -13,14 +13,15 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Collection;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 public final class NoopPartitionChangeExecutor implements PartitionChangeExecutor {
 
   @Override
   public ActorFuture<Void> join(
       final int partitionId,
-      final Map<MemberId, Integer> membersWithPriority,
-      final DynamicPartitionConfig config) {
+      final @Nullable Map<MemberId, Integer> membersWithPriority,
+      final @Nullable DynamicPartitionConfig config) {
     return CompletableActorFuture.completed();
   }
 
@@ -33,7 +34,7 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
   public ActorFuture<Void> bootstrap(
       final int partitionId,
       final int priority,
-      final DynamicPartitionConfig partitionConfig,
+      final @Nullable DynamicPartitionConfig partitionConfig,
       final boolean initializeFromSnapshot) {
     return CompletableActorFuture.completed();
   }
@@ -64,7 +65,7 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
       final int partitionId,
       final String exporterId,
       final long metadataVersionToUpdate,
-      final String initializeFrom) {
+      final @Nullable String initializeFrom) {
     return CompletableActorFuture.completed();
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -21,12 +21,12 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
       final int partitionId,
       final Map<MemberId, Integer> membersWithPriority,
       final DynamicPartitionConfig config) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
   public ActorFuture<Void> leave(final int partitionId) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
@@ -35,28 +35,28 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
       final int priority,
       final DynamicPartitionConfig partitionConfig,
       final boolean initializeFromSnapshot) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
   public ActorFuture<Void> reconfigurePriority(final int partitionId, final int newPriority) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
   public ActorFuture<Void> forceReconfigure(
       final int partitionId, final Collection<MemberId> members) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
   public ActorFuture<Void> disableExporter(final int partitionId, final String exporterId) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
   public ActorFuture<Void> deleteExporter(final int partitionId, final String exporterId) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 
   @Override
@@ -65,6 +65,6 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
       final String exporterId,
       final long metadataVersionToUpdate,
       final String initializeFrom) {
-    return CompletableActorFuture.completed(null);
+    return CompletableActorFuture.completed();
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -22,6 +24,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 public class PartitionBootstrapApplier implements MemberOperationApplier {
 
@@ -31,7 +34,7 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final Optional<DynamicPartitionConfig> config;
   private final boolean initializeFromSnapshot;
-  private DynamicPartitionConfig partitionConfig;
+  private @Nullable DynamicPartitionConfig partitionConfig;
 
   public PartitionBootstrapApplier(
       final PartitionBootstrapOperation operation,
@@ -100,18 +103,24 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
                   .formatted(partitionId)));
     }
 
-    partitionConfig = initPartitionConfig(currentClusterConfiguration);
+    final var dynamicPartitionConfig = initPartitionConfig(currentClusterConfiguration);
+    partitionConfig = dynamicPartitionConfig;
 
     return Either.right(
         memberState ->
-            memberState.addPartition(
-                partitionId, PartitionState.bootstrapping(priority, partitionConfig)));
+            requireNonNull(memberState)
+                .addPartition(
+                    partitionId, PartitionState.bootstrapping(priority, dynamicPartitionConfig)));
   }
 
   @Override
   public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
+    if (partitionConfig == null) {
+      return CompletableActorFuture.completedExceptionally(
+          new RuntimeException("partitionConfig is null"));
+    }
     partitionChangeExecutor
         .bootstrap(partitionId, priority, partitionConfig, initializeFromSnapshot)
         .onComplete(
@@ -150,7 +159,7 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
 
   private boolean isLocalMemberIsActive(final ClusterConfiguration currentClusterConfiguration) {
     return currentClusterConfiguration.hasMember(memberId)
-        && currentClusterConfiguration.getMember(memberId).state() == State.ACTIVE;
+        && requireNonNull(currentClusterConfiguration.getMember(memberId)).state() == State.ACTIVE;
   }
 
   // For now, we only allow adding new partitions with continuous IDs. In theory, it should not
@@ -167,9 +176,10 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
 
   private boolean isPartitionAlreadyBootstrapping(
       final ClusterConfiguration currentClusterConfiguration) {
-    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final MemberState member = requireNonNull(currentClusterConfiguration.getMember(memberId));
     return member.hasPartition(partitionId)
-        && member.getPartition(partitionId).state() == PartitionState.State.BOOTSTRAPPING;
+        && requireNonNull(member.getPartition(partitionId)).state()
+            == PartitionState.State.BOOTSTRAPPING;
   }
 
   private boolean partitionExists(final ClusterConfiguration currentClusterConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.Collection;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the executor that executes the actual process to start or start. The concrete
@@ -108,5 +109,5 @@ public interface PartitionChangeExecutor {
    * @return a future that completes when the exporter is enabled
    */
   ActorFuture<Void> enableExporter(
-      int partitionId, String exporterId, long metadataVersion, String initializeFrom);
+      int partitionId, String exporterId, long metadataVersion, @Nullable String initializeFrom);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDeleteExporterApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.changes;
 
 import static io.camunda.zeebe.dynamic.config.state.ExporterState.State.CONFIG_NOT_FOUND;
+import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
@@ -55,7 +56,7 @@ final class PartitionDeleteExporterApplier implements MemberOperationApplier {
                   memberId)));
     }
 
-    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final MemberState member = requireNonNull(currentClusterConfiguration.getMember(memberId));
     final var partitionExistsInLocalMember = member.hasPartition(partitionId);
 
     if (!partitionExistsInLocalMember) {
@@ -67,7 +68,8 @@ final class PartitionDeleteExporterApplier implements MemberOperationApplier {
     }
 
     final Map<String, ExporterState> exporters =
-        member.getPartition(partitionId).config().exporting().exporters();
+        requireNonNull(requireNonNull(member.getPartition(partitionId)).config().exporting())
+            .exporters();
 
     final var partitionHasExporter = exporters.containsKey(exporterId);
 
@@ -79,7 +81,7 @@ final class PartitionDeleteExporterApplier implements MemberOperationApplier {
                   partitionId, exporterId)));
     }
 
-    final var exporterState = exporters.get(exporterId).state();
+    final var exporterState = requireNonNull(exporters.get(exporterId)).state();
     final boolean isConfigNotFound = exporterState.equals(CONFIG_NOT_FOUND);
 
     if (!isConfigNotFound) {
@@ -101,15 +103,17 @@ final class PartitionDeleteExporterApplier implements MemberOperationApplier {
         .thenApply(
             (nothing) -> {
               return memberState ->
-                  memberState.updatePartition(
-                      partitionId,
-                      partition ->
-                          partition.updateConfig(config -> deleteExporter(config, exporterId)));
+                  requireNonNull(memberState)
+                      .updatePartition(
+                          partitionId,
+                          partition ->
+                              partition.updateConfig(config -> deleteExporter(config, exporterId)));
             });
   }
 
   private DynamicPartitionConfig deleteExporter(
       final DynamicPartitionConfig config, final String exporterId) {
-    return config.updateExporting(exporting -> exporting.deleteExporter(exporterId));
+    return config.updateExporting(
+        exporting -> requireNonNull(exporting).deleteExporter(exporterId));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -52,7 +54,7 @@ final class PartitionDisableExporterApplier implements MemberOperationApplier {
                   memberId)));
     }
 
-    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final MemberState member = requireNonNull(currentClusterConfiguration.getMember(memberId));
     final var partitionExistsInLocalMember = member.hasPartition(partitionId);
 
     if (!partitionExistsInLocalMember) {
@@ -64,7 +66,9 @@ final class PartitionDisableExporterApplier implements MemberOperationApplier {
     }
 
     final var partitionHasExporter =
-        member.getPartition(partitionId).config().exporting().exporters().containsKey(exporterId);
+        requireNonNull(requireNonNull(member.getPartition(partitionId)).config().exporting())
+            .exporters()
+            .containsKey(exporterId);
 
     if (!partitionHasExporter) {
       return Either.left(
@@ -89,11 +93,12 @@ final class PartitionDisableExporterApplier implements MemberOperationApplier {
               if (error == null) {
                 result.complete(
                     memberState ->
-                        memberState.updatePartition(
-                            partitionId,
-                            partition ->
-                                partition.updateConfig(
-                                    config -> disableExporter(config, exporterId))));
+                        requireNonNull(memberState)
+                            .updatePartition(
+                                partitionId,
+                                partition ->
+                                    partition.updateConfig(
+                                        config -> disableExporter(config, exporterId))));
               } else {
                 result.completeExceptionally(error);
               }
@@ -104,6 +109,7 @@ final class PartitionDisableExporterApplier implements MemberOperationApplier {
 
   private DynamicPartitionConfig disableExporter(
       final DynamicPartitionConfig config, final String exporterId) {
-    return config.updateExporting(exporting -> exporting.disableExporter(exporterId));
+    return config.updateExporting(
+        exporting -> requireNonNull(exporting).disableExporter(exporterId));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -58,7 +60,7 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
                   memberId)));
     }
 
-    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final MemberState member = requireNonNull(currentClusterConfiguration.getMember(memberId));
     final var partitionExistsInLocalMember = member.hasPartition(partitionId);
 
     if (!partitionExistsInLocalMember) {
@@ -70,7 +72,8 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
     }
 
     final var exportersInPartition =
-        member.getPartition(partitionId).config().exporting().exporters();
+        requireNonNull(requireNonNull(member.getPartition(partitionId)).config().exporting())
+            .exporters();
 
     if (initializeFrom.isPresent()) {
       final String otherExporterId = initializeFrom.orElseThrow();
@@ -82,7 +85,7 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
                     "Expected to enable exporter and initialize from exporter '%s', but the partition '%s' does not have exporter '%s'",
                     otherExporterId, partitionId, otherExporterId)));
       } else {
-        final var otherExporter = exportersInPartition.get(otherExporterId);
+        final var otherExporter = requireNonNull(exportersInPartition.get(otherExporterId));
         if (otherExporter.state() == State.DISABLED) {
           return Either.left(
               new IllegalStateException(
@@ -95,7 +98,8 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
 
     final var partitionHasExporter = exportersInPartition.containsKey(exporterId);
 
-    if (partitionHasExporter && exportersInPartition.get(exporterId).state() == State.ENABLED) {
+    final var exporter = partitionHasExporter ? exportersInPartition.get(exporterId) : null;
+    if (partitionHasExporter && requireNonNull(exporter).state() == State.ENABLED) {
       return Either.left(
           new IllegalStateException(
               String.format(
@@ -108,7 +112,7 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
       // whether the runtime state has the latest state. This is useful when the operation is
       // retried or if there was restart without a snapshot after a sequence of disable, enable
       // operations.
-      metadataVersionToUpdate = exportersInPartition.get(exporterId).metadataVersion() + 1;
+      metadataVersionToUpdate = requireNonNull(exporter).metadataVersion() + 1;
     } else {
       metadataVersionToUpdate = 1;
     }
@@ -129,8 +133,10 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
           if (error == null) {
             result.complete(
                 memberState ->
-                    memberState.updatePartition(
-                        partitionId, partition -> partition.updateConfig(this::enableExporter)));
+                    requireNonNull(memberState)
+                        .updatePartition(
+                            partitionId,
+                            partition -> partition.updateConfig(this::enableExporter)));
           } else {
             result.completeExceptionally(error);
           }
@@ -145,7 +151,8 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
             initializeFrom
                 .map(
                     otherExporterId ->
-                        c.enableExporter(exporterId, otherExporterId, metadataVersionToUpdate))
-                .orElse(c.enableExporter(exporterId, metadataVersionToUpdate)));
+                        requireNonNull(c)
+                            .enableExporter(exporterId, otherExporterId, metadataVersionToUpdate))
+                .orElse(requireNonNull(c).enableExporter(exporterId, metadataVersionToUpdate)));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionForceReconfigureApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionForceReconfigureApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -59,7 +61,8 @@ final class PartitionForceReconfigureApplier implements ClusterOperationApplier 
     for (final MemberId member : members) {
       final boolean memberIsActive =
           currentClusterConfiguration.hasMember(member)
-              && currentClusterConfiguration.getMember(member).state() == State.ACTIVE;
+              && requireNonNull(currentClusterConfiguration.getMember(member)).state()
+                  == State.ACTIVE;
       if (!memberIsActive) {
         return Either.left(
             new IllegalStateException(
@@ -68,7 +71,7 @@ final class PartitionForceReconfigureApplier implements ClusterOperationApplier 
                     partitionId, members, memberId)));
       }
 
-      final var memberState = currentClusterConfiguration.getMember(member);
+      final var memberState = requireNonNull(currentClusterConfiguration.getMember(member));
       if (!memberState.hasPartition(partitionId)) {
         return Either.left(
             new IllegalStateException(
@@ -104,8 +107,10 @@ final class PartitionForceReconfigureApplier implements ClusterOperationApplier 
     ClusterConfiguration updatedTopology = clusterConfiguration;
     for (final var member : clusterConfiguration.members().keySet()) {
       if (!members.contains(member)
-          && clusterConfiguration.getMember(member).hasPartition(partitionId)) {
-        updatedTopology = updatedTopology.updateMember(member, m -> m.removePartition(partitionId));
+          && requireNonNull(clusterConfiguration.getMember(member)).hasPartition(partitionId)) {
+        updatedTopology =
+            updatedTopology.updateMember(
+                member, m -> requireNonNull(m).removePartition(partitionId));
       }
     }
     return updatedTopology;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -21,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A Partition Join operation is executed when a member wants to start replicating a partition. This
@@ -31,8 +34,9 @@ final class PartitionJoinApplier implements MemberOperationApplier {
   private final int priority;
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final MemberId localMemberId;
-  private Map<MemberId, Integer> partitionMembersWithPriority;
-  private DynamicPartitionConfig partitionConfig;
+  // initialized in initMemberState
+  private @Nullable Map<MemberId, Integer> partitionMembersWithPriority;
+  private @Nullable DynamicPartitionConfig partitionConfig;
 
   PartitionJoinApplier(
       final int partitionId,
@@ -54,59 +58,71 @@ final class PartitionJoinApplier implements MemberOperationApplier {
   public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterConfiguration currentClusterConfiguration) {
 
-    final boolean localMemberIsActive =
-        currentClusterConfiguration.hasMember(localMemberId)
-            && currentClusterConfiguration.getMember(localMemberId).state() == State.ACTIVE;
-    if (!localMemberIsActive) {
-      return Either.left(
-          new IllegalStateException(
-              "Expected to join partition, but the local member is not active"));
-    }
+    try {
+      final boolean localMemberIsActive =
+          currentClusterConfiguration.hasMember(localMemberId)
+              && requireNonNull(currentClusterConfiguration.getMember(localMemberId)).state()
+                  == State.ACTIVE;
+      if (!localMemberIsActive) {
+        return Either.left(
+            new IllegalStateException(
+                "Expected to join partition, but the local member is not active"));
+      }
 
-    final var partitionHasActiveMember =
-        currentClusterConfiguration.members().values().stream()
-            .flatMap(
-                memberState ->
-                    memberState.partitions().entrySet().stream()
-                        .filter(partitionState -> partitionState.getKey() == partitionId)
-                        .map(Entry::getValue))
-            .anyMatch(partitionState -> partitionState.state() == PartitionState.State.ACTIVE);
-    if (!partitionHasActiveMember) {
-      return Either.left(
-          new IllegalStateException(
-              String.format(
-                  "Expected to join partition %s, but partition has no active members",
-                  partitionId)));
-    }
+      final var partitionHasActiveMember =
+          currentClusterConfiguration.members().values().stream()
+              .flatMap(
+                  memberState ->
+                      memberState.partitions().entrySet().stream()
+                          .filter(partitionState -> partitionState.getKey() == partitionId)
+                          .map(Entry::getValue))
+              .anyMatch(partitionState -> partitionState.state() == PartitionState.State.ACTIVE);
+      if (!partitionHasActiveMember) {
+        return Either.left(
+            new IllegalStateException(
+                String.format(
+                    "Expected to join partition %s, but partition has no active members",
+                    partitionId)));
+      }
 
-    final MemberState localMemberState = currentClusterConfiguration.getMember(localMemberId);
-    final boolean partitionExistsInLocalMember = localMemberState.hasPartition(partitionId);
-    if (partitionExistsInLocalMember
-        && localMemberState.getPartition(partitionId).state() != PartitionState.State.JOINING) {
-      return Either.left(
-          new IllegalStateException(
-              String.format(
-                  "Expected to join partition %s, but the local member already has the partition at state %s",
-                  partitionId, localMemberState.partitions().get(partitionId).state())));
-    }
+      final MemberState localMemberState =
+          requireNonNull(currentClusterConfiguration.getMember(localMemberId));
+      final boolean partitionExistsInLocalMember = localMemberState.hasPartition(partitionId);
+      if (partitionExistsInLocalMember
+          && requireNonNull(localMemberState.getPartition(partitionId)).state()
+              != PartitionState.State.JOINING) {
+        return Either.left(
+            new IllegalStateException(
+                String.format(
+                    "Expected to join partition %s, but the local member already has the partition at state %s",
+                    partitionId,
+                    requireNonNull(localMemberState.getPartition(partitionId)).state())));
+      }
 
-    // Collect the priority of each member, including the local member. This is needed to generate
-    // PartitionMetadata when joining the partition.
-    partitionMembersWithPriority = collectPriorityByMembers(currentClusterConfiguration);
+      // Collect the priority of each member, including the local member. This is needed to generate
+      // PartitionMetadata when joining the partition.
+      partitionMembersWithPriority = collectPriorityByMembers(currentClusterConfiguration);
 
-    if (partitionExistsInLocalMember
-        && localMemberState.getPartition(partitionId).state() == PartitionState.State.JOINING) {
-      // The state is already JOINING, so we don't need to change it. This can happen when the node
-      // was restarted while applying the join operation. To ensure that the configuration change
-      // can make progress, we do not treat this as an error.
-      partitionConfig = localMemberState.getPartition(partitionId).config();
-      return Either.right(memberState -> memberState);
-    } else {
-      partitionConfig = getPartitionConfig(currentClusterConfiguration);
-      return Either.right(
-          memberState ->
-              memberState.addPartition(
-                  partitionId, PartitionState.joining(priority, partitionConfig)));
+      if (partitionExistsInLocalMember
+          && requireNonNull(localMemberState.getPartition(partitionId)).state()
+              == PartitionState.State.JOINING) {
+        // The state is already JOINING, so we don't need to change it. This can happen when the
+        // node
+        // was restarted while applying the join operation. To ensure that the configuration change
+        // can make progress, we do not treat this as an error.
+        partitionConfig = requireNonNull(localMemberState.getPartition(partitionId)).config();
+        return Either.right(memberState -> memberState);
+      } else {
+        partitionConfig = getPartitionConfig(currentClusterConfiguration);
+        return Either.right(
+            memberState ->
+                requireNonNull(memberState)
+                    .addPartition(
+                        partitionId,
+                        PartitionState.joining(priority, requireNonNull(partitionConfig))));
+      }
+    } catch (final NullPointerException e) {
+      return Either.left(e);
     }
   }
 
@@ -115,19 +131,26 @@ final class PartitionJoinApplier implements MemberOperationApplier {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
 
-    partitionChangeExecutor
-        .join(partitionId, partitionMembersWithPriority, partitionConfig)
-        .onComplete(
-            (ignore, error) -> {
-              if (error == null) {
-                result.complete(
-                    memberState ->
-                        memberState.updatePartition(partitionId, PartitionState::toActive));
-              } else {
-                result.completeExceptionally(error);
-              }
-            });
-    return result;
+    try {
+      partitionChangeExecutor
+          .join(
+              partitionId,
+              requireNonNull(partitionMembersWithPriority),
+              requireNonNull(partitionConfig))
+          .onComplete(
+              (ignore, error) -> {
+                if (error == null) {
+                  result.complete(
+                      memberState ->
+                          memberState.updatePartition(partitionId, PartitionState::toActive));
+                } else {
+                  result.completeExceptionally(error);
+                }
+              });
+      return result;
+    } catch (final NullPointerException e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
   }
 
   private DynamicPartitionConfig getPartitionConfig(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionLeaveApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -44,7 +46,8 @@ record PartitionLeaveApplier(
     }
 
     final boolean partitionExistsInLocalMember =
-        currentClusterConfiguration.getMember(localMemberId).hasPartition(partitionId);
+        requireNonNull(currentClusterConfiguration.getMember(localMemberId))
+            .hasPartition(partitionId);
 
     if (!partitionExistsInLocalMember) {
       return Either.left(
@@ -55,7 +58,10 @@ record PartitionLeaveApplier(
     }
 
     final boolean partitionIsLeaving =
-        currentClusterConfiguration.getMember(localMemberId).getPartition(partitionId).state()
+        requireNonNull(
+                    requireNonNull(currentClusterConfiguration.getMember(localMemberId))
+                        .getPartition(partitionId))
+                .state()
             == PartitionState.State.LEAVING;
 
     if (partitionIsLeaving) {
@@ -77,7 +83,8 @@ record PartitionLeaveApplier(
                     partitionId, partitionReplicaCount, minimumAllowedReplicas)));
       }
       return Either.right(
-          memberState -> memberState.updatePartition(partitionId, PartitionState::toLeaving));
+          memberState ->
+              requireNonNull(memberState).updatePartition(partitionId, PartitionState::toLeaving));
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionReconfigurePriorityApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionReconfigurePriorityApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -46,14 +48,16 @@ public class PartitionReconfigurePriorityApplier implements MemberOperationAppli
       final ClusterConfiguration currentClusterConfiguration) {
     final boolean localMemberIsActive =
         currentClusterConfiguration.hasMember(localMemberId)
-            && currentClusterConfiguration.getMember(localMemberId).state() == State.ACTIVE;
+            && requireNonNull(currentClusterConfiguration.getMember(localMemberId)).state()
+                == State.ACTIVE;
     if (!localMemberIsActive) {
       return Either.left(
           new IllegalStateException(
               "Expected to change priority of a partition, but the local member is not active"));
     }
 
-    final MemberState localMemberState = currentClusterConfiguration.getMember(localMemberId);
+    final MemberState localMemberState =
+        requireNonNull(currentClusterConfiguration.getMember(localMemberId));
     final boolean partitionExistsInLocalMember = localMemberState.hasPartition(partitionId);
     if (!partitionExistsInLocalMember) {
       return Either.left(
@@ -62,7 +66,8 @@ public class PartitionReconfigurePriorityApplier implements MemberOperationAppli
                   "Expected to change priority of partition %d, but the local member does not have the partition",
                   partitionId)));
     }
-    final PartitionState.State partitionState = localMemberState.getPartition(partitionId).state();
+    final PartitionState.State partitionState =
+        requireNonNull(localMemberState.getPartition(partitionId)).state();
     if (partitionState != PartitionState.State.ACTIVE) {
       return Either.left(
           new IllegalStateException(
@@ -87,11 +92,14 @@ public class PartitionReconfigurePriorityApplier implements MemberOperationAppli
               if (error == null) {
                 result.complete(
                     memberState ->
-                        memberState.updatePartition(
-                            partitionId,
-                            partitionState ->
-                                new PartitionState(
-                                    partitionState.state(), newPriority, partitionState.config())));
+                        requireNonNull(memberState)
+                            .updatePartition(
+                                partitionId,
+                                partitionState ->
+                                    new PartitionState(
+                                        partitionState.state(),
+                                        newPriority,
+                                        partitionState.config())));
               } else {
                 result.completeExceptionally(error);
               }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An executor that supports partition scaling and monitoring progress of redistribution and
@@ -27,11 +28,11 @@ public interface PartitionScalingChangeExecutor {
   ActorFuture<Void> initiateScaleUp(int desiredPartitionCount);
 
   ActorFuture<Void> awaitRedistributionCompletion(
-      int desiredPartitionCount, Set<Integer> redistributedPartitions, Duration timeout);
+      int desiredPartitionCount, Set<Integer> redistributedPartitions, @Nullable Duration timeout);
 
   ActorFuture<Void> notifyPartitionBootstrapped(int partitionId);
 
-  ActorFuture<RoutingState> getRoutingState();
+  ActorFuture<@Nullable RoutingState> getRoutingState();
 
   final class NoopPartitionScalingChangeExecutor implements PartitionScalingChangeExecutor {
     @Override
@@ -43,7 +44,7 @@ public interface PartitionScalingChangeExecutor {
     public ActorFuture<Void> awaitRedistributionCompletion(
         final int desiredPartitionCount,
         final Set<Integer> redistributedPartitions,
-        final Duration timeout) {
+        final @Nullable Duration timeout) {
       return CompletableActorFuture.completed();
     }
 
@@ -53,7 +54,7 @@ public interface PartitionScalingChangeExecutor {
     }
 
     @Override
-    public ActorFuture<RoutingState> getRoutingState() {
+    public ActorFuture<@Nullable RoutingState> getRoutingState() {
       return CompletableActorFuture.completed(null);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/UpdateRoutingStateApplier.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 public class UpdateRoutingStateApplier implements ClusterOperationApplier {
 
@@ -35,10 +36,14 @@ public class UpdateRoutingStateApplier implements ClusterOperationApplier {
 
   @Override
   public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
-    final var routingState =
-        updateRoutingState.routingState().isPresent()
-            ? CompletableActorFuture.completed(updateRoutingState.routingState().get())
-            : executor.getRoutingState();
+    final ActorFuture<@Nullable RoutingState> routingState;
+    if (updateRoutingState.routingState().isPresent()) {
+      routingState =
+          CompletableActorFuture.<@Nullable RoutingState>completed(
+              updateRoutingState.routingState().get());
+    } else {
+      routingState = executor.getRoutingState();
+    }
 
     return routingState.thenApply(
         state -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/EnterRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/EnterRecoveryApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -46,7 +48,8 @@ public final class EnterRecoveryApplier implements PartitionGroupConfigurationCh
       final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
     final boolean localMemberIsActiveInCluster =
         currentGlobalConfiguration.hasMember(memberId)
-            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+            && requireNonNull(currentGlobalConfiguration.getMember(memberId)).state()
+                == BrokerState.State.ACTIVE;
     if (!localMemberIsActiveInCluster) {
       return Either.left(
           new IllegalStateException(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/ExitRecoveryApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -41,7 +43,8 @@ public final class ExitRecoveryApplier implements PartitionGroupConfigurationCha
       final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
     final boolean localMemberIsActiveInCluster =
         currentGlobalConfiguration.hasMember(memberId)
-            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+            && requireNonNull(currentGlobalConfiguration.getMember(memberId)).state()
+                == BrokerState.State.ACTIVE;
     if (!localMemberIsActiveInCluster) {
       return Either.left(
           new IllegalStateException(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberJoinApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
@@ -47,7 +49,8 @@ public final class MemberJoinApplier implements GlobalConfigurationChangeApplier
       final CurrentClusterConfiguration currentClusterConfiguration) {
     final var currentGlobalConfiguration = currentClusterConfiguration.globalConfiguration();
     if (currentGlobalConfiguration.hasMember(memberId)) {
-      final var currentState = currentGlobalConfiguration.getMember(memberId).state();
+      final var currentState =
+          requireNonNull(currentGlobalConfiguration.getMember(memberId)).state();
       if (currentState != State.JOINING) {
         return Either.left(
             new IllegalStateException(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberLeaveApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
@@ -55,7 +57,7 @@ public final class MemberLeaveApplier implements GlobalConfigurationChangeApplie
                   .formatted(memberId)));
     }
 
-    if (globalConfiguration.getMember(memberId).state() == State.LEFT) {
+    if (requireNonNull(globalConfiguration.getMember(memberId)).state() == State.LEFT) {
       return Either.left(
           new IllegalStateException(
               "Expected to remove member %s, but the member is already in state LEFT"

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionBootstrapApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionBootstrapApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -25,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * New-model applier for {@code
@@ -47,7 +50,7 @@ public final class PartitionBootstrapApplier implements PartitionGroupConfigurat
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final Optional<DynamicPartitionConfig> config;
   private final boolean initializeFromSnapshot;
-  private DynamicPartitionConfig partitionConfig;
+  private @Nullable DynamicPartitionConfig partitionConfig;
 
   public PartitionBootstrapApplier(
       final PartitionBootstrapOperation operation,
@@ -74,7 +77,8 @@ public final class PartitionBootstrapApplier implements PartitionGroupConfigurat
 
     final boolean localMemberIsActiveInCluster =
         currentGlobalConfiguration.hasMember(memberId)
-            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+            && requireNonNull(currentGlobalConfiguration.getMember(memberId)).state()
+                == BrokerState.State.ACTIVE;
     if (!localMemberIsActiveInCluster) {
       return Either.left(
           new IllegalStateException(
@@ -119,7 +123,7 @@ public final class PartitionBootstrapApplier implements PartitionGroupConfigurat
     final CompletableActorFuture<UnaryOperator<PartitionGroupConfiguration>> result =
         new CompletableActorFuture<>();
     partitionChangeExecutor
-        .bootstrap(partitionId, priority, partitionConfig, initializeFromSnapshot)
+        .bootstrap(partitionId, priority, requireNonNull(partitionConfig), initializeFromSnapshot)
         .onComplete(
             (ignore, error) -> {
               if (error == null) {
@@ -171,7 +175,8 @@ public final class PartitionBootstrapApplier implements PartitionGroupConfigurat
     final var member = currentPartitionGroupConfiguration.getMember(memberId);
     return member != null
         && member.hasPartition(partitionId)
-        && member.getPartition(partitionId).state() == PartitionState.State.BOOTSTRAPPING;
+        && requireNonNull(member.getPartition(partitionId)).state()
+            == PartitionState.State.BOOTSTRAPPING;
   }
 
   private boolean partitionExists(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDeleteExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDeleteExporterApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
 import static io.camunda.zeebe.dynamic.config.state.ExporterState.State.CONFIG_NOT_FOUND;
+import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
@@ -64,7 +65,7 @@ public final class PartitionDeleteExporterApplier
                   .formatted(memberId, partitionId)));
     }
 
-    final var exporters = localPartition.config().exporting().exporters();
+    final var exporters = requireNonNull(localPartition.config().exporting()).exporters();
     final var exporterState = exporters.get(exporterId);
     if (exporterState == null) {
       return Either.left(
@@ -101,6 +102,7 @@ public final class PartitionDeleteExporterApplier
   }
 
   private DynamicPartitionConfig deleteExporter(final DynamicPartitionConfig config) {
-    return config.updateExporting(exporting -> exporting.deleteExporter(exporterId));
+    return config.updateExporting(
+        exporting -> requireNonNull(exporting).deleteExporter(exporterId));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDisableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionDisableExporterApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -64,7 +66,7 @@ public final class PartitionDisableExporterApplier
     }
 
     final var partitionHasExporter =
-        localPartition.config().exporting().exporters().containsKey(exporterId);
+        requireNonNull(localPartition.config().exporting()).exporters().containsKey(exporterId);
     if (!partitionHasExporter) {
       return Either.left(
           new IllegalStateException(
@@ -102,6 +104,7 @@ public final class PartitionDisableExporterApplier
   }
 
   private DynamicPartitionConfig disableExporter(final DynamicPartitionConfig config) {
-    return config.updateExporting(exporting -> exporting.disableExporter(exporterId));
+    return config.updateExporting(
+        exporting -> requireNonNull(exporting).disableExporter(exporterId));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionEnableExporterApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -70,7 +72,8 @@ public final class PartitionEnableExporterApplier
                   .formatted(memberId, partitionId)));
     }
 
-    final var exportersInPartition = localPartition.config().exporting().exporters();
+    final var exportersInPartition =
+        requireNonNull(localPartition.config().exporting()).exporters();
 
     if (initializeFrom.isPresent()) {
       final String otherExporterId = initializeFrom.orElseThrow();
@@ -81,7 +84,7 @@ public final class PartitionEnableExporterApplier
                 "Expected to enable exporter and initialize from exporter '%s', but the partition '%s' does not have exporter '%s'"
                     .formatted(otherExporterId, partitionId, otherExporterId)));
       } else {
-        final var otherExporter = exportersInPartition.get(otherExporterId);
+        final var otherExporter = requireNonNull(exportersInPartition.get(otherExporterId));
         if (otherExporter.state() == State.DISABLED) {
           return Either.left(
               new IllegalStateException(
@@ -93,7 +96,8 @@ public final class PartitionEnableExporterApplier
 
     final var partitionHasExporter = exportersInPartition.containsKey(exporterId);
 
-    if (partitionHasExporter && exportersInPartition.get(exporterId).state() == State.ENABLED) {
+    if (partitionHasExporter
+        && requireNonNull(exportersInPartition.get(exporterId)).state() == State.ENABLED) {
       return Either.left(
           new IllegalStateException(
               "Expected to enable exporter, but the exporter '%s' is already enabled"
@@ -105,7 +109,8 @@ public final class PartitionEnableExporterApplier
       // whether the runtime state has the latest state. This is useful when the operation is
       // retried or if there was restart without a snapshot after a sequence of disable, enable
       // operations.
-      metadataVersionToUpdate = exportersInPartition.get(exporterId).metadataVersion() + 1;
+      metadataVersionToUpdate =
+          requireNonNull(exportersInPartition.get(exporterId)).metadataVersion() + 1;
     } else {
       metadataVersionToUpdate = 1;
     }
@@ -145,7 +150,8 @@ public final class PartitionEnableExporterApplier
             initializeFrom
                 .map(
                     otherExporterId ->
-                        c.enableExporter(exporterId, otherExporterId, metadataVersionToUpdate))
-                .orElse(c.enableExporter(exporterId, metadataVersionToUpdate)));
+                        requireNonNull(c)
+                            .enableExporter(exporterId, otherExporterId, metadataVersionToUpdate))
+                .orElse(requireNonNull(c).enableExporter(exporterId, metadataVersionToUpdate)));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionForceReconfigureApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionForceReconfigureApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -68,7 +70,8 @@ public final class PartitionForceReconfigureApplier
     for (final MemberId member : members) {
       final boolean memberIsActive =
           currentGlobalConfiguration.hasMember(member)
-              && currentGlobalConfiguration.getMember(member).state() == BrokerState.State.ACTIVE;
+              && requireNonNull(currentGlobalConfiguration.getMember(member)).state()
+                  == BrokerState.State.ACTIVE;
       if (!memberIsActive) {
         return Either.left(
             new IllegalStateException(
@@ -110,7 +113,8 @@ public final class PartitionForceReconfigureApplier
     // remove this partition from the state of non-members
     var updatedGroup = group;
     for (final var member : group.members().keySet()) {
-      if (!members.contains(member) && group.getMember(member).hasPartition(partitionId)) {
+      if (!members.contains(member)
+          && requireNonNull(group.getMember(member)).hasPartition(partitionId)) {
         updatedGroup =
             updatedGroup.updateMember(member, broker -> broker.removePartition(partitionId));
       }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionJoinApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -23,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * New-model applier for {@code
@@ -46,8 +49,8 @@ public final class PartitionJoinApplier implements PartitionGroupConfigurationCh
   private final int priority;
   private final PartitionChangeExecutor partitionChangeExecutor;
 
-  private Map<MemberId, Integer> partitionMembersWithPriority;
-  private DynamicPartitionConfig partitionConfig;
+  private @Nullable Map<MemberId, Integer> partitionMembersWithPriority;
+  private @Nullable DynamicPartitionConfig partitionConfig;
 
   public PartitionJoinApplier(
       final MemberId memberId,
@@ -67,7 +70,8 @@ public final class PartitionJoinApplier implements PartitionGroupConfigurationCh
 
     final boolean localMemberIsActiveInCluster =
         currentGlobalConfiguration.hasMember(memberId)
-            && currentGlobalConfiguration.getMember(memberId).state() == BrokerState.State.ACTIVE;
+            && requireNonNull(currentGlobalConfiguration.getMember(memberId)).state()
+                == BrokerState.State.ACTIVE;
     if (!localMemberIsActiveInCluster) {
       return Either.left(
           new IllegalStateException(
@@ -126,7 +130,10 @@ public final class PartitionJoinApplier implements PartitionGroupConfigurationCh
         new CompletableActorFuture<>();
 
     partitionChangeExecutor
-        .join(partitionId, partitionMembersWithPriority, partitionConfig)
+        .join(
+            partitionId,
+            requireNonNull(partitionMembersWithPriority),
+            requireNonNull(partitionConfig))
         .onComplete(
             (ignored, error) -> {
               if (error == null) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionReconfigurePriorityApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/PartitionReconfigurePriorityApplier.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
@@ -50,7 +52,7 @@ public final class PartitionReconfigurePriorityApplier
       final PartitionGroupConfiguration currentPartitionGroupConfiguration) {
     final boolean localMemberIsActiveInCluster =
         currentGlobalConfiguration.hasMember(localMemberId)
-            && currentGlobalConfiguration.getMember(localMemberId).state()
+            && requireNonNull(currentGlobalConfiguration.getMember(localMemberId)).state()
                 == BrokerState.State.ACTIVE;
     if (!localMemberIsActiveInCluster) {
       return Either.left(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateRoutingStateApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/UpdateRoutingStateApplier.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * New-model applier for {@code PartitionGroupOperation.UpdateRoutingState}, operating on a single
@@ -43,10 +44,14 @@ public final class UpdateRoutingStateApplier implements PartitionGroupConfigurat
 
   @Override
   public ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply() {
-    final var routingState =
-        updateRoutingState.routingState().isPresent()
-            ? CompletableActorFuture.completed(updateRoutingState.routingState().get())
-            : executor.getRoutingState();
+    final ActorFuture<@Nullable RoutingState> routingState;
+    if (updateRoutingState.routingState().isPresent()) {
+      routingState =
+          CompletableActorFuture.<@Nullable RoutingState>completed(
+              updateRoutingState.routingState().get());
+    } else {
+      routingState = executor.getRoutingState();
+    }
 
     return routingState.thenApply(
         state -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.changes.appliers;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.changes;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossipState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossipState.java
@@ -9,12 +9,13 @@ package io.camunda.zeebe.dynamic.config.gossip;
 
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 
 public final class ClusterConfigurationGossipState {
   // TODO: This should also tracks the BrokerInfo which is currently in SWIM member.properties
-  private ClusterConfiguration clusterConfiguration;
+  private @Nullable ClusterConfiguration clusterConfiguration;
 
-  public ClusterConfiguration getClusterConfiguration() {
+  public @Nullable ClusterConfiguration getClusterConfiguration() {
     return clusterConfiguration;
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.gossip;
 
+import static io.camunda.zeebe.util.Unit.unit;
+
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEvent.Type;
 import io.atomix.cluster.ClusterMembershipEventListener;
@@ -78,7 +80,7 @@ public final class ClusterConfigurationGossiper
     executor.run(
         () -> {
           internalStart();
-          startedFuture.complete(null);
+          startedFuture.complete(unit());
         });
     return startedFuture;
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,8 +213,9 @@ public final class ClusterConfigurationGossiper
         });
   }
 
-  public ActorFuture<ClusterConfiguration> queryClusterConfiguration(final MemberId memberId) {
-    final ActorFuture<ClusterConfiguration> responseFuture = executor.createFuture();
+  public ActorFuture<@Nullable ClusterConfiguration> queryClusterConfiguration(
+      final MemberId memberId) {
+    final ActorFuture<@Nullable ClusterConfiguration> responseFuture = executor.createFuture();
     sendSyncRequest(memberId)
         .whenCompleteAsync(
             (response, error) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.gossip;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.metrics;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.serializer;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
 import io.atomix.cluster.MemberId;
@@ -341,7 +343,7 @@ public class ProtoBufSerializer
 
   private PartitionConfig encodePartitionConfig(final DynamicPartitionConfig config) {
     return PartitionConfig.newBuilder()
-        .setExporting(encodeExportingConfig(config.exporting()))
+        .setExporting(encodeExportingConfig(requireNonNull(config.exporting())))
         .build();
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.serializer;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionState.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableSortedMap;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.SortedMap;
 import java.util.function.UnaryOperator;
 import org.jspecify.annotations.NullMarked;
@@ -50,8 +51,8 @@ public record BrokerPartitionState(
     long version, Instant lastUpdated, SortedMap<Integer, PartitionState> partitions, Mode mode) {
 
   public BrokerPartitionState {
-    Objects.requireNonNull(mode, "mode must not be null");
-    Objects.requireNonNull(lastUpdated, "lastUpdated must not be null");
+    requireNonNull(mode, "mode must not be null");
+    requireNonNull(lastUpdated, "lastUpdated must not be null");
     partitions = ImmutableSortedMap.copyOf(partitions);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerState.java
@@ -7,8 +7,9 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.Instant;
-import java.util.Objects;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -35,8 +36,8 @@ import org.jspecify.annotations.Nullable;
 public record BrokerState(long version, Instant lastUpdated, State state) {
 
   public BrokerState {
-    Objects.requireNonNull(lastUpdated, "lastUpdated must not be null");
-    Objects.requireNonNull(state, "state must not be null");
+    requireNonNull(lastUpdated, "lastUpdated must not be null");
+    requireNonNull(state, "state must not be null");
   }
 
   /** Creates an initial state at version {@code 0} in {@link State#ACTIVE}. */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
@@ -80,12 +82,12 @@ public record ClusterConfiguration(
           String.format("Version must be >= %d", UNINITIALIZED_VERSION));
     }
 
-    Objects.requireNonNull(members);
-    Objects.requireNonNull(lastChange);
-    Objects.requireNonNull(pendingChanges);
-    Objects.requireNonNull(routingState);
-    Objects.requireNonNull(clusterId);
-    Objects.requireNonNull(partitionDistributorConfig);
+    requireNonNull(members);
+    requireNonNull(lastChange);
+    requireNonNull(pendingChanges);
+    requireNonNull(routingState);
+    requireNonNull(clusterId);
+    requireNonNull(partitionDistributorConfig);
     if (incarnationNumber < 0) {
       throw new IllegalArgumentException("Incarnation number must be >= 0");
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -28,6 +28,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the cluster configuration which describes the current active, joining or leaving
@@ -187,7 +188,7 @@ public record ClusterConfiguration(
    * @return the updated ClusterConfiguration
    */
   public ClusterConfiguration updateMember(
-      final MemberId memberId, final UnaryOperator<MemberState> memberStateUpdater) {
+      final MemberId memberId, final UnaryOperator<@Nullable MemberState> memberStateUpdater) {
     final MemberState currentState = members.get(memberId);
     final var updateMemberState = memberStateUpdater.apply(currentState);
 
@@ -424,7 +425,7 @@ public record ClusterConfiguration(
     return members().containsKey(memberId);
   }
 
-  public MemberState getMember(final MemberId memberId) {
+  public @Nullable MemberState getMember(final MemberId memberId) {
     return members().get(memberId);
   }
 
@@ -490,8 +491,8 @@ public record ClusterConfiguration(
         .max(
             (e1, e2) ->
                 Integer.compare(
-                    e1.getValue().getPartition(partitionId).priority(),
-                    e2.getValue().getPartition(partitionId).priority()))
+                    requireNonNull(e1.getValue().getPartition(partitionId)).priority(),
+                    requireNonNull(e2.getValue().getPartition(partitionId)).priority()))
         .map(Entry::getKey);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
@@ -16,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -51,9 +52,9 @@ public record CurrentClusterConfiguration(
   public static final String DEFAULT_GROUP = "default";
 
   public CurrentClusterConfiguration {
-    Objects.requireNonNull(globalConfiguration, "globalConfiguration must not be null");
-    Objects.requireNonNull(partitionGroups, "partitionGroups must not be null");
-    Objects.requireNonNull(phasedChangeState, "phasedChangeState must not be null");
+    requireNonNull(globalConfiguration, "globalConfiguration must not be null");
+    requireNonNull(partitionGroups, "partitionGroups must not be null");
+    requireNonNull(phasedChangeState, "phasedChangeState must not be null");
     partitionGroups = Map.copyOf(partitionGroups);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -8,9 +8,10 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /** Represents configuration of a partition that can be updated during runtime. */
-public record DynamicPartitionConfig(ExportingConfig exporting) {
+public record DynamicPartitionConfig(@Nullable ExportingConfig exporting) {
 
   public static DynamicPartitionConfig uninitialized() {
     return new DynamicPartitionConfig(null);
@@ -29,7 +30,7 @@ public record DynamicPartitionConfig(ExportingConfig exporting) {
   }
 
   public DynamicPartitionConfig updateExporting(
-      final UnaryOperator<ExportingConfig> exportingUpdater) {
+      final UnaryOperator<@Nullable ExportingConfig> exportingUpdater) {
     return new DynamicPartitionConfig(exportingUpdater.apply(exporting));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
@@ -28,8 +30,8 @@ public record ExportingConfig(ExportingState state, SortedMap<String, ExporterSt
   }
 
   public ExportingConfig {
-    Objects.requireNonNull(state);
-    Objects.requireNonNull(exporters);
+    requireNonNull(state);
+    requireNonNull(exporters);
   }
 
   public static ExportingConfig init() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportingConfig.java
@@ -14,9 +14,9 @@ import com.google.common.collect.ImmutableSortedMap;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents configuration or state of exporting in a partition that can be updated during runtime.
@@ -49,12 +49,11 @@ public record ExportingConfig(ExportingState state, SortedMap<String, ExporterSt
   }
 
   public ExportingConfig disableExporter(final String exporterName) {
+    final var exporter = requireNonNull(exporters.get(exporterName));
     return updateExporter(
         exporterName,
         new ExporterState(
-            exporters.get(exporterName).metadataVersion(),
-            ExporterState.State.DISABLED,
-            Optional.empty()));
+            exporter.metadataVersion(), ExporterState.State.DISABLED, Optional.empty()));
   }
 
   public ExportingConfig deleteExporter(final String exporterName) {
@@ -69,13 +68,13 @@ public record ExportingConfig(ExportingState state, SortedMap<String, ExporterSt
     final var builder = ImmutableMap.<String, ExporterState>builder().putAll(exporters);
 
     exporterNames.forEach(
-        exporterName ->
-            builder.put(
-                exporterName,
-                new ExporterState(
-                    exporters.get(exporterName).metadataVersion(),
-                    ExporterState.State.DISABLED,
-                    Optional.empty())));
+        exporterName -> {
+          final var exporter = requireNonNull(exporters.get(exporterName));
+          builder.put(
+              exporterName,
+              new ExporterState(
+                  exporter.metadataVersion(), ExporterState.State.DISABLED, Optional.empty()));
+        });
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys
@@ -87,7 +86,9 @@ public record ExportingConfig(ExportingState state, SortedMap<String, ExporterSt
   }
 
   public ExportingConfig enableExporter(
-      final String exporterName, final String initializeFrom, final long metadataVersion) {
+      final String exporterName,
+      final @Nullable String initializeFrom,
+      final long metadataVersion) {
     return updateExporter(
         exporterName,
         new ExporterState(metadataVersion, State.ENABLED, Optional.ofNullable(initializeFrom)));
@@ -123,13 +124,15 @@ public record ExportingConfig(ExportingState state, SortedMap<String, ExporterSt
     final var builder = ImmutableMap.<String, ExporterState>builder().putAll(exporters);
 
     exporterNames.forEach(
-        exporterName ->
-            builder.put(
-                exporterName,
-                new ExporterState(
-                    exporters.get(exporterName).metadataVersion(),
-                    ExporterState.State.CONFIG_NOT_FOUND,
-                    exporters.get(exporterName).initializedFrom())));
+        exporterName -> {
+          final var exporter = requireNonNull(exporters.get(exporterName));
+          builder.put(
+              exporterName,
+              new ExporterState(
+                  exporter.metadataVersion(),
+                  ExporterState.State.CONFIG_NOT_FOUND,
+                  exporter.initializedFrom()));
+        });
 
     final var newExporters =
         builder.buildKeepingLast(); // choose last one if there are duplicate keys

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.function.UnaryOperator;
@@ -61,8 +60,7 @@ public record GlobalConfiguration(
   public GlobalConfiguration {
     requireNonNull(clusterId, "clusterId must not be null");
     requireNonNull(members, "members must not be null");
-    requireNonNull(
-        partitionDistributorConfig, "partitionDistributorConfig must not be null");
+    requireNonNull(partitionDistributorConfig, "partitionDistributorConfig must not be null");
     requireNonNull(pendingChanges, "pendingChanges must not be null");
     requireNonNull(lastChange, "lastChange must not be null");
     members = ImmutableSortedMap.copyOf(members);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
 import java.util.HashMap;
@@ -57,12 +59,12 @@ public record GlobalConfiguration(
   public static final long INITIAL_VERSION = 1;
 
   public GlobalConfiguration {
-    Objects.requireNonNull(clusterId, "clusterId must not be null");
-    Objects.requireNonNull(members, "members must not be null");
-    Objects.requireNonNull(
+    requireNonNull(clusterId, "clusterId must not be null");
+    requireNonNull(members, "members must not be null");
+    requireNonNull(
         partitionDistributorConfig, "partitionDistributorConfig must not be null");
-    Objects.requireNonNull(pendingChanges, "pendingChanges must not be null");
-    Objects.requireNonNull(lastChange, "lastChange must not be null");
+    requireNonNull(pendingChanges, "pendingChanges must not be null");
+    requireNonNull(lastChange, "lastChange must not be null");
     members = ImmutableSortedMap.copyOf(members);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/MemberState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/MemberState.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import java.time.Instant;
@@ -15,6 +17,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the state of a member in the cluster.
@@ -180,7 +183,10 @@ public record MemberState(
                 entry -> {
                   final Integer partitionId = entry.getKey();
                   final PartitionState partitionState = entry.getValue();
-                  final var otherPartitionState = other.partitions().get(partitionId);
+                  final var otherPartitionState =
+                      requireNonNull(
+                          other.partitions().get(partitionId),
+                          "Expected both member states to contain the same partition");
                   if (!partitionState.config().isInitialized()) {
                     return Map.entry(
                         partitionId, partitionState.updateConfig(otherPartitionState.config()));
@@ -236,7 +242,7 @@ public record MemberState(
     return partitions().containsKey(partitionId);
   }
 
-  public PartitionState getPartition(final int partitionId) {
+  public @Nullable PartitionState getPartition(final int partitionId) {
     return partitions.get(partitionId);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -7,13 +7,14 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.function.UnaryOperator;
@@ -58,10 +59,10 @@ public record PartitionGroupConfiguration(
   public static final long INITIAL_INCARNATION_NUMBER = 0;
 
   public PartitionGroupConfiguration {
-    Objects.requireNonNull(members, "members must not be null");
-    Objects.requireNonNull(routingState, "routingState must not be null");
-    Objects.requireNonNull(pendingChanges, "pendingChanges must not be null");
-    Objects.requireNonNull(lastChange, "lastChange must not be null");
+    requireNonNull(members, "members must not be null");
+    requireNonNull(routingState, "routingState must not be null");
+    requireNonNull(pendingChanges, "pendingChanges must not be null");
+    requireNonNull(lastChange, "lastChange must not be null");
     if (incarnationNumber < 0) {
       throw new IllegalArgumentException("Incarnation number must be >= 0");
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableSortedSet;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.protocol.Protocol;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -29,8 +30,8 @@ import java.util.stream.IntStream;
 public record RoutingState(
     long version, RequestHandling requestHandling, MessageCorrelation messageCorrelation) {
   public RoutingState {
-    Objects.requireNonNull(requestHandling);
-    Objects.requireNonNull(messageCorrelation);
+    requireNonNull(requestHandling);
+    requireNonNull(messageCorrelation);
 
     if (version < 0) {
       throw new IllegalArgumentException("Version must be positive");
@@ -137,8 +138,8 @@ public record RoutingState(
       }
 
       public ActivePartitions {
-        Objects.requireNonNull(additionalActivePartitions);
-        Objects.requireNonNull(inactivePartitions);
+        requireNonNull(additionalActivePartitions);
+        requireNonNull(inactivePartitions);
         validatePartitionCount(basePartitionCount);
 
         for (final int activePartition : additionalActivePartitions) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.state;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.Sets;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
@@ -85,7 +87,7 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
               partitionId,
               Set.copyOf(membersForPartition),
               priorities,
-              priorities.get(primary),
+              requireNonNull(priorities.get(primary)),
               primary));
     }
     return metadata;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/package-info.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/package-info.java
@@ -5,16 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+@NullMarked
+package io.camunda.zeebe.dynamic.config.util;
 
-import org.jspecify.annotations.Nullable;
-
-public record ErrorResponse(ErrorCode code, @Nullable String message) {
-
-  public enum ErrorCode {
-    INVALID_REQUEST,
-    OPERATION_NOT_ALLOWED,
-    CONCURRENT_MODIFICATION,
-    INTERNAL_ERROR;
-  }
-}
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Description
Make the module `zeebe/dynamic-config` null marked. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53252
