### PR TITLE
feat: add Operate InstanceHeader and small shared primitives

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
@@ -32,6 +32,10 @@ const config: KnipConfig = {
 		'src/operate/shared/FiltersPanel/**',
 		// TODO(#55642): remove when BatchOperation detail page is migrated
 		'src/operate/shared/PaginatedSortableTable/**',
+		// TODO(#56029, #56026): remove when Process Instance / Decision Instance shells are migrated
+		'src/operate/shared/InstanceHeader/**',
+		'src/operate/shared/CopyButton/**',
+		'src/operate/shared/VisuallyHiddenH1/**',
 	],
 	ignoreDependencies: ['@vitest/browser'],
 	typescript: {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.test.tsx
@@ -93,4 +93,28 @@ describe('<CopyButton />', () => {
 		await vi.advanceTimersByTimeAsync(5000);
 		await expect.element(screen.getByText('Copy')).toBeVisible();
 	});
+
+	it('should stay in the copy state when the clipboard write is rejected', async () => {
+		mockWriteText.mockRejectedValue(new Error('permission denied'));
+
+		const screen = await render(<CopyButton value="hello world" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+
+		await expect.element(screen.getByText('Copy')).toBeVisible();
+	});
+
+	it('should not throw when the clipboard API is unavailable', async () => {
+		Object.defineProperty(navigator, 'clipboard', {
+			value: undefined,
+			configurable: true,
+			writable: true,
+		});
+
+		const screen = await render(<CopyButton value="hello world" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+
+		await expect.element(screen.getByText('Copy')).toBeVisible();
+	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.test.tsx
@@ -36,13 +36,13 @@ describe('<CopyButton />', () => {
 	it('should render the copy button with default label and icon', async () => {
 		const screen = await render(<CopyButton value="some-value" />);
 
-		await expect.element(screen.getByRole('button', {name: 'Copy'})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Copy', exact: true})).toBeVisible();
 	});
 
 	it('should copy the value to clipboard when clicked', async () => {
 		const screen = await render(<CopyButton value="hello world" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 
 		expect(mockWriteText).toHaveBeenCalledWith('hello world');
 	});
@@ -50,7 +50,7 @@ describe('<CopyButton />', () => {
 	it('should show copied feedback after clicking', async () => {
 		const screen = await render(<CopyButton value="hello world" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 
 		await expect.element(screen.getByRole('button', {name: 'Copied'})).toBeVisible();
 	});
@@ -60,38 +60,38 @@ describe('<CopyButton />', () => {
 
 		const screen = await render(<CopyButton value="hello world" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 		await expect.element(screen.getByText('Copied')).toBeVisible();
 
 		await vi.advanceTimersByTimeAsync(5000);
 
-		await expect.element(screen.getByText('Copy')).toBeVisible();
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
 	});
 
 	it('should reset copied state when value prop changes', async () => {
 		const screen = await render(<CopyButton value="first" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 		await expect.element(screen.getByText('Copied')).toBeVisible();
 
 		await screen.rerender(<CopyButton value="second" />);
 
-		await expect.element(screen.getByText('Copy')).toBeVisible();
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
 	});
 
 	it('should cancel the feedback timeout when the value changes mid-countdown', async () => {
 		const screen = await render(<CopyButton value="first" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 		await expect.element(screen.getByText('Copied')).toBeVisible();
 
 		vi.useFakeTimers({shouldAdvanceTime: true});
 
 		await screen.rerender(<CopyButton value="second" />);
-		await expect.element(screen.getByText('Copy')).toBeVisible();
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
 
 		await vi.advanceTimersByTimeAsync(5000);
-		await expect.element(screen.getByText('Copy')).toBeVisible();
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
 	});
 
 	it('should stay in the copy state when the clipboard write is rejected', async () => {
@@ -99,9 +99,9 @@ describe('<CopyButton />', () => {
 
 		const screen = await render(<CopyButton value="hello world" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 
-		await expect.element(screen.getByText('Copy')).toBeVisible();
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
 	});
 
 	it('should not throw when the clipboard API is unavailable', async () => {
@@ -113,8 +113,29 @@ describe('<CopyButton />', () => {
 
 		const screen = await render(<CopyButton value="hello world" />);
 
-		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
 
-		await expect.element(screen.getByText('Copy')).toBeVisible();
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
+	});
+
+	it('should not show copied feedback for a stale write that resolves after the value changed', async () => {
+		let resolveWrite: () => void = () => {};
+		mockWriteText.mockImplementation(() => new Promise<void>((resolve) => (resolveWrite = resolve)));
+
+		const screen = await render(<CopyButton value="first" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy', exact: true}).element());
+
+		await screen.rerender(<CopyButton value="second" />);
+		await expect.element(screen.getByText('Copy', {exact: true})).toBeVisible();
+
+		resolveWrite();
+		// Flush past the stale write's .then() without advancing any timer, so a regression
+		// shows 'Copied' here instead of being masked by COPY_FEEDBACK_TIMEOUT_MS coincidentally
+		// elapsing during a longer, retrying assertion.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(screen.getByText('Copy', {exact: true}).elements()).toHaveLength(1);
+		expect(screen.getByText('Copied', {exact: true}).elements()).toHaveLength(0);
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {userEvent} from 'vitest/browser';
+import {CopyButton} from './CopyButton';
+
+describe('<CopyButton />', () => {
+	const mockWriteText = vi.fn();
+
+	beforeEach(() => {
+		mockWriteText.mockResolvedValue(undefined);
+		Object.defineProperty(navigator, 'clipboard', {
+			value: {writeText: mockWriteText},
+			configurable: true,
+			writable: true,
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.clearAllMocks();
+		Object.defineProperty(navigator, 'clipboard', {
+			value: undefined,
+			configurable: true,
+			writable: true,
+		});
+	});
+
+	it('should render the copy button with default label and icon', async () => {
+		const screen = await render(<CopyButton value="some-value" />);
+
+		await expect.element(screen.getByRole('button', {name: 'Copy'})).toBeVisible();
+	});
+
+	it('should copy the value to clipboard when clicked', async () => {
+		const screen = await render(<CopyButton value="hello world" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+
+		expect(mockWriteText).toHaveBeenCalledWith('hello world');
+	});
+
+	it('should show copied feedback after clicking', async () => {
+		const screen = await render(<CopyButton value="hello world" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+
+		await expect.element(screen.getByRole('button', {name: 'Copied'})).toBeVisible();
+	});
+
+	it('should reset to copy state after the feedback timeout', async () => {
+		vi.useFakeTimers({shouldAdvanceTime: true});
+
+		const screen = await render(<CopyButton value="hello world" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await expect.element(screen.getByText('Copied')).toBeVisible();
+
+		await vi.advanceTimersByTimeAsync(5000);
+
+		await expect.element(screen.getByText('Copy')).toBeVisible();
+	});
+
+	it('should reset copied state when value prop changes', async () => {
+		const screen = await render(<CopyButton value="first" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await expect.element(screen.getByText('Copied')).toBeVisible();
+
+		await screen.rerender(<CopyButton value="second" />);
+
+		await expect.element(screen.getByText('Copy')).toBeVisible();
+	});
+
+	it('should cancel the feedback timeout when the value changes mid-countdown', async () => {
+		const screen = await render(<CopyButton value="first" />);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Copy'}).element());
+		await expect.element(screen.getByText('Copied')).toBeVisible();
+
+		vi.useFakeTimers({shouldAdvanceTime: true});
+
+		await screen.rerender(<CopyButton value="second" />);
+		await expect.element(screen.getByText('Copy')).toBeVisible();
+
+		await vi.advanceTimersByTimeAsync(5000);
+		await expect.element(screen.getByText('Copy')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
@@ -23,6 +23,7 @@ const CopyButton: React.FC<Props> = ({value, hasIconOnly, tooltipAlignment}) => 
 	const {t} = useTranslation();
 	const [isCopied, setIsCopied] = useState(false);
 	const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const latestValueRef = useRef(value);
 
 	function resetTimeout() {
 		if (copyTimeoutRef.current !== null) {
@@ -38,6 +39,7 @@ const CopyButton: React.FC<Props> = ({value, hasIconOnly, tooltipAlignment}) => 
 	}, []);
 
 	useEffect(() => {
+		latestValueRef.current = value;
 		// eslint-disable-next-line react-hooks/set-state-in-effect
 		setIsCopied(false);
 		resetTimeout();
@@ -48,9 +50,15 @@ const CopyButton: React.FC<Props> = ({value, hasIconOnly, tooltipAlignment}) => 
 			return;
 		}
 
+		const copiedValue = value;
+
 		navigator.clipboard
-			.writeText(value)
+			.writeText(copiedValue)
 			.then(() => {
+				if (latestValueRef.current !== copiedValue) {
+					return;
+				}
+
 				setIsCopied(true);
 				if (copyTimeoutRef.current !== null) {
 					clearTimeout(copyTimeoutRef.current);

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
@@ -44,15 +44,24 @@ const CopyButton: React.FC<Props> = ({value, hasIconOnly, tooltipAlignment}) => 
 	}, [value]);
 
 	const handleCopy = useCallback(() => {
-		navigator.clipboard.writeText(value).then(() => {
-			setIsCopied(true);
-			if (copyTimeoutRef.current !== null) {
-				clearTimeout(copyTimeoutRef.current);
-			}
-			copyTimeoutRef.current = setTimeout(() => {
-				setIsCopied(false);
-			}, COPY_FEEDBACK_TIMEOUT_MS);
-		});
+		if (navigator.clipboard === undefined) {
+			return;
+		}
+
+		navigator.clipboard
+			.writeText(value)
+			.then(() => {
+				setIsCopied(true);
+				if (copyTimeoutRef.current !== null) {
+					clearTimeout(copyTimeoutRef.current);
+				}
+				copyTimeoutRef.current = setTimeout(() => {
+					setIsCopied(false);
+				}, COPY_FEEDBACK_TIMEOUT_MS);
+			})
+			.catch(() => {
+				// Clipboard write blocked (insecure context, missing permission) — silently ignore
+			});
 	}, [value]);
 
 	return (

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
@@ -68,7 +68,7 @@ const CopyButton: React.FC<Props> = ({value, hasIconOnly, tooltipAlignment}) => 
 				}, COPY_FEEDBACK_TIMEOUT_MS);
 			})
 			.catch(() => {
-				// Clipboard write blocked (insecure context, missing permission) — silently ignore
+				// Clipboard write blocked (insecure context, missing permission), silently ignore
 			});
 	}, [value]);
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CopyButton/CopyButton.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Checkmark, Copy} from '@carbon/react/icons';
+import {Button, type ButtonBaseProps} from '@carbon/react';
+
+type Props = {
+	value: string;
+	hasIconOnly?: ButtonBaseProps['hasIconOnly'];
+	tooltipAlignment?: ButtonBaseProps['tooltipAlignment'];
+};
+
+const COPY_FEEDBACK_TIMEOUT_MS = 5000;
+
+const CopyButton: React.FC<Props> = ({value, hasIconOnly, tooltipAlignment}) => {
+	const {t} = useTranslation();
+	const [isCopied, setIsCopied] = useState(false);
+	const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	function resetTimeout() {
+		if (copyTimeoutRef.current !== null) {
+			clearTimeout(copyTimeoutRef.current);
+			copyTimeoutRef.current = null;
+		}
+	}
+
+	useEffect(() => {
+		return () => {
+			resetTimeout();
+		};
+	}, []);
+
+	useEffect(() => {
+		// eslint-disable-next-line react-hooks/set-state-in-effect
+		setIsCopied(false);
+		resetTimeout();
+	}, [value]);
+
+	const handleCopy = useCallback(() => {
+		navigator.clipboard.writeText(value).then(() => {
+			setIsCopied(true);
+			if (copyTimeoutRef.current !== null) {
+				clearTimeout(copyTimeoutRef.current);
+			}
+			copyTimeoutRef.current = setTimeout(() => {
+				setIsCopied(false);
+			}, COPY_FEEDBACK_TIMEOUT_MS);
+		});
+	}, [value]);
+
+	return (
+		<Button
+			kind="ghost"
+			size="sm"
+			renderIcon={isCopied ? Checkmark : Copy}
+			iconDescription={
+				isCopied ? t('operate.shared.copyButton.copiedToClipboard') : t('operate.shared.copyButton.copyToClipboard')
+			}
+			hasIconOnly={hasIconOnly}
+			tooltipAlignment={tooltipAlignment}
+			onClick={handleCopy}
+		>
+			{isCopied ? t('operate.shared.copyButton.copied') : t('operate.shared.copyButton.copy')}
+		</Button>
+	);
+};
+
+export {CopyButton};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {describe, it, expect} from 'vitest';
+import {InstanceHeader} from './InstanceHeader';
+import {InstanceHeaderSkeleton} from './InstanceHeaderSkeleton';
+
+describe('<InstanceHeader />', () => {
+	it('should render the instance name, header columns and body columns', async () => {
+		const screen = await render(
+			<InstanceHeader
+				state="ACTIVE"
+				instanceName="orderProcess"
+				headerColumns={['Process Instance Key', 'Version']}
+				bodyColumns={[{title: '2251799813685467', content: '2251799813685467'}, {content: '1'}]}
+			/>,
+		);
+
+		await expect.element(screen.getByText('orderProcess')).toBeVisible();
+		await expect.element(screen.getByText('Process Instance Key')).toBeVisible();
+		await expect.element(screen.getByText('2251799813685467')).toBeVisible();
+		await expect.element(screen.getByTestId('ACTIVE-icon')).toBeVisible();
+	});
+
+	it('should show the incidents count when there is at least one incident', async () => {
+		const screen = await render(
+			<InstanceHeader
+				state="INCIDENT"
+				instanceName="orderProcess"
+				incidentsCount={3}
+				headerColumns={[]}
+				bodyColumns={[]}
+			/>,
+		);
+
+		await expect.element(screen.getByText('3 incidents')).toBeVisible();
+	});
+
+	it('should not show the incidents count when there are no incidents', async () => {
+		const screen = await render(
+			<InstanceHeader state="ACTIVE" instanceName="orderProcess" headerColumns={[]} bodyColumns={[]} />,
+		);
+
+		expect(screen.getByText(/incidents?$/).elements()).toHaveLength(0);
+	});
+
+	it('should show the name subtitle', async () => {
+		const screen = await render(
+			<InstanceHeader
+				state="ACTIVE"
+				instanceName="orderProcess"
+				nameSubtitle="Waiting"
+				headerColumns={[]}
+				bodyColumns={[]}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Waiting')).toBeVisible();
+	});
+
+	it('should skip hidden body columns', async () => {
+		const screen = await render(
+			<InstanceHeader
+				state="ACTIVE"
+				instanceName="orderProcess"
+				headerColumns={[]}
+				bodyColumns={[{content: 'hidden-content', hidden: true}]}
+			/>,
+		);
+
+		expect(screen.getByText('hidden-content').elements()).toHaveLength(0);
+	});
+
+	it('should render additional content', async () => {
+		const screen = await render(
+			<InstanceHeader
+				state="ACTIVE"
+				instanceName="orderProcess"
+				headerColumns={[]}
+				bodyColumns={[]}
+				additionalContent={<button>Cancel Instance</button>}
+			/>,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Cancel Instance'})).toBeVisible();
+	});
+});
+
+describe('<InstanceHeaderSkeleton />', () => {
+	it('should render a header column per entry', async () => {
+		const screen = await render(
+			<InstanceHeaderSkeleton
+				headerColumns={[
+					{name: 'Process Instance Key', skeletonWidth: '136px'},
+					{name: 'Version', skeletonWidth: '34px'},
+				]}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Process Instance Key')).toBeVisible();
+		await expect.element(screen.getByText('Version')).toBeVisible();
+		await expect.element(screen.getByTestId('instance-header-skeleton')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.tsx
@@ -29,7 +29,7 @@ type Column = {
 	hidden?: boolean;
 };
 
-type Props = {
+type InstanceHeaderProps = {
 	state: React.ComponentProps<typeof StateIcon>['state'];
 	instanceName: string;
 	incidentsCount?: number;
@@ -40,7 +40,7 @@ type Props = {
 	hideBottomBorder?: boolean;
 };
 
-const InstanceHeader: React.FC<Props> = ({
+const InstanceHeader: React.FC<InstanceHeaderProps> = ({
 	state,
 	headerColumns,
 	bodyColumns,
@@ -103,4 +103,4 @@ const InstanceHeader: React.FC<Props> = ({
 };
 
 export {InstanceHeader};
-export type {Column, Props};
+export type {Column, InstanceHeaderProps};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeader.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {
+	Container,
+	Table,
+	Th,
+	Td,
+	NameContainer,
+	InstanceName,
+	IncidentCount,
+	NameSubtitle,
+	SubtitleRow,
+	AdditionalContent,
+} from './styled';
+import {StateIcon} from '#/operate/shared/StateIcon/StateIcon';
+
+type Column = {
+	title?: string;
+	content: React.ReactNode;
+	dataTestId?: string;
+	hideOverflowingContent?: boolean;
+	hidden?: boolean;
+};
+
+type Props = {
+	state: React.ComponentProps<typeof StateIcon>['state'];
+	instanceName: string;
+	incidentsCount?: number;
+	nameSubtitle?: React.ReactNode;
+	headerColumns: string[];
+	bodyColumns: Column[];
+	additionalContent?: React.ReactNode;
+	hideBottomBorder?: boolean;
+};
+
+const InstanceHeader: React.FC<Props> = ({
+	state,
+	headerColumns,
+	bodyColumns,
+	instanceName,
+	incidentsCount = 0,
+	nameSubtitle,
+	additionalContent,
+	hideBottomBorder = false,
+}) => {
+	const {t} = useTranslation();
+
+	return (
+		<Container data-testid="instance-header" $hideBottomBorder={hideBottomBorder}>
+			<StateIcon state={state} size={24} />
+
+			<NameContainer title={instanceName}>
+				<InstanceName>{instanceName}</InstanceName>
+				{(incidentsCount > 0 || nameSubtitle) && (
+					<SubtitleRow>
+						{incidentsCount > 0 && (
+							<IncidentCount>
+								{t('operate.shared.instanceHeader.incidentsCount', {count: incidentsCount})}
+							</IncidentCount>
+						)}
+						{nameSubtitle && <NameSubtitle>{nameSubtitle}</NameSubtitle>}
+					</SubtitleRow>
+				)}
+			</NameContainer>
+			<Table>
+				<thead>
+					<tr>
+						{headerColumns.map((column, index) => (
+							<Th key={index}>{column}</Th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						{bodyColumns.map((column, index) => {
+							if (column.hidden) {
+								return null;
+							}
+							return (
+								<Td
+									key={index}
+									title={column.title}
+									data-testid={column.dataTestId}
+									$hideOverflowingContent={column.hideOverflowingContent}
+								>
+									{column.content}
+								</Td>
+							);
+						})}
+					</tr>
+				</tbody>
+			</Table>
+			<AdditionalContent>{additionalContent}</AdditionalContent>
+		</Container>
+	);
+};
+
+export {InstanceHeader};
+export type {Column, Props};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeaderSkeleton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/InstanceHeaderSkeleton.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Container, Table, Th, Td, SkeletonText, SkeletonIcon, NameContainer} from './styled';
+
+type Props = {
+	headerColumns: {name: string; skeletonWidth: string}[];
+};
+
+const InstanceHeaderSkeleton: React.FC<Props> = ({headerColumns}) => {
+	return (
+		<Container data-testid="instance-header-skeleton">
+			<SkeletonIcon />
+			<NameContainer>
+				<SkeletonText width="128px" />
+			</NameContainer>
+			<Table>
+				<thead>
+					<tr>
+						{headerColumns.map(({name}, index) => (
+							<Th key={index}>{name}</Th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						{headerColumns.map(({skeletonWidth}, index) => (
+							<Td key={index}>
+								<SkeletonText width={skeletonWidth} />
+							</Td>
+						))}
+					</tr>
+				</tbody>
+			</Table>
+		</Container>
+	);
+};
+
+export {InstanceHeaderSkeleton};
+export type {Props as InstanceHeaderSkeletonProps};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/InstanceHeader/styled.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {styles} from '@carbon/type';
+import {SkeletonText as BaseSkeletonText, SkeletonIcon as BaseSkeletonIcon} from '@carbon/react';
+
+const Table = styled.table`
+	table-layout: fixed;
+	border-collapse: separate;
+	border-spacing: 0 var(--cds-spacing-01);
+	color: var(--cds-text-secondary);
+
+	th:not(:first-child),
+	td:not(:first-child) {
+		padding-left: var(--cds-spacing-07);
+	}
+`;
+
+const Th = styled.th`
+	text-align: left;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	${styles.label01};
+`;
+
+type TDProps = {
+	$hideOverflowingContent?: boolean;
+};
+
+const Td = styled.td<TDProps>`
+	${({$hideOverflowingContent = true}) => {
+		return css`
+			${styles.label02};
+			${
+				$hideOverflowingContent &&
+				css`
+					text-overflow: ellipsis;
+					overflow: hidden;
+					white-space: nowrap;
+				`
+			}
+		`;
+	}}
+`;
+
+type ContainerProps = {
+	$hideBottomBorder?: boolean;
+};
+
+const Container = styled.header<ContainerProps>`
+	${({$hideBottomBorder}) => {
+		return css`
+			display: flex;
+			min-width: 0;
+			align-items: center;
+			gap: var(--cds-spacing-05);
+			background-color: var(--cds-layer-01);
+			padding: var(--cds-spacing-02) var(--cds-spacing-05);
+			border-bottom: 1px solid var(--cds-border-subtle-01);
+			${
+				$hideBottomBorder &&
+				css`
+					border-bottom: none;
+				`
+			}
+		`;
+	}}
+`;
+
+const AdditionalContent = styled.div`
+	margin-left: auto;
+	flex-shrink: 0;
+`;
+
+const NameContainer = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: var(--cds-spacing-01);
+	min-width: 0;
+	flex-shrink: 1;
+	margin-right: var(--cds-spacing-05);
+`;
+
+const InstanceName = styled.span`
+	${styles.label02};
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	color: var(--cds-text-secondary);
+
+	&:has(+ *) {
+		${styles.label01};
+	}
+`;
+
+const SubtitleRow = styled.div`
+	display: flex;
+	align-items: center;
+	gap: var(--cds-spacing-03);
+	min-width: 0;
+`;
+
+const IncidentCount = styled.span`
+	${styles.label02};
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	color: var(--cds-support-error);
+`;
+
+const NameSubtitle = styled.span`
+	align-self: flex-start;
+	display: inline-flex;
+	align-items: center;
+	font-size: var(--cds-label-01-font-size);
+	font-weight: var(--cds-heading-compact-01-font-weight);
+	letter-spacing: var(--cds-label-01-letter-spacing);
+	border-radius: 11px;
+	background-color: var(--cds-support-warning);
+	color: #000000;
+	padding: var(--cds-spacing-02) var(--cds-spacing-04);
+	white-space: nowrap;
+`;
+
+const SkeletonText = styled(BaseSkeletonText)`
+	margin: 0;
+`;
+
+const SkeletonIcon = styled(BaseSkeletonIcon)`
+	width: var(--cds-spacing-06);
+	height: var(--cds-spacing-06);
+`;
+
+export {
+	Table,
+	Td,
+	Th,
+	Container,
+	AdditionalContent,
+	SkeletonText,
+	SkeletonIcon,
+	NameContainer,
+	InstanceName,
+	IncidentCount,
+	NameSubtitle,
+	SubtitleRow,
+};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1.tsx
@@ -9,14 +9,15 @@
 import styled from 'styled-components';
 
 const VisuallyHiddenH1 = styled.h1`
-	border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
 	position: absolute;
 	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 `;
 
 export {VisuallyHiddenH1};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/VisuallyHiddenH1/VisuallyHiddenH1.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const VisuallyHiddenH1 = styled.h1`
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+`;
+
+export {VisuallyHiddenH1};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -514,6 +514,16 @@
 					"operatorExistsPlaceholder": "true oder false",
 					"operatorTypeLabel": "{{label}} Filtertyp",
 					"selectOperator": "Operator auswählen"
+				},
+				"instanceHeader": {
+					"incidentsCount_one": "{{count}} Vorfall",
+					"incidentsCount_other": "{{count}} Vorfälle"
+				},
+				"copyButton": {
+					"copy": "Kopieren",
+					"copied": "Kopiert",
+					"copyToClipboard": "In die Zwischenablage kopieren",
+					"copiedToClipboard": "In die Zwischenablage kopiert"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -528,6 +528,16 @@
 					"operatorExistsPlaceholder": "true or false",
 					"operatorTypeLabel": "{{label}} filter type",
 					"selectOperator": "Select operator"
+				},
+				"instanceHeader": {
+					"incidentsCount_one": "{{count}} incident",
+					"incidentsCount_other": "{{count}} incidents"
+				},
+				"copyButton": {
+					"copy": "Copy",
+					"copied": "Copied",
+					"copyToClipboard": "Copy to clipboard",
+					"copiedToClipboard": "Copied to clipboard"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -514,6 +514,16 @@
 					"operatorExistsPlaceholder": "true o false",
 					"operatorTypeLabel": "Tipo de filtro {{label}}",
 					"selectOperator": "Seleccionar operador"
+				},
+				"instanceHeader": {
+					"incidentsCount_one": "{{count}} incidente",
+					"incidentsCount_other": "{{count}} incidentes"
+				},
+				"copyButton": {
+					"copy": "Copiar",
+					"copied": "Copiado",
+					"copyToClipboard": "Copiar al portapapeles",
+					"copiedToClipboard": "Copiado al portapapeles"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -517,6 +517,16 @@
 					"operatorExistsPlaceholder": "true ou false",
 					"operatorTypeLabel": "Type de filtre {{label}}",
 					"selectOperator": "Sélectionner un opérateur"
+				},
+				"instanceHeader": {
+					"incidentsCount_one": "{{count}} incident",
+					"incidentsCount_other": "{{count}} incidents"
+				},
+				"copyButton": {
+					"copy": "Copier",
+					"copied": "Copié",
+					"copyToClipboard": "Copier dans le presse-papiers",
+					"copiedToClipboard": "Copié dans le presse-papiers"
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Ports the skeleton-aware `InstanceHeader` table used by both instance pages (Process Instance,
Decision Instance), plus the small unported primitives they both pull in: `CopyButton` and
`VisuallyHiddenH1`. Unblocks #56029 (Process Instance shell) and #56026 (Decision Instance shell).

The legacy `Link` primitive is intentionally not ported — Carbon's `Link` already composes with
TanStack Router's `Link` via the polymorphic `as` prop (precedent: `src/shared/pages/NotFoundPage.tsx`),
so no wrapper is needed for future consumers.

Deliberate deviations from legacy 1:1 (per review): `CopyButton`'s clipboard write now guards
against a missing `navigator.clipboard`, catches a rejected `writeText` call, and ignores a stale
write that resolves after `value` has already changed. Legacy has all three gaps unhandled.

Note: `InstanceHeader`'s incident-count string uses i18next plural keys (`incidentsCount_one`/`_other`),
matching the existing `panelHeader.resultCount_one/_other` convention. The migrator skill's
`fidelity.mjs` locale-coverage check doesn't recognize this suffix convention and reports a false
"missing key" for it — manually verified all four locales carry both plural forms correctly
(see PR discussion). Not fixed here; left for a separate change to that shared script.

de/fr/es translations are LLM-translated — native speaker review requested.

## Related issues

closes #58006