### PR TITLE
test: verify Tasklist Processes tab shows only latest process definition version

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1evpz8t" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Latest_Version_Process" name="Latest Version Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_03x48d1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_03x48d1" sourceRef="StartEvent_1" targetRef="Activity_1uji9vw" />
+    <bpmn:endEvent id="Event_11z59hi">
+      <bpmn:incoming>Flow_0rreful</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rreful" sourceRef="Activity_1uji9vw" targetRef="Event_11z59hi" />
+    <bpmn:userTask id="Activity_1uji9vw" name="LATEST_VERSION_TASK_NAME">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_Latest_Version" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03x48d1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rreful</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Latest_Version_Process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11z59hi_di" bpmnElement="Event_11z59hi">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dh90bl_di" bpmnElement="Activity_1uji9vw">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_03x48d1_di" bpmnElement="Flow_03x48d1">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rreful_di" bpmnElement="Flow_0rreful">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process.form
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process.form
@@ -1,0 +1,1 @@
+{"executionPlatform":"Camunda Cloud","executionPlatformVersion":"8.8.0","exporter":{"name":"Camunda Web Modeler","version":"b4df028"},"schemaVersion":19,"id":"Form_Latest_Version","components":[{"label":"Comment","type":"textfield","id":"Textfield_Comment","key":"comment","layout":{"row":"Row_0","columns":null}}],"type":"default"}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process_v1.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process_v1.bpmn
@@ -9,7 +9,7 @@
       <bpmn:incoming>Flow_0rreful</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0rreful" sourceRef="Activity_1uji9vw" targetRef="Event_11z59hi" />
-    <bpmn:userTask id="Activity_1uji9vw" name="LATEST_VERSION_TASK_NAME">
+    <bpmn:userTask id="Activity_1uji9vw" name="Latest Version Task V1">
       <bpmn:extensionElements>
         <zeebe:userTask />
         <zeebe:formDefinition formId="Form_Latest_Version" />

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process_v2.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/latest_version_process_v2.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1evpz8t" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.49.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="Latest_Version_Process" name="Latest Version Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_03x48d1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_03x48d1" sourceRef="StartEvent_1" targetRef="Activity_1uji9vw" />
+    <bpmn:endEvent id="Event_11z59hi">
+      <bpmn:incoming>Flow_0rreful</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rreful" sourceRef="Activity_1uji9vw" targetRef="Event_11z59hi" />
+    <bpmn:userTask id="Activity_1uji9vw" name="Latest Version Task V2">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="Form_Latest_Version" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03x48d1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rreful</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Latest_Version_Process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11z59hi_di" bpmnElement="Event_11z59hi">
+        <dc:Bounds x="422" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dh90bl_di" bpmnElement="Activity_1uji9vw">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_03x48d1_di" bpmnElement="Flow_03x48d1">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rreful_di" bpmnElement="Flow_0rreful">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="422" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -8,7 +8,7 @@
 
 import {expect} from '@playwright/test';
 import {publicTest as test} from 'fixtures';
-import {deploy} from 'utils/zeebeClient';
+import {deploy, deployWithSubstitutions} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
@@ -196,5 +196,64 @@ test.describe('process page', () => {
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible({
       timeout: 60000,
     });
+  });
+
+  // Regression test for https://github.com/camunda/camunda/issues/40045
+  test('show only the latest version of a process definition', async ({
+    page,
+    tasklistHeader,
+    tasklistProcessesPage,
+    taskPanelPage,
+  }) => {
+    await deploy(['./resources/latest_version_process.form']);
+    await deployWithSubstitutions('./resources/latest_version_process.bpmn', {
+      LATEST_VERSION_TASK_NAME: 'Latest Version Task V1',
+    });
+    await deployWithSubstitutions('./resources/latest_version_process.bpmn', {
+      LATEST_VERSION_TASK_NAME: 'Latest Version Task V2',
+    });
+    await sleep(2000);
+
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    await tasklistProcessesPage.searchForProcess('Latest_Version_Process');
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(tasklistProcessesPage.processTile).toHaveCount(1);
+        await expect(tasklistProcessesPage.processTile).toContainText(
+          'Latest Version Process',
+        );
+      },
+      onFailure: async () => {
+        await page.reload();
+        if (await tasklistProcessesPage.continueButton.isVisible()) {
+          await tasklistProcessesPage.continueButton.click();
+        }
+        await tasklistProcessesPage.searchForProcess('Latest_Version_Process');
+      },
+    });
+
+    await tasklistProcessesPage.startProcessButton.click();
+    await expect(page.getByText('Process has started')).toBeVisible();
+
+    await tasklistHeader.clickTasksTab();
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          taskPanelPage.availableTasks
+            .getByText('Latest Version Task V2')
+            .first(),
+        ).toBeVisible();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+    await expect(
+      taskPanelPage.availableTasks.getByText('Latest Version Task V1'),
+    ).toBeHidden();
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -8,7 +8,7 @@
 
 import {expect} from '@playwright/test';
 import {publicTest as test} from 'fixtures';
-import {deploy, deployWithSubstitutions} from 'utils/zeebeClient';
+import {deploy} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
@@ -206,12 +206,8 @@ test.describe('process page', () => {
     taskPanelPage,
   }) => {
     await deploy(['./resources/latest_version_process.form']);
-    await deployWithSubstitutions('./resources/latest_version_process.bpmn', {
-      LATEST_VERSION_TASK_NAME: 'Latest Version Task V1',
-    });
-    await deployWithSubstitutions('./resources/latest_version_process.bpmn', {
-      LATEST_VERSION_TASK_NAME: 'Latest Version Task V2',
-    });
+    await deploy(['./resources/latest_version_process_v1.bpmn']);
+    await deploy(['./resources/latest_version_process_v2.bpmn']);
 
     await tasklistHeader.clickProcessesTab();
     await expect(page).toHaveURL('/tasklist/processes');

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -212,7 +212,6 @@ test.describe('process page', () => {
     await deployWithSubstitutions('./resources/latest_version_process.bpmn', {
       LATEST_VERSION_TASK_NAME: 'Latest Version Task V2',
     });
-    await sleep(2000);
 
     await tasklistHeader.clickProcessesTab();
     await expect(page).toHaveURL('/tasklist/processes');


### PR DESCRIPTION
## Description

Adds an E2E regression test for #40045 to the orchestration cluster test suite.

The test:
- deploys `latest_version_process.form` and two versions of `Latest_Version_Process` (user task name changed between deployments to force a new version; form linked to the user task)
- opens the Tasklist Processes tab and searches for the process
- asserts exactly one tile is listed
- starts the process and asserts the created task is `Latest Version Task V2` (latest version) and no `...V1` task appears

Verified locally against Docker Compose (elasticsearch): full `processes-page.spec.ts` — 8 passed, 1 skipped (pre-existing), 0 flaky.

Note: the test searches by process definition ID because the Processes tab search does not match display names — bug report to follow.

Closes #58050
Related: #40045, camunda/team-qa-engineering#554

🤖 Generated with [Claude Code](https://claude.com/claude-code)