### PR TITLE
test: add Optimize startup and accessibility check to orchestration cluster e2e suite

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml
@@ -575,6 +575,16 @@ jobs:
                 echo "Starting with default Tasklist V2 mode"
                 DATABASE=elasticsearch docker compose up -d camunda
               fi
+
+              # Optimize is a separate application (reads exported data from
+              # Elasticsearch). Start it too, but only on branches whose compose
+              # defines the service, so this is a no-op elsewhere.
+              if DATABASE=elasticsearch docker compose config --services | grep -qx optimize; then
+                echo "Starting Optimize"
+                DATABASE=elasticsearch docker compose up -d optimize
+              else
+                echo "optimize service not defined in this branch's compose; skipping"
+              fi
             fi
           }
 
@@ -696,6 +706,7 @@ jobs:
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ matrix.tasklist_mode == 'v2' && 'true' || 'false' }}
           MATRIX_TASKLIST_MODE: ${{ matrix.tasklist_mode }}
           BASE_BRANCH: ${{ needs.validate-branch.outputs.base }}
+          OPTIMIZE_BASE_URL: "http://localhost:8083"
         run: |
           if [[ "$NON_STANDALONE" == "true" ]]; then
             export CORE_APPLICATION_TASKLIST_URL="http://localhost:8080"
@@ -730,6 +741,26 @@ jobs:
               fi
             fi
           fi
+          # Include the Optimize startup check in the same Playwright run when
+          # the Optimize container is up (branches whose compose defines it).
+          if docker ps --format '{{.Names}}' | grep -qx optimize; then
+            echo "Optimize container detected; waiting for readiness before adding the optimize-startup project"
+            # Optimize redirects an unauthenticated root request to the OIDC login
+            # (HTTP 302); that is the expected ready state (a 200 would signal auth
+            # is not wired as expected).
+            for i in {1..60}; do
+              optimize_status="$(curl -s -o /dev/null -w '%{http_code}' -m 5 http://localhost:8083/ || true)"
+              optimize_status="${optimize_status:-000}"
+              if [[ "$optimize_status" == "302" ]]; then
+                echo "Optimize is ready (HTTP $optimize_status)."
+                break
+              fi
+              echo "Waiting for Optimize... ($i/60) HTTP $optimize_status"
+              sleep 10
+            done
+            TEST_ARGS+=(--project=optimize-startup)
+          fi
+
           echo "Running tests with args: ${TEST_ARGS[*]}"
           npm run test -- "${TEST_ARGS[@]}"
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite

--- a/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml
@@ -34,14 +34,16 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Set CAMUNDA_DOCKER_IMAGE
+      - name: Set CAMUNDA_DOCKER_IMAGE and OPTIMIZE_DOCKER_IMAGE
         run: |
           branch="${{ inputs.branch }}"
           if [[ "$branch" == "main" ]]; then
             echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:SNAPSHOT" >> "$GITHUB_ENV"
+            echo "OPTIMIZE_DOCKER_IMAGE=camunda/optimize:SNAPSHOT" >> "$GITHUB_ENV"
           elif [[ "$branch" == stable/* ]]; then
             minor="${branch#stable/}"
             echo "CAMUNDA_DOCKER_IMAGE=camunda/camunda:${minor}-SNAPSHOT" >> "$GITHUB_ENV"
+            echo "OPTIMIZE_DOCKER_IMAGE=camunda/optimize:${minor}-SNAPSHOT" >> "$GITHUB_ENV"
           fi
 
       - name: Start Camunda
@@ -80,6 +82,37 @@ jobs:
           done
 
           echo "Failed to start Camunda after ${attempts} attempts."
+          exit 1
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
+      - name: Start Optimize
+        # Optimize is a separate application that only exists in the compose file
+        # on branches where it has been added. Gate on its presence so this step
+        # is a no-op on branches that do not (yet) define the service.
+        run: |
+          if ! DATABASE=elasticsearch docker compose config --services | grep -qx optimize; then
+            echo "optimize service not defined in this branch's compose; skipping."
+            exit 0
+          fi
+
+          start_optimize() {
+            DATABASE=elasticsearch docker compose up -d optimize
+          }
+
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            if start_optimize; then
+              echo "Optimize started on attempt ${attempt}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${attempts} to start Optimize failed."
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Retrying in 15s..."
+              sleep 15
+            fi
+          done
+
+          echo "Failed to start Optimize after ${attempts} attempts."
           exit 1
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -131,6 +164,34 @@ jobs:
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
+      - name: Wait for Optimize to be ready
+        # Only runs when Optimize was started (service present in this branch).
+        run: |
+          if ! docker ps --format '{{.Names}}' | grep -qx optimize; then
+            echo "Optimize container not running; skipping wait."
+            exit 0
+          fi
+
+          # An unauthenticated request to Optimize's root always redirects to the
+          # OIDC login (HTTP 302); that is the expected ready state. A 200 would
+          # mean auth is not wired as expected, so it is not treated as ready.
+          echo "Waiting for Optimize to be reachable on http://localhost:8083 ..."
+          for i in {1..60}; do
+            status="$(curl -s -o /dev/null -w '%{http_code}' -m 5 http://localhost:8083/ || true)"
+            status="${status:-000}"
+            if [[ "$status" == "302" ]]; then
+              echo "Optimize is ready (HTTP $status)."
+              exit 0
+            fi
+            echo "Waiting for Optimize... ($i/60) HTTP $status"
+            sleep 10
+          done
+
+          echo "Optimize failed to become ready in time."
+          docker logs optimize --tail 100 || true
+          exit 1
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
       - name: Print Docker logs before failing
         if: failure()
         # DATABASE must be set: docker-compose.yml interpolates it into the
@@ -143,6 +204,9 @@ jobs:
             DATABASE=elasticsearch docker compose logs operate
           else
             DATABASE=elasticsearch docker compose logs camunda
+          fi
+          if docker ps -a --format '{{.Names}}' | grep -qx optimize; then
+            DATABASE=elasticsearch docker compose logs optimize
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
 
@@ -196,6 +260,7 @@ jobs:
           SLACK_BOT_USER_OAUTH_TOKEN: ${{ steps.secrets.outputs.SLACK_CORE_DOMAIN_BOT_TOKEN }}
           VERSION: ${{ inputs.branch }}
           CAMUNDA_TASKLIST_V2_MODE_ENABLED: ${{ inputs.tasklist_mode == 'v2' && 'true' || 'false' }}
+          OPTIMIZE_BASE_URL: "http://localhost:8083"
         run: |
           if [[ "${{ inputs.branch }}" == "stable/8.7" ]]; then
             export CORE_APPLICATION_TASKLIST_URL="http://localhost:8080"
@@ -206,16 +271,27 @@ jobs:
             export ZEEBE_REST_ADDRESS="http://localhost:8080"
           fi
 
+          # Include the Optimize startup check in the same Playwright run (so it
+          # shares one JUnit/JSON/HTML report) only when the Optimize container is
+          # running — i.e. on branches whose compose defines the service.
+          OPTIMIZE_ARGS=""
+          if docker ps --format '{{.Names}}' | grep -qx optimize; then
+            echo "Optimize container detected; including the optimize-startup project."
+            OPTIMIZE_ARGS="--project=optimize-startup"
+          else
+            echo "Optimize container not running; optimize-startup project will be skipped."
+          fi
+
           if [[ "${{ inputs.tasklist_mode }}" == "v2" ]]; then
             if [[ "${{ inputs.branch }}" == "main" ]]; then
               echo "Running all tests in V2 mode on main"
-              npm run test -- --project=chromium
+              npm run test -- --project=chromium $OPTIMIZE_ARGS
             elif [[ "${{ inputs.branch }}" == "stable/8.9" ]]; then
               echo "Running all tests in V2 mode on ${{ inputs.branch }}, excluding V1-specific tests"
-              npm run test -- --project=chromium --grep-invert "tests/(common-flows/v1|tasklist/v1)/"
+              npm run test -- --project=chromium $OPTIMIZE_ARGS --grep-invert "tests/(common-flows/v1|tasklist/v1)/"
             else
               echo "Running all tests in V2 mode: excluding @v1-only tests"
-              npm run test -- --project=chromium --grep-invert "@v1-only"
+              npm run test -- --project=chromium $OPTIMIZE_ARGS --grep-invert "@v1-only"
             fi
           else
             if [[ "${{ inputs.branch }}" == "stable/8.9" ]]; then
@@ -226,7 +302,7 @@ jobs:
               npm run test -- --project=chromium tests/tasklist/ tests/common-flows/
             else
               echo "Running all tests in V1 mode"
-              npm run test -- --project=chromium
+              npm run test -- --project=chromium $OPTIMIZE_ARGS
             fi
           fi
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -10,6 +10,11 @@ For multi-app journeys that span Modeler, Optimize, Connectors, or Console (SaaS
 use the sibling [`c8-cross-component-e2e-tests`](https://github.com/camunda/c8-cross-component-e2e-tests)
 repository instead.
 
+> **Exception — infrastructure smoke checks:** basic startup/accessibility checks for a
+> component bundled in this suite's Docker Compose stack (e.g. verifying Optimize starts and
+> is reachable) are in scope here, even though they exercise only that component. Deeper
+> Optimize/Connectors/Modeler _feature_ coverage still belongs in `c8-cross-component-e2e-tests`.
+
 ## Tech Stack
 
 - **Framework**: `@playwright/test` ^1.51.0
@@ -262,7 +267,9 @@ Each supported version lives on its own branch in `camunda/camunda`:
 ## Contributing
 
 - Follow the Page Object Model: page interactions belong in `pages/`, not in spec files.
-- Every test must involve at least one core component (Operate, Tasklist, Identity, Zeebe).
+- Every test must involve at least one core component (Operate, Tasklist, Identity, Zeebe),
+  except infrastructure smoke checks that verify a component bundled in the suite's Docker
+  Compose stack starts and is accessible (e.g. the Optimize startup check).
 - Reviewers must include someone from the Test Automation Team and a product team developer.
 - **Run the on-demand workflow against your branch before requesting review.** PRs without a completed run will be returned. If failures exist, document them in the PR description and confirm they are pre-existing.
 - Link the [TestRail test case suite](https://camunda.testrail.com/index.php?/suites/view/17050) in the PR description if any test or page file is modified.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -144,3 +144,44 @@ services:
       - zeebe_network
     env_file:
       - envs/.env.database.${DATABASE}
+
+  # Optimize is not part of the consolidated `camunda` container; it is a
+  # separate application that reads the exported data from Elasticsearch. It is
+  # only started explicitly (e.g. `docker compose up -d optimize`) so that the
+  # default orchestration-cluster stack stays lightweight. The OIDC settings
+  # point at the `camunda-platform` Keycloak realm for when Identity-based login
+  # is provisioned; startup and readiness do not depend on the realm existing.
+  optimize:
+    container_name: optimize
+    image: ${OPTIMIZE_DOCKER_IMAGE:-camunda/optimize:SNAPSHOT}
+    depends_on:
+      - elasticsearch
+    ports:
+      - 8083:8090
+      - 8092:8092
+    environment:
+      - SPRING_PROFILES_ACTIVE=ccsm
+      - OPTIMIZE_ELASTICSEARCH_HOST=elasticsearch
+      - OPTIMIZE_ELASTICSEARCH_HTTP_PORT=9200
+      - CAMUNDA_OPTIMIZE_ZEEBE_ENABLED=true
+      - CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT=2
+      - CAMUNDA_OPTIMIZE_ENTERPRISE=false
+      - CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED=false
+      - CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL=http://localhost:18080/auth/realms/camunda-platform
+      - CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL=http://keycloak:8080/auth/realms/camunda-platform
+      - CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID=optimize
+      - CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET=XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
+      - CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE=optimize-api
+      - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g -XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget -q --spider http://localhost:8092/actuator/health || exit 1',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - zeebe_network

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -180,7 +180,13 @@ const normalProjects = [
       ...devices['Desktop Chrome'],
     },
   },
-
+  {
+    name: 'optimize-startup',
+    testMatch: ['tests/api/v2/optimize/optimize-startup.spec.ts'],
+    use: {
+      ...devices['Desktop Chrome'],
+    },
+  },
 ];
 
 const v2StatelessProjects = [

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/optimize/optimize-startup.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/optimize/optimize-startup.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+
+const OPTIMIZE_BASE_URL =
+  process.env.OPTIMIZE_BASE_URL ?? 'http://localhost:8083';
+
+test.describe('Optimize startup and accessibility', () => {
+  test('should start and redirect unauthenticated users to the OIDC login', async ({
+    request,
+  }) => {
+    let redirectLocation = '';
+
+    await test.step('Optimize web endpoint becomes reachable', async () => {
+      await expect
+        .poll(
+          async () => {
+            try {
+              const response = await request.get(`${OPTIMIZE_BASE_URL}/`, {
+                maxRedirects: 0,
+                timeout: 5000,
+              });
+              redirectLocation = response.headers()['location'] ?? '';
+              return response.status();
+            } catch {
+              return 0;
+            }
+          },
+          {timeout: 120_000, intervals: [2_000, 5_000]},
+        )
+        .toBe(302);
+    });
+
+    await test.step('redirect targets the Optimize OIDC login', () => {
+      expect(redirectLocation).toContain('/protocol/openid-connect/auth');
+      expect(redirectLocation).toContain('client_id=optimize');
+      expect(redirectLocation).toContain('audience=optimize-api');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds Optimize to the orchestration-cluster E2E test environment and a small basic test that verifies it **starts correctly and is accessible**, and wires it into the nightly E2E workflow.

- **`config/docker-compose.yml`** — new `optimize` service (Elasticsearch-backed, `ccsm` profile), health-gated on the management `/actuator/health` endpoint, published on `8083` (web) and `8092` (management). Started explicitly so the default lightweight orchestration-cluster stack is unchanged.
- **`tests/api/v2/optimize/optimize-startup.spec.ts`** — polls the Optimize web endpoint and asserts it redirects unauthenticated users to the OIDC login (`client_id=optimize`, `audience=optimize-api`). A deterministic "started + accessible + correctly wired" signal.
- **`playwright.config.ts`** — new `optimize-startup` project.
- **`.github/workflows/c8-orchestration-cluster-reusable-e2e-tests.yml`** — starts Optimize, waits for it, and includes the `optimize-startup` project in the E2E run. Every Optimize step is **gated on the service/container being present**, so version branches that do not (yet) define the service are completely unaffected. The project runs in the **same** Playwright invocation as `chromium`, so results share one JUnit/JSON/HTML report and flow to TestRail without clobbering the existing reports.

## Why

Closes a testing gap raised on camunda/camunda-distributions#506: the Docker Compose distribution tests do not cover Optimize. This adds startup/accessibility coverage for Optimize in the orchestration-cluster E2E suite.

## Validation (local)

- `DATABASE=elasticsearch docker compose up -d --wait optimize` -> the container reports **healthy** against the suite's existing Elasticsearch. Optimize boots in ~5s; the OIDC realm is only required at login time, not at startup.
- `npx playwright test --project=optimize-startup` -> **1 passed** (web root `302` -> `.../protocol/openid-connect/auth?client_id=optimize&...&audience=optimize-api`).
- Confirmed the Optimize test is captured in the shared `junit-report.xml` (so it reaches TestRail in the combined run) and that gating leaves the chromium reports intact.
- `npx eslint` + `npx tsc --noEmit` -> pass; workflow YAML parses.

## Scope / follow-ups

- **Full UI-login coverage** (actually logging in to Optimize) additionally requires the Identity app + `camunda/keycloak` to provision the `camunda-platform` realm and `optimize` client (see `optimize/docker-compose.ccsm-with-optimize.yml`). This PR covers startup/accessibility only.
- **Backports:** per the suite's branching rules this lands on `main` first and should be backported to `stable/8.10 -> 8.7` (older branches use a different compose layout, so the service addition may need per-branch adaptation). The workflow gating means un-backported branches are unaffected until then.
- **TestRail case:** a dedicated TestRail case can be linked for the new test.
- **Placement note:** this suite's `AGENTS.md` currently scopes Optimize to the sibling `c8-cross-component-e2e-tests` repo and expects tests to involve a core component. This follows the direction on camunda-distributions#506 — please confirm placement.

## CI validation (on-demand)

The on-demand workflow was run against this branch. The Optimize wiring works and the new test passes:

- `Starting Optimize` → image pulled → container started → `Optimize is ready (HTTP 302)`
- `✓ [optimize-startup] › tests/api/v2/optimize/optimize-startup.spec.ts › Optimize starts and redirects unauthenticated users to the OIDC login`

### Pre-existing failures (not from this PR)

All red checks are a pre-existing `main` regression that landed on the 2026-07-17 nightly (`main` was green on 07-15 and 07-16). The same specs fail on `main`:

- **API:** `tests/api/v2/cluster-variables/*` — `409 Conflict` on create + `/metadata is not declared in spec`. Same failures on `main` nightly run `29549432075`.
- **E2E:** `tests/operate/processInstancesFilters.spec.ts` ("Variable filtering…") and `tests/operate/processInstanceVariables.spec.ts` ("Add variables"). Same failures on `main` nightly run `29550436924`.

These are variable-handling regressions owned by the engine/Operate side (`zeebe/` / `operate/`) and are unrelated to this PR, which only adds Optimize startup coverage. The `Zeebe / Smoke` check also failed on a transient Docker registry `503` (`reg.mini.dev`), an infra flake.
