### PR TITLE
fix: make session refresh holder a singleton bean in slice tests

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigParameterizedTest.java
@@ -159,6 +159,27 @@ public class BasicAuthWebSecurityConfigParameterizedTest {
      */
     @Bean(name = "requestContextBasedAuthenticationHolder")
     public CamundaAuthenticationHolder requestContextBasedAuthenticationHolder() {
+      return noOpAuthenticationHolder();
+    }
+
+    /**
+     * Same rationale as {@link #requestContextBasedAuthenticationHolder()} above: CSL's default
+     * {@code httpSessionBasedAuthenticationHolder} also injects {@link
+     * jakarta.servlet.http.HttpServletRequest}, unavailable in this {@link
+     * org.springframework.boot.WebApplicationType#NONE} context. A no-op override satisfies
+     * {@code @ConditionalOnMissingBean} so the CSL default is skipped, without resorting to
+     * {@code @RequestScope} on the bean itself — that would defer construction enough to dodge this
+     * context's missing {@code HttpServletRequest}, but at the cost of giving every concurrent
+     * request its own independent holder instance (and thus its own empty refresh-dedup cache),
+     * defeating the JVM-local guard {@code HttpSessionBasedAuthenticationHolder} relies on (see its
+     * class Javadoc and camunda-security-library#510).
+     */
+    @Bean(name = "httpSessionBasedAuthenticationHolder")
+    public CamundaAuthenticationHolder httpSessionBasedAuthenticationHolder() {
+      return noOpAuthenticationHolder();
+    }
+
+    private static CamundaAuthenticationHolder noOpAuthenticationHolder() {
       return new CamundaAuthenticationHolder() {
         @Override
         public boolean supports() {

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -41,7 +41,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.context.annotation.RequestScope;
 
 /**
  * Slice-test bootstrap. Mirrors the previous {@code WebSecurityConfigTestContext} by importing the
@@ -59,7 +58,6 @@ import org.springframework.web.context.annotation.RequestScope;
 public class WebSecurityConfigTestContext {
 
   @Bean
-  @RequestScope
   public CamundaAuthenticationHolder httpSessionBasedAuthenticationHolder(
       final HttpServletRequest request, final CamundaSecurityLibraryProperties properties) {
     return new HttpSessionBasedAuthenticationHolder(request, properties.getAuthentication());


### PR DESCRIPTION
## Description

`SessionAuthenticationRefreshTest$BasicAuthTest.shouldOnlyRefreshOnceWhenMultipleConcurrentRequests`
was intermittently flaky in CI: under concurrent requests, two independent
session refreshes could happen instead of one.

Root cause: `WebSecurityConfigTestContext` registered the
`httpSessionBasedAuthenticationHolder` bean with `@RequestScope`, directly
contradicting the holder's own documented contract (it must be a singleton
so its JVM-local refresh-dedup cache is shared across concurrent requests
for the same session). Every concurrent request got its own empty cache,
so the dedup guard never engaged. Confirmed by reproducing the exact
failure signature locally (2 failures in 30 repeats against the unfixed
wiring) and verifying 0 failures in 50 repeats after the fix.

Removing `@RequestScope` exposed a second, pre-existing issue:
`BasicAuthWebSecurityConfigParameterizedTest` boots a
`WebApplicationType.NONE` context with no `HttpServletRequest` bean
available at all, so eagerly constructing the now-singleton holder failed
DI there. Fixed with the same no-op bean override already used for the
sibling `requestContextBasedAuthenticationHolder` bean in that same test
class — no new pattern introduced.

Full `authentication` module suite passes (297 tests; the only 2 errors
are pre-existing, environment-only Testcontainers/Docker failures
unrelated to this change).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58063
