### PR TITLE
ci: add Nexus credentials to PR Maven dependency snapshot job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1982,6 +1982,31 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      # HeroDevs NES artifacts (e.g. spring-boot-dependencies on stable) are private and served from
+      # Nexus, so the snapshot resolution needs authenticated access via the nexus.camunda.cloud mirror.
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+      - name: Configure Maven credentials
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Submit Maven dependency snapshot
         id: submit
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0


### PR DESCRIPTION
## Problem

The `Security / Submit Maven Dependency Snapshot` **PR-side** job fails on `stable/8.7` and `stable/8.8` with a 401 on HeroDevs NES Spring artifacts, e.g.:

```
Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.16-spring-boot-3.5.17 (absent):
Could not transfer artifact ... from/to zeebe (https://artifacts.camunda.com/artifactory/zeebe-io/): status code: 401
```

This also trips the `Security / Dependency Vulnerability Gate` (`pr-vuln-check`), which **fails closed** when the head snapshot did not succeed (`head-snapshot-succeeded` guard). So both jobs go red from a single cause. Example run: https://github.com/camunda/camunda/actions/runs/29575402328?pr=58018

## Root cause

There are **two** dependency-submission jobs:

| Job | File | Trigger | Creds |
|-----|------|---------|-------|
| `submit-maven-snapshot` | `maven-dependency-snapshot.yml` | push (base) | ✅ fixed in #57577 |
| `pr-maven-snapshot` | `ci.yml` | pull_request (head) | ❌ **missing** |

The `pr-maven-snapshot` job runs `advanced-security/maven-dependency-submission-action` directly, bypassing the `setup-build` composite action that configures the `nexus.camunda.cloud` mirror + credentials. #57577 only patched the push-side job in `maven-dependency-snapshot.yml`; the PR-side job in `ci.yml` was never covered.

On stable branches the parent POM pins private HeroDevs NES versions (`spring-boot-dependencies`, `spring-security-bom`, `spring-framework-bom`), so the unauthenticated resolution 401s.

## Fix

Add the same steps the push-side job already uses (identical to #57577):
- `Import secrets` — Vault approle → `NEXUS_USR` / `NEXUS_PSW`
- `Configure Maven credentials` — `s4u/maven-settings-action` (`camunda-nexus` server + `nexus.camunda.cloud` internal group mirror, `mirrorOf: *`)

## Note on main vs stable

`main` is **not** currently failing — it uses public Spring versions (7.x), not HeroDevs NES. But the same latent gap exists in `main`'s `pr-maven-snapshot`. Fixing on `main` first so the change can be backported to the affected stable branches (`stable/8.7`, `stable/8.8`).

## Validation

`actionlint` on `ci.yml` reports no new findings (the only findings are pre-existing custom-runner-label / placeholder-`if` warnings, identical count before and after this change).