### PR TITLE
[DO NOT MERGE] test: validate PR Maven snapshot Nexus creds fix (#58077) on stable/8.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1889,6 +1889,31 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      # HeroDevs NES artifacts (e.g. spring-boot-dependencies on stable) are private and served from
+      # Nexus, so the snapshot resolution needs authenticated access via the nexus.camunda.cloud mirror.
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+      - name: Configure Maven credentials
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Submit Maven dependency snapshot
         id: submit
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -140,6 +140,23 @@
         </configuration>
       </plugin>
 
+      <!-- Build this module's own sources jar before the package phase, so the shade plugin
+           (createSourcesJar) can merge it with the base module sources. Reuses the release
+           parent's "attach-sources" execution id to move it from package to prepare-package. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Shade plugin to include and relocate classes from camunda-spring-boot-starter -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -153,6 +170,9 @@
             <phase>package</phase>
             <configuration>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Also shade the sources jar so it carries the base module sources plus our
+                   overrides, instead of only this module's few files (see #48090). -->
+              <createSourcesJar>true</createSourcesJar>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
@@ -170,6 +190,13 @@
                     <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.class</exclude>
+                    <!-- The same overrides in the shaded sources jar (createSourcesJar). Filters
+                         match by literal path, so the .class excludes above don't cover .java. -->
+                    <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java</exclude>
                     <!-- Exclude META-INF services that we override -->
                     <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
                   </excludes>


### PR DESCRIPTION
**Throwaway validation PR — do not merge, do not review.**

Reproduces the failure from PR #58018 (branch `48090-spring-boot-4-starter-sources-jar`, base stable/8.8) and applies the fix from #58077 on top, to prove the `pr-maven-snapshot` / `pr-vuln-check` jobs go green.

- Base branch of this PR = same as #58018 head (so identical dep changes → `deps-changed == true` → `pr-maven-snapshot` runs).
- Added the same Vault approle `Import secrets` + `s4u/maven-settings-action` (nexus.camunda.cloud mirror) steps that #58077 adds to `pr-maven-snapshot` in `ci.yml`.

Expected: "Security / Submit Maven Dependency Snapshot" and "Security / Dependency Vulnerability Gate" both pass (previously 401 on HeroDevs NES `spring-boot-dependencies` / `spring-security-bom` / `spring-framework-bom`).

Will be closed once CI confirms. Real fix: #58077 (main) → backport to stable/8.7 + stable/8.8.