### PR TITLE
fix: only active members count for quorum

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -180,6 +180,9 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
   private <T extends Comparable<T>> Optional<T> getQuorumFor(
       final Collection<RaftMember> members,
       final Function<RaftMemberContext, T> calculateMemberValue) {
+    // Under joint consensus, `remoteMemberContexts` is not authoritative, because it contains
+    // entries from old and new configurations. So filter for members that actually are in the
+    // configuration.
     final var activeMembers =
         members.stream().filter(member -> member.getType() == Type.ACTIVE).toList();
     final var includeLocalMemberInQuorum =

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -160,25 +159,12 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
    */
   public <T extends Comparable<T>> Optional<T> getQuorumFor(
       final Function<RaftMemberContext, T> calculateMemberValue) {
-    final var contexts = new ArrayList<>(remoteActiveMembers);
-
     if (configuration.requiresJointConsensus()) {
       final var oldMembers = configuration.oldMembers();
       final var newMembers = configuration.newMembers();
 
-      final var oldContexts =
-          contexts.stream()
-              .filter(context -> oldMembers.contains(context.getMember()))
-              .collect(Collectors.toCollection(ArrayList::new));
-      final var newContexts =
-          contexts.stream()
-              .filter(context -> newMembers.contains(context.getMember()))
-              .collect(Collectors.toCollection(ArrayList::new));
-
-      final var oldQuorum =
-          getQuorumFor(oldContexts, calculateMemberValue, oldMembers.contains(localMember));
-      final var newQuorum =
-          getQuorumFor(newContexts, calculateMemberValue, newMembers.contains(localMember));
+      final var oldQuorum = getQuorumFor(oldMembers, calculateMemberValue);
+      final var newQuorum = getQuorumFor(newMembers, calculateMemberValue);
       if (oldQuorum.isPresent() && newQuorum.isPresent()) {
         return Optional.of(Comparators.min(oldQuorum.get(), newQuorum.get()));
       } else if (oldQuorum.isPresent()) {
@@ -188,14 +174,22 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
       }
     }
 
-    return getQuorumFor(
-        contexts, calculateMemberValue, configuration.newMembers().contains(localMember));
+    return getQuorumFor(configuration.newMembers(), calculateMemberValue);
   }
 
   private <T extends Comparable<T>> Optional<T> getQuorumFor(
-      final List<RaftMemberContext> contexts,
-      final Function<RaftMemberContext, T> calculateMemberValue,
-      final boolean includeLocalMemberInQuorum) {
+      final Collection<RaftMember> members,
+      final Function<RaftMemberContext, T> calculateMemberValue) {
+    final var activeMembers =
+        members.stream().filter(member -> member.getType() == Type.ACTIVE).toList();
+    final var includeLocalMemberInQuorum =
+        activeMembers.stream().anyMatch(member -> member.memberId().equals(localMember.memberId()));
+    final var contexts =
+        activeMembers.stream()
+            .filter(member -> !member.memberId().equals(localMember.memberId()))
+            .map(member -> remoteMemberContexts.get(member.memberId()))
+            .collect(Collectors.toCollection(ArrayList::new));
+
     if (contexts.isEmpty()) {
       return Optional.empty();
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -263,9 +263,11 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
           new JointConsensusVoteQuorum(
               callback,
               configuration.oldMembers().stream()
+                  .filter(member -> member.getType() == Type.ACTIVE)
                   .map(RaftMember::memberId)
                   .collect(Collectors.toSet()),
               configuration.newMembers().stream()
+                  .filter(member -> member.getType() == Type.ACTIVE)
                   .map(RaftMember::memberId)
                   .collect(Collectors.toSet()));
     } else {
@@ -273,6 +275,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
           new SimpleVoteQuorum(
               callback,
               configuration.newMembers().stream()
+                  .filter(member -> member.getType() == Type.ACTIVE)
                   .map(RaftMember::memberId)
                   .collect(Collectors.toSet()));
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -186,6 +186,23 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     final var currentMembers = raft.getCluster().getMembers();
     final var updatedMembers = request.members();
 
+    // A configuration with members but no ACTIVE ones could neither elect a leader nor commit
+    // entries, permanently stranding the remaining members. The empty configuration stays allowed:
+    // it is the result of the last member leaving when scaling a partition down to zero.
+    final var hasActiveMember =
+        updatedMembers.stream().anyMatch(member -> member.getType() == RaftMember.Type.ACTIVE);
+    if (!updatedMembers.isEmpty() && !hasActiveMember) {
+      return CompletableFuture.completedFuture(
+          logResponse(
+              ReconfigureResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(
+                      Type.CONFIGURATION_ERROR,
+                      "Requested configuration %s must be empty or have at least one active member"
+                          .formatted(updatedMembers))
+                  .build()));
+    }
+
     if (equalMembership(currentMembers, updatedMembers)) {
       return CompletableFuture.completedFuture(
           logResponse(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -710,6 +710,127 @@ final class ReconfigurationTest {
               });
       assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(1));
     }
+
+    @Test
+    void canElectLeaderWithPassiveMemberWhenOneActiveMemberIsDown(@TempDir final Path tmp) {
+      // given - a cluster [1A, 2A, 3A] extended with an unreachable PASSIVE member 4
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+      final var id4 = MemberId.from("4");
+
+      final var m1 = createServer(tmp, createMembershipService(id1, id2, id3));
+      final var m2 = createServer(tmp, createMembershipService(id2, id1, id3));
+      final var m3 = createServer(tmp, createMembershipService(id3, id1, id2));
+
+      CompletableFuture.allOf(
+              m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+          .join();
+
+      // commit an entry to ensure that the leader is ready to accept new configuration
+      assertThat(appendEntry(awaitLeader(m1, m2, m3)).commit())
+          .succeedsWithin(Duration.ofSeconds(1));
+
+      final var leader = getLeaderServer(List.of(m1, m2, m3)).orElseThrow();
+      final var leaderId = leader.cluster().getLocalMember().memberId();
+      final var configuration = leader.getContext().getCluster().getConfiguration();
+      final var withPassiveMember =
+          List.<RaftMember>of(
+              new DefaultRaftMember(id1, Type.ACTIVE, Instant.now()),
+              new DefaultRaftMember(id2, Type.ACTIVE, Instant.now()),
+              new DefaultRaftMember(id3, Type.ACTIVE, Instant.now()),
+              new DefaultRaftMember(id4, Type.PASSIVE, Instant.now()));
+      final var response =
+          protocolFactory
+              .newServerProtocol(MemberId.from("test-client"))
+              .reconfigure(
+                  leaderId,
+                  ReconfigureRequest.builder()
+                      .withIndex(configuration.index())
+                      .withTerm(configuration.term())
+                      .withMembers(withPassiveMember)
+                      .from(leaderId.id())
+                      .build());
+      assertThat(response)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .satisfies(
+              reconfigureResponse -> assertThat(reconfigureResponse.status()).isEqualTo(Status.OK));
+
+      // when - one ACTIVE follower is down and the leader steps down
+      final var follower = Stream.of(m1, m2, m3).filter(s -> !s.isLeader()).findAny().orElseThrow();
+      final var remaining = Stream.of(m1, m2, m3).filter(s -> s != follower).toList();
+      follower.shutdown().join();
+      getLeaderServer(remaining).orElseThrow().stepDown().join();
+
+      // then - the two remaining ACTIVE members can elect a leader and commit entries: the
+      // PASSIVE member must not count towards the vote or commit quorum
+      final var newLeader = awaitLeader(remaining.toArray(RaftServer[]::new));
+      assertThat(appendEntry(newLeader).commit()).succeedsWithin(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void doesNotCommitConfigurationWhileVotingMemberIsUnreachable(@TempDir final Path tmp) {
+      // given - a single member cluster [1A] with an unreachable PASSIVE member 2
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, createMembershipService(id1, id2));
+      m1.bootstrap(id1).join();
+
+      // commit an entry to ensure that the leader is ready to accept new configuration
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(1));
+
+      final var client = protocolFactory.newServerProtocol(MemberId.from("test-client"));
+      final var configuration = m1.getContext().getCluster().getConfiguration();
+      final var withPassiveMember =
+          List.<RaftMember>of(
+              new DefaultRaftMember(id1, Type.ACTIVE, Instant.now()),
+              new DefaultRaftMember(id2, Type.PASSIVE, Instant.now()));
+      assertThat(
+              client.reconfigure(
+                  id1,
+                  ReconfigureRequest.builder()
+                      .withIndex(configuration.index())
+                      .withTerm(configuration.term())
+                      .withMembers(withPassiveMember)
+                      .from(id1.id())
+                      .build()))
+          .describedAs("Adding a PASSIVE member commits without its ack")
+          .succeedsWithin(Duration.ofSeconds(10))
+          .satisfies(
+              reconfigureResponse -> assertThat(reconfigureResponse.status()).isEqualTo(Status.OK));
+
+      // when - promoting the unreachable member to ACTIVE, making it a voting member of the new
+      // configuration
+      final var commitIndexBeforePromotion = m1.getContext().getCommitIndex();
+      final var committedConfiguration = m1.getContext().getCluster().getConfiguration();
+      final var promoted =
+          List.<RaftMember>of(
+              new DefaultRaftMember(id1, Type.ACTIVE, Instant.now()),
+              new DefaultRaftMember(id2, Type.ACTIVE, Instant.now()));
+      final var response =
+          client.reconfigure(
+              id1,
+              ReconfigureRequest.builder()
+                  .withIndex(committedConfiguration.index())
+                  .withTerm(committedConfiguration.term())
+                  .withMembers(promoted)
+                  .from(id1.id())
+                  .build());
+
+      // then - the configuration does not commit without the new voting member's ack: the leader
+      // eventually steps down instead of committing governed solely by the old configuration
+      Awaitility.await("Leader steps down because the new configuration cannot commit")
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> !m1.isLeader());
+      assertThat(m1.getContext().getCommitIndex()).isEqualTo(commitIndexBeforePromotion);
+      Awaitility.await("Reconfigure request completes")
+          .atMost(Duration.ofSeconds(30))
+          .until(response::isDone);
+      assertThat(response.isCompletedExceptionally() || response.join().status() == Status.ERROR)
+          .describedAs("Reconfigure request must not succeed")
+          .isTrue();
+    }
   }
 
   @Nested

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -14,10 +14,13 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.CancelledBootstrapException;
+import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
@@ -569,6 +572,23 @@ final class ReconfigurationTest {
     }
 
     @Test
+    void lastMemberCanLeaveCluster(@TempDir final Path tmp) {
+      // given - a cluster with a single member
+      final var id1 = MemberId.from("1");
+      final var m1 = createServer(tmp, createMembershipService(id1));
+      m1.bootstrap(id1).join();
+
+      // commit an entry to ensure that the leader is ready to accept new configuration
+      assertThat(appendEntry(awaitLeader(m1)).commit()).succeedsWithin(Duration.ofSeconds(1));
+
+      // when - the last member leaves, scaling the partition down to zero members
+      assertThat(m1.leave()).succeedsWithin(Duration.ofSeconds(5));
+
+      // then - the committed configuration is empty
+      assertThat(m1.cluster().getMembers()).isEmpty();
+    }
+
+    @Test
     void cannotLeaveWhenNewConfigurationDoesNotHaveQuorum(@TempDir final Path tmp) {
       // given - a cluster with 2 members
       final var id1 = MemberId.from("1");
@@ -639,6 +659,56 @@ final class ReconfigurationTest {
       // then -- remaining three can elect a leader and commit entries
       final var leader = awaitLeader(m1, m2);
       assertThat(appendEntry(leader).commit()).succeedsWithin(Duration.ofSeconds(1));
+    }
+  }
+
+  @Nested
+  final class Reconfiguring {
+    @Test
+    void shouldRejectConfigurationWithoutActiveMembers(@TempDir final Path tmp) {
+      // given - a cluster with 2 members
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, createMembershipService(id1, id2));
+      final var m2 = createServer(tmp, createMembershipService(id2, id1));
+
+      CompletableFuture.allOf(m1.bootstrap(id1, id2), m2.bootstrap(id1, id2)).join();
+
+      // commit an entry to ensure that the leader is ready to accept new configuration
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(1));
+
+      final var leader = getLeaderServer(List.of(m1, m2)).orElseThrow();
+      final var leaderId = leader.cluster().getLocalMember().memberId();
+      final var configuration = leader.getContext().getCluster().getConfiguration();
+
+      // when - requesting a configuration where no member is ACTIVE
+      final var allPassive =
+          List.<RaftMember>of(
+              new DefaultRaftMember(id1, Type.PASSIVE, Instant.now()),
+              new DefaultRaftMember(id2, Type.PASSIVE, Instant.now()));
+      final var response =
+          protocolFactory
+              .newServerProtocol(MemberId.from("test-client"))
+              .reconfigure(
+                  leaderId,
+                  ReconfigureRequest.builder()
+                      .withIndex(configuration.index())
+                      .withTerm(configuration.term())
+                      .withMembers(allPassive)
+                      .from(leaderId.id())
+                      .build());
+
+      // then - the reconfiguration is rejected and the cluster remains functional
+      assertThat(response)
+          .succeedsWithin(Duration.ofSeconds(5))
+          .satisfies(
+              reconfigureResponse -> {
+                assertThat(reconfigureResponse.status()).isEqualTo(Status.ERROR);
+                assertThat(reconfigureResponse.error().type())
+                    .isEqualTo(RaftError.Type.CONFIGURATION_ERROR);
+              });
+      assertThat(appendEntry(awaitLeader(m1, m2)).commit()).succeedsWithin(Duration.ofSeconds(1));
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -356,6 +356,116 @@ final class RaftClusterContextTest {
     assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(4L);
   }
 
+  @ParameterizedTest
+  @EnumSource(value = Type.class, names = "ACTIVE", mode = EnumSource.Mode.EXCLUDE)
+  void shouldIgnoreNonActiveMemberWhenCalculatingQuorum(final Type nonActiveMemberType) {
+    // given
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var activeMember1 = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var activeMember2 = new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now());
+    final var nonActiveMember =
+        new DefaultRaftMember(new MemberId("4"), nonActiveMemberType, Instant.now());
+    final var configuration =
+        new Configuration(
+            1,
+            1,
+            Instant.now().toEpochMilli(),
+            List.of(localMember, activeMember1, activeMember2, nonActiveMember));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    context.getMemberContext(activeMember1.memberId()).setMatchIndex(2);
+    context.getMemberContext(activeMember2.memberId()).setMatchIndex(3);
+    context.getMemberContext(nonActiveMember.memberId()).setMatchIndex(5);
+
+    // then
+    assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(3L);
+  }
+
+  @Test
+  void shouldNotCountNonActiveLocalMemberWhenCalculatingQuorum() {
+    // given
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.PASSIVE, Instant.now());
+    final var activeMember1 = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var activeMember2 = new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now());
+    final var configuration =
+        new Configuration(
+            1, 1, Instant.now().toEpochMilli(), List.of(localMember, activeMember1, activeMember2));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    context.getMemberContext(activeMember1.memberId()).setMatchIndex(2);
+    context.getMemberContext(activeMember2.memberId()).setMatchIndex(3);
+
+    // then
+    assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(2L);
+  }
+
+  @Test
+  void shouldUseActiveMembersFromEachConfigurationWhenCalculatingJointConsensusQuorum() {
+    // given
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var oldActiveMember =
+        new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var newPassiveMember =
+        new DefaultRaftMember(new MemberId("2"), Type.PASSIVE, Instant.now());
+    final var newActiveMember =
+        new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now());
+    final var configuration =
+        new Configuration(
+            1,
+            1,
+            Instant.now().toEpochMilli(),
+            List.of(localMember, newPassiveMember, newActiveMember),
+            List.of(localMember, oldActiveMember));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    context.getMemberContext(oldActiveMember.memberId()).setMatchIndex(5);
+    context.getMemberContext(newActiveMember.memberId()).setMatchIndex(2);
+
+    // then
+    assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(2L);
+  }
+
+  @Test
+  void shouldCountLocalMemberOnlyWhenActiveInJointConsensusConfiguration() {
+    // given
+    final var oldLocalMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var newLocalMember =
+        new DefaultRaftMember(new MemberId("1"), Type.PASSIVE, Instant.now());
+    final var oldActiveMember =
+        new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var newActiveMember1 =
+        new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now());
+    final var newActiveMember2 =
+        new DefaultRaftMember(new MemberId("4"), Type.ACTIVE, Instant.now());
+    final var configuration =
+        new Configuration(
+            1,
+            1,
+            Instant.now().toEpochMilli(),
+            List.of(newLocalMember, newActiveMember1, newActiveMember2),
+            List.of(oldLocalMember, oldActiveMember));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(oldLocalMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    context.getMemberContext(oldActiveMember.memberId()).setMatchIndex(5);
+    context.getMemberContext(newActiveMember1.memberId()).setMatchIndex(4);
+    context.getMemberContext(newActiveMember2.memberId()).setMatchIndex(3);
+
+    // then
+    assertThat(context.getQuorumFor(RaftMemberContext::getMatchIndex)).hasValue(3L);
+  }
+
   @Test
   void shouldNotIncludeLocalMemberInQuorumWhenItIsNotPartOfNewConfiguration() {
     // given

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 final class RaftClusterContextTest {
 
@@ -230,6 +232,100 @@ final class RaftClusterContextTest {
     verifyNoInteractions(callback);
 
     quorum.succeed(new MemberId("2"));
+    verify(callback).accept(true);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = Type.class, names = "ACTIVE", mode = EnumSource.Mode.EXCLUDE)
+  void shouldIgnoreVoteFromNonActiveMember(final Type nonActiveMemberType) {
+    // given
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var activeMember = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var nonActiveMember =
+        new DefaultRaftMember(new MemberId("3"), nonActiveMemberType, Instant.now());
+    final var configuration =
+        new Configuration(
+            1,
+            1,
+            Instant.now().toEpochMilli(),
+            List.of(localMember, activeMember, nonActiveMember));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    final Consumer<Boolean> callback = mock();
+    final var quorum = context.getVoteQuorum(callback);
+    quorum.succeed(nonActiveMember.memberId());
+
+    // then
+    verifyNoInteractions(callback);
+
+    quorum.succeed(activeMember.memberId());
+    verify(callback).accept(true);
+  }
+
+  @Test
+  void shouldNotCountVoteFromNonActiveLocalMember() {
+    // given
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.PASSIVE, Instant.now());
+    final var activeMember1 = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var activeMember2 = new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now());
+    final var configuration =
+        new Configuration(
+            1, 1, Instant.now().toEpochMilli(), List.of(localMember, activeMember1, activeMember2));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    final Consumer<Boolean> callback = mock();
+    final var quorum = context.getVoteQuorum(callback);
+    quorum.succeed(activeMember1.memberId());
+
+    // then
+    verifyNoInteractions(callback);
+
+    quorum.succeed(activeMember2.memberId());
+    verify(callback).accept(true);
+  }
+
+  @Test
+  void shouldIgnoreVotesFromNonActiveMembersInJointConsensus() {
+    // given
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var oldActiveMember =
+        new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var oldPassiveMember =
+        new DefaultRaftMember(new MemberId("3"), Type.PASSIVE, Instant.now());
+    final var newActiveMember =
+        new DefaultRaftMember(new MemberId("4"), Type.ACTIVE, Instant.now());
+    final var newPromotableMember =
+        new DefaultRaftMember(new MemberId("5"), Type.PROMOTABLE, Instant.now());
+    final var configuration =
+        new Configuration(
+            1,
+            1,
+            Instant.now().toEpochMilli(),
+            List.of(localMember, newActiveMember, newPromotableMember),
+            List.of(localMember, oldActiveMember, oldPassiveMember));
+    final var raft = raftWithStoredConfiguration(configuration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when
+    final Consumer<Boolean> callback = mock();
+    final var quorum = context.getVoteQuorum(callback);
+    quorum.succeed(oldPassiveMember.memberId());
+    quorum.succeed(newPromotableMember.memberId());
+
+    // then
+    verifyNoInteractions(callback);
+
+    quorum.succeed(oldActiveMember.memberId());
+    verifyNoInteractions(callback);
+
+    quorum.succeed(newActiveMember.memberId());
     verify(callback).accept(true);
   }
 


### PR DESCRIPTION
This contains three fixes:

1. Only active members contribute to the vote quorum
2. Only active members contribute to the commit quorum
3. Reconfigure requests that would result in passive-only configurations are rejected


Closes #57387