### PR TITLE
ci: dedupe redundant artifact downloads in detect-new-flaky-tests gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1731,53 +1731,28 @@ jobs:
 
       - name: Setup jq
         if: steps.bypass.outputs.present != 'true'
-        uses: dcarbone/install-jq-action@8867ddb4788346d7c22b72ea2e2ffe4d514c7bcb # v2.1.0
+        uses: dcarbone/install-jq-action@4fcb5062d7ce9bc4382d1a352d19ba3ba2c317c1 # v4.0.1
         with:
-          version: 1.6
+          version: 1.8.2
           force: 'true'
 
-      - name: Read Zeebe unit tests matrix outputs
+      - name: Read matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        id: zeebe-matrix-read
+        id: matrix-read
         shell: bash
         run: |
-          result="$(find . -maxdepth 2 -name zeebe-unit-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
-          echo "result=${result}" >> "$GITHUB_OUTPUT"
-      - name: Read Integration tests matrix outputs
-        if: steps.bypass.outputs.present != 'true'
-        id: integration-matrix-read
-        shell: bash
-        run: |
-          result="$(find . -maxdepth 2 -name integration-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
-          echo "result=${result}" >> "$GITHUB_OUTPUT"
-      - name: Read Physical-tenant acceptance tests matrix outputs
-        if: steps.bypass.outputs.present != 'true'
-        id: physical-tenant-acceptance-matrix-read
-        shell: bash
-        run: |
-          result="$(find . -maxdepth 2 -name physical-tenant-acceptance-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
-          echo "result=${result}" >> "$GITHUB_OUTPUT"
-      - name: Read Database integration tests matrix outputs
-        if: steps.bypass.outputs.present != 'true'
-        id: database-integration-matrix-read
-        shell: bash
-        run: |
-          result="$(find . -maxdepth 2 -name database-integration-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
-          echo "result=${result}" >> "$GITHUB_OUTPUT"
-      - name: Read history tests matrix outputs
-        if: steps.bypass.outputs.present != 'true'
-        id: history-matrix-read
-        shell: bash
-        run: |
-          result="$(find . -maxdepth 2 -name history-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
-          echo "result=${result}" >> "$GITHUB_OUTPUT"
-      - name: Read identity tests matrix outputs
-        if: steps.bypass.outputs.present != 'true'
-        id: identity-matrix-read
-        shell: bash
-        run: |
-          result="$(find . -maxdepth 2 -name identity-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
-          echo "result=${result}" >> "$GITHUB_OUTPUT"
+          for pair in \
+            "zeebe:zeebe-unit-tests" \
+            "integration:integration-tests" \
+            "physical-tenant-acceptance:physical-tenant-acceptance-tests" \
+            "database-integration:database-integration-tests" \
+            "history:history-tests" \
+            "identity:identity-tests"; do
+            output_name="${pair%%:*}"
+            artifact_name="${pair#*:}"
+            result="$(find . -maxdepth 2 -name "${artifact_name}" -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+            echo "${output_name}=${result}" >> "$GITHUB_OUTPUT"
+          done
 
       - name: Collect flaky test results
         if: steps.bypass.outputs.present != 'true'
@@ -1787,21 +1762,21 @@ jobs:
           general-unit-tests-result: ${{ needs.general-unit-tests.result }}
           general-unit-tests-flaky: ${{ needs.general-unit-tests.outputs.flakyTests }}
           database-integration-tests-result: ${{ needs.database-integration-tests.result }}
-          database-matrix-output-result: ${{ steps.database-integration-matrix-read.outputs.result }}
+          database-matrix-output-result: ${{ steps.matrix-read.outputs.database-integration }}
           history-tests-result: ${{ needs.history-tests.result }}
-          history-matrix-output-result: ${{ steps.history-matrix-read.outputs.result }}
+          history-matrix-output-result: ${{ steps.matrix-read.outputs.history }}
           identity-tests-result: ${{ needs.identity-tests.result }}
-          identity-matrix-output-result: ${{ steps.identity-matrix-read.outputs.result }}
+          identity-matrix-output-result: ${{ steps.matrix-read.outputs.identity }}
           rdbms-tests-result: ${{ needs.rdbms-integration-tests.result }}
           rdbms-tests-flaky: ${{ needs.rdbms-integration-tests.outputs.flakyTests }}
           docker-checks-result: ${{ needs.docker-checks.result }}
           docker-checks-flaky: ${{ needs.docker-checks.outputs.flakyTests }}
           zeebe-tests-result: ${{ needs.zeebe-unit-tests.result }}
-          zeebe-matrix-output-result: ${{ steps.zeebe-matrix-read.outputs.result }}
+          zeebe-matrix-output-result: ${{ steps.matrix-read.outputs.zeebe }}
           integration-tests-result: ${{ needs.integration-tests.result }}
-          integration-matrix-output-result: ${{ steps.integration-matrix-read.outputs.result }}
+          integration-matrix-output-result: ${{ steps.matrix-read.outputs.integration }}
           physical-tenant-acceptance-tests-result: ${{ needs.physical-tenant-acceptance-tests.result }}
-          physical-tenant-acceptance-matrix-output-result: ${{ steps.physical-tenant-acceptance-matrix-read.outputs.result }}
+          physical-tenant-acceptance-matrix-output-result: ${{ steps.matrix-read.outputs.physical-tenant-acceptance }}
 
       - name: Check if there are flaky tests to analyze
         if: steps.bypass.outputs.present != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1741,42 +1741,42 @@ jobs:
         id: zeebe-matrix-read
         shell: bash
         run: |
-          result="$(find . -name zeebe-unit-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          result="$(find . -maxdepth 2 -name zeebe-unit-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
           echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read Integration tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
         id: integration-matrix-read
         shell: bash
         run: |
-          result="$(find . -name integration-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          result="$(find . -maxdepth 2 -name integration-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
           echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read Physical-tenant acceptance tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
         id: physical-tenant-acceptance-matrix-read
         shell: bash
         run: |
-          result="$(find . -name physical-tenant-acceptance-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          result="$(find . -maxdepth 2 -name physical-tenant-acceptance-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
           echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read Database integration tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
         id: database-integration-matrix-read
         shell: bash
         run: |
-          result="$(find . -name database-integration-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          result="$(find . -maxdepth 2 -name database-integration-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
           echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read history tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
         id: history-matrix-read
         shell: bash
         run: |
-          result="$(find . -name history-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          result="$(find . -maxdepth 2 -name history-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
           echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read identity tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
         id: identity-matrix-read
         shell: bash
         run: |
-          result="$(find . -name identity-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          result="$(find . -maxdepth 2 -name identity-tests -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
       - name: Collect flaky test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1720,42 +1720,64 @@ jobs:
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # cloudposse/github-action-matrix-outputs-read downloads the run's ENTIRE
+      # artifact set on every invocation (no `name:` filter). With 6 matrix jobs
+      # to read, calling it 6x re-downloaded that same growing pool 6x. Download
+      # once here, then reuse the composite action's own extraction logic
+      # (find + jq) locally per matrix-step-name below — no repeat network cost.
+      - name: Download matrix output artifacts
+        if: steps.bypass.outputs.present != 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+
+      - name: Setup jq
+        if: steps.bypass.outputs.present != 'true'
+        uses: dcarbone/install-jq-action@8867ddb4788346d7c22b72ea2e2ffe4d514c7bcb # v2.1.0
+        with:
+          version: 1.6
+          force: 'true'
+
       - name: Read Zeebe unit tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: zeebe-matrix-read
-        with:
-          matrix-step-name: zeebe-unit-tests
+        shell: bash
+        run: |
+          result="$(find . -name zeebe-unit-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read Integration tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: integration-matrix-read
-        with:
-          matrix-step-name: integration-tests
+        shell: bash
+        run: |
+          result="$(find . -name integration-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read Physical-tenant acceptance tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: physical-tenant-acceptance-matrix-read
-        with:
-          matrix-step-name: physical-tenant-acceptance-tests
+        shell: bash
+        run: |
+          result="$(find . -name physical-tenant-acceptance-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read Database integration tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: database-integration-matrix-read
-        with:
-          matrix-step-name: database-integration-tests
+        shell: bash
+        run: |
+          result="$(find . -name database-integration-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read history tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: history-matrix-read
-        with:
-          matrix-step-name: history-tests
+        shell: bash
+        run: |
+          result="$(find . -name history-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          echo "result=${result}" >> "$GITHUB_OUTPUT"
       - name: Read identity tests matrix outputs
         if: steps.bypass.outputs.present != 'true'
-        uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # 1.0.0
         id: identity-matrix-read
-        with:
-          matrix-step-name: identity-tests
+        shell: bash
+        run: |
+          result="$(find . -name identity-tests -maxdepth 2 -exec cat {} \; | jq -c --slurp 'map(to_entries | map(.key as $matrix_key | .value | map_values({($matrix_key): .}))) | flatten | reduce .[] as $item ({}; . * $item)')"
+          echo "result=${result}" >> "$GITHUB_OUTPUT"
 
       - name: Collect flaky test results
         if: steps.bypass.outputs.present != 'true'


### PR DESCRIPTION
Closes #58090

## Summary
- `detect-new-flaky-tests` job was running >5min (see run [29577820225](https://github.com/camunda/camunda/actions/runs/29577820225/job/87879769049)).
- Traced it to 6x calls to `cloudposse/github-action-matrix-outputs-read`, which internally does `actions/download-artifact@v4` with no `name:` filter — each call re-downloads the run's *entire* artifact pool (one artifact per matrix cell across all 6 matrix jobs), then locally greps out one job's slice and discards the rest.
- Fix: download the artifact pool once, then run the same `find | jq` extraction logic (lifted from the composite action's source) locally per matrix-step-name — no repeated network transfer, same output shape (`steps.<id>.outputs.result`), zero changes needed downstream in `collect-flaky-tests`.

## Test plan
- [x] CI run confirms `detect-new-flaky-tests` job duration drops meaningfully vs the baseline ~5:45 — verified on run [29580509474](https://github.com/camunda/camunda/actions/runs/29580509474/job/87888825999): ~5:45 → ~2:06.
- [x] Confirm `collect-flaky-tests` step still receives correctly merged matrix outputs for all 6 test types — checked actual job logs, all 6 `*-matrix-output-result` inputs populated correctly (including a real flaky test detected via `database-integration-tests` surviving intact).
- [x] actionlint / yaml validation clean (done locally).
