### PR TITLE
ci: disable load-test starter IT

### DIFF
--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,6 +50,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "worker", "it"})
+@Disabled("Temporarily disabled due to https://camunda.slack.com/archives/C0BJW0K7YL8")
 class StarterWorkerIT {
 
   @Container


### PR DESCRIPTION
## Description

Tests are flaky and prevent merging:

* https://app.incident.io/camunda/incidents/6586
* https://app.incident.io/camunda/incidents/6564

This is likely a spurious failure but it's affecting unrelated PRs at the moment: disable the test until we have an actual fix.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/58041
* https://app.incident.io/camunda/incidents/6586
* https://app.incident.io/camunda/incidents/6564
