### PR TITLE
fix: load-test: multiple fixes for storage=none

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -712,8 +712,6 @@ jobs:
 
           make "${INSTALL_TARGET}" \
             scenario="${SCENARIO}" \
-            secondary_storage="${SECONDARY_STORAGE_TYPE}" \
-            enable_optimize="${ENABLE_OPTIMIZE}" \
             chaos="${ENABLE_CHAOS}" \
             physical_tenants="${PHYSICAL_TENANTS}" \
             additional_platform_configuration="$additional_platform_config" \

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -130,42 +130,41 @@ install_es_prom_exporter = false
 # Disable Optimize if not enabled
 ifneq ($(enable_optimize),true)
 	platform_values += --set optimize.enabled=false
-else ifeq ($(secondary_storage),none)
-	# Optimize requires a secondary storage backend (Elasticsearch, OpenSearch,
-	# or a dedicated Elasticsearch cluster); it cannot run at all when secondary
-	# storage is disabled entirely.
-	platform_values += --set optimize.enabled=false
-else ifeq ($(secondary_storage),opensearch)
-	# When deploying the OpenSearch secondary storage, Optimize needs the
-	# OpenSearch-specific exporter/client configuration.
-    ifneq ($(wildcard camunda-platform-values-optimize-opensearch.yaml),)
-        platform_values += -f camunda-platform-values-optimize-opensearch.yaml
-    endif
-
-	install_es_prom_exporter = true
-	es_prom_exporter_es_uri = http://opensearch:9200
-	_load_test_setup_flags += --set metricsExporter.database.url=http://opensearch:9200
-else ifeq ($(secondary_storage),elasticsearch)
-	# When deploying the Elasticsearch secondary storage, Optimize needs the
-	# Elasticsearch-specific exporter/client configuration.
-	platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
-
-	install_es_prom_exporter = true
-	es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
-	_load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
 else
-	ifeq ($(filter $(secondary_storage),$(optimize_self_sufficient_storages)),)
-		# If we are not using Elasticsearch/OpenSearch as a secondary storage, Optimize will
-		# be configured with the Elasticsearch backend, either:
-		# * Using the same Elasticsearch cluster as the secondary storage, if
-		#   the secondary storage is also Elasticsearch.
-		# * Or using its dedicated Elasticsearch cluster, different from the
-		#   configured secondary storage.
-		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+	platform_values += -f camunda-platform-values-optimize.yaml
+
+    ifeq ($(secondary_storage),opensearch)
+        # When deploying the OpenSearch secondary storage, Optimize needs the
+        # OpenSearch-specific exporter/client configuration.
+        ifneq ($(wildcard camunda-platform-values-optimize-opensearch.yaml),)
+            platform_values += -f camunda-platform-values-optimize-opensearch.yaml
+        endif
+
+        install_es_prom_exporter = true
+        es_prom_exporter_es_uri = http://opensearch:9200
+        _load_test_setup_flags += --set metricsExporter.database.url=http://opensearch:9200
+    else ifeq ($(secondary_storage),elasticsearch)
+        # When deploying the Elasticsearch secondary storage, Optimize needs the
+        # Elasticsearch-specific exporter/client configuration.
+        platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+
         install_es_prom_exporter = true
         es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
         _load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
-	endif
+    else
+        ifeq ($(filter $(secondary_storage),$(optimize_self_sufficient_storages)),)
+            # If we are not using Elasticsearch/OpenSearch as a secondary storage, Optimize will
+            # be configured with the Elasticsearch backend, either:
+            # * Using the same Elasticsearch cluster as the secondary storage, if
+            #   the secondary storage is also Elasticsearch.
+            # * Or using its dedicated Elasticsearch cluster, different from the
+            #   configured secondary storage.
+            platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+            install_es_prom_exporter = true
+            es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
+            _load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
+        endif
+    endif
 endif
 
 # Platform values with stable configuration

--- a/load-tests/setup/common.mk
+++ b/load-tests/setup/common.mk
@@ -125,6 +125,8 @@ else ifeq ($(secondary_storage),none)
 endif
 platform_values += -f camunda-platform-values-$(secondary_storage).yaml
 
+install_es_prom_exporter = false
+
 # Disable Optimize if not enabled
 ifneq ($(enable_optimize),true)
 	platform_values += --set optimize.enabled=false
@@ -136,13 +138,21 @@ else ifeq ($(secondary_storage),none)
 else ifeq ($(secondary_storage),opensearch)
 	# When deploying the OpenSearch secondary storage, Optimize needs the
 	# OpenSearch-specific exporter/client configuration.
-ifneq ($(wildcard camunda-platform-values-optimize-opensearch.yaml),)
-	platform_values += -f camunda-platform-values-optimize-opensearch.yaml
-endif
+    ifneq ($(wildcard camunda-platform-values-optimize-opensearch.yaml),)
+        platform_values += -f camunda-platform-values-optimize-opensearch.yaml
+    endif
+
+	install_es_prom_exporter = true
+	es_prom_exporter_es_uri = http://opensearch:9200
+	_load_test_setup_flags += --set metricsExporter.database.url=http://opensearch:9200
 else ifeq ($(secondary_storage),elasticsearch)
 	# When deploying the Elasticsearch secondary storage, Optimize needs the
 	# Elasticsearch-specific exporter/client configuration.
 	platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+
+	install_es_prom_exporter = true
+	es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
+	_load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
 else
 	ifeq ($(filter $(secondary_storage),$(optimize_self_sufficient_storages)),)
 		# If we are not using Elasticsearch/OpenSearch as a secondary storage, Optimize will
@@ -152,29 +162,14 @@ else
 		# * Or using its dedicated Elasticsearch cluster, different from the
 		#   configured secondary storage.
 		platform_values += -f camunda-platform-values-optimize-elasticsearch.yaml
+        install_es_prom_exporter = true
+        es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
+        _load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
 	endif
 endif
 
 # Platform values with stable configuration
 platform_values_stable = $(platform_values) -f values-stable.yaml
-
-ifeq ($(secondary_storage),elasticsearch)
-	install_es_prom_exporter = true
-	es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
-	_load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
-else ifeq ($(secondary_storage),opensearch)
-	install_es_prom_exporter = true
-	es_prom_exporter_es_uri = http://opensearch:9200
-	_load_test_setup_flags += --set metricsExporter.database.url=http://opensearch:9200
-else ifeq ($(enable_optimize),true)
-	# Here, the secondary storage is either none or an RDBMS database.
-	# Elasticsearch is always used in this case as the backend for Optimize.
-	install_es_prom_exporter = true
-	es_prom_exporter_es_uri = http://elasticsearch-es-http:9200
-	_load_test_setup_flags += --set metricsExporter.database.url=http://elasticsearch-es-http:9200
-else
-	install_es_prom_exporter = false
-endif
 
 ifeq ($(chaos),true)
 	_load_test_setup_flags += --set chaosKiller.enabled=true

--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -38,7 +38,6 @@ global:
     component: benchmark-n2-standard-4
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
-  # Identity authentication is enabled for Optimize
   identity:
     keycloak:
       auth:
@@ -48,11 +47,6 @@ global:
           existingSecretKey: identity-keycloak-admin-password
     auth:
       enabled: true
-      optimize:
-        clientId: optimize
-        secret:
-          existingSecret: camunda-credentials
-          existingSecretKey: identity-optimize-client-token
   security:
     authentication:
       type: oidc
@@ -64,74 +58,10 @@ identity:
     secret:
       existingSecret: camunda-credentials
       existingSecretKey: identity-firstuser-password
-  # Dedicated M2M Keycloak client for the load-tester's Optimize meter, with `write:*` on optimize-api.
-  clients:
-    - id: optimize-loadtest
-      name: Optimize Load Tester
-      type: m2m
-      secret:
-        existingSecret: camunda-credentials
-        existingSecretKey: identity-optimize-loadtest-client-secret
-      permissions:
-        - resourceServerId: optimize-api
-          definition: write:*
   env:
     # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
     - name: IDENTITY_LOG_APPENDER
       value: Stackdriver
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule
-
-optimize:
-  enabled: true
-  fullnameOverride: optimize # we override the names for simplicity of the deployment
-  extraConfiguration:
-    - file: application.yml
-      content: |
-        historyCleanup:
-          cronTrigger: '*/30 * * * *'
-          ttl: 'P1D'
-          processDataCleanup:
-            enabled: true
-  env:
-    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
-    - name: OPTIMIZE_LOG_APPENDER
-      value: Stackdriver
-    # Bearer-token (JWT) auth for /api/** (camunda/camunda#46878); consumed by the load-tester meter.
-    - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
-      value: "true"
-    - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
-      value: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
-
-    # Configure Optimize to use the full size of the ES/OS cluster it connects
-    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
-    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
-    # the cluster.
-    # Ideally, this value should default to the number of Elasticsearch nodes
-    # in the cluster.
-    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-
-    # Improve performances of Optimize for the load tests.
-    # This is load-test specific and different configuration of cluster
-    # configuration (different hardware resources for instance) and/or type of
-    # workload may benefit (or even require) from a different value here.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
-      value: "1000" # default 200
-
-    # Disable object variable flattening: Optimize's own default (true) turns
-    # every object variable into multiple stored variables (one per property,
-    # plus the raw serialized value), causing outsized ES storage on top of
-    # Optimize's already-higher per-variable cost. SaaS already disables this
-    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-      value: "false" # default true
-
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/setup/main/values/camunda-platform-values-optimize.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize.yaml
@@ -1,0 +1,76 @@
+global:
+  # Identity authentication is enabled for Optimize
+  identity:
+    auth:
+      optimize:
+        clientId: optimize
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-optimize-client-token
+
+identity:
+  # Dedicated M2M Keycloak client for the load-tester's Optimize meter, with `write:*` on optimize-api.
+  clients:
+    - id: optimize-loadtest
+      name: Optimize Load Tester
+      type: m2m
+      secret:
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-optimize-loadtest-client-secret
+      permissions:
+        - resourceServerId: optimize-api
+          definition: write:*
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        historyCleanup:
+          cronTrigger: '*/30 * * * *'
+          ttl: 'P1D'
+          processDataCleanup:
+            enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
+    # Bearer-token (JWT) auth for /api/** (camunda/camunda#46878); consumed by the load-tester meter.
+    - name: CAMUNDA_OPTIMIZE_API_JWT_AUTH_ENABLED
+      value: "true"
+    - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+      value: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+

--- a/load-tests/setup/newLoadTest.sh
+++ b/load-tests/setup/newLoadTest.sh
@@ -177,7 +177,14 @@ case "$secondary_storage" in
     ;;
 esac
 
-if [[ "$enable_optimize" == "true" ]]; then
+
+if [[ "$enable_optimize" == "true" && "$secondary_storage" == "none" ]]; then
+  echo "Optimize requires a secondary storage backend; forcefully disabling Optimize."
+  enable_optimize=false
+elif [[ "$enable_optimize" == "true" ]]; then
+  # Optimize-specific configuration
+  cp -v "$VERSION_DIR/values/camunda-platform-values-optimize.yaml" "$TARGET_DIRECTORY/"
+
   if [[ "$secondary_storage" == "elasticsearch" ]]; then
     # stable-87's Makefile uses this file when secondary_storage=elasticsearch;
     # for other versions it's harmlessly present (their Makefiles skip it for ES).
@@ -185,10 +192,9 @@ if [[ "$enable_optimize" == "true" ]]; then
   elif [[ "$secondary_storage" == "opensearch" ]]; then
     optimize_opensearch_config_file="$VERSION_DIR/values/camunda-platform-values-optimize-opensearch.yaml"
     if [[ -f "$optimize_opensearch_config_file" ]]; then
+      # We don't ship the OpenSearch configuration for Optimize on 8.8
       cp -v "$optimize_opensearch_config_file" "$TARGET_DIRECTORY/"
     fi
-  elif [[ "$secondary_storage" == "none" ]]; then
-    echo "Optimize requires a secondary storage backend; ignoring enable_optimize=true because secondary_storage=none"
   else
     # Non-ES/non-OS storage: forcefully configure Optimize to use Elasticsearch.
     elasticsearchEnabled=true

--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -39,10 +39,6 @@ global:
         existingSecret:
           name: camunda-credentials
         existingSecretKey: identity-zeebe-client-token
-      optimize:
-        clientId: optimize
-        existingSecret: camunda-credentials
-        existingSecretKey: identity-optimize-client-token
       operate:
         clientId: operate
         existingSecret: camunda-credentials
@@ -72,100 +68,6 @@ identity:
       value: Stackdriver
   nodeSelector:
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule
-
-optimize:
-  enabled: true
-  fullnameOverride: optimize # we override the names for simplicity of the deployment
-  resources:
-    requests:
-      cpu: 1
-      memory: 2Gi
-    limits:
-      cpu: 2
-      memory: 4Gi
-
-  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
-  # not from application.yml via spring.config.import.
-  # To provide a different/additional configuration from the default configuration, we therefore
-  # have to override the full environment-config.yaml via `configuration` and repeat the default
-  # configuration: to see the differences compared to the default one, see the marker in the
-  # configuration itself.
-  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
-  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
-  configuration: |
-    zeebe:
-      enabled: true
-      partitionCount: 3
-      name: "zeebe-record"
-    es:
-      connection:
-        nodes:
-          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
-            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
-    spring:
-      servlet:
-        multipart:
-          max-file-size: "10MB"
-          max-request-size: "10MB"
-      profiles:
-        active: "ccsm"
-    security:
-      auth:
-        cookie:
-          same-site:
-            enabled: false
-        ccsm:
-          redirectRootUrl: "http://localhost:8083"
-    api:
-      audience: "optimize-api"
-      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
-
-    ## Changed from the default configuration
-    # Configure and enable the process data cleanup
-    historyCleanup:
-      cronTrigger: '*/30 * * * *'
-      ttl: 'P1D'
-      processDataCleanup:
-        enabled: true
-  env:
-    # https://docs.camunda.io/docs/8.7/self-managed/optimize-deployment/configuration/logging/#google-stackdriver-json-logging
-    - name: JSON_LOGGING
-      value: "true"
-
-    # Configure Optimize to use the full size of the ES/OS cluster it connects
-    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
-    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
-    # the cluster.
-    # Ideally, this value should default to the number of Elasticsearch nodes
-    # in the cluster.
-    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-
-    # Improve performances of Optimize for the load tests.
-    # This is load-test specific and different configuration of cluster
-    # configuration (different hardware resources for instance) and/or type of
-    # workload may benefit (or even require) from a different value here.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
-      value: "1000" # default 200
-
-    # Disable object variable flattening: Optimize's own default (true) turns
-    # every object variable into multiple stored variables (one per property,
-    # plus the raw serialized value), causing outsized ES storage on top of
-    # Optimize's already-higher per-variable cost. SaaS already disables this
-    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-      value: "false" # default true
-
-  nodeSelector:
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/setup/stable-87/values/camunda-platform-values-optimize.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-optimize.yaml
@@ -1,0 +1,102 @@
+global:
+  identity:
+    auth:
+      optimize:
+        clientId: optimize
+        existingSecret: camunda-credentials
+        existingSecretKey: identity-optimize-client-token
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 2
+      memory: 4Gi
+
+  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
+  # not from application.yml via spring.config.import.
+  # To provide a different/additional configuration from the default configuration, we therefore
+  # have to override the full environment-config.yaml via `configuration` and repeat the default
+  # configuration: to see the differences compared to the default one, see the marker in the
+  # configuration itself.
+  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
+  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
+  configuration: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
+            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    ## Changed from the default configuration
+    # Configure and enable the process data cleanup
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true
+  env:
+    # https://docs.camunda.io/docs/8.7/self-managed/optimize-deployment/configuration/logging/#google-stackdriver-json-logging
+    - name: JSON_LOGGING
+      value: "true"
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
+  nodeSelector:
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -38,15 +38,10 @@ global:
     component: benchmark-n2-standard-4
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
-  # Identity authentication is enabled for Optimize
   identity:
     auth:
       enabled: true
-      optimize:
-        clientId: optimize
-        secret:
-          existingSecret: camunda-credentials
-          existingSecretKey: identity-optimize-client-token
+
   security:
     authentication:
       method: oidc
@@ -62,89 +57,6 @@ identity:
     # https://docs.camunda.io/docs/self-managed/components/management-identity/miscellaneous/configuration-variables/#google-stackdriver-json-logging
     - name: IDENTITY_LOG_APPENDER
       value: Stackdriver
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule
-
-optimize:
-  enabled: true
-  fullnameOverride: optimize # we override the names for simplicity of the deployment
-  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
-  # not from application.yml via spring.config.import. We therefore override the full
-  # environment-config.yaml via `configuration` so the cleanup block is in the correct file.
-  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
-  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
-  configuration: |
-    zeebe:
-      enabled: true
-      partitionCount: 3
-      name: "zeebe-record"
-    es:
-      connection:
-        nodes:
-          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
-            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
-    spring:
-      servlet:
-        multipart:
-          max-file-size: "10MB"
-          max-request-size: "10MB"
-      profiles:
-        active: "ccsm"
-    security:
-      auth:
-        cookie:
-          same-site:
-            enabled: false
-        ccsm:
-          redirectRootUrl: "http://localhost:8083"
-    api:
-      audience: "optimize-api"
-      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
-
-    ## Configure Optimize data cleanup
-    historyCleanup:
-      cronTrigger: '*/30 * * * *'
-      ttl: 'P1D'
-      processDataCleanup:
-        enabled: true
-  env:
-    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
-    - name: OPTIMIZE_LOG_APPENDER
-      value: Stackdriver
-
-    # Configure Optimize to use the full size of the ES/OS cluster it connects
-    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
-    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
-    # the cluster.
-    # Ideally, this value should default to the number of Elasticsearch nodes
-    # in the cluster.
-    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-
-    # Improve performances of Optimize for the load tests.
-    # This is load-test specific and different configuration of cluster
-    # configuration (different hardware resources for instance) and/or type of
-    # workload may benefit (or even require) from a different value here.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
-      value: "1000" # default 200
-
-    # Disable object variable flattening: Optimize's own default (true) turns
-    # every object variable into multiple stored variables (one per property,
-    # plus the raw serialized value), causing outsized ES storage on top of
-    # Optimize's already-higher per-variable cost. SaaS already disables this
-    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-      value: "false" # default true
-
-  nodeSelector:
-    component: benchmark-n2-standard-4
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
-
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/setup/stable-88/values/camunda-platform-values-optimize.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-optimize.yaml
@@ -1,0 +1,93 @@
+global:
+  # Identity authentication is enabled for Optimize
+  identity:
+    auth:
+      optimize:
+        clientId: optimize
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-optimize-client-token
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  # Optimize reads historyCleanup only from environment-config.yaml (its custom config loader),
+  # not from application.yml via spring.config.import. We therefore override the full
+  # environment-config.yaml via `configuration` so the cleanup block is in the correct file.
+  # ES host/port use Optimize's ${VAR:default} placeholder syntax so they stay dynamic at
+  # runtime (the deployment sets OPTIMIZE_ELASTICSEARCH_HOST / OPTIMIZE_ELASTICSEARCH_HTTP_PORT).
+  configuration: |
+    zeebe:
+      enabled: true
+      partitionCount: 3
+      name: "zeebe-record"
+    es:
+      connection:
+        nodes:
+          - host: "${OPTIMIZE_ELASTICSEARCH_HOST:localhost}"
+            httpPort: ${OPTIMIZE_ELASTICSEARCH_HTTP_PORT:9200}
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: "ccsm"
+    security:
+      auth:
+        cookie:
+          same-site:
+            enabled: false
+        ccsm:
+          redirectRootUrl: "http://localhost:8083"
+    api:
+      audience: "optimize-api"
+      jwtSetUri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+
+    ## Configure Optimize data cleanup
+    historyCleanup:
+      cronTrigger: '*/30 * * * *'
+      ttl: 'P1D'
+      processDataCleanup:
+        enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
+  nodeSelector:
+    component: benchmark-n2-standard-4
+    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule
+

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -38,15 +38,9 @@ global:
     component: benchmark-n2-standard-4
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 
-  # Identity authentication is enabled for Optimize
   identity:
     auth:
       enabled: true
-      optimize:
-        clientId: optimize
-        secret:
-          existingSecret: camunda-credentials
-          existingSecretKey: identity-optimize-client-token
   security:
     authentication:
       type: oidc
@@ -68,53 +62,6 @@ identity:
       value: n2-standard-4
       effect: NoSchedule
 
-optimize:
-  enabled: true
-  fullnameOverride: optimize # we override the names for simplicity of the deployment
-  extraConfiguration:
-    - file: application.yml
-      content: |
-        historyCleanup:
-          cronTrigger: '*/30 * * * *'
-          ttl: 'P1D'
-          processDataCleanup:
-            enabled: true
-  env:
-    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
-    - name: OPTIMIZE_LOG_APPENDER
-      value: Stackdriver
-
-    # Configure Optimize to use the full size of the ES/OS cluster it connects
-    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
-    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
-    # the cluster.
-    # Ideally, this value should default to the number of Elasticsearch nodes
-    # in the cluster.
-    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
-      value: "3" # default 1
-
-    # Improve performances of Optimize for the load tests.
-    # This is load-test specific and different configuration of cluster
-    # configuration (different hardware resources for instance) and/or type of
-    # workload may benefit (or even require) from a different value here.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
-      value: "1000" # default 200
-
-    # Disable object variable flattening: Optimize's own default (true) turns
-    # every object variable into multiple stored variables (one per property,
-    # plus the raw serialized value), causing outsized ES storage on top of
-    # Optimize's already-higher per-variable cost. SaaS already disables this
-    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
-      value: "false" # default true
-
-  tolerations:
-    - key: nodepool
-      operator: Equal
-      value: n2-standard-4
-      effect: NoSchedule
 
 identityKeycloak:
   enabled: true

--- a/load-tests/setup/stable-89/values/camunda-platform-values-optimize.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-optimize.yaml
@@ -1,0 +1,58 @@
+
+global:
+  identity:
+    auth:
+      # Identity authentication is enabled for Optimize
+      optimize:
+        clientId: optimize
+        secret:
+          existingSecret: camunda-credentials
+          existingSecretKey: identity-optimize-client-token
+
+optimize:
+  enabled: true
+  fullnameOverride: optimize # we override the names for simplicity of the deployment
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        historyCleanup:
+          cronTrigger: '*/30 * * * *'
+          ttl: 'P1D'
+          processDataCleanup:
+            enabled: true
+  env:
+    # https://docs.camunda.io/docs/self-managed/components/optimize/configuration/logging/#google-stackdriver-json-logging
+    - name: OPTIMIZE_LOG_APPENDER
+      value: Stackdriver
+
+    # Configure Optimize to use the full size of the ES/OS cluster it connects
+    # to. Otherwise, the default configuration of 1 primary + 1 replica creates
+    # bottlenecks on 2 nodes and doesn't spread the disk usage correctly across
+    # the cluster.
+    # Ideally, this value should default to the number of Elasticsearch nodes
+    # in the cluster.
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_NUMBER_OF_SHARDS
+      value: "3" # default 1
+
+    # Improve performances of Optimize for the load tests.
+    # This is load-test specific and different configuration of cluster
+    # configuration (different hardware resources for instance) and/or type of
+    # workload may benefit (or even require) from a different value here.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
+      value: "1000" # default 200
+
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
+  tolerations:
+    - key: nodepool
+      operator: Equal
+      value: n2-standard-4
+      effect: NoSchedule

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/configmap.yaml
@@ -158,15 +158,6 @@ data:
         webmodeler:
           root-url: "http://localhost:8070"
       clients:
-        - id: optimize-loadtest
-          name: Optimize Load Tester
-          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
-          redirectUris: 
-          rootUrl: 
-          type: m2m
-          permissions:
-            - definition: write:*
-              resourceServerId: optimize-api
       users:
         - username: "demo"
           password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}

--- a/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/none-optimize/platform/templates/identity/deployment.yaml
@@ -78,11 +78,6 @@ spec:
                 secretKeyRef:
                   name: camunda-credentials
                   key: identity-firstuser-password
-            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: camunda-credentials
-                  key: identity-optimize-loadtest-client-secret
             - name: IDENTITY_LOG_APPENDER
               value: Stackdriver
           envFrom:

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/configmap.yaml
@@ -158,15 +158,6 @@ data:
         webmodeler:
           root-url: "http://localhost:8070"
       clients:
-        - id: optimize-loadtest
-          name: Optimize Load Tester
-          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
-          redirectUris: 
-          rootUrl: 
-          type: m2m
-          permissions:
-            - definition: write:*
-              resourceServerId: optimize-api
       users:
         - username: "demo"
           password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/deployment.yaml
@@ -78,11 +78,6 @@ spec:
                 secretKeyRef:
                   name: camunda-credentials
                   key: identity-firstuser-password
-            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: camunda-credentials
-                  key: identity-optimize-loadtest-client-secret
             - name: IDENTITY_LOG_APPENDER
               value: Stackdriver
           envFrom:

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/configmap.yaml
@@ -169,15 +169,6 @@ data:
         webmodeler:
           root-url: "http://localhost:8070"
       clients:
-        - id: optimize-loadtest
-          name: Optimize Load Tester
-          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
-          redirectUris: 
-          rootUrl: 
-          type: m2m
-          permissions:
-            - definition: write:*
-              resourceServerId: optimize-api
       users:
         - username: "demo"
           password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/deployment.yaml
@@ -83,11 +83,6 @@ spec:
                 secretKeyRef:
                   name: camunda-credentials
                   key: identity-firstuser-password
-            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: camunda-credentials
-                  key: identity-optimize-loadtest-client-secret
             - name: IDENTITY_LOG_APPENDER
               value: Stackdriver
           envFrom:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/configmap.yaml
@@ -169,15 +169,6 @@ data:
         webmodeler:
           root-url: "http://localhost:8070"
       clients:
-        - id: optimize-loadtest
-          name: Optimize Load Tester
-          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
-          redirectUris: 
-          rootUrl: 
-          type: m2m
-          permissions:
-            - definition: write:*
-              resourceServerId: optimize-api
       users:
         - username: "demo"
           password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/deployment.yaml
@@ -83,11 +83,6 @@ spec:
                 secretKeyRef:
                   name: camunda-credentials
                   key: identity-firstuser-password
-            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: camunda-credentials
-                  key: identity-optimize-loadtest-client-secret
             - name: IDENTITY_LOG_APPENDER
               value: Stackdriver
           envFrom:

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/configmap.yaml
@@ -169,15 +169,6 @@ data:
         webmodeler:
           root-url: "http://localhost:8070"
       clients:
-        - id: optimize-loadtest
-          name: Optimize Load Tester
-          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
-          redirectUris: 
-          rootUrl: 
-          type: m2m
-          permissions:
-            - definition: write:*
-              resourceServerId: optimize-api
       users:
         - username: "demo"
           password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/deployment.yaml
@@ -83,11 +83,6 @@ spec:
                 secretKeyRef:
                   name: camunda-credentials
                   key: identity-firstuser-password
-            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: camunda-credentials
-                  key: identity-optimize-loadtest-client-secret
             - name: IDENTITY_LOG_APPENDER
               value: Stackdriver
           envFrom:


### PR DESCRIPTION
## Description

This fixes multiple issues with `storage=none`:

1. Follow-up of #57772: don't install the Prometheus exporter for Elasticsearch if secondary storage is none, as there's nothing to monitor.
   https://github.com/camunda/camunda/pull/58038 [failed](https://github.com/camunda/camunda/actions/runs/29563815601/job/87833075875?pr=58038) with:
   <img width="941" height="285" alt="image" src="https://github.com/user-attachments/assets/af29c649-5b65-4d71-9aad-490c66c0ec8d" />
2. Configure Optimize even less than before ; we don't run it anymore at all when storage=none


For 2., I extracted Optimize's configuration into dedicated files and clarified whether "Optimize is enabled or not":

* Before, even when `storage=none`, we were configuring our load-test with `enabled_optimize=true` and we add additional checks in the Makefile to turn it off.
* Now this is all precomputed and:
  1. We don't configure  `enabled_optimize=true` in the load test if Optimize will be disabled (explicitly, or because of incompatible configuration)
  2. We just don't include all the Optimize-specific configuration if Optimize is disabled


> [!IMPORTANT]
> This doesn't fix all the issues for `storage=none`, see #58191. In particular, we still need [this fix](https://github.com/camunda/camunda-platform-helm/pull/6582) for `main` which is not released yet and our load-test are still stuck on 8.10-alpha1.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/58191
