### PR TITLE
feat: implement SecretReference.RESOLUTION_REQUESTED event applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -170,12 +170,14 @@ public final class EventAppliers implements EventApplier {
     registerJobMetricsBatchEventAppliers(state);
     registerAgentInstanceEventAppliers(state);
     registerAgentHistoryEventAppliers(state);
-    registerSecretReferenceEventAppliers();
+    registerSecretReferenceEventAppliers(state);
     return this;
   }
 
-  private void registerSecretReferenceEventAppliers() {
-    register(SecretReferenceIntent.RESOLUTION_REQUESTED, NOOP_EVENT_APPLIER);
+  private void registerSecretReferenceEventAppliers(final MutableProcessingState state) {
+    register(
+        SecretReferenceIntent.RESOLUTION_REQUESTED,
+        new SecretReferenceResolutionRequestedApplier(state.getSecretReferenceState()));
     register(SecretReferenceIntent.RESOLUTION_COMPLETED, NOOP_EVENT_APPLIER);
     register(SecretReferenceIntent.RESOLUTION_FAILED, NOOP_EVENT_APPLIER);
     register(SecretReferenceIntent.BATCH_JOBS_REACTIVATED, NOOP_EVENT_APPLIER);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+
+public final class SecretReferenceResolutionRequestedApplier
+    implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
+
+  private final MutableSecretReferenceState secretReferenceState;
+
+  public SecretReferenceResolutionRequestedApplier(
+      final MutableSecretReferenceState secretReferenceState) {
+    this.secretReferenceState = secretReferenceState;
+  }
+
+  @Override
+  public void applyState(final long key, final SecretReferenceRecord value) {
+    final String storeId = value.getStoreId();
+    final String secretReference = value.getSecretReference();
+
+    secretReferenceState.addPendingSecretReference(storeId, secretReference);
+
+    for (final long jobKey : value.getJobKeys()) {
+      secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class SecretReferenceResolutionRequestedApplierTest {
+
+  private MutableProcessingState processingState;
+  private MutableSecretReferenceState state;
+  private SecretReferenceResolutionRequestedApplier applier;
+
+  @BeforeEach
+  void setUp() {
+    state = processingState.getSecretReferenceState();
+    applier = new SecretReferenceResolutionRequestedApplier(state);
+  }
+
+  @Test
+  void shouldMarkSecretReferenceAsPending() {
+    // given
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then
+    assertThat(state.isPending("store-1", "secret-a")).isTrue();
+  }
+
+  @Test
+  void shouldAddAllJobsWaitingForSecretReference() {
+    // given
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L)
+            .addJobKey(2L);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then — CF3: jobs indexed by (storeId, secretReference)
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(waitingJobs).containsExactlyInAnyOrder(1L, 2L);
+  }
+
+  @Test
+  void shouldIndexSecretReferenceByJob() {
+    // given
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then — CF2: (storeId, secretReference) pairs indexed by job
+    final List<Object> pairs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        1L,
+        (storeId, secretReference) -> {
+          pairs.add(tuple(storeId, secretReference));
+          return true;
+        });
+    assertThat(pairs).containsExactly(tuple("store-1", "secret-a"));
+  }
+
+  @Test
+  void shouldBeIdempotentOnReplay() {
+    // given
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+
+    // when — apply twice, as replay would
+    applier.applyState(100L, record);
+    applier.applyState(100L, record);
+
+    // then — no duplicate waiting-job entries
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(state.isPending("store-1", "secret-a")).isTrue();
+    assertThat(waitingJobs).containsExactly(1L);
+  }
+
+  @Test
+  void shouldMarkPendingEvenWithoutJobs() {
+    // given — a record with no job keys
+    final var record =
+        new SecretReferenceRecord().setStoreId("store-1").setSecretReference("secret-a");
+
+    // when
+    applier.applyState(100L, record);
+
+    // then
+    assertThat(state.isPending("store-1", "secret-a")).isTrue();
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(waitingJobs).isEmpty();
+  }
+
+  @Test
+  void shouldIndexMultipleSecretReferencesByJob() {
+    // given — the same job key waiting on two different secret references
+    final var record1 =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+    final var record2 =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-b")
+            .addJobKey(1L);
+
+    // when
+    applier.applyState(100L, record1);
+    applier.applyState(101L, record2);
+
+    // then — CF2: both (storeId, secretReference) pairs are indexed under job 1
+    final List<Object> pairs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        1L,
+        (storeId, secretReference) -> {
+          pairs.add(tuple(storeId, secretReference));
+          return true;
+        });
+    assertThat(pairs)
+        .containsExactlyInAnyOrder(tuple("store-1", "secret-a"), tuple("store-1", "secret-b"));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import java.util.ArrayList;
 import java.util.List;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,6 +76,38 @@ final class SecretReferenceResolutionRequestedApplierTest {
   }
 
   @Test
+  void shouldAccumulateJobsAcrossSeparateResolutionRequestedEvents() {
+    // given — two separate RESOLUTION_REQUESTED events for the same secret, each adding a different
+    // job
+    final var record1 =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+    final var record2 =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(2L);
+
+    // when
+    applier.applyState(100L, record1);
+    applier.applyState(101L, record2);
+
+    // then — both jobs are in the waiting-jobs index and the reference stays pending
+    assertThat(state.isPending("store-1", "secret-a")).isTrue();
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(waitingJobs).containsExactlyInAnyOrder(1L, 2L);
+  }
+
+  @Test
   void shouldIndexSecretReferenceByJob() {
     // given
     final var record =
@@ -87,7 +120,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
     applier.applyState(100L, record);
 
     // then — CF2: (storeId, secretReference) pairs indexed by job
-    final List<Object> pairs = new ArrayList<>();
+    final List<Tuple> pairs = new ArrayList<>();
     state.visitSecretReferencesByJob(
         1L,
         (storeId, secretReference) -> {
@@ -98,7 +131,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   }
 
   @Test
-  void shouldBeIdempotentOnReplay() {
+  void shouldNotDuplicateJobOnRepeatedResolutionRequest() {
     // given
     final var record =
         new SecretReferenceRecord()
@@ -106,9 +139,9 @@ final class SecretReferenceResolutionRequestedApplierTest {
             .setSecretReference("secret-a")
             .addJobKey(1L);
 
-    // when — apply twice, as replay would
+    // when — apply twice, as would happen when the same job triggers a repeated activation attempt
     applier.applyState(100L, record);
-    applier.applyState(100L, record);
+    applier.applyState(101L, record);
 
     // then — no duplicate waiting-job entries
     final List<Long> waitingJobs = new ArrayList<>();
@@ -164,7 +197,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
     applier.applyState(101L, record2);
 
     // then — CF2: both (storeId, secretReference) pairs are indexed under job 1
-    final List<Object> pairs = new ArrayList<>();
+    final List<Tuple> pairs = new ArrayList<>();
     state.visitSecretReferencesByJob(
         1L,
         (storeId, secretReference) -> {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+
+public final class SecretReferenceResolutionRequestedApplier
+    implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
+
+  private final MutableSecretReferenceState secretReferenceState;
+
+  public SecretReferenceResolutionRequestedApplier(
+      final MutableSecretReferenceState secretReferenceState) {
+    this.secretReferenceState = secretReferenceState;
+  }
+
+  @Override
+  public void applyState(final long key, final SecretReferenceRecord value) {
+    final String storeId = value.getStoreId();
+    final String secretReference = value.getSecretReference();
+
+    secretReferenceState.addPendingSecretReference(storeId, secretReference);
+
+    for (final long jobKey : value.getJobKeys()) {
+      secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Implements the event applier for `SecretReference.RESOLUTION_REQUESTED`, which is the state-side counterpart of the event that kicks off secret resolution.

The applier writes to all three column families in `SecretReferenceState`:
1. Upserts the `(storeId, secretReference)` pair into CF1 (pending secret references) — upsert semantics prevent duplicate entries when multiple jobs await the same secret.
2. For each job key in the record, writes an entry to CF2 `(jobKey, storeId, secretReference)` and CF3 `(storeId, secretReference, jobKey)` via `addWaitingJob`, which always keeps both indexes in sync.

Also wires the applier into `EventAppliers`, replacing the previous NOOP registration, and refreshes the golden file snapshot.

## Checklist

<!-- Please complete all items and check all items by replacing [ ] with [x] -->

- [ ] I have read the [Contributing Guide](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md)
- [ ] I have added tests that cover my changes
- [ ] I have updated the documentation if required

## Related issues

closes #57851