### PR TITLE
56574 aws secrets manager config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,7 +692,7 @@ jobs:
           # ============================================================================
 
           # Zeebe modules owned by @camunda/core-features
-          CORE_FEATURES="':zeebe-auth',':camunda-load-tester',':zeebe-bpmn-model',':zeebe-dmn',':zeebe-expression-language',':zeebe-feel-integration',':zeebe-msgpack-core',':zeebe-msgpack-value',':zeebe-test-util',':zeebe-util',':zeebe-db',':zeebe-workflow-engine',':camunda-secret-store-api',':camunda-secret-store-file'"
+          CORE_FEATURES="':zeebe-auth',':camunda-load-tester',':zeebe-bpmn-model',':zeebe-dmn',':zeebe-expression-language',':zeebe-feel-integration',':zeebe-msgpack-core',':zeebe-msgpack-value',':zeebe-test-util',':zeebe-util',':zeebe-db',':zeebe-workflow-engine',':camunda-secret-store-api',':camunda-secret-store-file',':camunda-secret-store-aws'"
           PROTOCOL="':zeebe-protocol',':zeebe-protocol-asserts',':zeebe-protocol-impl',':zeebe-protocol-jackson',':zeebe-protocol-test-util'"
           GATEWAY="':zeebe-gateway',':zeebe-gateway-grpc',':zeebe-gateway-protocol',':zeebe-gateway-protocol-impl',':zeebe-gateway-rest'"
           EXPORTER="':zeebe-elasticsearch-exporter',':zeebe-opensearch-exporter',':camunda-exporter',':rdbms-exporter',':zeebe-exporter-api',':zeebe-exporter-common',':zeebe-exporter-test'"

--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -10,6 +10,7 @@ package io.camunda.configuration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
@@ -19,6 +20,11 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *
  * <ul>
  *   <li>{@code camunda.secrets.stores.file.<id>.path}
+ *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.region}
+ *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.path-prefix}
+ *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.batch-enabled}
+ *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.batch-size}
+ *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.container-secret-id}
  * </ul>
  *
  * <p>Secrets configuration is overridable per physical tenant via {@code
@@ -40,6 +46,7 @@ public class Secrets {
   public static class Stores {
 
     private Map<String, FileStore> file = new LinkedHashMap<>();
+    private Map<String, AwsSecretsManagerStore> awsSecretsManager = new LinkedHashMap<>();
 
     public Map<String, FileStore> getFile() {
       return file;
@@ -47,6 +54,21 @@ public class Secrets {
 
     public void setFile(final Map<String, FileStore> file) {
       this.file = file;
+    }
+
+    /**
+     * @throws IllegalArgumentException if any store's batch-size is outside the 1..20 range AWS
+     *     accepts, or if a store sets both batch-enabled and container-secret-id (the two are
+     *     contradictory: batching fetches multiple distinct secrets in one call, while a container
+     *     secret id means only one secret is ever fetched)
+     */
+    public Map<String, AwsSecretsManagerStore> getAwsSecretsManager() {
+      awsSecretsManager.forEach((id, store) -> store.validate(id));
+      return awsSecretsManager;
+    }
+
+    public void setAwsSecretsManager(final Map<String, AwsSecretsManagerStore> awsSecretsManager) {
+      this.awsSecretsManager = awsSecretsManager;
     }
   }
 
@@ -64,6 +86,112 @@ public class Secrets {
 
     public void setPath(final String path) {
       this.path = path;
+    }
+  }
+
+  /**
+   * Configuration for an AWS Secrets Manager store. Authentication is always identity-based (AWS
+   * SDK default credentials provider chain): no static credentials are accepted here by design.
+   */
+  public static class AwsSecretsManagerStore {
+
+    /**
+     * AWS region for this store. Optional: when omitted the SDK resolves it from the environment
+     * ({@code AWS_REGION}) or instance metadata.
+     */
+    private @Nullable String region;
+
+    /**
+     * Optional prefix prepended, with no separator inserted, to every reference name to form the
+     * AWS secret id (e.g. {@code camunda/} plus reference {@code db-password} resolves to secret id
+     * {@code camunda/db-password}; include the trailing separator here if one is wanted). When
+     * omitted, references map to bare secret names. Applies to {@link #containerSecretId} as well,
+     * since that is itself resolved as an AWS secret id.
+     */
+    private @Nullable String pathPrefix;
+
+    /**
+     * Opt-in: resolve secrets via AWS's {@code BatchGetSecretValue} (fewer round-trips) instead of
+     * one {@code GetSecretValue} call per reference. Off by default because it requires the {@code
+     * secretsmanager:BatchGetSecretValue} IAM action in addition to {@code GetSecretValue}, which
+     * not every deployment's IAM policy grants. Mutually exclusive with {@link #containerSecretId}.
+     */
+    private boolean batchEnabled = false;
+
+    /**
+     * Maximum number of secret ids per {@code BatchGetSecretValue} call when {@link #batchEnabled}
+     * is set. Only meaningful when batching is enabled. Must be between 1 and 20 (AWS's cap).
+     */
+    private int batchSize = 20;
+
+    /**
+     * Opt-in: instead of one AWS secret per reference, treat every reference as a JSON key inside
+     * this one named secret (e.g. {@code app-config}, a JSON object of key-value pairs). Mutually
+     * exclusive with {@link #batchEnabled}, since only this single secret is ever fetched.
+     */
+    private @Nullable String containerSecretId;
+
+    public @Nullable String getRegion() {
+      return region;
+    }
+
+    public void setRegion(final @Nullable String region) {
+      this.region = region;
+    }
+
+    public @Nullable String getPathPrefix() {
+      return pathPrefix;
+    }
+
+    public void setPathPrefix(final @Nullable String pathPrefix) {
+      this.pathPrefix = pathPrefix;
+    }
+
+    public boolean isBatchEnabled() {
+      return batchEnabled;
+    }
+
+    public void setBatchEnabled(final boolean batchEnabled) {
+      this.batchEnabled = batchEnabled;
+    }
+
+    public int getBatchSize() {
+      return batchSize;
+    }
+
+    public void setBatchSize(final int batchSize) {
+      this.batchSize = batchSize;
+    }
+
+    public @Nullable String getContainerSecretId() {
+      return containerSecretId;
+    }
+
+    public void setContainerSecretId(final @Nullable String containerSecretId) {
+      this.containerSecretId = containerSecretId;
+    }
+
+    /**
+     * @throws IllegalArgumentException if batch-size is outside the 1..20 range AWS accepts, or if
+     *     both batch-enabled and container-secret-id are set (the two are contradictory: batching
+     *     fetches multiple distinct secrets in one call, while a container secret id means only one
+     *     secret is ever fetched)
+     */
+    void validate(final String storeId) {
+      if (batchSize < 1 || batchSize > 20) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.aws-secrets-manager."
+                + storeId
+                + ".batch-size must be between 1 and 20, but was "
+                + batchSize);
+      }
+      if (batchEnabled && containerSecretId != null) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.aws-secrets-manager."
+                + storeId
+                + ".batch-enabled and .container-secret-id are mutually exclusive, but both were "
+                + "configured");
+      }
     }
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
@@ -9,15 +9,17 @@ package io.camunda.configuration.physicaltenants;
 
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Secrets;
+import io.camunda.configuration.Secrets.AwsSecretsManagerStore;
 import io.camunda.configuration.Secrets.FileStore;
 import io.camunda.configuration.physicaltenants.MapOverlaySpec.MapDescriptor;
 import java.util.List;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Per-tenant {@link Secrets} resolution: registers the {@code stores.file} named map so that {@link
- * PhysicalTenantMapOverlay} deep-merges it per physical tenant (the generic two-bind has a defect
- * that drops unmentioned root entries when a tenant overrides only some map keys).
+ * Per-tenant {@link Secrets} resolution: registers the {@code stores.file} and {@code
+ * stores.aws-secrets-manager} named maps so that {@link PhysicalTenantMapOverlay} deep-merges them
+ * per physical tenant (the generic two-bind has a defect that drops unmentioned root entries when a
+ * tenant overrides only some map keys).
  */
 @NullMarked
 final class PhysicalTenantSecretConfigurations {
@@ -28,7 +30,11 @@ final class PhysicalTenantSecretConfigurations {
           Secrets.class,
           Secrets::new,
           List.of(
-              new MapDescriptor<>("stores.file", FileStore.class, s -> s.getStores().getFile())),
+              new MapDescriptor<>("stores.file", FileStore.class, s -> s.getStores().getFile()),
+              new MapDescriptor<>(
+                  "stores.aws-secrets-manager",
+                  AwsSecretsManagerStore.class,
+                  s -> s.getStores().getAwsSecretsManager())),
           MapOverlaySpec.noHook(),
           Camunda::setSecrets);
 

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -8,6 +8,7 @@
 package io.camunda.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,210 @@ class SecretsTest {
       // then stores is non-null (field initializer) and the file map is empty
       assertThat(secrets.getStores()).isNotNull();
       assertThat(secrets.getStores().getFile()).isEmpty();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.aws-secrets-manager.aws-prod.region=eu-west-1",
+        "camunda.secrets.stores.aws-secrets-manager.aws-prod.path-prefix=camunda/",
+        "camunda.secrets.stores.aws-secrets-manager.aws-minimal.path-prefix=team/"
+      })
+  class WithAwsSecretsManagerStoreConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithAwsSecretsManagerStoreConfigured(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindAwsSecretsManagerStoreProperties() {
+      // given the camunda.secrets.stores.aws-secrets-manager.aws-prod.* properties are set
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the named store is present and its fields are bound
+      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-prod"))
+          .satisfies(
+              store -> {
+                assertThat(store.getRegion()).isEqualTo("eu-west-1");
+                assertThat(store.getPathPrefix()).isEqualTo("camunda/");
+              });
+    }
+
+    @Test
+    void shouldDefaultBatchingToDisabled() {
+      // given batch-enabled/batch-size are not set for aws-prod (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then batching defaults to off, with the standard AWS batch size as an inert default
+      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-prod"))
+          .satisfies(
+              store -> {
+                assertThat(store.isBatchEnabled()).isFalse();
+                assertThat(store.getBatchSize()).isEqualTo(20);
+              });
+    }
+
+    @Test
+    void shouldDefaultContainerSecretIdToNull() {
+      // given container-secret-id is not set for aws-prod (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then it defaults to the flat one-secret-per-reference mode
+      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-prod").getContainerSecretId())
+          .isNull();
+    }
+
+    @Test
+    void shouldBindMultipleStoresKeyedById() {
+      // given two aws-secrets-manager stores are configured (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then both store ids are present
+      assertThat(secrets.getStores().getAwsSecretsManager())
+          .containsKeys("aws-prod", "aws-minimal");
+    }
+
+    @Test
+    void shouldAllowOptionalRegion() {
+      // given aws-minimal has no region set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then region is null and path-prefix is still bound
+      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-minimal"))
+          .satisfies(
+              store -> {
+                assertThat(store.getRegion()).isNull();
+                assertThat(store.getPathPrefix()).isEqualTo("team/");
+              });
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.aws-secrets-manager.batched.batch-enabled=true",
+        "camunda.secrets.stores.aws-secrets-manager.batched.batch-size=5"
+      })
+  class WithBatchingConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBatchingConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindBatchEnabledAndBatchSize() {
+      // given batch-enabled/batch-size are set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then both are bound onto the named store
+      assertThat(secrets.getStores().getAwsSecretsManager().get("batched"))
+          .satisfies(
+              store -> {
+                assertThat(store.isBatchEnabled()).isTrue();
+                assertThat(store.getBatchSize()).isEqualTo(5);
+              });
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.aws-secrets-manager.bundled.container-secret-id=app-config"
+      })
+  class WithContainerSecretIdConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithContainerSecretIdConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindContainerSecretId() {
+      // given container-secret-id is set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then it is bound onto the named store
+      assertThat(secrets.getStores().getAwsSecretsManager().get("bundled").getContainerSecretId())
+          .isEqualTo("app-config");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.aws-secrets-manager.conflicted.batch-enabled=true",
+        "camunda.secrets.stores.aws-secrets-manager.conflicted.container-secret-id=app-config"
+      })
+  class WithBatchingAndContainerSecretIdBothConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBatchingAndContainerSecretIdBothConfigured(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectBatchEnabledWithContainerSecretId() {
+      // given batch-enabled and container-secret-id are both set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws, since the combination is contradictory
+      assertThatThrownBy(stores::getAwsSecretsManager).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {"camunda.secrets.stores.aws-secrets-manager.oversized.batch-size=50"})
+  class WithBatchSizeOutOfRange {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBatchSizeOutOfRange(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectBatchSizeAboveAwsCap() {
+      // given batch-size is set above AWS's cap of 20 (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getAwsSecretsManager).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class WithoutAwsSecretsManagerStoreConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithoutAwsSecretsManagerStoreConfigured(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldDefaultToEmptyAwsSecretsManagerMap() {
+      // given no camunda.secrets.* property is set
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the aws-secrets-manager map is empty
+      assertThat(secrets.getStores().getAwsSecretsManager()).isEmpty();
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
@@ -146,4 +146,159 @@ class PhysicalTenantSecretsOverlayTest {
                 .getPath())
         .isEqualTo("/root/secrets.txt");
   }
+
+  @Test
+  void shouldOverlayAwsSecretsManagerStorePerTenant() {
+    // given a root aws-secrets-manager store and a tenant that overrides its path-prefix
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.path-prefix",
+                    "tenanta/")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta gets its own path-prefix and the synthesized default keeps the root one
+    assertThat(
+            resolver
+                .forPhysicalTenant("tenanta")
+                .getSecrets()
+                .getStores()
+                .getAwsSecretsManager()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("tenanta/");
+    assertThat(
+            resolver
+                .forPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getSecrets()
+                .getStores()
+                .getAwsSecretsManager()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("camunda/");
+  }
+
+  @Test
+  void shouldInheritRootAwsSecretsManagerStoreWhenTenantHasNoSecretsOverride() {
+    // given only a root aws-secrets-manager store; the tenant overrides no secrets field
+    setProperties(
+        new HashMap<>(
+            Map.of("camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta inherits the root store (non-overridden -> seeded from root bind)
+    assertThat(
+            resolver
+                .forPhysicalTenant("tenanta")
+                .getSecrets()
+                .getStores()
+                .getAwsSecretsManager()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("camunda/");
+  }
+
+  @Test
+  void shouldOverrideOnlyTheFieldTenantSetsForAwsSecretsManagerStore() {
+    // given root sets both region and path-prefix; tenant overrides only region
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.aws-secrets-manager.shared.region", "eu-west-1",
+                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.region",
+                    "us-east-1")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta's region is overridden but path-prefix survives the deep merge from root
+    final var store =
+        resolver
+            .forPhysicalTenant("tenanta")
+            .getSecrets()
+            .getStores()
+            .getAwsSecretsManager()
+            .get("shared");
+    assertThat(store.getRegion()).isEqualTo("us-east-1");
+    assertThat(store.getPathPrefix()).isEqualTo("camunda/");
+  }
+
+  @Test
+  void shouldOverrideBatchEnabledPerTenantWhileInheritingPathPrefix() {
+    // given root has batching off and a path-prefix; tenant opts into batching only
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.batch-enabled",
+                    "true")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta's batch-enabled is overridden but path-prefix survives the deep merge
+    final var store =
+        resolver
+            .forPhysicalTenant("tenanta")
+            .getSecrets()
+            .getStores()
+            .getAwsSecretsManager()
+            .get("shared");
+    assertThat(store.isBatchEnabled()).isTrue();
+    assertThat(store.getPathPrefix()).isEqualTo("camunda/");
+    assertThat(
+            resolver
+                .forPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getSecrets()
+                .getStores()
+                .getAwsSecretsManager()
+                .get("shared")
+                .isBatchEnabled())
+        .isFalse();
+  }
+
+  @Test
+  void shouldExposePerTenantAwsSecretsManagerStoreViaRegistry() {
+    // given a root and a tenant override, verify
+    // PhysicalTenantResolver.mapValues(Camunda::getSecrets)
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.path-prefix",
+                    "tenanta/")),
+        "tenanta");
+
+    // when the registry is built from the resolver
+    final Map<String, Secrets> registry = newResolver().mapValues(Camunda::getSecrets);
+
+    // then it contains a Secrets per tenant with the correct per-tenant path-prefix
+    assertThat(registry).containsKeys("tenanta", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(
+            registry
+                .get("tenanta")
+                .getStores()
+                .getAwsSecretsManager()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("tenanta/");
+    assertThat(
+            registry
+                .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getStores()
+                .getAwsSecretsManager()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("camunda/");
+  }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -304,6 +304,7 @@ processing.max-commands-in-batch
 processing.max-recoverable-retries
 processing.scheduled-tasks-check-interval
 processing.skip-positions
+secrets.stores.aws-secrets-manager
 secrets.stores.file
 security.authentication
 security.authentication.authentication-refresh-interval

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1003,6 +1003,11 @@
         <artifactId>camunda-secret-store-file</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-secret-store-aws</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Camunda Process Testing modules -->
 

--- a/secret-store/secret-store-aws/pom.xml
+++ b/secret-store/secret-store-aws/pom.xml
@@ -10,20 +10,19 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-secret-store</artifactId>
     <version>8.10.0-SNAPSHOT</version>
-    <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>camunda-secret-store</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>camunda-secret-store-aws</artifactId>
 
-  <name>Camunda Secret Store</name>
+  <name>Camunda Secret Store AWS Secrets Manager Implementation</name>
 
-  <modules>
-    <module>secret-store-api</module>
-    <module>secret-store-file</module>
-    <module>secret-store-aws</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/package-info.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+@NullMarked
+package io.camunda.secretstore.aws;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Description

Groundwork for AWS Secrets Manager as a secret store backend, split out from the full
implementation so config/module scaffolding lands independently:

- Creates the `camunda-secret-store-aws` Maven module (empty for now — just `pom.xml`
  registration in `parent/pom.xml`/`secret-store/pom.xml`, CI core-features wiring, and
  `package-info.java`).
- Adds the `camunda.secrets.stores.aws-secrets-manager.<id>.*` configuration schema
  (`Secrets.AwsSecretsManagerStore`: `region`, `path-prefix`, `batch-enabled`, `batch-size`,
  `container-secret-id`) and registers it for per-physical-tenant overlay resolution.
- Regenerates the physical-tenant overridable-properties golden file for the new property.

The actual `AwsSecretsManagerSecretStore`/resolver implementation and its wiring into
`SecretStoreRegistry` are intentionally not included here — they depend on these files and
land in a follow-up PR.

## Related issues

Part of https://github.com/camunda/camunda/issues/56574
