### PR TITLE
test(e2e): add Tasklist Processes start-form filter coverage

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -82,38 +82,6 @@ class TasklistProcessesPage {
     await this.processFilterDropdown.click();
     await this.page.getByRole('option', {name: option, exact: true}).click();
   }
-
-  // Open the Processes tab with the start-form filter and/or a name search
-  // applied via the URL. The suite runs against a shared cluster where many
-  // process definitions exist and other tests deploy concurrently, so pinning
-  // to a specific process by name (plus the filter) is the only way to make
-  // presence/absence assertions deterministic and pagination-proof. Combining
-  // both via the search widget and the filter dropdown is unreliable because
-  // they share a single debounced URL updater, so the URL is set directly.
-  async openProcessesFiltered(params: {
-    hasStartForm?: 'yes' | 'no';
-    search?: string;
-  }): Promise<void> {
-    const query = new URLSearchParams();
-    if (params.hasStartForm) {
-      query.set('hasStartForm', params.hasStartForm);
-    }
-    if (params.search) {
-      query.set('search', params.search);
-    }
-    const queryString = query.toString();
-    await this.page.goto(
-      `/tasklist/processes${queryString ? `?${queryString}` : ''}`,
-      {waitUntil: 'load'},
-    );
-    await this.dismissFirstTimeModalIfPresent();
-  }
-
-  async dismissFirstTimeModalIfPresent(): Promise<void> {
-    if (await this.continueButton.isVisible().catch(() => false)) {
-      await this.continueButton.click();
-    }
-  }
 }
 
 export {TasklistProcessesPage};

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -6,7 +6,13 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {Page, Locator} from '@playwright/test';
+import {expect, type Page, type Locator} from '@playwright/test';
+
+const START_FORM_FILTER_URL_PARAM = {
+  'All Processes': null,
+  'Requires form input to start': 'yes',
+  'Does not require form input to start': 'no',
+} as const;
 
 class TasklistProcessesPage {
   private page: Page;
@@ -34,7 +40,7 @@ class TasklistProcessesPage {
   }
 
   processTileByName(name: string): Locator {
-    return this.processTile.filter({hasText: name});
+    return this.processTile.filter({hasText: name}).first();
   }
 
   requiresFormInputTagFor(name: string): Locator {
@@ -74,13 +80,21 @@ class TasklistProcessesPage {
   }
 
   async filterByStartForm(
-    option:
-      | 'All Processes'
-      | 'Requires form input to start'
-      | 'Does not require form input to start',
+    option: keyof typeof START_FORM_FILTER_URL_PARAM,
   ): Promise<void> {
     await this.processFilterDropdown.click();
     await this.page.getByRole('option', {name: option, exact: true}).click();
+
+    // The search box and this dropdown share one debounced URL updater, so
+    // wait for the filter's URL update to commit before a caller searches.
+    const paramValue = START_FORM_FILTER_URL_PARAM[option];
+    if (paramValue === null) {
+      await expect(this.page).not.toHaveURL(/hasStartForm=/);
+    } else {
+      await expect(this.page).toHaveURL(
+        new RegExp(`hasStartForm=${paramValue}`),
+      );
+    }
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/TasklistProcessesPage.ts
@@ -17,6 +17,7 @@ class TasklistProcessesPage {
   readonly searchProcessesInput: Locator;
   readonly processTile: Locator;
   readonly startProcessSubButton: Locator;
+  readonly processFilterDropdown: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -29,6 +30,17 @@ class TasklistProcessesPage {
     this.docsLink = page.getByRole('link', {name: 'here'});
     this.searchProcessesInput = page.getByPlaceholder('Search processes');
     this.processTile = page.getByTestId('process-tile');
+    this.processFilterDropdown = page.getByTestId('process-filters');
+  }
+
+  processTileByName(name: string): Locator {
+    return this.processTile.filter({hasText: name});
+  }
+
+  requiresFormInputTagFor(name: string): Locator {
+    return this.processTileByName(name).locator('.cds--tag__label', {
+      hasText: 'Requires form input',
+    });
   }
 
   async goto() {
@@ -59,6 +71,48 @@ class TasklistProcessesPage {
 
   async clickStartProcessSubButton(): Promise<void> {
     await this.startProcessSubButton.click();
+  }
+
+  async filterByStartForm(
+    option:
+      | 'All Processes'
+      | 'Requires form input to start'
+      | 'Does not require form input to start',
+  ): Promise<void> {
+    await this.processFilterDropdown.click();
+    await this.page.getByRole('option', {name: option, exact: true}).click();
+  }
+
+  // Open the Processes tab with the start-form filter and/or a name search
+  // applied via the URL. The suite runs against a shared cluster where many
+  // process definitions exist and other tests deploy concurrently, so pinning
+  // to a specific process by name (plus the filter) is the only way to make
+  // presence/absence assertions deterministic and pagination-proof. Combining
+  // both via the search widget and the filter dropdown is unreliable because
+  // they share a single debounced URL updater, so the URL is set directly.
+  async openProcessesFiltered(params: {
+    hasStartForm?: 'yes' | 'no';
+    search?: string;
+  }): Promise<void> {
+    const query = new URLSearchParams();
+    if (params.hasStartForm) {
+      query.set('hasStartForm', params.hasStartForm);
+    }
+    if (params.search) {
+      query.set('search', params.search);
+    }
+    const queryString = query.toString();
+    await this.page.goto(
+      `/tasklist/processes${queryString ? `?${queryString}` : ''}`,
+      {waitUntil: 'load'},
+    );
+    await this.dismissFirstTimeModalIfPresent();
+  }
+
+  async dismissFirstTimeModalIfPresent(): Promise<void> {
+    if (await this.continueButton.isVisible().catch(() => false)) {
+      await this.continueButton.click();
+    }
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -133,6 +133,90 @@ test.describe('process page', () => {
     await expect(page.getByText('Task completed')).toBeVisible();
   });
 
+  test('filter processes by "Requires form input to start"', async ({
+    page,
+    tasklistHeader,
+    tasklistProcessesPage,
+  }) => {
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    // The filter control applies the "hasStartForm=yes" query parameter.
+    await tasklistProcessesPage.filterByStartForm(
+      'Requires form input to start',
+    );
+    await expect(page).toHaveURL(/hasStartForm=yes/);
+
+    // A process with a linked start form is shown under this filter, tagged
+    // "Requires form input". Searching by name keeps the assertion stable on a
+    // shared cluster (many processes, concurrent deployments, pagination).
+    await tasklistProcessesPage.openProcessesFiltered({
+      hasStartForm: 'yes',
+      search: 'processWithStartNodeFormDeployed',
+    });
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
+      timeout: 30000,
+    });
+    await expect(
+      tasklistProcessesPage.requiresFormInputTagFor(
+        'processWithStartNodeFormDeployed',
+      ),
+    ).toHaveText('Requires form input');
+
+    // A process without a start form is excluded by the filter.
+    await tasklistProcessesPage.openProcessesFiltered({
+      hasStartForm: 'yes',
+      search: 'User_Process',
+    });
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeVisible();
+    await expect(tasklistProcessesPage.processTile).toHaveCount(0);
+  });
+
+  test('filter processes by "Does not require form input to start"', async ({
+    page,
+    tasklistHeader,
+    tasklistProcessesPage,
+  }) => {
+    await tasklistHeader.clickProcessesTab();
+    await expect(page).toHaveURL('/tasklist/processes');
+    await tasklistProcessesPage.continueButton.click();
+
+    // The filter control applies the "hasStartForm=no" query parameter.
+    await tasklistProcessesPage.filterByStartForm(
+      'Does not require form input to start',
+    );
+    await expect(page).toHaveURL(/hasStartForm=no/);
+
+    // A process without a start form is shown under this filter and is not
+    // tagged. Searching by name keeps the assertion stable on a shared cluster.
+    await tasklistProcessesPage.openProcessesFiltered({
+      hasStartForm: 'no',
+      search: 'User_Process',
+    });
+    await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
+      timeout: 30000,
+    });
+    await expect(tasklistProcessesPage.processTile).toContainText(
+      'User_Process',
+    );
+    await expect(
+      tasklistProcessesPage.requiresFormInputTagFor('User_Process'),
+    ).toBeHidden();
+
+    // A process with a linked start form is excluded by the filter.
+    await tasklistProcessesPage.openProcessesFiltered({
+      hasStartForm: 'no',
+      search: 'processWithStartNodeFormDeployed',
+    });
+    await expect(
+      page.getByText('We could not find any process with that name'),
+    ).toBeVisible();
+    await expect(tasklistProcessesPage.processTile).toHaveCount(0);
+  });
+
   test('complete process with start node having deployed form', async ({
     page,
     tasklistHeader,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -133,6 +133,8 @@ test.describe('process page', () => {
     await expect(page.getByText('Task completed')).toBeVisible();
   });
 
+  const NOT_FOUND_MESSAGE = 'We could not find any process with that name';
+
   test('filter processes by "Requires form input to start"', async ({
     page,
     tasklistHeader,
@@ -142,19 +144,17 @@ test.describe('process page', () => {
     await expect(page).toHaveURL('/tasklist/processes');
     await tasklistProcessesPage.continueButton.click();
 
-    // The filter control applies the "hasStartForm=yes" query parameter.
+    // Wait for the filter to commit to the URL before searching: the search box
+    // and the filter dropdown share one debounced URL updater.
     await tasklistProcessesPage.filterByStartForm(
       'Requires form input to start',
     );
     await expect(page).toHaveURL(/hasStartForm=yes/);
 
-    // A process with a linked start form is shown under this filter, tagged
-    // "Requires form input". Searching by name keeps the assertion stable on a
-    // shared cluster (many processes, concurrent deployments, pagination).
-    await tasklistProcessesPage.openProcessesFiltered({
-      hasStartForm: 'yes',
-      search: 'processWithStartNodeFormDeployed',
-    });
+    // A process with a start form is shown under this filter, tagged.
+    await tasklistProcessesPage.searchForProcess(
+      'processWithStartNodeFormDeployed',
+    );
     await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
       timeout: 30000,
     });
@@ -164,14 +164,9 @@ test.describe('process page', () => {
       ),
     ).toHaveText('Requires form input');
 
-    // A process without a start form is excluded by the filter.
-    await tasklistProcessesPage.openProcessesFiltered({
-      hasStartForm: 'yes',
-      search: 'User_Process',
-    });
-    await expect(
-      page.getByText('We could not find any process with that name'),
-    ).toBeVisible();
+    // A process without a start form is excluded by this filter.
+    await tasklistProcessesPage.searchForProcess('User_Process');
+    await expect(page.getByText(NOT_FOUND_MESSAGE)).toBeVisible();
     await expect(tasklistProcessesPage.processTile).toHaveCount(0);
   });
 
@@ -184,18 +179,13 @@ test.describe('process page', () => {
     await expect(page).toHaveURL('/tasklist/processes');
     await tasklistProcessesPage.continueButton.click();
 
-    // The filter control applies the "hasStartForm=no" query parameter.
     await tasklistProcessesPage.filterByStartForm(
       'Does not require form input to start',
     );
     await expect(page).toHaveURL(/hasStartForm=no/);
 
-    // A process without a start form is shown under this filter and is not
-    // tagged. Searching by name keeps the assertion stable on a shared cluster.
-    await tasklistProcessesPage.openProcessesFiltered({
-      hasStartForm: 'no',
-      search: 'User_Process',
-    });
+    // A process without a start form is shown under this filter and not tagged.
+    await tasklistProcessesPage.searchForProcess('User_Process');
     await expect(tasklistProcessesPage.processTile).toHaveCount(1, {
       timeout: 30000,
     });
@@ -206,14 +196,11 @@ test.describe('process page', () => {
       tasklistProcessesPage.requiresFormInputTagFor('User_Process'),
     ).toBeHidden();
 
-    // A process with a linked start form is excluded by the filter.
-    await tasklistProcessesPage.openProcessesFiltered({
-      hasStartForm: 'no',
-      search: 'processWithStartNodeFormDeployed',
-    });
-    await expect(
-      page.getByText('We could not find any process with that name'),
-    ).toBeVisible();
+    // A process with a start form is excluded by this filter.
+    await tasklistProcessesPage.searchForProcess(
+      'processWithStartNodeFormDeployed',
+    );
+    await expect(page.getByText(NOT_FOUND_MESSAGE)).toBeVisible();
     await expect(tasklistProcessesPage.processTile).toHaveCount(0);
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -144,12 +144,9 @@ test.describe('process page', () => {
     await expect(page).toHaveURL('/tasklist/processes');
     await tasklistProcessesPage.continueButton.click();
 
-    // Wait for the filter to commit to the URL before searching: the search box
-    // and the filter dropdown share one debounced URL updater.
     await tasklistProcessesPage.filterByStartForm(
       'Requires form input to start',
     );
-    await expect(page).toHaveURL(/hasStartForm=yes/);
 
     // A process with a start form is shown under this filter, tagged.
     await tasklistProcessesPage.searchForProcess(
@@ -182,7 +179,6 @@ test.describe('process page', () => {
     await tasklistProcessesPage.filterByStartForm(
       'Does not require form input to start',
     );
-    await expect(page).toHaveURL(/hasStartForm=no/);
 
     // A process without a start form is shown under this filter and not tagged.
     await tasklistProcessesPage.searchForProcess('User_Process');


### PR DESCRIPTION
## Description

Automates issue #58054 — E2E coverage for the Tasklist **Processes** tab start-form filter ("Requires form input to start" / "Does not require form input to start").

Two new tests in `qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts` reuse the resources already deployed by the file's `beforeAll` — `processWithStartNodeFormDeployed.bpmn` (linked start form) and `user_process.bpmn` (no start form):

- **"Requires form input to start"**: applying the filter, then searching by name, shows the form process tagged `Requires form input`; searching for the non-form process under the same filter yields no results.
- **"Does not require form input to start"**: the non-form process is shown untagged; the form process yields no results under this filter.

New `TasklistProcessesPage` helpers: `processFilterDropdown`, `filterByStartForm()`, `processTileByName()`, `requiresFormInputTagFor()`.

### Reviewer notes
- The search box and the start-form filter dropdown share one debounced URL updater in the app. `filterByStartForm()` waits for its own URL param to commit before returning, so a caller's subsequent search reads already-updated state instead of racing it.
- "Load more" under an active start-form filter appears to load unfiltered processes (tiles without the tag appear). Flagged separately for product investigation; these tests avoid pagination entirely by filtering + searching by exact process name.
- Both tests pass locally against a self-managed cluster (elasticsearch, `--project=chromium`) and in the on-demand E2E workflow (both Tasklist v2 E2E modes).

## Checklist

- [x] Enable backports when necessary.
- [x] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run before requesting review. Ran locally and via the on-demand workflow — both new tests pass.

## Related issues

closes #58054
