### PR TITLE
fix: resource-scoped group/role/tenant membership authorization gaps

### DIFF
--- a/identity/client/src/utility/api/membership/mutations.ts
+++ b/identity/client/src/utility/api/membership/mutations.ts
@@ -29,54 +29,54 @@ export const membershipMutations = {
     mutationOptions({
       mutationFn: (body: Pick<Group, "groupId"> & Pick<User, "username">) =>
         unwrap(assignGroupMember(body)(getApiBaseUrl())),
-      onSuccess: (_data, variables) =>
+      onSuccess: () =>
         qc.invalidateQueries({
-          queryKey: ["groups", "members", variables.groupId],
+          queryKey: ["enrichedMembers", "groups"],
         }),
     }),
   unassignGroupMember: (qc: QueryClient) =>
     mutationOptions({
       mutationFn: (body: Pick<Group, "groupId"> & Pick<User, "username">) =>
         unwrap(unassignGroupMember(body)(getApiBaseUrl())),
-      onSuccess: (_data, variables) =>
+      onSuccess: () =>
         qc.invalidateQueries({
-          queryKey: ["groups", "members", variables.groupId],
+          queryKey: ["enrichedMembers", "groups"],
         }),
     }),
   assignTenantMember: (qc: QueryClient) =>
     mutationOptions({
       mutationFn: (body: Pick<Tenant, "tenantId"> & Pick<User, "username">) =>
         unwrap(assignTenantMember(body)(getApiBaseUrl())),
-      onSuccess: (_data, variables) =>
+      onSuccess: () =>
         qc.invalidateQueries({
-          queryKey: ["tenants", "members", variables.tenantId],
+          queryKey: ["enrichedMembers", "tenants"],
         }),
     }),
   unassignTenantMember: (qc: QueryClient) =>
     mutationOptions({
       mutationFn: (body: Pick<Tenant, "tenantId"> & Pick<User, "username">) =>
         unwrap(unassignTenantMember(body)(getApiBaseUrl())),
-      onSuccess: (_data, variables) =>
+      onSuccess: () =>
         qc.invalidateQueries({
-          queryKey: ["tenants", "members", variables.tenantId],
+          queryKey: ["enrichedMembers", "tenants"],
         }),
     }),
   assignRoleMember: (qc: QueryClient) =>
     mutationOptions({
       mutationFn: (body: Pick<Role, "roleId"> & Pick<User, "username">) =>
         unwrap(assignRoleMember(body)(getApiBaseUrl())),
-      onSuccess: (_data, variables) =>
+      onSuccess: () =>
         qc.invalidateQueries({
-          queryKey: ["roles", "members", variables.roleId],
+          queryKey: ["enrichedMembers", "roles"],
         }),
     }),
   unassignRoleMember: (qc: QueryClient) =>
     mutationOptions({
       mutationFn: (body: Pick<Role, "roleId"> & Pick<User, "username">) =>
         unwrap(unassignRoleMember(body)(getApiBaseUrl())),
-      onSuccess: (_data, variables) =>
+      onSuccess: () =>
         qc.invalidateQueries({
-          queryKey: ["roles", "members", variables.roleId],
+          queryKey: ["enrichedMembers", "roles"],
         }),
     }),
 };

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupMemberFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupMemberFilterTransformer.java
@@ -44,6 +44,8 @@ public class GroupMemberFilterTransformer extends IndexFilterTransformer<GroupMe
   @Override
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
-    return stringTerms(GROUP_ID, authorization.resourceIds());
+    return hasParentQuery(
+        IdentityJoinRelationshipType.GROUP.getType(),
+        stringTerms(GROUP_ID, authorization.resourceIds()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleMemberFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleMemberFilterTransformer.java
@@ -40,6 +40,8 @@ public class RoleMemberFilterTransformer extends IndexFilterTransformer<RoleMemb
   @Override
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
-    return stringTerms(RoleIndex.ROLE_ID, authorization.resourceIds());
+    return hasParentQuery(
+        IdentityJoinRelationshipType.ROLE.getType(),
+        stringTerms(RoleIndex.ROLE_ID, authorization.resourceIds()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantMemberFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantMemberFilterTransformer.java
@@ -41,6 +41,8 @@ public class TenantMemberFilterTransformer extends IndexFilterTransformer<Tenant
   @Override
   protected SearchQuery toAuthorizationCheckSearchQuery(
       final RequiredAuthorization<?> authorization) {
-    return stringTerms(TENANT_ID, authorization.resourceIds());
+    return hasParentQuery(
+        IdentityJoinRelationshipType.TENANT.getType(),
+        stringTerms(TENANT_ID, authorization.resourceIds()));
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupMemberQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/GroupMemberQueryTransformerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.security.api.model.authz.EntityType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryOption;
@@ -88,14 +89,21 @@ public class GroupMemberQueryTransformerTest extends AbstractTransformerTest {
                       query ->
                           assertThat(query.queryOption())
                               .isInstanceOfSatisfying(
-                                  SearchTermsQuery.class,
-                                  (termsQuery) -> {
-                                    assertThat(termsQuery.field()).isEqualTo(GroupIndex.GROUP_ID);
-                                    assertThat(
-                                            termsQuery.values().stream()
-                                                .map(TypedValue::stringValue)
-                                                .toList())
-                                        .containsExactlyInAnyOrder("1", "2");
+                                  SearchHasParentQuery.class,
+                                  (hasParentQuery) -> {
+                                    assertThat(hasParentQuery.parentType()).isEqualTo("group");
+                                    assertThat(hasParentQuery.query().queryOption())
+                                        .isInstanceOfSatisfying(
+                                            SearchTermsQuery.class,
+                                            (termsQuery) -> {
+                                              assertThat(termsQuery.field())
+                                                  .isEqualTo(GroupIndex.GROUP_ID);
+                                              assertThat(
+                                                      termsQuery.values().stream()
+                                                          .map(TypedValue::stringValue)
+                                                          .toList())
+                                                  .containsExactlyInAnyOrder("1", "2");
+                                            });
                                   }));
             });
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleMemberQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/RoleMemberQueryTransformerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.security.api.model.authz.EntityType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryOption;
@@ -73,14 +74,21 @@ public class RoleMemberQueryTransformerTest extends AbstractTransformerTest {
                       query ->
                           assertThat(query.queryOption())
                               .isInstanceOfSatisfying(
-                                  SearchTermsQuery.class,
-                                  (termsQuery) -> {
-                                    assertThat(termsQuery.field()).isEqualTo(RoleIndex.ROLE_ID);
-                                    assertThat(
-                                            termsQuery.values().stream()
-                                                .map(TypedValue::stringValue)
-                                                .toList())
-                                        .containsExactlyInAnyOrder("1", "2");
+                                  SearchHasParentQuery.class,
+                                  (hasParentQuery) -> {
+                                    assertThat(hasParentQuery.parentType()).isEqualTo("role");
+                                    assertThat(hasParentQuery.query().queryOption())
+                                        .isInstanceOfSatisfying(
+                                            SearchTermsQuery.class,
+                                            (termsQuery) -> {
+                                              assertThat(termsQuery.field())
+                                                  .isEqualTo(RoleIndex.ROLE_ID);
+                                              assertThat(
+                                                      termsQuery.values().stream()
+                                                          .map(TypedValue::stringValue)
+                                                          .toList())
+                                                  .containsExactlyInAnyOrder("1", "2");
+                                            });
                                   }));
             });
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantMemberQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantMemberQueryTransformerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.security.api.model.authz.EntityType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryOption;
@@ -65,14 +66,21 @@ public class TenantMemberQueryTransformerTest extends AbstractTransformerTest {
                       query ->
                           assertThat(query.queryOption())
                               .isInstanceOfSatisfying(
-                                  SearchTermsQuery.class,
-                                  (termsQuery) -> {
-                                    assertThat(termsQuery.field()).isEqualTo(TenantIndex.TENANT_ID);
-                                    assertThat(
-                                            termsQuery.values().stream()
-                                                .map(TypedValue::stringValue)
-                                                .toList())
-                                        .containsExactlyInAnyOrder("1", "2");
+                                  SearchHasParentQuery.class,
+                                  (hasParentQuery) -> {
+                                    assertThat(hasParentQuery.parentType()).isEqualTo("tenant");
+                                    assertThat(hasParentQuery.query().queryOption())
+                                        .isInstanceOfSatisfying(
+                                            SearchTermsQuery.class,
+                                            (termsQuery) -> {
+                                              assertThat(termsQuery.field())
+                                                  .isEqualTo(TenantIndex.TENANT_ID);
+                                              assertThat(
+                                                      termsQuery.values().stream()
+                                                          .map(TypedValue::stringValue)
+                                                          .toList())
+                                                  .containsExactlyInAnyOrder("1", "2");
+                                            });
                                   }));
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -73,7 +73,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     final var record = command.getValue();
     final var isAuthorized =
         permissionsBehavior.isAuthorized(
-            command, AuthorizationResourceType.GROUP, PermissionType.UPDATE);
+            command, AuthorizationResourceType.GROUP, PermissionType.UPDATE, record.getGroupId());
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupAddEntityAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupAddEntityAuthorizationTest.java
@@ -60,11 +60,9 @@ public class GroupAddEntityAuthorizationTest {
   public void shouldBeAuthorizedToAddEntityToGroupWithScopedPermission() {
     // given
     final var allowedGroupId = Strings.newRandomValidIdentityId();
-    final var deniedGroupId = Strings.newRandomValidIdentityId();
     final var user = createUser();
     final var member = createUser();
     engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
-    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
     engine
         .authorization()
         .newAuthorization()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupAddEntityAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupAddEntityAuthorizationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+@NullMarked
+public class GroupAddEntityAuthorizationTest {
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToAddEntityToGroupWithScopedPermission() {
+    // given
+    final var allowedGroupId = Strings.newRandomValidIdentityId();
+    final var deniedGroupId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    final var member = createUser();
+    engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GROUP)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedGroupId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - a member is added to the specifically-granted group
+    engine
+        .group()
+        .addEntity(allowedGroupId)
+        .withEntityId(member.getUsername())
+        .withEntityType(EntityType.USER)
+        .add(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.groupRecords(GroupIntent.ENTITY_ADDED)
+                .withGroupId(allowedGroupId)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToAddEntityToGroupWithScopedPermissionOnDifferentGroup() {
+    // given
+    final var allowedGroupId = Strings.newRandomValidIdentityId();
+    final var deniedGroupId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    final var member = createUser();
+    engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GROUP)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedGroupId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - adding a member to a different group ID is rejected
+    final var rejection =
+        engine
+            .group()
+            .addEntity(deniedGroupId)
+            .withEntityId(member.getUsername())
+            .withEntityType(EntityType.USER)
+            .expectRejection()
+            .add(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'UPDATE' on resource 'GROUP'");
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+}


### PR DESCRIPTION
## Summary
- Scope the `GROUP`/`UPDATE` authorization check in `GroupAddEntityProcessor` to the target group (was defaulting to wildcard), matching `GroupUpdateProcessor`/`GroupRemoveEntityProcessor`/`RoleAddEntityProcessor` — a role granted `UPDATE` on a single group could not assign members to it.
- Fix `GroupMemberFilterTransformer`/`RoleMemberFilterTransformer`/`TenantMemberFilterTransformer` (ES/OS) to wrap their resource-scoped authorization filter in `hasParentQuery`, matching the parent-child join structure of these indices — the previous flat `stringTerms` filter matched a field that only exists on the parent document, so any non-wildcard authorization silently returned zero members even though the data existed.
- Fix the Identity frontend's membership mutations to invalidate the `["enrichedMembers", ...]` query key actually used by the members list pages, instead of an unused `["groups"|"roles"|"tenants", "members", id]` key — assign/unassign succeeded but the UI never refreshed without a full reload.

## Test plan
- [x] `GroupAddEntityAuthorizationTest` (new): scoped `UPDATE` grant can add a member to its own group, and is rejected (`FORBIDDEN`) for a different group.
- [x] Updated `GroupMemberQueryTransformerTest`/`RoleMemberQueryTransformerTest`/`TenantMemberQueryTransformerTest` to assert the authorization filter is a `hasParent`-wrapped terms query.
- [x] `./mvnw verify -pl zeebe/engine -Dtest='*Group*'` — 90 tests pass, no regressions.
- [x] `./mvnw verify -pl search/search-client-query-transformer` — full module suite passes.
- [x] `tsc --noEmit` and `eslint` clean on the frontend change.
- [x] `./mvnw install -Dquickly -pl <changed modules> -amd` — downstream modules still compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)