### PR TITLE
feat: validate QueueItem statementId at enqueue time

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -21,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.ibatis.executor.BatchResult;
@@ -42,6 +43,10 @@ public class DefaultExecutionQueue implements ExecutionQueue {
           Pattern.compile(".*update.*HistoryCleanupDate$"),
           Pattern.compile(".*\\.createIfNotExists$"),
           Pattern.compile("io.camunda.db.rdbms.sql.BatchOperationMapper.activate"));
+
+  // Statement IDs that already passed validation, so repeated enqueues of the same
+  // <Mapper>.<method> combination skip the reflection lookup.
+  private static final Set<String> VALIDATED_STATEMENT_IDS = ConcurrentHashMap.newKeySet();
 
   private final SqlSessionFactory sessionFactory;
   private final List<PreFlushListener> preFlushListeners = new ArrayList<>();
@@ -75,6 +80,7 @@ public class DefaultExecutionQueue implements ExecutionQueue {
 
   @Override
   public void executeInQueue(final QueueItem entry) {
+    assertKnownStatement(entry.statementId());
     LOG.trace("[RDBMS ExecutionQueue, Partition {}] Added entry to queue: {}", partitionId, entry);
     synchronized (queue) {
       if (queue.isEmpty()) {
@@ -374,6 +380,61 @@ public class DefaultExecutionQueue implements ExecutionQueue {
       throw new IllegalStateException(
           "Failed to verify autoCommit mode of the RDBMS connection before flushing", e);
     }
+  }
+
+  /**
+   * Verifies that {@code statementId} references a real {@code <MapperInterface>.<method>}
+   * combination.
+   *
+   * <p>{@link QueueItem#statementId()} is a hand-typed string used later for dynamic dispatch via
+   * {@link SqlSession#update(String, Object)} during {@link #doFlush()}, which runs asynchronously
+   * and much later than the writer call that built the item. A typo there would otherwise surface
+   * as a MyBatis {@code BindingException} deep in a batched flush, far from its cause, and only for
+   * whichever code path happens to hit it. Validating eagerly at enqueue time — on the same thread
+   * as the writer call — turns that into an immediate, diagnosable error.
+   */
+  private static void assertKnownStatement(final String statementId) {
+    if (VALIDATED_STATEMENT_IDS.contains(statementId)) {
+      return;
+    }
+
+    final int lastDot = statementId.lastIndexOf('.');
+    if (lastDot < 0) {
+      throw new IllegalArgumentException(
+          "QueueItem statementId '"
+              + statementId
+              + "' is not a valid <MapperInterface>.<method> reference");
+    }
+
+    final var mapperClassName = statementId.substring(0, lastDot);
+    final var methodName = statementId.substring(lastDot + 1);
+    final Class<?> mapperClass;
+    try {
+      mapperClass = Class.forName(mapperClassName);
+    } catch (final ClassNotFoundException e) {
+      throw new IllegalArgumentException(
+          "QueueItem statementId '"
+              + statementId
+              + "' references unknown class '"
+              + mapperClassName
+              + "'",
+          e);
+    }
+
+    final boolean methodExists =
+        Arrays.stream(mapperClass.getDeclaredMethods())
+            .anyMatch(method -> method.getName().equals(methodName));
+    if (!methodExists) {
+      throw new IllegalArgumentException(
+          "QueueItem statementId '"
+              + statementId
+              + "' does not match any method named '"
+              + methodName
+              + "' on "
+              + mapperClassName);
+    }
+
+    VALIDATED_STATEMENT_IDS.add(statementId);
   }
 
   LinkedList<QueueItem> getQueue() {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -54,7 +54,7 @@ class DefaultExecutionQueueTest {
 
   @Test
   public void whenElementIsAddedNoFlushHappensBelowLimit() {
-    executionQueue.executeInQueue(mock(QueueItem.class));
+    executionQueue.executeInQueue(mockQueueItem());
 
     Mockito.verifyNoInteractions(sqlSessionFactory);
   }
@@ -63,9 +63,15 @@ class DefaultExecutionQueueTest {
   public void whenElementIsAddedNoFlushHappens() {
     executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0, 0, metrics);
 
-    executionQueue.executeInQueue(mock(QueueItem.class));
+    executionQueue.executeInQueue(mockQueueItem());
 
     Mockito.verifyNoInteractions(sqlSessionFactory);
+  }
+
+  private static QueueItem mockQueueItem() {
+    final var item = mock(QueueItem.class);
+    when(item.statementId()).thenReturn("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert");
+    return item;
   }
 
   @Test
@@ -76,7 +82,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item1);
 
@@ -96,7 +102,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item1);
 
@@ -116,21 +122,21 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     final var item2 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement2",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
             "parameter2");
     final var item3 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement3",
+            "io.camunda.db.rdbms.sql.AuditLogMapper.insert",
             "parameter3");
     executionQueue.executeInQueue(item1);
     executionQueue.executeInQueue(item2);
@@ -143,8 +149,8 @@ class DefaultExecutionQueueTest {
 
     verify(sqlSessionFactory)
         .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
-    verify(session).update("statement1", "parameter1");
-    verify(session).update("statement2", "parameter2");
+    verify(session).update("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert", "parameter1");
+    verify(session).update("io.camunda.db.rdbms.sql.AgentInstanceMapper.update", "parameter2");
     verify(session).flushStatements();
     verify(session).commit();
   }
@@ -156,7 +162,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item1);
 
@@ -165,7 +171,7 @@ class DefaultExecutionQueueTest {
 
     verify(sqlSessionFactory)
         .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
-    verify(session).update("statement1", "parameter1");
+    verify(session).update("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert", "parameter1");
     verify(session).flushStatements();
     verify(session).commit();
     verify(session).close();
@@ -204,7 +210,7 @@ class DefaultExecutionQueueTest {
             ContextType.EXPORTER_POSITION,
             WriteStatementType.UPDATE,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     final var preFlushListener = mock(PreFlushListener.class);
     final var postFlushListener = mock(PostFlushListener.class);
@@ -236,7 +242,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item);
     final var inTransactionHook = mock(InTransactionHook.class);
@@ -248,7 +254,9 @@ class DefaultExecutionQueueTest {
     // then - hook is called with the session before queue items are executed
     final var inOrder = Mockito.inOrder(inTransactionHook, session);
     inOrder.verify(inTransactionHook).onTransactionStart(session);
-    inOrder.verify(session).update("statement1", "parameter1");
+    inOrder
+        .verify(session)
+        .update("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert", "parameter1");
     inOrder.verify(session).commit();
   }
 
@@ -260,7 +268,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item);
 
@@ -268,7 +276,7 @@ class DefaultExecutionQueueTest {
     executionQueue.flush();
 
     // then - no exception, normal commit
-    verify(session).update("statement1", "parameter1");
+    verify(session).update("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert", "parameter1");
     verify(session).commit();
   }
 
@@ -280,7 +288,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item);
     final var postFlushListener = mock(PostFlushListener.class);
@@ -321,7 +329,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item1);
 
@@ -345,14 +353,14 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     final var preFlushItem =
         new QueueItem(
             ContextType.EXPORTER_POSITION,
             WriteStatementType.UPDATE,
             1L,
-            "statement2",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
             "parameter2");
     executionQueue.executeInQueue(item1);
 
@@ -381,7 +389,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     executionQueue.executeInQueue(item1);
 
@@ -410,14 +418,14 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     final var item2 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             2L,
-            "statement2",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
             "parameter2");
     executionQueue.executeInQueue(item1);
     executionQueue.executeInQueue(item2);
@@ -436,7 +444,7 @@ class DefaultExecutionQueueTest {
                     originalItem.contextType(),
                     WriteStatementType.INSERT,
                     1L,
-                    "statement1",
+                    "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
                     "parameter1+");
               }
             });
@@ -455,14 +463,14 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     final var item2 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             2L,
-            "statement2",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
             "parameter2");
     executionQueue.executeInQueue(item1);
     executionQueue.executeInQueue(item2);
@@ -481,7 +489,7 @@ class DefaultExecutionQueueTest {
                     originalItem.contextType(),
                     WriteStatementType.INSERT,
                     1L,
-                    "statement1",
+                    "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
                     "parameter1+");
               }
             });
@@ -499,50 +507,71 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.UPDATE,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1"));
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement2",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
             "parameter2"));
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.DELETE,
             1L,
-            "statement3",
+            "io.camunda.db.rdbms.sql.AuditLogMapper.insert",
             "parameter3"));
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.FLOW_NODE, WriteStatementType.UPDATE, 1L, "statement4", "parameter4"));
+            ContextType.FLOW_NODE,
+            WriteStatementType.UPDATE,
+            1L,
+            "io.camunda.db.rdbms.sql.AuthorizationMapper.insert",
+            "parameter4"));
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.FLOW_NODE, WriteStatementType.INSERT, 1L, "statement5", "parameter5"));
+            ContextType.FLOW_NODE,
+            WriteStatementType.INSERT,
+            1L,
+            "io.camunda.db.rdbms.sql.AuthorizationMapper.delete",
+            "parameter5"));
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER_TASK, WriteStatementType.DELETE, 1L, "statement6", "parameter6"));
+            ContextType.USER_TASK,
+            WriteStatementType.DELETE,
+            1L,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.insertItems",
+            "parameter6"));
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER_TASK, WriteStatementType.INSERT, 1L, "statement7", "parameter7"));
+            ContextType.USER_TASK,
+            WriteStatementType.INSERT,
+            1L,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.insertErrors",
+            "parameter7"));
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER_TASK, WriteStatementType.DELETE, 1L, "statement8", "parameter8"));
+            ContextType.USER_TASK,
+            WriteStatementType.DELETE,
+            1L,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.updateCompleted",
+            "parameter8"));
 
     // when
     executionQueue.flush();
 
     // then
-    verify(session).update(eq("statement5"), any());
-    verify(session).update(eq("statement2"), any());
-    verify(session).update(eq("statement6"), any());
-    verify(session).update(eq("statement7"), any());
-    verify(session).update(eq("statement8"), any());
-    verify(session).update(eq("statement4"), any());
-    verify(session).update(eq("statement1"), any());
-    verify(session).update(eq("statement3"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.AuthorizationMapper.delete"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.update"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.BatchOperationMapper.insertItems"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.BatchOperationMapper.insertErrors"), any());
+    verify(session)
+        .update(eq("io.camunda.db.rdbms.sql.BatchOperationMapper.updateCompleted"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.AuthorizationMapper.insert"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert"), any());
+    verify(session).update(eq("io.camunda.db.rdbms.sql.AuditLogMapper.insert"), any());
   }
 
   @ParameterizedTest
@@ -561,6 +590,36 @@ class DefaultExecutionQueueTest {
   }
 
   @Test
+  public void shouldRejectStatementIdReferencingUnknownClass() {
+    final var item =
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            1L,
+            "io.camunda.db.rdbms.sql.NotARealMapper.insert",
+            "parameter1");
+
+    assertThatThrownBy(() -> executionQueue.executeInQueue(item))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("NotARealMapper");
+  }
+
+  @Test
+  public void shouldRejectStatementIdReferencingUnknownMethod() {
+    final var item =
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            1L,
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.notARealMethod",
+            "parameter1");
+
+    assertThatThrownBy(() -> executionQueue.executeInQueue(item))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("notARealMethod");
+  }
+
+  @Test
   public void whenMemoryLimitIsReachedFlushShouldHappen() {
     // Set a small memory limit (1 MB)
     executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 1000, 1, metrics);
@@ -570,10 +629,18 @@ class DefaultExecutionQueueTest {
     final var largeParam = "x".repeat(600_000); // ~600 KB each
     final var item1 =
         new QueueItem(
-            ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 1L, "statement1", largeParam);
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            1L,
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
+            largeParam);
     final var item2 =
         new QueueItem(
-            ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 2L, "statement2", largeParam);
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            2L,
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
+            largeParam);
 
     executionQueue.executeInQueue(item1);
     verifyNoInteractions(sqlSessionFactory);
@@ -587,8 +654,8 @@ class DefaultExecutionQueueTest {
 
     verify(sqlSessionFactory)
         .openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_COMMITTED);
-    verify(session).update("statement1", largeParam);
-    verify(session).update("statement2", largeParam);
+    verify(session).update("io.camunda.db.rdbms.sql.AgentInstanceMapper.insert", largeParam);
+    verify(session).update("io.camunda.db.rdbms.sql.AgentInstanceMapper.update", largeParam);
     verify(session).flushStatements();
     verify(session).commit();
   }
@@ -603,7 +670,7 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
 
     executionQueue.executeInQueue(item1);
@@ -625,21 +692,21 @@ class DefaultExecutionQueueTest {
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             1L,
-            "statement1",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
             "parameter1");
     final var item2 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             2L,
-            "statement2",
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
             "parameter2");
     final var item3 =
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
             WriteStatementType.INSERT,
             3L,
-            "statement3",
+            "io.camunda.db.rdbms.sql.AuditLogMapper.insert",
             "parameter3");
 
     executionQueue.executeInQueue(item1);
@@ -666,10 +733,18 @@ class DefaultExecutionQueueTest {
     final var largeParam = "x".repeat(600_000); // ~600 KB each
     final var item1 =
         new QueueItem(
-            ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 1L, "statement1", largeParam);
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            1L,
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.insert",
+            largeParam);
     final var item2 =
         new QueueItem(
-            ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 2L, "statement2", largeParam);
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            2L,
+            "io.camunda.db.rdbms.sql.AgentInstanceMapper.update",
+            largeParam);
 
     executionQueue.executeInQueue(item1);
     executionQueue.executeInQueue(item2);


### PR DESCRIPTION
## Summary

`QueueItem.statementId` is a hand-typed string (e.g. `"io.camunda.db.rdbms.sql.AgentInstanceMapper.insert"`) used for dynamic dispatch via `SqlSession.update()` during `DefaultExecutionQueue.doFlush()`, which runs asynchronously and much later than the writer call that built the item. A typo there previously surfaced as a MyBatis `BindingException` deep in a batched flush, far from its cause, and only for whichever write path happened to hit it.

`executeInQueue()` now validates `statementId` eagerly via reflection against the referenced `<MapperInterface>.<method>` pair, on the same thread as the writer call, with validated IDs cached to avoid repeated reflection. Merged items are exempt since `QueueItemMerger` implementations only ever replace the parameter, never the statementId, of an already-validated item.

`DefaultExecutionQueueTest` previously exercised this path with placeholder strings (`"statement1"`, etc.) that don't correspond to real classes; replaced them with real Mapper.method references so the new validation doesn't reject them.

## Test plan

- [x] `./mvnw clean verify -pl db/rdbms -DskipTests=false -Dquickly` — 1561 tests, 0 failures
- [x] New tests for both rejection paths (unknown class, unknown method)