### PR TITLE
fix: stop load-tester ITs racing history cleanup (StarterWorkerIT)

### DIFF
--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.it;
 
+import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CAMUNDA_ENV_DATA_SECONDARYSTORAGE_RDBMS_HISTORY_DEFAULTHISTORYTTL;
+
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.time.Duration;
@@ -40,7 +42,12 @@ final class CamundaContainerProvider {
         System.getProperty(
             IMAGE_VERSION_PROPERTY, CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION);
     return new CamundaContainer(DockerImageName.parse(imageName).withTag(imageVersion))
-        .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)));
+        .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)))
+        // CamundaContainer defaults the RDBMS history TTL to PT2S and runs cleanup every 2-5s, so
+        // completed process instances are purged within seconds of completion. These ITs query
+        // completed instances after an async delay, which races that cleanup and flakes when the
+        // runner is slow. Extend the TTL so instances survive the assertion window.
+        .withEnv(CAMUNDA_ENV_DATA_SECONDARYSTORAGE_RDBMS_HISTORY_DEFAULTHISTORYTTL, "PT1H");
   }
 
   static void registerClientProperties(

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/CamundaContainerProvider.java
@@ -12,7 +12,10 @@ import static io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs.CAMUNDA_
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.DockerImageName;
 
@@ -32,6 +35,8 @@ final class CamundaContainerProvider {
   private static final String IMAGE_VERSION_PROPERTY =
       "io.camunda.process.test.camundaDockerImageVersion";
 
+  private static final Logger CONTAINER_LOG = LoggerFactory.getLogger("camunda.container");
+
   private CamundaContainerProvider() {}
 
   static CamundaContainer createCamundaContainer() {
@@ -43,6 +48,9 @@ final class CamundaContainerProvider {
             IMAGE_VERSION_PROPERTY, CamundaProcessTestRuntimeDefaults.CAMUNDA_DOCKER_IMAGE_VERSION);
     return new CamundaContainer(DockerImageName.parse(imageName).withTag(imageVersion))
         .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(12)))
+        // capture container-side broker/exporter stdout so IT failures (indexing stalls,
+        // backpressure, crashes, early history cleanup) are diagnosable from the test log
+        .withLogConsumer(new Slf4jLogConsumer(CONTAINER_LOG).withPrefix("camunda"))
         // CamundaContainer defaults the RDBMS history TTL to PT2S and runs cleanup every 2-5s, so
         // completed process instances are purged within seconds of completion. These ITs query
         // completed instances after an async delay, which races that cleanup and flakes when the

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/it/StarterWorkerIT.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.LoadTesterApplication;
 import io.camunda.zeebe.metrics.StarterMetricsDoc;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -50,7 +49,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
       "load-tester.perform-read-benchmarks=false",
     })
 @ActiveProfiles({"starter", "worker", "it"})
-@Disabled("Temporarily disabled due to https://camunda.slack.com/archives/C0BJW0K7YL8")
 class StarterWorkerIT {
 
   @Container

--- a/load-tests/load-tester/src/test/resources/application-it.yaml
+++ b/load-tests/load-tester/src/test/resources/application-it.yaml
@@ -1,4 +1,10 @@
 # Integration test configuration — overrides application.yaml to enable the Camunda client
+logging:
+  level:
+    # surface container-side broker/exporter stdout (Slf4jLogConsumer); root stays WARN
+    # (from application.yaml) to keep client retry noise down
+    camunda.container: INFO
+
 camunda:
   client:
     enabled: true


### PR DESCRIPTION
## Summary

Re-enables `StarterWorkerIT` and fixes its flake (reported in #58041), scoped to the **load-tests** module.

## Root cause — a history-cleanup race, not indexing lag

`CamundaContainer` (camunda-process-test-java) configures RDBMS secondary storage with a **2-second** default history TTL and cleanup running every 2–5s, so completed process instances are purged ~2–7s after completion. `StarterWorkerIT` creates instances, lets the worker complete them, then queries the completed instances via REST search after an async delay — racing that cleanup. Timeline from a failed CI run (captured via the new container-log consumer):

| time | event |
|---|---|
| 07:39:14–18 | 5 `benchmark` instances created + committed |
| 07:39:14.8 | completed; `HISTORY_CLEANUP_DATE` set ≈ now |
| **07:39:21** | history cleanup **DELETEs** all 5 |
| 07:39:22 | test's first search poll — too late → 0 |

With a fast runner the first poll wins the race; under CI CPU starvation it lands after cleanup and returns empty for the whole window. Raising the await does not help — the rows are gone permanently.

## Why it started suddenly (~2026-07-16)

#57916 renamed CPT's env vars from `ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_*` to the `CAMUNDA_DATA_SECONDARYSTORAGE_RDBMS_*` namespace. Before that, the current image **ignored** the old names, so the `PT2S` TTL was a no-op and retention stayed at its 30-day default. After #57916 the `PT2S` TTL became **effective**, introducing the 2s cleanup this test races — matching #58041's onset.

## Fix

Override the RDBMS default history TTL to `PT1H` on the shared test container so completed instances survive the assertion window. Verified: with a 1-CPU throttle that previously produced a >120s failure, the test now passes in ~27s with zero mid-window deletions.

## Scope note for #58041

This fixes **only** the CPT/RDBMS-based load-tester ITs. The other classes in #58041 do not use CPT and are unrelated to this change:
- `BasicAuthOverRestIT` / `BasicAuthOverGrpcIT`, `MultiTenancyIT` — `TestStandaloneBroker` + `ElasticsearchContainer` (ES indexing/readiness).
- `StartStandaloneCamundaWithUnifiedConfigurationCamundaDockerIT` — full-app docker standalone startup readiness.

They share only the Awaitility-timeout symptom under CI load; #58041 should likely be split accordingly.

Refs #58041
Caused by #57916

🤖 Generated with [Claude Code](https://claude.com/claude-code)