### PR TITLE
fix: make stale-backport Slack payload compatible with slack-github-action v4

### DIFF
--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -316,14 +316,15 @@ jobs:
           # v4 enforces strict YAML 1.2 indentation, so a multi-line `toJSON(...)`
           # value in the payload fails to parse ("deficient indentation"). A single
           # compact line is valid YAML flow and parses cleanly.
-          blocks=$(printf '%s' "$payload" | jq -c '.blocks')
+          # Extract strictly: abort if .blocks is missing or not an array, so a
+          # malformed formatter output fails here (visibly) instead of producing
+          # `blocks: null` and failing inside the continue-on-error Slack step.
+          blocks=$(printf '%s' "$payload" | jq -ce '.blocks | select(type == "array")') || {
+            echo "::error::format-slack-report.sh did not produce a .blocks array — aborting before posting an invalid Slack payload" >&2
+            exit 1
+          }
 
-          {
-            echo "payload<<PAYLOAD_EOF"
-            echo "$payload"
-            echo "PAYLOAD_EOF"
-            echo "blocks=$blocks"
-          } >> "$GITHUB_OUTPUT"
+          echo "blocks=$blocks" >> "$GITHUB_OUTPUT"
 
       - name: Find existing Slack message to update
         id: find-message

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -312,13 +312,7 @@ jobs:
           payload=$(printf '%s' "$STALE_DATA" | \
             .ci/scripts/stale-backport-scripts/format-slack-report.sh)
 
-          # Emit the blocks array as COMPACT single-line JSON. slack-github-action
-          # v4 enforces strict YAML 1.2 indentation, so a multi-line `toJSON(...)`
-          # value in the payload fails to parse ("deficient indentation"). A single
-          # compact line is valid YAML flow and parses cleanly.
-          # Extract strictly: abort if .blocks is missing or not an array, so a
-          # malformed formatter output fails here (visibly) instead of producing
-          # `blocks: null` and failing inside the continue-on-error Slack step.
+          # Compact single-line JSON: slack-github-action v4's strict YAML parser rejects multi-line toJSON() output.
           blocks=$(printf '%s' "$payload" | jq -ce '.blocks | select(type == "array")') || {
             echo "::error::format-slack-report.sh did not produce a .blocks array — aborting before posting an invalid Slack payload" >&2
             exit 1

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -312,10 +312,17 @@ jobs:
           payload=$(printf '%s' "$STALE_DATA" | \
             .ci/scripts/stale-backport-scripts/format-slack-report.sh)
 
+          # Emit the blocks array as COMPACT single-line JSON. slack-github-action
+          # v4 enforces strict YAML 1.2 indentation, so a multi-line `toJSON(...)`
+          # value in the payload fails to parse ("deficient indentation"). A single
+          # compact line is valid YAML flow and parses cleanly.
+          blocks=$(printf '%s' "$payload" | jq -c '.blocks')
+
           {
             echo "payload<<PAYLOAD_EOF"
             echo "$payload"
             echo "PAYLOAD_EOF"
+            echo "blocks=$blocks"
           } >> "$GITHUB_OUTPUT"
 
       - name: Find existing Slack message to update
@@ -381,7 +388,7 @@ jobs:
             channel: "${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}"
             ts: "${{ steps.find-message.outputs.message_ts }}"
             text: "Stale backport report"
-            blocks: ${{ toJSON(fromJSON(steps.format.outputs.payload).blocks) }}
+            blocks: ${{ steps.format.outputs.blocks }}
 
       - name: Pin existing Slack message if not already pinned
         if: steps.find-message.outputs.found == 'true' && steps.find-message.outputs.is_pinned == 'false'
@@ -441,7 +448,7 @@ jobs:
           payload: |
             channel: "${{ inputs.slack_channel_id || steps.secrets.outputs.SLACK_TOPMONOREPOCI_CHANNEL_ID }}"
             text: "Stale backport report"
-            blocks: ${{ toJSON(fromJSON(steps.format.outputs.payload).blocks) }}
+            blocks: ${{ steps.format.outputs.blocks }}
 
       - name: Pin new Slack message
         if: steps.find-message.outputs.found != 'true'


### PR DESCRIPTION
## Problem

The **Stale Backport Tracker** Slack step [failed silently](https://github.com/camunda/camunda/actions/runs/29723108149/job/88291636917) since 2026-07-19:

```
##[error]Invalid input! Failed to parse contents of the provided payload
YAMLException: deficient indentation (166:1)
SlackError: Invalid input! Failed to parse contents of the provided payload
```

Job shows green because both slack steps use `continue-on-error: true` — the Slack message has silently not been posted/updated since the break.

## Root cause

Renovate PR #58158 bumped `slackapi/slack-github-action` **v3.0.5 → v4.0.0** (merged 2026-07-19). v4 enforces strict YAML 1.2 indentation. The payload passed the blocks array via `blocks: ${{ toJSON(...) }}`, which GitHub renders as multi-line pretty-printed JSON whose continuation lines sit at column 0 — no longer valid under v4's parser.

## Fix

Stay on v4. Emit the blocks array as **compact single-line JSON** (`jq -c '.blocks'`) from the format step and reference it directly (`blocks: ${{ steps.format.outputs.blocks }}`). A single line is valid YAML flow, so it parses cleanly. Applied to both the `chat.update` and `chat.postMessage` steps.

## Validation

- Reproduced the exact production error (`deficient indentation (166:1)`) against the real 30-block payload from the failing run, using `js-yaml` (the parser v4 uses).
- Confirmed the compact form parses cleanly (all 30 blocks).
- `actionlint` clean.
- Test run from [feature branch worked](https://camunda.slack.com/archives/C071KP5BTHB/p1784532666218559)