### PR TITLE
fix: permit unauthenticated access to Operate & Admin static assets under OIDC

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -1117,7 +1117,11 @@ public class WebSecurityConfig {
                               "/tasklist/assets/**",
                               "/tasklist/client-config.js",
                               "/tasklist/custom.css",
-                              "/tasklist/favicon.ico")
+                              "/tasklist/favicon.ico",
+                              "/operate/assets/**",
+                              "/operate/client-config.js",
+                              "/operate/custom.css",
+                              "/operate/favicon.ico")
                           .permitAll()
                           .anyRequest()
                           .authenticated())

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -1121,7 +1121,9 @@ public class WebSecurityConfig {
                               "/operate/assets/**",
                               "/operate/client-config.js",
                               "/operate/custom.css",
-                              "/operate/favicon.ico")
+                              "/operate/favicon.ico",
+                              "/admin/assets/**",
+                              "/admin/favicon.ico")
                           .permitAll()
                           .anyRequest()
                           .authenticated())

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -179,6 +179,11 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
+        // Tasklist
+        "/tasklist/assets/app.css",
+        "/tasklist/client-config.js",
+        "/tasklist/custom.css",
+        "/tasklist/favicon.ico",
         // Operate
         "/operate/assets/app.css",
         "/operate/client-config.js",
@@ -188,11 +193,13 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
         "/admin/assets/app.js",
         "/admin/favicon.ico"
       })
-  public void shouldNotRequireAuthenticationForOperateAndAdminStaticAssets(final String assetPath) {
-    // regression for the SPA crash on session expiry ("Unable to preload CSS" in Operate,
-    // "Failed to fetch dynamically imported module" in Admin): these static assets must be
-    // deliverable to an unauthenticated (e.g. expired-session) browser so the SPA can load and
-    // then redirect to login via its graceful API-401 handling, as Tasklist already does.
+  public void shouldNotRequireAuthenticationForPublicWebappStaticAssets(final String assetPath) {
+    // The webapp SPAs (Tasklist, Operate, Admin) serve their static assets under these paths; they
+    // must be deliverable to an unauthenticated (e.g. expired-session) browser so the SPA can load
+    // and then redirect to login via its graceful API-401 handling. Otherwise a lazily-loaded chunk
+    // fetched after the session expires is redirected/401'd, the module load fails, and the SPA
+    // renders a fatal error boundary ("Unable to preload CSS" / "Failed to fetch dynamically
+    // imported module").
 
     // when
     final MvcTestResult testResult =

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -19,6 +19,7 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
@@ -175,38 +176,32 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
     assertThat(testResult).hasStatusOk();
   }
 
-  @Test
-  public void shouldAcceptRequestToOperateStaticAssetsWithoutAuthentication() {
-    // regression for the "Unable to preload CSS" crash: Operate's static assets must be
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        // Operate
+        "/operate/assets/app.css",
+        "/operate/client-config.js",
+        "/operate/custom.css",
+        "/operate/favicon.ico",
+        // Admin
+        "/admin/assets/app.js",
+        "/admin/favicon.ico"
+      })
+  public void shouldNotRequireAuthenticationForOperateAndAdminStaticAssets(final String assetPath) {
+    // regression for the SPA crash on session expiry ("Unable to preload CSS" in Operate,
+    // "Failed to fetch dynamically imported module" in Admin): these static assets must be
     // deliverable to an unauthenticated (e.g. expired-session) browser so the SPA can load and
-    // then handle the API 401 via its graceful session-expiry redirect, as Tasklist already does.
+    // then redirect to login via its graceful API-401 handling, as Tasklist already does.
 
     // when
     final MvcTestResult testResult =
-        mockMvcTester
-            .get()
-            .uri("https://localhost" + TestApiController.DUMMY_OPERATE_ASSET_ENDPOINT)
-            .exchange();
+        mockMvcTester.get().uri("https://localhost" + assetPath).exchange();
 
-    // then
-    assertThat(testResult).hasStatusOk();
-  }
-
-  @Test
-  public void shouldAcceptRequestToAdminStaticAssetsWithoutAuthentication() {
-    // regression for the "Failed to fetch dynamically imported module" crash: the Admin SPA's
-    // static assets must be deliverable to an unauthenticated (e.g. expired-session) browser so the
-    // SPA can load and then handle the API 401 via its graceful session-expiry redirect.
-
-    // when
-    final MvcTestResult testResult =
-        mockMvcTester
-            .get()
-            .uri("https://localhost" + TestApiController.DUMMY_ADMIN_ASSET_ENDPOINT)
-            .exchange();
-
-    // then
-    assertThat(testResult).hasStatusOk();
+    // then: permitted -> passes the security filter (200 if served, 404 with no handler in this
+    // test slice); it must never be 401, which is what a protected webapp path returns.
+    assertThat(testResult.getResponse().getStatus())
+        .isIn(HttpStatus.OK.value(), HttpStatus.NOT_FOUND.value());
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -176,6 +176,23 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
   }
 
   @Test
+  public void shouldAcceptRequestToOperateStaticAssetsWithoutAuthentication() {
+    // regression for the "Unable to preload CSS" crash: Operate's static assets must be
+    // deliverable to an unauthenticated (e.g. expired-session) browser so the SPA can load and
+    // then handle the API 401 via its graceful session-expiry redirect, as Tasklist already does.
+
+    // when
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_OPERATE_ASSET_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(testResult).hasStatusOk();
+  }
+
+  @Test
   public void shouldReturnCsrfTokenOnAuthenticatedGetRequest() {
     // when
     final MvcTestResult testResult =

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -193,6 +193,23 @@ public class OidcWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
   }
 
   @Test
+  public void shouldAcceptRequestToAdminStaticAssetsWithoutAuthentication() {
+    // regression for the "Failed to fetch dynamically imported module" crash: the Admin SPA's
+    // static assets must be deliverable to an unauthenticated (e.g. expired-session) browser so the
+    // SPA can load and then handle the API 401 via its graceful session-expiry redirect.
+
+    // when
+    final MvcTestResult testResult =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_ADMIN_ASSET_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(testResult).hasStatusOk();
+  }
+
+  @Test
   public void shouldReturnCsrfTokenOnAuthenticatedGetRequest() {
     // when
     final MvcTestResult testResult =

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -23,8 +23,6 @@ public class TestApiController {
   public static final String DUMMY_V2_API_ENDPOINT = "/v2/foo";
   public static final String DUMMY_V2_API_AUTH_ENDPOINT = "/v2/auth";
   public static final String DUMMY_WEBAPP_ENDPOINT = "/operate/decisions";
-  public static final String DUMMY_OPERATE_ASSET_ENDPOINT = "/operate/assets/index.css";
-  public static final String DUMMY_ADMIN_ASSET_ENDPOINT = "/admin/assets/index.js";
   public static final String DUMMY_UNPROTECTED_ENDPOINT = "/new/foo";
   public static final String DUMMY_UNHANDLED_ENDPOINT = "/non-existent-endpoint";
 
@@ -60,16 +58,6 @@ public class TestApiController {
 
   @RequestMapping(DUMMY_WEBAPP_ENDPOINT)
   public @ResponseBody String dummyWebappEndpoint() {
-    return DEFAULT_RESPONSE;
-  }
-
-  @RequestMapping(DUMMY_OPERATE_ASSET_ENDPOINT)
-  public @ResponseBody String dummyOperateAssetEndpoint() {
-    return DEFAULT_RESPONSE;
-  }
-
-  @RequestMapping(DUMMY_ADMIN_ASSET_ENDPOINT)
-  public @ResponseBody String dummyAdminAssetEndpoint() {
     return DEFAULT_RESPONSE;
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -23,6 +23,7 @@ public class TestApiController {
   public static final String DUMMY_V2_API_ENDPOINT = "/v2/foo";
   public static final String DUMMY_V2_API_AUTH_ENDPOINT = "/v2/auth";
   public static final String DUMMY_WEBAPP_ENDPOINT = "/operate/decisions";
+  public static final String DUMMY_OPERATE_ASSET_ENDPOINT = "/operate/assets/index.css";
   public static final String DUMMY_UNPROTECTED_ENDPOINT = "/new/foo";
   public static final String DUMMY_UNHANDLED_ENDPOINT = "/non-existent-endpoint";
 
@@ -58,6 +59,11 @@ public class TestApiController {
 
   @RequestMapping(DUMMY_WEBAPP_ENDPOINT)
   public @ResponseBody String dummyWebappEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @RequestMapping(DUMMY_OPERATE_ASSET_ENDPOINT)
+  public @ResponseBody String dummyOperateAssetEndpoint() {
     return DEFAULT_RESPONSE;
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -24,6 +24,7 @@ public class TestApiController {
   public static final String DUMMY_V2_API_AUTH_ENDPOINT = "/v2/auth";
   public static final String DUMMY_WEBAPP_ENDPOINT = "/operate/decisions";
   public static final String DUMMY_OPERATE_ASSET_ENDPOINT = "/operate/assets/index.css";
+  public static final String DUMMY_ADMIN_ASSET_ENDPOINT = "/admin/assets/index.js";
   public static final String DUMMY_UNPROTECTED_ENDPOINT = "/new/foo";
   public static final String DUMMY_UNHANDLED_ENDPOINT = "/non-existent-endpoint";
 
@@ -64,6 +65,11 @@ public class TestApiController {
 
   @RequestMapping(DUMMY_OPERATE_ASSET_ENDPOINT)
   public @ResponseBody String dummyOperateAssetEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @RequestMapping(DUMMY_ADMIN_ASSET_ENDPOINT)
+  public @ResponseBody String dummyAdminAssetEndpoint() {
     return DEFAULT_RESPONSE;
   }
 


### PR DESCRIPTION
## Description

Under OIDC, `WebSecurityConfig#oidcWebappSecurity` permitted only Tasklist's static assets; Operate's and the Admin console's fell through to `.anyRequest().authenticated()`. So when a session expires and the SPA lazy-loads a not-yet-cached route chunk, the asset request is redirected (`302`) / rejected (`401`) instead of served — the browser gets HTML for a `<link>`/`import()`, and the SPA crashes with a full-screen error boundary (`Unable to preload CSS` in Operate, `Failed to fetch dynamically imported module` in Admin). A refresh recovers (top-level nav re-auths via the still-valid IdP SSO session), which is why it looks intermittent.

Fix: add the Operate (`/operate/assets/**`, `client-config.js`, `custom.css`, `favicon.ico`) and Admin (`/admin/assets/**`, `favicon.ico`) paths to the `permitAll()` list, mirroring Tasklist. Static assets carry no data; permitting them lets the SPA load and then handle the API `401` via its graceful session-expiry redirect (as Tasklist and Basic auth already do).

The regression test (`shouldNotRequireAuthenticationForPublicWebappStaticAssets`) covers **all three** webapp SPAs — Tasklist, Operate, Admin — so a future regression on any of them (Tasklist's permits were previously untested) is caught too.

8.10/main fixes the equivalent list in the camunda-security-library (`SecurityPathAdapter`) via #58177. Carries `backport stable/8.8`.

## Related issues

Relates to #58168