### PR TITLE
feat: show grpc requests by POD

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -10798,11 +10798,11 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (method, statusCode)",
+              "expr": "sum(label_replace(label_replace(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]), \"method\", \"$1\", \"grpc_method\", \"(.+)\"), \"statusCode\", \"$1\", \"code\", \"(.+)\") or on(method, statusCode, pod) rate(grpc_server_processing_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (method, statusCode, pod)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{method}} ({{statusCode}})",
+              "legendFormat": "{{method}} ({{statusCode}}) in {{pod}}",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
## Description
Shows the `gRPC > Total requests` by pods, so it's eays to see any difference in number of requests served by pod.
For self managed deployments, this is especially useful because gateway runs embedded w/ the broker, increasing the cpu usage of a broker.
<img width="929" height="319" alt="image" src="https://github.com/user-attachments/assets/e3e1ed55-3141-4777-ac9a-a2888b05b0cc" />

