### PR TITLE
Validate job lease on AGENT_HISTORY:CREATE and propagate lease in COMMIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -121,6 +121,68 @@ public class AgentHistoryCommitLifecycleIT {
         tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.DISCARDED));
   }
 
+  @Test
+  void shouldDiscardSupersededActivationAndCommitWinningActivationOnJobCompletion() {
+    final long processInstanceKey = deployAndStartProcessInstance();
+    final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey);
+
+    // Activation 1 (superseded): activate with lease, create a history item, then fail the job.
+    final var activation1 = activateAgenticJob(processInstanceKey, true);
+    final long supersededItemKey =
+        createHistoryItem(
+            agentInstanceKey,
+            elementInstanceKey,
+            activation1,
+            AgentInstanceHistoryRole.USER,
+            "Message from superseded activation",
+            OffsetDateTime.parse("2025-06-01T10:00:00Z"));
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "superseded item indexed as PENDING before fail",
+        tuple(supersededItemKey, AgentInstanceHistoryCommitStatus.PENDING));
+
+    camundaClient
+        .newFailCommand(activation1.getKey())
+        .retries(1)
+        .withLeaseToken(activation1.getLeaseToken())
+        .execute();
+
+    // Activation 2 (winning): same job re-activated under a new lease.
+    final var activation2 = activateAgenticJob(processInstanceKey, true);
+    assertThat(activation2.getKey())
+        .as("re-activation must reuse the same job key")
+        .isEqualTo(activation1.getKey());
+    assertThat(activation2.getLeaseToken())
+        .as("re-activation must advance the lease token")
+        .isNotEqualTo(activation1.getLeaseToken());
+
+    final long winningItemKey =
+        createHistoryItem(
+            agentInstanceKey,
+            elementInstanceKey,
+            activation2,
+            AgentInstanceHistoryRole.ASSISTANT,
+            "Message from winning activation",
+            OffsetDateTime.parse("2025-06-01T10:01:00Z"));
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "both items PENDING before completion",
+        tuple(supersededItemKey, AgentInstanceHistoryCommitStatus.PENDING),
+        tuple(winningItemKey, AgentInstanceHistoryCommitStatus.PENDING));
+
+    // Complete the winning activation — JobCompleteProcessor propagates the stored lease token
+    // into AGENT_HISTORY:COMMIT, so visitByJobLease commits the winning item and discards the
+    // superseded one.
+    camundaClient.newCompleteCommand(activation2).execute();
+
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "winning item COMMITTED, superseded item DISCARDED",
+        tuple(winningItemKey, AgentInstanceHistoryCommitStatus.COMMITTED),
+        tuple(supersededItemKey, AgentInstanceHistoryCommitStatus.DISCARDED));
+  }
+
   // --- helpers: each step below is called directly from the test bodies above ---
 
   private long deployAndStartProcessInstance() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
@@ -45,12 +46,12 @@ public class AgentHistoryCommitLifecycleIT {
     final long processInstanceKey = deployAndStartProcessInstance();
     final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
     final long agentInstanceKey = createAgentInstance(elementInstanceKey);
-    final long jobKey = activateAgenticJob(processInstanceKey);
+    final var activatedJob = activateAgenticJob(processInstanceKey, false);
     final long historyItemKey1 =
         createHistoryItem(
             agentInstanceKey,
             elementInstanceKey,
-            jobKey,
+            activatedJob,
             AgentInstanceHistoryRole.USER,
             "Hello, what can you do?",
             OffsetDateTime.parse("2025-06-01T10:00:00Z"));
@@ -58,7 +59,7 @@ public class AgentHistoryCommitLifecycleIT {
         createHistoryItem(
             agentInstanceKey,
             elementInstanceKey,
-            jobKey,
+            activatedJob,
             AgentInstanceHistoryRole.ASSISTANT,
             "I can help with many tasks.",
             OffsetDateTime.parse("2025-06-01T10:01:00Z"));
@@ -69,7 +70,7 @@ public class AgentHistoryCommitLifecycleIT {
         tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.PENDING));
 
     // --- complete the job → engine emits COMMIT → items become COMMITTED ---
-    camundaClient.newCompleteCommand(jobKey).execute();
+    camundaClient.newCompleteCommand(activatedJob).execute();
 
     // --- verify items are COMMITTED after job completion ---
     awaitHistoryStatuses(
@@ -85,12 +86,12 @@ public class AgentHistoryCommitLifecycleIT {
     final long processInstanceKey = deployAndStartProcessInstance();
     final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
     final long agentInstanceKey = createAgentInstance(elementInstanceKey);
-    final long jobKey = activateAgenticJob(processInstanceKey);
+    final var activatedJob = activateAgenticJob(processInstanceKey, false);
     final long historyItemKey1 =
         createHistoryItem(
             agentInstanceKey,
             elementInstanceKey,
-            jobKey,
+            activatedJob,
             AgentInstanceHistoryRole.USER,
             "Hello, what can you do?",
             OffsetDateTime.parse("2025-06-01T10:00:00Z"));
@@ -98,7 +99,7 @@ public class AgentHistoryCommitLifecycleIT {
         createHistoryItem(
             agentInstanceKey,
             elementInstanceKey,
-            jobKey,
+            activatedJob,
             AgentInstanceHistoryRole.ASSISTANT,
             "I can help with many tasks.",
             OffsetDateTime.parse("2025-06-01T10:01:00Z"));
@@ -171,12 +172,13 @@ public class AgentHistoryCommitLifecycleIT {
     return agentInstanceKey;
   }
 
-  private long activateAgenticJob(final long processInstanceKey) {
+  private ActivatedJob activateAgenticJob(final long processInstanceKey, final boolean withLease) {
     final var activatedJobs =
         camundaClient
             .newActivateJobsCommand()
             .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
             .maxJobsToActivate(1)
+            .withLease(withLease)
             .timeout(Duration.ofMinutes(5))
             .send()
             .join()
@@ -184,26 +186,28 @@ public class AgentHistoryCommitLifecycleIT {
     assertThat(activatedJobs)
         .as("expected to activate one agent job for process instance %d", processInstanceKey)
         .isNotEmpty();
-    return activatedJobs.get(0).getKey();
+    return activatedJobs.getFirst();
   }
 
   private long createHistoryItem(
       final long agentInstanceKey,
       final long elementInstanceKey,
-      final long jobKey,
+      final ActivatedJob activatedJob,
       final AgentInstanceHistoryRole role,
       final String text,
       final OffsetDateTime producedAt) {
-    return camundaClient
-        .newCreateAgentHistoryItemCommand(agentInstanceKey)
-        .elementInstanceKey(elementInstanceKey)
-        .jobKey(jobKey)
-        .role(role)
-        .content(List.of(AgentInstanceHistoryContent.text(text)))
-        .producedAt(producedAt)
-        .send()
-        .join()
-        .getHistoryItemKey();
+    final var finalCommandStep =
+        camundaClient
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(activatedJob.getKey())
+            .role(role)
+            .content(List.of(AgentInstanceHistoryContent.text(text)))
+            .producedAt(producedAt);
+    if (activatedJob.getLeaseToken() != null) {
+      finalCommandStep.jobLease(activatedJob.getLeaseToken());
+    }
+    return finalCommandStep.execute().getHistoryItemKey();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -91,8 +91,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
     }
     final var job = jobState.getJob(jobKey);
 
-    final var jobLeaseToken = job.getLeaseToken();
-    if (!jobLeaseToken.isEmpty() && !commandValue.getJobLease().equals(jobLeaseToken)) {
+    if (job.hasLeaseToken() && !commandValue.getJobLease().equals(job.getLeaseToken())) {
       writeRejection(
           command,
           RejectionType.NOT_FOUND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -91,6 +91,16 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
     }
     final var job = jobState.getJob(jobKey);
 
+    final var jobLeaseToken = job.getLeaseToken();
+    if (!jobLeaseToken.isEmpty() && !commandValue.getJobLease().equals(jobLeaseToken)) {
+      writeRejection(
+          command,
+          RejectionType.NOT_FOUND,
+          "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
+              .formatted(jobKey));
+      return;
+    }
+
     final var jobElementInstanceKey = job.getElementInstanceKey();
     final var commandElementInstanceKey = commandValue.getElementInstanceKey();
     if (jobElementInstanceKey != commandElementInstanceKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -227,7 +227,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
       commandWriter.appendFollowUpCommand(
           command.getKey(),
           AgentHistoryIntent.COMMIT,
-          new AgentHistoryRecord().setJobKey(command.getKey()).setJobLease(""));
+          new AgentHistoryRecord().setJobKey(command.getKey()).setJobLease(job.getLeaseToken()));
     }
 
     jobMetrics.countJobEvent(JobAction.COMPLETED, job.getJobKind(), job.getType());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -164,6 +164,73 @@ public class AgentHistoryCommitTest {
         .containsExactly(lease2ItemKey);
   }
 
+  @Test
+  public void shouldCommitWinningAndDiscardSupersededOnLeasedJobCompletion() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+
+    // Activation 1 (superseded): create a history item, then fail to trigger re-activation.
+    final var job1 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    final long supersededItemKey =
+        createHistoryItem(agentInstanceKey, job1.key(), elementInstanceKey, job1.leaseToken());
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withLeaseToken(job1.leaseToken())
+        .withRetries(1)
+        .fail();
+
+    // Activation 2 (winning): create a history item, then complete the job.
+    final var job2 = activateJobForProcessInstanceWithLease(processInstanceKey);
+    assertThat(job2.key()).as("re-activation must reuse the same job key").isEqualTo(job1.key());
+    assertThat(job2.leaseToken())
+        .as("re-activation must advance the lease token")
+        .isNotEqualTo(job1.leaseToken());
+    final long winningItemKey =
+        createHistoryItem(agentInstanceKey, job2.key(), elementInstanceKey, job2.leaseToken());
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(JOB_TYPE)
+        .withLeaseToken(job2.leaseToken())
+        .complete();
+
+    // JobCompleteProcessor emits AGENT_HISTORY:COMMIT; scope subsequent assertions to it.
+    final var firstCommitted =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withJobKey(job2.key())
+            .getFirst();
+    final long commitPosition = firstCommitted.getSourceRecordPosition();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // visitByJobLease(job2.leaseToken()) → winning item COMMITTED
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.COMMITTED)
+                .filter(r -> r.getSourceRecordPosition() == commitPosition)
+                .map(Record::getKey))
+        .as("only the winning activation's history item should be committed")
+        .containsExactly(winningItemKey);
+
+    // discard pass → superseded item DISCARDED
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.DISCARDED)
+                .filter(r -> r.getSourceRecordPosition() == commitPosition)
+                .map(Record::getKey))
+        .as("the superseded activation's history item should be discarded")
+        .containsExactly(supersededItemKey);
+  }
+
   // --- helpers ---
 
   private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
@@ -237,4 +304,23 @@ public class AgentHistoryCommitTest {
 
     return createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
   }
+
+  private static ActivatedJob activateJobForProcessInstanceWithLease(
+      final long processInstanceKey) {
+    final var batchRecord = ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final int jobIndex = batchRecord.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("expected activated job batch to contain job key %d", jobKey)
+        .isGreaterThanOrEqualTo(0);
+    final String leaseToken = batchRecord.getValue().getJobs().get(jobIndex).getLeaseToken();
+    return new ActivatedJob(jobKey, leaseToken);
+  }
+
+  private record ActivatedJob(long key, String leaseToken) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -177,6 +177,93 @@ public class AgentHistoryCreateTest {
     assertThat(rejection.getRejectionReason()).contains(String.valueOf(secondElementInstanceKey));
   }
 
+  @Test
+  public void shouldSucceedWhenJobHasNoLease() {
+    // given — job activated without withLease(), so leaseToken is empty
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    // when
+    final Record<AgentHistoryRecordValue> created =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(jobKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withRole(AgentHistoryRole.USER)
+            .withJobLease("")
+            .create();
+
+    // then — lease check is skipped and history record was created
+    assertThat(created.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(created.getIntent()).isEqualTo(AgentHistoryIntent.CREATED);
+  }
+
+  @Test
+  public void shouldRejectWhenJobLeaseMismatch() {
+    // given — job activated with withLease(), but CREATE carries a stale/wrong lease string
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+
+    // when
+    final Record<AgentHistoryRecordValue> rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(job.key())
+            .withElementInstanceKey(elementInstanceKey)
+            .withRole(AgentHistoryRole.USER)
+            .withJobLease("stale-lease-that-does-not-match")
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
+                .formatted(job.key()));
+  }
+
+  @Test
+  public void shouldRejectWhenJobHasLeaseButCommandOmitsIt() {
+    // given — job activated with withLease(), but CREATE carries no lease (empty string)
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var job = activateJobForProcessInstanceWithLease(processInstanceKey);
+
+    // when — empty string does not equal the stored token, so the lease check fires
+    final Record<AgentHistoryRecordValue> rejection =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(job.key())
+            .withElementInstanceKey(elementInstanceKey)
+            .withRole(AgentHistoryRole.USER)
+            .expectRejection()
+            .create();
+
+    // then
+    assertThat(rejection.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+    assertThat(rejection.getRejectionReason())
+        .isEqualTo(
+            "Expected to create agent history entry for job with key '%d', but the supplied lease does not match. The job may have been re-activated."
+                .formatted(job.key()));
+  }
+
   // --- helpers ---
 
   private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
@@ -213,4 +300,23 @@ public class AgentHistoryCreateTest {
         .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
         .create();
   }
+
+  private static ActivatedJob activateJobForProcessInstanceWithLease(
+      final long processInstanceKey) {
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(JOB_TYPE)
+            .getFirst()
+            .getKey();
+    final var batchRecord = ENGINE.jobs().withType(JOB_TYPE).withLease().activate();
+    final int jobIndex = batchRecord.getValue().getJobKeys().indexOf(jobKey);
+    assertThat(jobIndex)
+        .as("expected activated job batch to contain job key %d", jobKey)
+        .isGreaterThanOrEqualTo(0);
+    final String leaseToken = batchRecord.getValue().getJobs().get(jobIndex).getLeaseToken();
+    return new ActivatedJob(jobKey, leaseToken);
+  }
+
+  private record ActivatedJob(long key, String leaseToken) {}
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -498,6 +498,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return bufferAsString(leaseTokenProp.getValue());
   }
 
+  @JsonIgnore
+  public boolean hasLeaseToken() {
+    return !getLeaseToken().isEmpty();
+  }
+
   public JobRecord setLeaseToken(final String leaseToken) {
     leaseTokenProp.setValue(leaseToken);
     return this;


### PR DESCRIPTION
## Description

### Context

`AGENT_HISTORY:CREATE` records are how agent workers log reasoning steps for a running job. Before this change, any caller could create a history entry for a job regardless of which activation produced it. If a job timed out and was re-activated by another worker, the original worker could still append history entries with a stale lease token, causing `AGENT_HISTORY:COMMIT` to resolve the wrong items.

Additionally, when `JobCompleteProcessor` emitted the follow-up `AGENT_HISTORY:COMMIT` command on job completion, it always set `jobLease` to an empty string — so the commit never carried the real lease token. This meant the lease-based discard logic (which drops history items from superseded activations) could not distinguish between activations, rendering lease-scoped commits inoperative.

### What changed

**Lease matching check:** `AgentHistoryCreateProcessor` now rejects `CREATE` commands where the job has a non-empty stored lease token and the supplied `jobLease` does not match. The check is intentionally skipped for jobs without a stored lease token (activated without `withLease(true)`), preserving the pre-lease behavior for non-leasing workers and covering the ADR 0005-810 D7 rolling-upgrade degradation case. The rejection message omits the actual token value, following the convention in `JobLeaseFencingCheck` to avoid leaking lease tokens into error responses.

**Lease propagation in COMMIT:** `JobCompleteProcessor` now sets `jobLease` to the job's actual stored lease token (via `job.getLeaseToken()`) when appending the follow-up `AGENT_HISTORY:COMMIT` command, replacing the previously hard-coded empty string. This enables the commit processor to correctly use `visitByJobLease` to commit only the winning activation's items and discard items from superseded activations.

> [!NOTE]
> **Divergence from original acceptance criteria:**
> The original issue proposed rejecting `AGENT_HISTORY:CREATE` when the job has no stored lease token. This check was intentionally omitted to preserve backward compatibility with non-leasing workers and to support rolling-upgrade degradation (ADR 0005-810 D7), where an older broker may return a job without a token. The correctness guarantee therefore applies only to leased activations: the lease matching check combined with lease propagation in `COMMIT` ensure that only the winning activation's items are committed and superseded items are discarded.

### Impact

Workers that activate jobs with `withLease(true)` must pass the received lease token as `jobLease` on every `AGENT_HISTORY:CREATE` command. A command carrying a stale token from a superseded activation will be rejected with `NOT_FOUND`, preventing history corruption across re-activation boundaries. Workers that do not use `withLease(true)` are unaffected — the check is only enforced when the job has a stored lease.

On completion, the winning activation's lease token is correctly propagated to `AGENT_HISTORY:COMMIT`, so only items created under that lease are committed while superseded items are discarded.

### Test changes

Three new engine unit tests are added to `AgentHistoryCreateTest`: two rejection tests verify that mismatched and omitted lease values are rejected with the correct `NOT_FOUND` type and message, and one positive regression test documents that jobs without a stored lease can have history items created regardless of the `jobLease` value supplied in the command.

A new engine unit test in `AgentHistoryCommitTest` covers the full commit path via job completion: after a fail-and-reactivate cycle, completing the winning activation produces `COMMITTED` for its item and `DISCARDED` for the superseded one. No existing engine tests required adaptation — they all activate jobs without `withLease()` so the new check is never triggered.

On the acceptance-test side, a refactor aligns `AgentHistoryCommitLifecycleIT` helpers to use the client's `ActivatedJob` type directly (carrying both key and lease token), and a new end-to-end test verifies the full superseded-activation scenario: two activations of the same job, history items under each, job completion under the winning lease, and confirmation that the winning item reaches `COMMITTED` while the superseded item reaches `DISCARDED`.

## Checklist

- [ ] Enable backports when necessary.

## Related issues

closes #56164