### PR TITLE
feat: support metadata filter in cluster variable search REST API

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/ClusterVariableMapper.java
@@ -7,14 +7,25 @@
  */
 package io.camunda.gateway.mapping.http.mapper;
 
+import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToUntypedOperations;
+
 import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.validator.ClusterVariableRequestValidator;
+import io.camunda.gateway.protocol.model.AdvancedMetadataValueFilter;
 import io.camunda.gateway.protocol.model.ClusterVariableKindEnum;
 import io.camunda.gateway.protocol.model.CreateClusterVariableRequest;
 import io.camunda.gateway.protocol.model.UpdateClusterVariableRequest;
+import io.camunda.search.entities.ValueTypeEnum;
+import io.camunda.search.filter.MetadataValueFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
+import io.camunda.search.filter.UntypedOperation;
 import io.camunda.service.ClusterVariableServices.ClusterVariableRequest;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableKind;
 import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.ProblemDetail;
 
@@ -96,5 +107,67 @@ public class ClusterVariableMapper {
       case JSON -> ClusterVariableKind.JSON;
       case SECRET_REFERENCE -> ClusterVariableKind.SECRET_REFERENCE;
     };
+  }
+
+  public static List<MetadataValueFilter> toMetadataValueFilters(
+      final Map<String, AdvancedMetadataValueFilter> metadata,
+      final List<String> validationErrors) {
+    final List<MetadataValueFilter> filters = new ArrayList<>();
+    for (final var entry : metadata.entrySet()) {
+      final String key = entry.getKey();
+      if (entry.getValue() == null) {
+        validationErrors.add("The filter on metadata key '%s' must not be null.".formatted(key));
+        continue;
+      }
+      final List<Operation<Object>> operations = mapToUntypedOperations().apply(entry.getValue());
+      validateMetadataOperations(key, operations, validationErrors);
+      final List<UntypedOperation> valueOperations =
+          operations.stream().map(ClusterVariableMapper::toMetadataValueOperation).toList();
+      filters.add(
+          new MetadataValueFilter.Builder().key(key).valueOperations(valueOperations).build());
+    }
+    return filters;
+  }
+
+  /**
+   * Builds an {@link UntypedOperation} preserving the JSON scalar type from the value's Java
+   * runtime type (as deserialized by Jackson).
+   */
+  private static UntypedOperation toMetadataValueOperation(final Operation<Object> operation) {
+    final ValueTypeEnum type = metadataValueType(operation.value());
+    return new UntypedOperation(operation.operator(), operation.values(), type);
+  }
+
+  /**
+   * Rejects a {@code $exists: false} filter combined with other operations on the same key, which
+   * the query transformer cannot represent and would otherwise throw on (surfacing as a 500).
+   */
+  private static void validateMetadataOperations(
+      final String key,
+      final List<Operation<Object>> operations,
+      final List<String> validationErrors) {
+    final boolean hasNotExists =
+        operations.stream().anyMatch(op -> op.operator() == Operator.NOT_EXISTS);
+    if (hasNotExists && operations.size() > 1) {
+      validationErrors.add(
+          "The '$exists: false' filter on metadata key '%s' cannot be combined with other operations."
+              .formatted(key));
+    }
+  }
+
+  private static ValueTypeEnum metadataValueType(final @Nullable Object value) {
+    if (value == null) {
+      return ValueTypeEnum.NULL;
+    }
+    if (value instanceof Double || value instanceof Float) {
+      return ValueTypeEnum.DOUBLE;
+    }
+    if (value instanceof Number) {
+      return ValueTypeEnum.LONG;
+    }
+    if (value instanceof Boolean) {
+      return ValueTypeEnum.BOOLEAN;
+    }
+    return ValueTypeEnum.STRING;
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -89,7 +89,6 @@ import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
-import io.camunda.util.ValueTypeUtil;
 import io.camunda.zeebe.util.Either;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
@@ -425,21 +424,11 @@ public class SearchQueryFilterMapper {
 
   /**
    * Builds an {@link UntypedOperation} preserving the JSON scalar type from the value's Java
-   * runtime type (as deserialized by Jackson), rather than re-inferring it from string content.
-   * This keeps the query side consistent with the write side, which types metadata by {@code
-   * instanceof Number}: a value sent as a JSON string stays a string even when it looks numeric
-   * (e.g. "007").
+   * runtime type (as deserialized by Jackson).
    */
   private static UntypedOperation toMetadataValueOperation(final Operation<Object> operation) {
     final ValueTypeEnum type = metadataValueType(operation.value());
-    // exists operations carry no values (null), mirror that instead of dereferencing it
-    final List<Object> values =
-        operation.values() == null
-            ? null
-            : operation.values().stream()
-                .map(value -> ValueTypeUtil.mapValueType(value, type))
-                .toList();
-    return new UntypedOperation(operation.operator(), values, type);
+    return new UntypedOperation(operation.operator(), operation.values(), type);
   }
 
   /**
@@ -459,7 +448,6 @@ public class SearchQueryFilterMapper {
     }
   }
 
-  /** Derives the metadata value type from the Java runtime type, not from string content. */
   private static ValueTypeEnum metadataValueType(final @Nullable Object value) {
     if (value == null) {
       return ValueTypeEnum.NULL;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -11,6 +11,7 @@ import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapT
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToKeyOperations;
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations;
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToStringOperations;
+import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToUntypedOperations;
 import static io.camunda.gateway.mapping.http.util.KeyUtil.mapKeyToLong;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
@@ -47,6 +48,7 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.search.filter.AuditLogFilter;
@@ -72,7 +74,9 @@ import io.camunda.search.filter.JobTypeStatisticsFilter;
 import io.camunda.search.filter.JobWorkerStatisticsFilter;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.filter.MessageSubscriptionFilter;
+import io.camunda.search.filter.MetadataValueFilter;
 import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessDefinitionInstanceVersionStatisticsFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
@@ -80,15 +84,18 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter.Builder;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.filter.TenantFilter;
+import io.camunda.search.filter.UntypedOperation;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableValueFilter;
+import io.camunda.util.ValueTypeUtil;
 import io.camunda.zeebe.util.Either;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
@@ -371,14 +378,16 @@ public class SearchQueryFilterMapper {
     return Either.right(builder.build());
   }
 
-  static ClusterVariableFilter toClusterVariableFilter(
+  static Either<List<String>, ClusterVariableFilter> toClusterVariableFilter(
       final @Nullable ClusterVariableSearchQueryFilterRequest filter) {
 
+    final var builder = FilterBuilders.clusterVariable();
+
     if (filter == null) {
-      return FilterBuilders.clusterVariable().build();
+      return Either.right(builder.build());
     }
 
-    final var builder = FilterBuilders.clusterVariable();
+    final List<String> validationErrors = new ArrayList<>();
 
     ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
     ofNullable(filter.getValue()).map(mapToStringOperations()).ifPresent(builder::valueOperations);
@@ -387,9 +396,84 @@ public class SearchQueryFilterMapper {
         .map(mapToStringOperations())
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
+    ofNullable(filter.getMetadata())
+        .map(metadata -> toMetadataValueFilters(metadata, validationErrors))
+        .ifPresent(builder::metadataOperations);
     ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
 
-    return builder.build();
+
+    return validationErrors.isEmpty()
+        ? Either.right(builder.build())
+        : Either.left(validationErrors);
+  }
+
+  private static List<MetadataValueFilter> toMetadataValueFilters(
+      final Map<String, io.camunda.gateway.protocol.model.AdvancedMetadataValueFilter> metadata,
+      final List<String> validationErrors) {
+    final List<MetadataValueFilter> filters = new ArrayList<>();
+    for (final var entry : metadata.entrySet()) {
+      final String key = entry.getKey();
+      final List<Operation<Object>> operations = mapToUntypedOperations().apply(entry.getValue());
+      validateMetadataOperations(key, operations, validationErrors);
+      final List<UntypedOperation> valueOperations =
+          operations.stream().map(SearchQueryFilterMapper::toMetadataValueOperation).toList();
+      filters.add(
+          new MetadataValueFilter.Builder().key(key).valueOperations(valueOperations).build());
+    }
+    return filters;
+  }
+
+  /**
+   * Builds an {@link UntypedOperation} preserving the JSON scalar type from the value's Java
+   * runtime type (as deserialized by Jackson), rather than re-inferring it from string content.
+   * This keeps the query side consistent with the write side, which types metadata by {@code
+   * instanceof Number}: a value sent as a JSON string stays a string even when it looks numeric
+   * (e.g. "007").
+   */
+  private static UntypedOperation toMetadataValueOperation(final Operation<Object> operation) {
+    final ValueTypeEnum type = metadataValueType(operation.value());
+    // exists operations carry no values (null), mirror that instead of dereferencing it
+    final List<Object> values =
+        operation.values() == null
+            ? null
+            : operation.values().stream()
+                .map(value -> ValueTypeUtil.mapValueType(value, type))
+                .toList();
+    return new UntypedOperation(operation.operator(), values, type);
+  }
+
+  /**
+   * Rejects a {@code $exists: false} filter combined with other operations on the same key, which
+   * the query transformer cannot represent and would otherwise throw on (surfacing as a 500).
+   */
+  private static void validateMetadataOperations(
+      final String key,
+      final List<Operation<Object>> operations,
+      final List<String> validationErrors) {
+    final boolean hasNotExists =
+        operations.stream().anyMatch(op -> op.operator() == Operator.NOT_EXISTS);
+    if (hasNotExists && operations.size() > 1) {
+      validationErrors.add(
+          "The '$exists: false' filter on metadata key '%s' cannot be combined with other operations."
+              .formatted(key));
+    }
+  }
+
+  /** Derives the metadata value type from the Java runtime type, not from string content. */
+  private static ValueTypeEnum metadataValueType(final @Nullable Object value) {
+    if (value == null) {
+      return ValueTypeEnum.NULL;
+    }
+    if (value instanceof Double || value instanceof Float) {
+      return ValueTypeEnum.DOUBLE;
+    }
+    if (value instanceof Number) {
+      return ValueTypeEnum.LONG;
+    }
+    if (value instanceof Boolean) {
+      return ValueTypeEnum.BOOLEAN;
+    }
+    return ValueTypeEnum.STRING;
   }
 
   static BatchOperationFilter toBatchOperationFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -11,7 +11,6 @@ import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapT
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToKeyOperations;
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToOffsetDateTimeOperations;
 import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToStringOperations;
-import static io.camunda.gateway.mapping.http.util.AdvancedSearchFilterUtil.mapToUntypedOperations;
 import static io.camunda.gateway.mapping.http.util.KeyUtil.mapKeyToLong;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
@@ -30,6 +29,7 @@ import io.camunda.gateway.mapping.http.converters.AuditLogResultConverter;
 import io.camunda.gateway.mapping.http.converters.BatchOperationTypeConverter;
 import io.camunda.gateway.mapping.http.converters.DecisionInstanceStateConverter;
 import io.camunda.gateway.mapping.http.converters.ProcessInstanceStateConverter;
+import io.camunda.gateway.mapping.http.mapper.ClusterVariableMapper;
 import io.camunda.gateway.mapping.http.validator.TagsValidator;
 import io.camunda.gateway.protocol.model.BaseProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryFilterRequest;
@@ -48,7 +48,6 @@ import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
-import io.camunda.search.entities.ValueTypeEnum;
 import io.camunda.search.filter.AgentInstanceFilter;
 import io.camunda.search.filter.AgentInstanceHistoryFilter;
 import io.camunda.search.filter.AuditLogFilter;
@@ -74,9 +73,7 @@ import io.camunda.search.filter.JobTypeStatisticsFilter;
 import io.camunda.search.filter.JobWorkerStatisticsFilter;
 import io.camunda.search.filter.MappingRuleFilter;
 import io.camunda.search.filter.MessageSubscriptionFilter;
-import io.camunda.search.filter.MetadataValueFilter;
 import io.camunda.search.filter.Operation;
-import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessDefinitionInstanceVersionStatisticsFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
@@ -84,7 +81,6 @@ import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter.Builder;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.filter.TenantFilter;
-import io.camunda.search.filter.UntypedOperation;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
@@ -94,7 +90,6 @@ import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
@@ -396,72 +391,13 @@ public class SearchQueryFilterMapper {
         .ifPresent(builder::tenantIdOperations);
     ofNullable(filter.getIsTruncated()).ifPresent(builder::isTruncated);
     ofNullable(filter.getMetadata())
-        .map(metadata -> toMetadataValueFilters(metadata, validationErrors))
+        .map(metadata -> ClusterVariableMapper.toMetadataValueFilters(metadata, validationErrors))
         .ifPresent(builder::metadataOperations);
     ofNullable(filter.getKind()).map(mapToStringOperations()).ifPresent(builder::kindOperations);
-
 
     return validationErrors.isEmpty()
         ? Either.right(builder.build())
         : Either.left(validationErrors);
-  }
-
-  private static List<MetadataValueFilter> toMetadataValueFilters(
-      final Map<String, io.camunda.gateway.protocol.model.AdvancedMetadataValueFilter> metadata,
-      final List<String> validationErrors) {
-    final List<MetadataValueFilter> filters = new ArrayList<>();
-    for (final var entry : metadata.entrySet()) {
-      final String key = entry.getKey();
-      final List<Operation<Object>> operations = mapToUntypedOperations().apply(entry.getValue());
-      validateMetadataOperations(key, operations, validationErrors);
-      final List<UntypedOperation> valueOperations =
-          operations.stream().map(SearchQueryFilterMapper::toMetadataValueOperation).toList();
-      filters.add(
-          new MetadataValueFilter.Builder().key(key).valueOperations(valueOperations).build());
-    }
-    return filters;
-  }
-
-  /**
-   * Builds an {@link UntypedOperation} preserving the JSON scalar type from the value's Java
-   * runtime type (as deserialized by Jackson).
-   */
-  private static UntypedOperation toMetadataValueOperation(final Operation<Object> operation) {
-    final ValueTypeEnum type = metadataValueType(operation.value());
-    return new UntypedOperation(operation.operator(), operation.values(), type);
-  }
-
-  /**
-   * Rejects a {@code $exists: false} filter combined with other operations on the same key, which
-   * the query transformer cannot represent and would otherwise throw on (surfacing as a 500).
-   */
-  private static void validateMetadataOperations(
-      final String key,
-      final List<Operation<Object>> operations,
-      final List<String> validationErrors) {
-    final boolean hasNotExists =
-        operations.stream().anyMatch(op -> op.operator() == Operator.NOT_EXISTS);
-    if (hasNotExists && operations.size() > 1) {
-      validationErrors.add(
-          "The '$exists: false' filter on metadata key '%s' cannot be combined with other operations."
-              .formatted(key));
-    }
-  }
-
-  private static ValueTypeEnum metadataValueType(final @Nullable Object value) {
-    if (value == null) {
-      return ValueTypeEnum.NULL;
-    }
-    if (value instanceof Double || value instanceof Float) {
-      return ValueTypeEnum.DOUBLE;
-    }
-    if (value instanceof Number) {
-      return ValueTypeEnum.LONG;
-    }
-    if (value instanceof Boolean) {
-      return ValueTypeEnum.BOOLEAN;
-    }
-    return ValueTypeEnum.STRING;
   }
 
   static BatchOperationFilter toBatchOperationFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -697,7 +697,7 @@ public final class SearchQueryRequestMapper {
                 request.getSort()),
             SortOptionBuilders::clusterVariable,
             SearchQuerySortRequestMapper::applyClusterVariableSortField);
-    final ClusterVariableFilter filter =
+    final Either<List<String>, ClusterVariableFilter> filter =
         SearchQueryFilterMapper.toClusterVariableFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::clusterVariableSearchQuery);
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtil.java
@@ -69,6 +69,16 @@ public class AdvancedSearchFilterUtil {
     return (final Object filter) -> mapToTypedOperations(filter, Object::toString);
   }
 
+  /**
+   * Maps an advanced filter to operations that preserve the raw scalar value (string or number)
+   * without coercing it to a string. Booleans are handled as `exists` operations, lists (e.g.
+   * `$in`) are converted element-wise. Used for untyped filters such as metadata, where numeric vs
+   * string typing must be preserved for downstream range queries.
+   */
+  public static Function<Object, List<Operation<Object>>> mapToUntypedOperations() {
+    return (final Object filter) -> mapToTypedOperations(filter, value -> value);
+  }
+
   public static Function<Object, List<Operation<String>>> mapToStringOperations(
       final String fieldName,
       final List<String> validationErrors,

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/util/AdvancedSearchFilterUtilTest.java
@@ -15,6 +15,7 @@ import io.camunda.gateway.mapping.http.converters.CustomConverter;
 import io.camunda.gateway.mapping.http.converters.ProcessInstanceStateConverter;
 import io.camunda.gateway.protocol.model.AdvancedDateTimeFilter;
 import io.camunda.gateway.protocol.model.AdvancedIntegerFilter;
+import io.camunda.gateway.protocol.model.AdvancedMetadataValueFilter;
 import io.camunda.gateway.protocol.model.AdvancedStringFilter;
 import io.camunda.gateway.protocol.model.BasicStringFilter;
 import io.camunda.search.filter.Operation;
@@ -450,6 +451,58 @@ class AdvancedSearchFilterUtilTest {
 
     // then — null element causes the whole operation to be dropped
     assertThat(actual).isEmpty();
+  }
+
+  @Test
+  void shouldPreserveStringValuesInUntypedOperations() {
+    // given
+    final var filter = AdvancedMetadataValueFilter.Builder.create().build();
+    filter.set$Eq("this");
+    filter.set$In(List.of("a", "b"));
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToUntypedOperations().apply(filter);
+
+    // then — string values are preserved as String, not coerced
+    assertThat(actual)
+        .containsExactlyInAnyOrder(
+            new Operation<>(Operator.EQUALS, List.of("this")),
+            new Operation<>(Operator.IN, List.of("a", "b")));
+  }
+
+  @Test
+  void shouldPreserveNumericValuesInUntypedOperations() {
+    // given
+    final var filter = AdvancedMetadataValueFilter.Builder.create().build();
+    filter.set$Eq(5);
+    filter.set$In(List.of(1, 2));
+
+    // when
+    final var actual = AdvancedSearchFilterUtil.mapToUntypedOperations().apply(filter);
+
+    // then — numeric values keep their runtime type (Number), not stringified
+    assertThat(actual)
+        .containsExactlyInAnyOrder(
+            new Operation<>(Operator.EQUALS, List.of(5)),
+            new Operation<>(Operator.IN, List.of(1, 2)));
+    assertThat(actual).allSatisfy(op -> assertThat(op.values()).allMatch(v -> v instanceof Number));
+  }
+
+  @Test
+  void shouldMapBooleanToExistsInUntypedOperations() {
+    // given
+    final var existsFilter = AdvancedMetadataValueFilter.Builder.create().build();
+    existsFilter.set$Exists(true);
+    final var notExistsFilter = AdvancedMetadataValueFilter.Builder.create().build();
+    notExistsFilter.set$Exists(false);
+
+    // when
+    final var exists = AdvancedSearchFilterUtil.mapToUntypedOperations().apply(existsFilter);
+    final var notExists = AdvancedSearchFilterUtil.mapToUntypedOperations().apply(notExistsFilter);
+
+    // then
+    assertThat(exists).containsExactly(Operation.exists(true));
+    assertThat(notExists).containsExactly(Operation.exists(false));
   }
 
   /** Creates an ArrayList that allows null elements (unlike List.of). */

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster-variables.yaml
@@ -637,6 +637,13 @@ components:
           description: |
             Filter cluster variables by truncation status of their stored values. When true, returns only variables whose stored values are truncated (i.e., the value exceeds the storage size limit and is truncated in storage). When false, returns only variables with non-truncated stored values. This filter is based on the underlying storage characteristic, not the response format.
           type: boolean
+        metadata:
+          description: >-
+            Filter by metadata entries. A map of metadata key to an advanced filter on that key's
+            value. Metadata values are strings or numbers.
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AdvancedMetadataValueFilter'
         kind:
           description: The kind filter for cluster variables.
           allOf:
@@ -644,6 +651,47 @@ components:
       x-properties-added-in-version:
         - propertyName: "kind"
           addedInVersion: "8.10"
+        - propertyName: "metadata"
+          addedInVersion: "8.10"
+    AdvancedMetadataValueFilter:
+      title: Advanced filter
+      description: Advanced filter on a metadata value (string or number).
+      type: object
+      properties:
+        $eq:
+          description: Checks for equality with the provided value.
+          oneOf:
+            - type: string
+            - type: number
+        $neq:
+          description: Checks for inequality with the provided value.
+          oneOf:
+            - type: string
+            - type: number
+        $exists:
+          description: Checks if the metadata key exists.
+          type: boolean
+        $gt:
+          description: Greater than comparison with the provided value.
+          type: number
+        $gte:
+          description: Greater than or equal comparison with the provided value.
+          type: number
+        $lt:
+          description: Lower than comparison with the provided value.
+          type: number
+        $lte:
+          description: Lower than or equal comparison with the provided value.
+          type: number
+        $in:
+          description: Checks if the property matches any of the provided values.
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: number
+        $like:
+          $ref: "filters.yaml#/components/schemas/LikeFilter"
     ClusterVariableScopeFilterProperty:
       description: ClusterVariableScopeEnum property with full advanced search capabilities.
       oneOf:


### PR DESCRIPTION
## What

Adds an advanced filter on cluster variable **metadata** entries to the cluster variable REST search endpoint, supporting `$eq`, `$neq`, `$exists`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, and `$like` operators per metadata key.

## Why

Completes the REST wiring for metadata filtering on the cluster variable search API (issue below).

## Notes

- The value type is derived from the JSON scalar's Java runtime type rather than re-inferred from string content, keeping the filter consistent with how the write side types metadata — a numeric-looking string (e.g. `"007"`) stays a string.
- Invalid metadata operand combinations (e.g. `$exists: false` combined with other operators on the same key) are surfaced as validation errors instead of throwing a 500.

## Dependencies

Part of #54797. Depends on #55089 (search domain metadata filter) and #55090 (REST metadata on response DTOs).

Closes #55091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
