### PR TITLE
fix: use iteration over recursion for feel to msgpack

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableNestingDepthRejectionTest.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -296,11 +295,7 @@ public final class VariableNestingDepthRejectionTest {
         .contains(EXPECTED_REJECTION_REASON);
   }
 
-  //   TODO: This test will fail due to a recursive call in the FEEL engine when evaluating the
-  //   expression. FeelToMessagePackTransformer can result in stack overflows through the recursive
-  //   handling of nested objects. This will be addressed in a follow-up issue.
   @Test
-  @Ignore("https://github.com/camunda/camunda/issues/57504")
   public void shouldRejectScriptTaskWithDeeplyNestedExpression() {
     // given
     final String deeplyNestedFeelExpression =

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.el;
 
 import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static io.camunda.zeebe.test.util.MsgPackUtil.assertEquality;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -171,6 +172,26 @@ public class ExpressionLanguageTest {
     assertThat(expression.getVariableName()).contains("x");
     assertThat(evaluationResult.getFailureMessage()).isNull();
     assertThat(evaluationResult.getWarnings()).isEmpty();
+  }
+
+  @Test
+  public void shouldEvaluateNestedObjects() {
+    final var expressionString = "{\"a\": {\"b\": [[1, 2], 3] }, \"c\": { \"d\": \"e\" } }";
+    final var expression = expressionLanguage.parseExpression("=" + expressionString);
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertEquality(evaluationResult.toBuffer(), expressionString);
+  }
+
+  @Test
+  public void shouldEvaluateNestedArray() {
+    final var expressionString = "[[{\"a\": [1]}, {\"b\": \"c\"}], 3]";
+    final var expression = expressionLanguage.parseExpression("=" + expressionString);
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertEquality(evaluationResult.toBuffer(), expressionString);
   }
 
   @Test

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
@@ -229,6 +229,20 @@ public class ExpressionLanguageTest {
   }
 
   @Test
+  public void shouldEvaluateVeryDeeplyNestedAlternatingListsAndContextsWithoutStackOverflow() {
+    // given
+    final var depth = 3_000;
+    final var expressionString =
+        String.format(
+            "(for i in 1..%s return if i = 1 then {\"a\": 1} else if modulo(i,2) = 0 then [partial[-1]] else {\"a\": partial[-1]})[-1]",
+            depth);
+    final var expression = expressionLanguage.parseExpression("=" + expressionString);
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertThat(evaluationResult.toBuffer().capacity()).isPositive();
+  }
+
+  @Test
   public void shouldEvaluateExpressionWithMissingVariables() {
     final var expression = expressionLanguage.parseExpression("=x");
     final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
@@ -195,6 +195,40 @@ public class ExpressionLanguageTest {
   }
 
   @Test
+  public void shouldEvaluateEmptyList() {
+    final var expression = expressionLanguage.parseExpression("=[]");
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertEquality(evaluationResult.toBuffer(), "[]");
+  }
+
+  @Test
+  public void shouldEvaluateEmptyContext() {
+    final var expression = expressionLanguage.parseExpression("={}");
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertEquality(evaluationResult.toBuffer(), "{}");
+  }
+
+  @Test
+  public void shouldEvaluateVeryDeeplyNestedContextWithoutStackOverflow() {
+    // a "for" loop wraps the previous result in a new object on every iteration, building a list
+    // nested `depth` levels deep without a correspondingly deep parse tree or source string
+    final var depth = 3_000;
+    final var expressionString =
+        String.format(
+            "(for i in 1..%s return if i = 1 then {\"a\": 1} else {\"a\": partial[-1]})[-1]",
+            depth);
+    final var expression = expressionLanguage.parseExpression("=" + expressionString);
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+
+    assertThat(evaluationResult.isFailure()).isFalse();
+    assertThat(evaluationResult.toBuffer().capacity()).isPositive();
+  }
+
+  @Test
   public void shouldEvaluateExpressionWithMissingVariables() {
     final var expression = expressionLanguage.parseExpression("=x");
     final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
@@ -12,6 +12,9 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -30,6 +33,8 @@ import org.camunda.feel.syntaxtree.ValNumber;
 import org.camunda.feel.syntaxtree.ValString;
 import org.camunda.feel.syntaxtree.ValTime;
 import org.camunda.feel.syntaxtree.ValYearMonthDuration;
+import scala.Tuple2;
+import scala.collection.Iterator;
 
 public class FeelToMessagePackTransformer {
   final MsgPackWriter writer = new MsgPackWriter();
@@ -45,7 +50,61 @@ public class FeelToMessagePackTransformer {
     return resultView;
   }
 
-  private void writeValue(final Val value) {
+  /**
+   * Writes a (possibly deeply nested) FEEL value to msgpack using an iterative depth-first search
+   * approach. This avoids using the call stack from recursion and instead uses an explicit
+   * work-stack to manage nested lists/contexts.
+   */
+  private void writeValue(final Val root) {
+    final Deque<Object> stack = new ArrayDeque<>();
+    writeScalarOrPushCursor(root, stack);
+
+    while (!stack.isEmpty()) {
+      final var cursor = stack.peek();
+      switch (cursor) {
+        case final ListCursor listCursor -> {
+          if (listCursor.items().hasNext()) {
+            writeScalarOrPushCursor(listCursor.items().next(), stack);
+          } else {
+            stack.pop();
+          }
+        }
+        case final ContextCursor contextCursor -> {
+          if (contextCursor.entries().hasNext()) {
+            writeContextEntry(contextCursor.entries().next(), stack);
+          } else {
+            stack.pop();
+          }
+        }
+        default -> throw new IllegalStateException("Unexpected cursor on stack: " + cursor);
+      }
+    }
+  }
+
+  private void writeContextEntry(final Tuple2<String, Object> entry, final Deque<Object> pending) {
+    final var entryKey = entry._1();
+    final var entryValue = entry._2();
+    stringWrapper.wrap(entryKey.getBytes(StandardCharsets.UTF_8));
+    writer.writeString(stringWrapper);
+
+    switch (entryValue) {
+      case final Val entryVal -> writeScalarOrPushCursor(entryVal, pending);
+      case final DirectBuffer entryBuffer -> writer.writeRaw(entryBuffer);
+      default -> {
+        writer.writeNil();
+        LOGGER.trace(
+            "No FEEL to MessagePack transformation for '{}'. Using 'null' for context entry with key '{}'.",
+            entryValue,
+            entryKey);
+      }
+    }
+  }
+
+  /**
+   * Writes a scalar value directly, or writes a list/map header and pushes a cursor onto {@code
+   * pending} so its items/entries are processed by the caller's loop instead of recursively.
+   */
+  private void writeScalarOrPushCursor(final Val value, final Deque<Object> pending) {
     switch (value) {
       case final ValNull$ ignored -> writer.writeNil();
       case final ValNumber number -> {
@@ -58,13 +117,9 @@ public class FeelToMessagePackTransformer {
       case final ValBoolean booleanValue -> writer.writeBoolean(booleanValue.value());
       case final ValString string -> writeStringValue(string.value());
       case final ValList list -> {
-        writer.writeArrayHeader(list.items().size());
-        list.itemsAsSeq()
-            .foreach(
-                item -> {
-                  writeValue(item);
-                  return null;
-                });
+        final var items = list.itemsAsSeq();
+        writer.writeArrayHeader(items.size());
+        pending.push(new ListCursor(items.iterator()));
       }
       case final ValContext context -> {
         if (context.context() instanceof final MessagePackContext msgPackContext) {
@@ -72,26 +127,7 @@ public class FeelToMessagePackTransformer {
         } else {
           final var variables = context.context().variableProvider().getVariables();
           writer.writeMapHeader(variables.size());
-          variables.foreach(
-              entry -> {
-                final var entryKey = entry._1();
-                final var entryValue = entry._2();
-                stringWrapper.wrap(entryKey.getBytes());
-                writer.writeString(stringWrapper);
-
-                switch (entryValue) {
-                  case final Val entryVal -> writeValue(entryVal);
-                  case final DirectBuffer entryBuffer -> writer.writeRaw(entryBuffer);
-                  default -> {
-                    writer.writeNil();
-                    LOGGER.trace(
-                        "No FEEL to MessagePack transformation for '{}'. Using 'null' for context entry with key '{}'.",
-                        entryValue,
-                        entryKey);
-                  }
-                }
-                return null;
-              });
+          pending.push(new ContextCursor(variables.iterator()));
         }
       }
       case final ValTime time -> writeStringValue(time.value().format());
@@ -112,7 +148,13 @@ public class FeelToMessagePackTransformer {
   }
 
   private void writeStringValue(final String value) {
-    stringWrapper.wrap(value.getBytes());
+    stringWrapper.wrap(value.getBytes(StandardCharsets.UTF_8));
     writer.writeString(stringWrapper);
   }
+
+  /** Cursor over a {@link ValList}'s pending, not-yet-written items. */
+  private record ListCursor(Iterator<Val> items) {}
+
+  /** Cursor over a {@link ValContext}'s pending, not-yet-written entries. */
+  private record ContextCursor(Iterator<Tuple2<String, Object>> entries) {}
 }

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
@@ -12,7 +12,6 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import org.agrona.DirectBuffer;
@@ -84,7 +83,7 @@ public class FeelToMessagePackTransformer {
   private void writeContextEntry(final Tuple2<String, Object> entry, final Deque<Object> pending) {
     final var entryKey = entry._1();
     final var entryValue = entry._2();
-    stringWrapper.wrap(entryKey.getBytes(StandardCharsets.UTF_8));
+    stringWrapper.wrap(entryKey.getBytes());
     writer.writeString(stringWrapper);
 
     switch (entryValue) {
@@ -148,7 +147,7 @@ public class FeelToMessagePackTransformer {
   }
 
   private void writeStringValue(final String value) {
-    stringWrapper.wrap(value.getBytes(StandardCharsets.UTF_8));
+    stringWrapper.wrap(value.getBytes());
     writer.writeString(stringWrapper);
   }
 


### PR DESCRIPTION
## Summary
- `FeelToMessagePackTransformer.writeValue` recursed once per level of nesting in a FEEL object/array, so deeply nested expressions could blow the JVM call stack.
- Rewrites the traversal as an iterative depth-first walk using an explicit `ArrayDeque` work-stack instead of recursion.
- Re-enables `shouldRejectScriptTaskWithDeeplyNestedExpression`, previously `@Ignore`d for this issue, and adds `shouldEvaluateNestedObjects`/`shouldEvaluateNestedArray` coverage for nested contexts/lists.

Closes #57504

## Test plan
- [x] `./mvnw verify -pl zeebe/expression-language -Dtest=ExpressionLanguageTest -DskipTests=false -DskipITs -Dquickly` — 18/18 passed
- [x] `./mvnw verify -pl zeebe/engine -Dtest=VariableNestingDepthRejectionTest -DskipTests=false -DskipITs -Dquickly` — 10/10 passed