### PR TITLE
feat: implement BATCH_REACTIVATE_JOBS processor and BATCH_JOBS_REACTIVATED applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -506,7 +506,8 @@ public final class EngineProcessors {
     AgentHistoryProcessors.addAgentHistoryProcessors(
         keyGenerator, typedRecordProcessors, writers, authCheckBehavior, processingState);
 
-    SecretReferenceProcessors.addSecretReferenceProcessors(typedRecordProcessors);
+    SecretReferenceProcessors.addSecretReferenceProcessors(
+        typedRecordProcessors, writers, keyGenerator, processingState);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessor.java
@@ -18,9 +18,7 @@ import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @ExcludeAuthorizationCheck
 public final class SecretReferenceBatchReactivateJobsProcessor
@@ -49,13 +47,10 @@ public final class SecretReferenceBatchReactivateJobsProcessor
     final var storeId = value.getStoreId();
     final var secretReference = value.getSecretReference();
 
-    // Write the current batch as an event first. Applying this event removes these job keys from
-    // the waiting-jobs index, so they will not be re-selected by the next-batch query below.
     stateWriter.appendFollowUpEvent(
         record.getKey(), SecretReferenceIntent.BATCH_JOBS_REACTIVATED, value);
 
-    final Set<Long> currentBatch = new HashSet<>(value.getJobKeys());
-    final List<Long> nextBatch = buildNextBatch(storeId, secretReference, currentBatch);
+    final List<Long> nextBatch = buildNextBatch(storeId, secretReference);
 
     if (!nextBatch.isEmpty()) {
       final var nextRecord =
@@ -68,16 +63,13 @@ public final class SecretReferenceBatchReactivateJobsProcessor
     }
   }
 
-  private List<Long> buildNextBatch(
-      final String storeId, final String secretReference, final Set<Long> currentBatch) {
+  private List<Long> buildNextBatch(final String storeId, final String secretReference) {
     final List<Long> nextBatch = new ArrayList<>();
     secretReferenceState.visitJobsBySecretReference(
         storeId,
         secretReference,
         jobKey -> {
-          if (!currentBatch.contains(jobKey)) {
-            nextBatch.add(jobKey);
-          }
+          nextBatch.add(jobKey);
           return nextBatch.size() < MAX_BATCH_SIZE;
         });
     return nextBatch;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessor.java
@@ -7,13 +7,79 @@
  */
 package io.camunda.zeebe.engine.processing.secretreference;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
+@ExcludeAuthorizationCheck
 public final class SecretReferenceBatchReactivateJobsProcessor
     implements TypedRecordProcessor<SecretReferenceRecord> {
 
+  private static final int MAX_BATCH_SIZE = 100;
+
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final KeyGenerator keyGenerator;
+  private final SecretReferenceState secretReferenceState;
+
+  public SecretReferenceBatchReactivateJobsProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final SecretReferenceState secretReferenceState) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    this.keyGenerator = keyGenerator;
+    this.secretReferenceState = secretReferenceState;
+  }
+
   @Override
-  public void processRecord(final TypedRecord<SecretReferenceRecord> record) {}
+  public void processRecord(final TypedRecord<SecretReferenceRecord> record) {
+    final var value = record.getValue();
+    final var storeId = value.getStoreId();
+    final var secretReference = value.getSecretReference();
+
+    // Write the current batch as an event first. Applying this event removes these job keys from
+    // the waiting-jobs index, so they will not be re-selected by the next-batch query below.
+    stateWriter.appendFollowUpEvent(
+        record.getKey(), SecretReferenceIntent.BATCH_JOBS_REACTIVATED, value);
+
+    final Set<Long> currentBatch = new HashSet<>(value.getJobKeys());
+    final List<Long> nextBatch = buildNextBatch(storeId, secretReference, currentBatch);
+
+    if (!nextBatch.isEmpty()) {
+      final var nextRecord =
+          new SecretReferenceRecord().setStoreId(storeId).setSecretReference(secretReference);
+      for (final long jobKey : nextBatch) {
+        nextRecord.addJobKey(jobKey);
+      }
+      commandWriter.appendFollowUpCommand(
+          keyGenerator.nextKey(), SecretReferenceIntent.BATCH_REACTIVATE_JOBS, nextRecord);
+    }
+  }
+
+  private List<Long> buildNextBatch(
+      final String storeId, final String secretReference, final Set<Long> currentBatch) {
+    final List<Long> nextBatch = new ArrayList<>();
+    secretReferenceState.visitJobsBySecretReference(
+        storeId,
+        secretReference,
+        jobKey -> {
+          if (!currentBatch.contains(jobKey)) {
+            nextBatch.add(jobKey);
+          }
+          return nextBatch.size() < MAX_BATCH_SIZE;
+        });
+    return nextBatch;
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
@@ -8,15 +8,21 @@
 package io.camunda.zeebe.engine.processing.secretreference;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public final class SecretReferenceProcessors {
 
   private SecretReferenceProcessors() {}
 
   public static void addSecretReferenceProcessors(
-      final TypedRecordProcessors typedRecordProcessors) {
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState) {
     typedRecordProcessors.onCommand(
         ValueType.SECRET_REFERENCE,
         SecretReferenceIntent.RESOLUTION_COMPLETE,
@@ -28,7 +34,8 @@ public final class SecretReferenceProcessors {
     typedRecordProcessors.onCommand(
         ValueType.SECRET_REFERENCE,
         SecretReferenceIntent.BATCH_REACTIVATE_JOBS,
-        new SecretReferenceBatchReactivateJobsProcessor());
+        new SecretReferenceBatchReactivateJobsProcessor(
+            writers, keyGenerator, processingState.getSecretReferenceState()));
     typedRecordProcessors.onCommand(
         ValueType.SECRET_REFERENCE,
         SecretReferenceIntent.BATCH_CREATE_INCIDENTS,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -180,7 +180,9 @@ public final class EventAppliers implements EventApplier {
         new SecretReferenceResolutionRequestedApplier(state.getSecretReferenceState()));
     register(SecretReferenceIntent.RESOLUTION_COMPLETED, NOOP_EVENT_APPLIER);
     register(SecretReferenceIntent.RESOLUTION_FAILED, NOOP_EVENT_APPLIER);
-    register(SecretReferenceIntent.BATCH_JOBS_REACTIVATED, NOOP_EVENT_APPLIER);
+    register(
+        SecretReferenceIntent.BATCH_JOBS_REACTIVATED,
+        new SecretReferenceBatchJobsReactivatedApplier(state));
     register(SecretReferenceIntent.BATCH_INCIDENTS_CREATED, NOOP_EVENT_APPLIER);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
@@ -13,6 +13,9 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public final class SecretReferenceBatchJobsReactivatedApplier
     implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
@@ -31,7 +34,25 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     final var secretReference = value.getSecretReference();
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.removeWaitingJob(storeId, secretReference, jobKey);
-      jobState.makeActivatable(jobKey);
+      if (isEligible(jobKey)) {
+        jobState.makeActivatable(jobKey);
+      }
     }
+  }
+
+  private boolean isEligible(final long jobKey) {
+    final List<Map.Entry<String, String>> refs = new ArrayList<>();
+    secretReferenceState.visitSecretReferencesByJob(
+        jobKey,
+        (sid, sref) -> {
+          refs.add(Map.entry(sid, sref));
+          return true;
+        });
+    for (final Map.Entry<String, String> ref : refs) {
+      if (secretReferenceState.isPending(ref.getKey(), ref.getValue())) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
@@ -44,8 +44,8 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     final List<Map.Entry<String, String>> refs = new ArrayList<>();
     secretReferenceState.visitSecretReferencesByJob(
         jobKey,
-        (sid, sref) -> {
-          refs.add(Map.entry(sid, sref));
+        (secretId, secretRef) -> {
+          refs.add(Map.entry(secretId, secretRef));
           return true;
         });
     for (final Map.Entry<String, String> ref : refs) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
@@ -35,7 +35,7 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.removeWaitingJob(storeId, secretReference, jobKey);
       if (isEligible(jobKey)) {
-        jobState.makeActivatable(jobKey);
+        jobState.makeActivatableAfterSecretResolution(jobKey);
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplier.java
@@ -44,8 +44,8 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     final List<Map.Entry<String, String>> refs = new ArrayList<>();
     secretReferenceState.visitSecretReferencesByJob(
         jobKey,
-        (secretId, secretRef) -> {
-          refs.add(Map.entry(secretId, secretRef));
+        (storeId, secretRef) -> {
+          refs.add(Map.entry(storeId, secretRef));
           return true;
         });
     for (final Map.Entry<String, String> ref : refs) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -265,7 +265,7 @@ public final class DbJobState implements JobState, MutableJobState {
   }
 
   @Override
-  public void makeActivatable(final long key) {
+  public void makeActivatableAfterSecretResolution(final long key) {
     final JobRecord record = getJob(key);
     if (record != null) {
       updateJobState(key, State.ACTIVATABLE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -269,6 +269,14 @@ public final class DbJobState implements JobState, MutableJobState {
    */
   @Deprecated
   @Override
+  public void makeActivatable(final long key) {
+    final JobRecord record = getJob(key);
+    if (record != null) {
+      updateJob(key, record, State.ACTIVATABLE);
+    }
+  }
+
+  @Override
   public void resolve(final long key, final JobRecord updatedValue) {
     updateJob(key, updatedValue, State.ACTIVATABLE);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -264,18 +264,20 @@ public final class DbJobState implements JobState, MutableJobState {
     updateJob(key, updatedValue, State.ACTIVATABLE);
   }
 
-  /**
-   * @deprecated see {@link #create(long, JobRecord)}.
-   */
-  @Deprecated
   @Override
   public void makeActivatable(final long key) {
     final JobRecord record = getJob(key);
     if (record != null) {
-      updateJob(key, record, State.ACTIVATABLE);
+      updateJobState(key, State.ACTIVATABLE);
+      makeJobActivatableByPriority(
+          record.getTypeBuffer(), key, record.getTenantId(), record.getPriority());
     }
   }
 
+  /**
+   * @deprecated see {@link #create(long, JobRecord)}.
+   */
+  @Deprecated
   @Override
   public void resolve(final long key, final JobRecord updatedValue) {
     updateJob(key, updatedValue, State.ACTIVATABLE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -63,12 +63,6 @@ public interface MutableJobState extends JobState {
   /**
    * Makes a job activatable after its pending secret references have been resolved. Silently does
    * nothing if the job no longer exists.
-   *
-   * <p>Callers must ensure the job is not currently {@link
-   * io.camunda.zeebe.engine.state.immutable.JobState.State#ACTIVATED} — flipping an actively held
-   * job back to activatable would risk double activation. Ideally this is enforced via a dedicated
-   * {@code WAITING_FOR_SECRET} job state; until that state is introduced, the calling flow is
-   * responsible for the precondition.
    */
   void makeActivatableAfterSecretResolution(long key);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -60,8 +60,17 @@ public interface MutableJobState extends JobState {
   @Deprecated
   void yield(long key, JobRecord updatedValue);
 
-  /** Makes the job activatable; silently does nothing if the job no longer exists. */
-  void makeActivatable(long key);
+  /**
+   * Makes a job activatable after its pending secret references have been resolved. Silently does
+   * nothing if the job no longer exists.
+   *
+   * <p>Callers must ensure the job is not currently {@link
+   * io.camunda.zeebe.engine.state.immutable.JobState.State#ACTIVATED} — flipping an actively held
+   * job back to activatable would risk double activation. Ideally this is enforced via a dedicated
+   * {@code WAITING_FOR_SECRET} job state; until that state is introduced, the calling flow is
+   * responsible for the precondition.
+   */
+  void makeActivatableAfterSecretResolution(long key);
 
   /**
    * @deprecated see {@link #create(long, JobRecord)}.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -60,6 +60,8 @@ public interface MutableJobState extends JobState {
   @Deprecated
   void yield(long key, JobRecord updatedValue);
 
+  void makeActivatable(long key);
+
   /**
    * @deprecated see {@link #create(long, JobRecord)}.
    */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableJobState.java
@@ -60,6 +60,7 @@ public interface MutableJobState extends JobState {
   @Deprecated
   void yield(long key, JobRecord updatedValue);
 
+  /** Makes the job activatable; silently does nothing if the job no longer exists. */
   void makeActivatable(long key);
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
@@ -144,7 +144,7 @@ public final class DbSecretReferenceState implements MutableSecretReferenceState
     this.storeId.wrapString(storeId);
     this.secretReference.wrapString(secretReference);
     this.jobKey.wrapLong(jobKey);
-    waitingJobsByJobKeyColumnFamily.deleteExisting(jobKeyAndSecretRef);
-    waitingJobsBySecretRefColumnFamily.deleteExisting(secretRefAndJobKey);
+    waitingJobsByJobKeyColumnFamily.deleteIfExists(jobKeyAndSecretRef);
+    waitingJobsBySecretRefColumnFamily.deleteIfExists(secretRefAndJobKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessorTest.java
@@ -70,10 +70,7 @@ public final class SecretReferenceBatchReactivateJobsProcessorTest {
 
   @Test
   void shouldWriteBatchJobsReactivatedEventForCurrentBatch() {
-    // given - two eligible jobs on the command; both are also present in state
-    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 2L);
+    // given - two jobs on the command; not seeded in state (event application removes them first)
     final var value =
         new SecretReferenceRecord()
             .setStoreId(STORE_ID)
@@ -98,10 +95,9 @@ public final class SecretReferenceBatchReactivateJobsProcessorTest {
 
   @Test
   void shouldWriteFollowUpBatchReactivateJobsCommandWhenMoreJobsExist() {
-    // given - three jobs waiting in state; command carries only the first two (current batch)
+    // given - job 3 is still in state (jobs 1 and 2 were removed by event application already);
+    //         command carries jobs 1 and 2 as the current batch
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 2L);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 3L);
     final var value =
         new SecretReferenceRecord()
@@ -126,10 +122,7 @@ public final class SecretReferenceBatchReactivateJobsProcessorTest {
 
   @Test
   void shouldNotWriteFollowUpCommandWhenNoBatchJobsRemain() {
-    // given - all waiting jobs are on the command (current batch)
-    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 2L);
+    // given - no jobs remain in state (all were removed by event application); command carries all
     final var value =
         new SecretReferenceRecord()
             .setStoreId(STORE_ID)
@@ -150,11 +143,11 @@ public final class SecretReferenceBatchReactivateJobsProcessorTest {
 
   @Test
   void shouldIncludeIneligibleJobsInNextBatch() {
-    // given - jobs 3 and 4 are waiting; job 3 also has another pending ref (secret2), making it
+    // given - job 1 is on the current batch (already removed from state by event application);
+    //         jobs 3 and 4 remain; job 3 also waits on secret2 (still pending), making it
     //         ineligible for reactivation, but it should still appear in the next batch command
     //         (the applier decides eligibility, not the processor)
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
-    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 3L);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 4L);
     secretReferenceState.addPendingSecretReference(STORE_ID, "secret2");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceBatchReactivateJobsProcessorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+@ExtendWith(ProcessingStateExtension.class)
+public final class SecretReferenceBatchReactivateJobsProcessorTest {
+
+  private static final String STORE_ID = "storeA";
+  private static final String SECRET_REF = "secret1";
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableSecretReferenceState secretReferenceState;
+  private StateWriter stateWriter;
+  private TypedCommandWriter commandWriter;
+  private KeyGenerator keyGenerator;
+  private SecretReferenceBatchReactivateJobsProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    secretReferenceState = processingState.getSecretReferenceState();
+
+    stateWriter = mock(StateWriter.class);
+    commandWriter = mock(TypedCommandWriter.class);
+    keyGenerator = mock(KeyGenerator.class);
+    when(keyGenerator.nextKey()).thenReturn(999L);
+
+    final var writers = mock(Writers.class);
+    when(writers.state()).thenReturn(stateWriter);
+    when(writers.command()).thenReturn(commandWriter);
+
+    processor =
+        new SecretReferenceBatchReactivateJobsProcessor(
+            writers, keyGenerator, secretReferenceState);
+  }
+
+  private MockTypedRecord<SecretReferenceRecord> command(final SecretReferenceRecord value) {
+    return new MockTypedRecord<>(500L, new RecordMetadata(), value);
+  }
+
+  @Test
+  void shouldWriteBatchJobsReactivatedEventForCurrentBatch() {
+    // given - two eligible jobs on the command; both are also present in state
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 2L);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(1L)
+            .addJobKey(2L);
+
+    // when
+    processor.processRecord(command(value));
+
+    // then - the current batch is written back as a BATCH_JOBS_REACTIVATED event on the same key
+    final var eventCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(stateWriter)
+        .appendFollowUpEvent(
+            eq(500L), eq(SecretReferenceIntent.BATCH_JOBS_REACTIVATED), eventCaptor.capture());
+    Assertions.assertThat(eventCaptor.getValue().getJobKeys()).containsExactly(1L, 2L);
+
+    // and - no follow-up command, since state holds only the current batch
+    verify(commandWriter, never())
+        .appendFollowUpCommand(org.mockito.ArgumentMatchers.anyLong(), any(), any());
+  }
+
+  @Test
+  void shouldWriteFollowUpBatchReactivateJobsCommandWhenMoreJobsExist() {
+    // given - three jobs waiting in state; command carries only the first two (current batch)
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 2L);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 3L);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(1L)
+            .addJobKey(2L);
+
+    // when
+    processor.processRecord(command(value));
+
+    // then - a follow-up BATCH_REACTIVATE_JOBS command is written for the remaining job
+    final var commandCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(999L), eq(SecretReferenceIntent.BATCH_REACTIVATE_JOBS), commandCaptor.capture());
+    final var next = commandCaptor.getValue();
+    Assertions.assertThat(next.getStoreId()).isEqualTo(STORE_ID);
+    Assertions.assertThat(next.getSecretReference()).isEqualTo(SECRET_REF);
+    Assertions.assertThat(next.getJobKeys()).containsExactly(3L);
+  }
+
+  @Test
+  void shouldNotWriteFollowUpCommandWhenNoBatchJobsRemain() {
+    // given - all waiting jobs are on the command (current batch)
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 2L);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(1L)
+            .addJobKey(2L);
+
+    // when
+    processor.processRecord(command(value));
+
+    // then
+    verify(commandWriter, never())
+        .appendFollowUpCommand(
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void shouldIncludeIneligibleJobsInNextBatch() {
+    // given - jobs 3 and 4 are waiting; job 3 also has another pending ref (secret2), making it
+    //         ineligible for reactivation, but it should still appear in the next batch command
+    //         (the applier decides eligibility, not the processor)
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 1L);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 3L);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, 4L);
+    secretReferenceState.addPendingSecretReference(STORE_ID, "secret2");
+    secretReferenceState.addWaitingJob(STORE_ID, "secret2", 3L);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(1L);
+
+    // when
+    processor.processRecord(command(value));
+
+    // then - both job 3 (ineligible) and job 4 (eligible) appear in the next batch
+    final var commandCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(commandWriter)
+        .appendFollowUpCommand(
+            eq(999L), eq(SecretReferenceIntent.BATCH_REACTIVATE_JOBS), commandCaptor.capture());
+    Assertions.assertThat(commandCaptor.getValue().getJobKeys()).containsExactlyInAnyOrder(3L, 4L);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public final class SecretReferenceBatchJobsReactivatedApplierTest {
+
+  private static final String STORE_ID = "storeA";
+  private static final String SECRET_REF = "secret1";
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableSecretReferenceState secretReferenceState;
+  private MutableJobState jobState;
+  private SecretReferenceBatchJobsReactivatedApplier applier;
+
+  @BeforeEach
+  public void setup() {
+    secretReferenceState = processingState.getSecretReferenceState();
+    jobState = processingState.getJobState();
+    applier = new SecretReferenceBatchJobsReactivatedApplier(processingState);
+  }
+
+  private void createActivatedJob(final long jobKey) {
+    final var jobRecord =
+        new JobRecord()
+            .setType("test")
+            .setRetries(3)
+            .setDeadline(256L)
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    jobState.create(jobKey, jobRecord);
+    jobState.activate(jobKey, jobRecord);
+  }
+
+  @Test
+  void shouldMakeJobActivatable() {
+    // given
+    final long jobKey = 1L;
+    createActivatedJob(jobKey);
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(jobKey);
+
+    // when
+    applier.applyState(100L, value);
+
+    // then
+    assertThat(jobState.getState(jobKey)).isEqualTo(State.ACTIVATABLE);
+  }
+
+  @Test
+  void shouldRemoveWaitingJobEntryFromState() {
+    // given
+    final long jobKey = 2L;
+    createActivatedJob(jobKey);
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(jobKey);
+
+    // when
+    applier.applyState(100L, value);
+
+    // then - the (storeId, secretReference) prefix no longer visits this job key
+    final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);
+    secretReferenceState.visitJobsBySecretReference(
+        STORE_ID,
+        SECRET_REF,
+        visitedJobKey -> {
+          if (visitedJobKey == jobKey) {
+            stillWaiting.set(true);
+          }
+          return true;
+        });
+    assertThat(stillWaiting.get()).isFalse();
+  }
+
+  @Test
+  void shouldNotMakeJobActivatableWhenOtherRefsArePending() {
+    // given - job is activated and waiting on two references; one is being resolved (secret1),
+    //         but the other (secret2) is still pending
+    final long jobKey = 4L;
+    createActivatedJob(jobKey);
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
+    secretReferenceState.addPendingSecretReference(STORE_ID, "secret2");
+    secretReferenceState.addWaitingJob(STORE_ID, "secret2", jobKey);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(jobKey);
+
+    // when
+    applier.applyState(100L, value);
+
+    // then - the secret1 waiting entry is removed
+    final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);
+    secretReferenceState.visitJobsBySecretReference(
+        STORE_ID,
+        SECRET_REF,
+        visitedJobKey -> {
+          if (visitedJobKey == jobKey) {
+            stillWaiting.set(true);
+          }
+          return true;
+        });
+    assertThat(stillWaiting.get()).isFalse();
+
+    // but job is NOT made activatable — it still waits on secret2
+    assertThat(jobState.getState(jobKey)).isNotEqualTo(State.ACTIVATABLE);
+  }
+
+  @Test
+  void shouldSkipActivationIfJobNoLongerExistsInState() {
+    // given - a waiting-job entry exists but the job itself was already removed
+    final long jobKey = 3L;
+    secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
+    secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
+    final var value =
+        new SecretReferenceRecord()
+            .setStoreId(STORE_ID)
+            .setSecretReference(SECRET_REF)
+            .addJobKey(jobKey);
+
+    // when / then - no exception is thrown and the waiting entry is still removed
+    applier.applyState(100L, value);
+
+    final var stillWaiting = new java.util.concurrent.atomic.AtomicBoolean(false);
+    secretReferenceState.visitJobsBySecretReference(
+        STORE_ID,
+        SECRET_REF,
+        visitedJobKey -> {
+          if (visitedJobKey == jobKey) {
+            stillWaiting.set(true);
+          }
+          return true;
+        });
+    assertThat(stillWaiting.get()).isFalse();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceBatchJobsReactivatedApplierTest.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +43,7 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
     applier = new SecretReferenceBatchJobsReactivatedApplier(processingState);
   }
 
-  private void createActivatedJob(final long jobKey) {
+  private JobRecord createActivatedJob(final long jobKey) {
     final var jobRecord =
         new JobRecord()
             .setType("test")
@@ -50,13 +52,14 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
             .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     jobState.create(jobKey, jobRecord);
     jobState.activate(jobKey, jobRecord);
+    return jobRecord;
   }
 
   @Test
   void shouldMakeJobActivatable() {
     // given
     final long jobKey = 1L;
-    createActivatedJob(jobKey);
+    final var job = createActivatedJob(jobKey);
     secretReferenceState.addPendingSecretReference(STORE_ID, SECRET_REF);
     secretReferenceState.addWaitingJob(STORE_ID, SECRET_REF, jobKey);
     final var value =
@@ -70,6 +73,15 @@ public final class SecretReferenceBatchJobsReactivatedApplierTest {
 
     // then
     assertThat(jobState.getState(jobKey)).isEqualTo(State.ACTIVATABLE);
+    final var activatableJobs = new ArrayList<>();
+    jobState.forEachActivatableJobs(
+        job.getTypeBuffer(),
+        List.of(job.getTenantId()),
+        (key, record) -> {
+          activatableJobs.add(key);
+          return true;
+        });
+    assertThat(activatableJobs).containsExactly(jobKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_BATCH_JOBS_REACTIVATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_BATCH_JOBS_REACTIVATED_v1.golden
@@ -35,7 +35,7 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.removeWaitingJob(storeId, secretReference, jobKey);
       if (isEligible(jobKey)) {
-        jobState.makeActivatable(jobKey);
+        jobState.makeActivatableAfterSecretResolution(jobKey);
       }
     }
   }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_BATCH_JOBS_REACTIVATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_BATCH_JOBS_REACTIVATED_v1.golden
@@ -13,6 +13,9 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public final class SecretReferenceBatchJobsReactivatedApplier
     implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
@@ -31,7 +34,25 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     final var secretReference = value.getSecretReference();
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.removeWaitingJob(storeId, secretReference, jobKey);
-      jobState.makeActivatable(jobKey);
+      if (isEligible(jobKey)) {
+        jobState.makeActivatable(jobKey);
+      }
     }
+  }
+
+  private boolean isEligible(final long jobKey) {
+    final List<Map.Entry<String, String>> refs = new ArrayList<>();
+    secretReferenceState.visitSecretReferencesByJob(
+        jobKey,
+        (secretId, secretRef) -> {
+          refs.add(Map.entry(secretId, secretRef));
+          return true;
+        });
+    for (final Map.Entry<String, String> ref : refs) {
+      if (secretReferenceState.isPending(ref.getKey(), ref.getValue())) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_BATCH_JOBS_REACTIVATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_BATCH_JOBS_REACTIVATED_v1.golden
@@ -44,8 +44,8 @@ public final class SecretReferenceBatchJobsReactivatedApplier
     final List<Map.Entry<String, String>> refs = new ArrayList<>();
     secretReferenceState.visitSecretReferencesByJob(
         jobKey,
-        (secretId, secretRef) -> {
-          refs.add(Map.entry(secretId, secretRef));
+        (storeId, secretRef) -> {
+          refs.add(Map.entry(storeId, secretRef));
           return true;
         });
     for (final Map.Entry<String, String> ref : refs) {


### PR DESCRIPTION
## Description

Implements the `BATCH_REACTIVATE_JOBS` command processor and `BATCH_JOBS_REACTIVATED` event applier for the secret reference resolution flow (part of #56563).

When a secret reference resolves, jobs waiting on it need to be reactivated. This PR batches that work into chunks of up to 100 jobs per command to avoid stalling the stream processor on large waitlists.

A few design decisions worth noting:

1. **Eligibility checking is done in the applier, not the processor.** This ensures `(secretRef, jobKey)` index entries are always cleaned up when a reference resolves — even for jobs that still have other pending refs and aren't yet reactivatable. The processor simply batches all remaining waiting jobs; the applier decides which ones to make activatable.
2. **Two-pass collect-then-check** in the applier's eligibility logic avoids shared key buffer reentrancy in `DbSecretReferenceState`.
3. **`MutableJobState.makeActivatable(long key)`** is added to avoid fetching a full `JobRecord` from the applier. `removeWaitingJob` is changed to `deleteIfExists` so replay is safe if an entry is already absent.

The batching chain terminates: each applied batch removes all its keys from the index, so the next batch always starts fresh and finds a strictly smaller set.

## Checklist

<!-- https://github.com/camunda/camunda/wiki/Pull-Request-and-Review-Guidelines#submitting-a-pull-request -->
- [ ] I have not introduced code that is not required to implement the task
- [ ] I have written/extended tests to cover my changes
- [ ] I have run `./mvnw license:format spotless:apply -T1C` and formatted my code
- [ ] I understand the impact of my changes and have updated relevant documentation if necessary

## Related issues

closes #57852