### PR TITLE
Trigger engine-expert skill when reviewing, not just when authoring

### DIFF
--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -1,7 +1,7 @@
 ---
 
 name: engine-expert
-description: Use when implementing or fixing Zeebe engine code in zeebe/engine/ — BPMN process execution, DMN decision evaluation, job lifecycle, user/identity management, batch operations, variables, deployments, signals, messages, timers, multi-tenancy, or authorization. Also when modifying processors, event appliers, state classes, record value types, intents, or engine tests.
+description: Use when implementing, fixing, or reviewing Zeebe engine code in zeebe/engine/ — BPMN process execution, DMN decision evaluation, job lifecycle, user/identity management, batch operations, variables, deployments, signals, messages, timers, multi-tenancy, or authorization. Also when modifying or reviewing processors, event appliers, state classes, record value types, intents, or engine tests.
 
 ---
 


### PR DESCRIPTION
## Description

`engine-expert`'s trigger description only listed authoring verbs (implementing, fixing, modifying), so it never got picked up while reviewing PR #58000 even though the change squarely touched its domain — two genuine engine-invariant violations went undetected as a result, later caught in [this review comment](https://github.com/camunda/camunda/pull/58000#discussion_r3604057847) and [this one](https://github.com/camunda/camunda/pull/58000#discussion_r3604087614). Adding "reviewing" lets the skill self-trigger for review tasks the same way it already does for authoring, so no other skill needs to special-case it.

## Checklist

- [x] Enable backports (stable/8.7, stable/8.8, stable/8.9 all carry the same stale description)