### PR TITLE
fix: do not inherit root-declared autoconfigured exporters into physical tenants

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
@@ -49,7 +49,9 @@ import org.springframework.core.env.Environment;
  * exporters ({@value BrokerBasedPropertiesOverride#CAMUNDA_EXPORTER_NAME} and {@value
  * BrokerBasedPropertiesOverride#RDBMS_EXPORTER_NAME}) sit outside the catalog: their configuration
  * is derived downstream from the tenant's secondary-storage properties, and args-tuning declared
- * for them is taken as-is.
+ * for them is taken as-is. A root-declared entry for one of these ids is therefore <em>not</em>
+ * inherited by the tenant: its args pin the root connection, which would override the tenant's
+ * derivation and silently route the tenant's exports into root's storage.
  *
  * <p><b>Deliberately not implemented yet (ADR-0008 §6 step 2, gated on <a
  * href="https://github.com/camunda/camunda/issues/56652">#56652</a>):</b> the {@code
@@ -88,8 +90,21 @@ final class PhysicalTenantExporterConfigurations {
       final String tenantId,
       final Environment environment) {
     final Map<String, Exporter> tenantDeclared = bindTenantDeclared(environment, tenantId);
+    // Root-declared entries for the autoconfigured ids must not reach the tenant: their
+    // configuration is derived downstream from the tenant's own secondary-storage properties
+    // (ADR-0008 §1), and an inherited root entry — whose args pin the root connection — would
+    // otherwise override that derivation and route the tenant's exports into root's storage.
+    // Tenant-declared args-tuning for these ids is still taken as-is.
+    physicalTenant
+        .getData()
+        .getExporters()
+        .keySet()
+        .removeIf(
+            exporterId ->
+                AUTOCONFIGURED_EXPORTER_IDS.contains(exporterId)
+                    && !tenantDeclared.containsKey(exporterId));
     if (tenantDeclared.isEmpty()) {
-      // the two-bind left every root entry untouched on this tenant — nothing to recompute
+      // the two-bind left every other root entry untouched on this tenant — nothing to recompute
       return;
     }
 

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
@@ -200,6 +200,24 @@ class PhysicalTenantExporterConfigurationsTest {
   }
 
   @Test
+  void shouldNotInheritRootDeclaredAutoconfiguredExporter() {
+    // given — a root-declared explicit camundaexporter pinning the root connection, and a tenant
+    // that does not declare the id at all
+    properties.put(
+        "camunda.data.exporters.camundaexporter.class-name", "io.camunda.exporter.CamundaExporter");
+    properties.put("camunda.data.exporters.camundaexporter.args.connect.url", "http://root:9200");
+    properties.put("camunda.data.exporters.camundaexporter.args.index.prefix", "root");
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("camundaexporter");
+
+    // then — the root entry is not inherited: the tenant's camundaexporter is derived downstream
+    // from the tenant's own secondary-storage properties, and the inherited root args would
+    // override that derivation and route the tenant's exports into root's storage
+    assertThat(resolved).isNull();
+  }
+
+  @Test
   void shouldWrapMergeFailureWithExporterAndTenantId() {
     // given — a catalog entry whose merger throws
     properties.put(

--- a/dist/src/test/java/io/camunda/zeebe/broker/PhysicalTenantCamundaExporterIsolationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/PhysicalTenantCamundaExporterIsolationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.application.commons.configuration.UnifiedConfigurationModule;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.service.UserServices;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
+import io.camunda.zeebe.dynamic.nodeid.Version;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * An explicitly declared root {@code camunda.data.exporters.camundaexporter} entry must not
+ * override a physical tenant's autoconfigured exporter connection: the autoconfigured entry is
+ * derived from the tenant's own secondary-storage properties (ADR-0008 §1), which is what keeps a
+ * tenant's exported data inside its own storage. Exercises the full production assembly — Spring
+ * property binding via {@link UnifiedConfigurationModule}, per-tenant resolution, and {@link
+ * SystemContextLoader#createSystemContext()} — with only broker infrastructure mocked.
+ */
+final class PhysicalTenantCamundaExporterIsolationTest {
+
+  @TempDir private Path workingDirectory;
+
+  @Test
+  void shouldDeriveTenantCamundaExporterFromTenantStorageDespiteExplicitRootExporter() {
+    // given a root-declared explicit camundaexporter pinning the root connection, and a tenant
+    // whose secondary storage overrides the index prefix
+    new ApplicationContextRunner()
+        .withUserConfiguration(UnifiedConfigurationModule.class)
+        .withPropertyValues(
+            "spring.profiles.active=broker",
+            "camunda.data.secondary-storage.type=elasticsearch",
+            "camunda.data.secondary-storage.elasticsearch.url=http://root-es:9200",
+            "camunda.data.secondary-storage.elasticsearch.index-prefix=root",
+            "camunda.data.exporters.camundaexporter.class-name=io.camunda.exporter.CamundaExporter",
+            "camunda.data.exporters.camundaexporter.args.connect.url=http://root-es:9200",
+            "camunda.data.exporters.camundaexporter.args.connect.indexPrefix=root",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix=tenanta",
+            "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]=tenanta-admin")
+        .run(
+            context -> {
+              // when the broker assembles its per-tenant system context from the bound beans
+              final SystemContext systemContext =
+                  newLoader(
+                          context.getBean(UnifiedConfiguration.class),
+                          context.getBean(BrokerBasedProperties.class),
+                          context.getBean(PhysicalTenantResolver.class))
+                      .createSystemContext();
+
+              // then the tenant's camundaexporter connection comes from the tenant's secondary
+              // storage, not from the inherited root exporter entry
+              final Map<String, Object> args =
+                  systemContext
+                      .getPhysicalTenantContext("tenanta")
+                      .config()
+                      .getExporters()
+                      .get("camundaexporter")
+                      .getArgs();
+              assertThat(argAt(args, "connect", "indexPrefix")).isEqualTo("tenanta");
+              assertThat(argAt(args, "connect", "url")).isEqualTo("http://root-es:9200");
+            });
+  }
+
+  private SystemContextLoader newLoader(
+      final UnifiedConfiguration unifiedConfiguration,
+      final BrokerBasedProperties rootBrokerCfg,
+      final PhysicalTenantResolver physicalTenantResolver) {
+    final var nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.currentNodeInstance()).thenReturn(new NodeInstance(0, Version.zero()));
+
+    return new SystemContextLoader()
+        .withShutdownTimeout(SystemContext.DEFAULT_SHUTDOWN_TIMEOUT)
+        .withRootBrokerCfg(rootBrokerCfg)
+        .withRootCamunda(unifiedConfiguration.getCamunda())
+        .withActorScheduler(mock(ActorScheduler.class))
+        .withCluster(mock(AtomixCluster.class))
+        .withBrokerClient(mock(BrokerClient.class))
+        .withMeterRegistry(new SimpleMeterRegistry())
+        .withPhysicalTenantResolver(physicalTenantResolver)
+        .withUserServicesForTenant(tenantId -> mock(UserServices.class))
+        .withPasswordEncoder(mock(PasswordEncoder.class))
+        .withJwtDecoderFactory(authentication -> mock(JwtDecoder.class))
+        .withOidcClaimsProviderFactory(
+            authentication -> (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims)
+        .withSearchClientsProxy(mock(SearchClientsProxy.class))
+        .withNodeIdProvider(nodeIdProvider)
+        .withWorkingDirectory(workingDirectory)
+        .withExporterDescriptors(null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Object argAt(final Map<String, Object> args, final String... path) {
+    Object current = args;
+    for (final String key : path) {
+      current = ((Map<String, Object>) current).get(key);
+    }
+    return current;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExplicitRootCamundaExporterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExplicitRootCamundaExporterIT.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+/**
+ * Verifies that a {@code camundaexporter} declared explicitly in the <b>root</b> configuration
+ * (under {@code camunda.data.exporters}, pinning the root connection in its args — a documented
+ * production pattern) does not override a physical tenant's autoconfigured exporter: the tenant's
+ * exporter configuration is derived from the tenant's own secondary-storage properties (ADR-0008
+ * §1), so the tenant's documents must land under the tenant's own index prefix, never the root's.
+ * The autoconfigure-only variants of this isolation are covered by {@link
+ * PhysicalTenantCamundaExporterBackgroundTaskIT} (shared cluster) and {@link
+ * PhysicalTenantSeparateSecondaryStorageIT} (separate clusters).
+ */
+@Timeout(240)
+@ZeebeIntegration
+final class PhysicalTenantExplicitRootCamundaExporterIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String DEFAULT_PREFIX = "defaultprefix";
+  private static final String TENANT_A_PREFIX = "tenantaprefix";
+
+  @SuppressWarnings("resource")
+  private static final ElasticsearchContainer ES =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  private static final String ES_URL;
+
+  static {
+    ES.start();
+    ES_URL = "http://" + ES.getHttpHostAddress();
+  }
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(
+              PhysicalTenantsITHelper.DEFAULT_TENANT_ID,
+              Storage.elasticsearch(ES_URL, DEFAULT_PREFIX))
+          .withTenant(TENANT_A, Storage.elasticsearch(ES_URL, TENANT_A_PREFIX))
+          .build();
+
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS
+          .configure(new TestStandaloneBroker().withUnauthenticatedAccess().withCreateSchema(true))
+          .withExporter(
+              "camundaexporter",
+              cfg -> {
+                cfg.setClassName("io.camunda.exporter.CamundaExporter");
+                cfg.setArgs(
+                    Map.of(
+                        "connect",
+                        Map.of(
+                            "url",
+                            ES_URL,
+                            "type",
+                            "elasticsearch",
+                            "indexPrefix",
+                            DEFAULT_PREFIX)));
+              });
+
+  @AutoClose private CamundaClient tenantAClient;
+  @AutoClose private CamundaClient defaultClient;
+
+  @BeforeEach
+  void setUp() {
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+  }
+
+  @Test
+  void shouldExportTenantDocumentsUnderTenantPrefixDespiteExplicitRootExporter() throws Exception {
+    // given a process instance in each tenant
+    deployAndStart(defaultClient, "default-process");
+    deployAndStart(tenantAClient, "tenanta-process");
+
+    // then each tenant's documents land under that tenant's own index prefix
+    Awaitility.await("each tenant's documents are written under the tenant's own index prefix")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              assertThat(countDocuments(DEFAULT_PREFIX, "default-process")).isPositive();
+              assertThat(countDocuments(TENANT_A_PREFIX, "tenanta-process")).isPositive();
+            });
+
+    // ... and the tenant's documents never leak under the root's prefix
+    assertThat(countDocuments(DEFAULT_PREFIX, "tenanta-process")).isZero();
+  }
+
+  /** Counts documents matching the process id across all indices of the given prefix. */
+  private static long countDocuments(final String indexPrefix, final String processId)
+      throws IOException, InterruptedException {
+    final var query =
+        URLEncoder.encode("bpmnProcessId:\"" + processId + "\"", StandardCharsets.UTF_8);
+    final var request =
+        HttpRequest.newBuilder(URI.create(ES_URL + "/" + indexPrefix + "*/_count?q=" + query))
+            .GET()
+            .build();
+    final var response = HTTP.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return MAPPER.readTree(response.body()).path("count").asLong();
+  }
+
+  private static void deployAndStart(final CamundaClient client, final String processId) {
+    final var process = Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+    Awaitility.await("process is deployed for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+    client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+  }
+}


### PR DESCRIPTION
## What's broken

Declaring a `camundaexporter` explicitly in the **root** configuration silently breaks physical-tenant storage isolation: every tenant's partitions export their data into the **root** tenant's storage, while the tenant's readers and security chain query the tenant's own (empty) storage.

```yaml
camunda:
  data:
    secondary-storage:
      elasticsearch: { url: http://es-root:9200, index-prefix: root }
    exporters:
      camundaexporter:                # explicit root declaration
        class-name: io.camunda.exporter.CamundaExporter
        args:
          connect: { url: http://es-root:9200, indexPrefix: root }
  physical-tenants:
    tenanta:
      data:
        secondary-storage:
          elasticsearch: { url: http://es-tenanta:9200, index-prefix: tenanta }
```

Expected: `tenanta` exports to `es-tenanta:9200` / prefix `tenanta`. Actual: everything lands on `es-root:9200` / prefix `root`.

This is the root cause of the permanent 401s in the physical-tenant ES acceptance tests (#55350 / #57286): the tenant's seeded admin user is exported into root's cluster, so the tenant's Basic Auth lookup against its own storage never finds it.

## Why it happens

1. The resolver builds each tenant's `Camunda` by binding root `camunda.*` first, so the tenant **inherits the explicit root exporter entry verbatim** — args still pinning the root connection.
2. During conversion, [`populateCamundaExporter` derives the correct entry](https://github.com/camunda/camunda/blob/95365a2453cae97990d1b0a25f83542e0dc92190/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java#L167) from the tenant's own secondary storage —
3. — and [`populateFromExporters` immediately overwrites it](https://github.com/camunda/camunda/blob/95365a2453cae97990d1b0a25f83542e0dc92190/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java#L170) with the inherited root entry. Last write wins, no warning. The isolation validations pass because the *secondary-storage* config is correct — only the exporter's derived copy gets clobbered.

## The fix

[ADR-0008 D2](https://github.com/camunda/camunda/blob/main/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0008-physical-tenant-exporter-assignment-and-args-merge.md) already decides that the autoconfigured exporters (`camundaexporter`, `rdbms`) "derive their config from the tenant's already-per-tenant-resolved secondary-storage properties". This PR enforces that: [`PhysicalTenantExporterConfigurations` now strips root-inherited entries for autoconfigured ids the tenant did not declare itself](https://github.com/camunda/camunda/blob/95365a2453cae97990d1b0a25f83542e0dc92190/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java#L96-L107), so the tenant-derived entry survives.

- Root/default tenant behavior unchanged (it keeps using the root `BrokerCfg`; explicit config still wins there).
- Tenant-declared args-tuning for these ids keeps its as-declared semantics.
- Behavioral note: root-level args tuning on an explicit `camundaexporter` no longer leaks into tenants — per the ADR, tenants derive their own.

## Tests — each verified red without the fix, green with it

- **Unit**: `PhysicalTenantExporterConfigurationsTest.shouldNotInheritRootDeclaredAutoconfiguredExporter`.
- **Production path** (`dist`): `PhysicalTenantCamundaExporterIsolationTest` — real `UnifiedConfigurationModule` bean wiring + `SystemContextLoader`; red run resolved the root prefix for the tenant.
- **Integration**: `PhysicalTenantExplicitRootCamundaExporterIT` — real broker, two tenants, one ES cluster with distinct prefixes; red run left the tenant prefix at 0 documents. Neighboring PT exporter ITs re-run green.

Relates to #55155 and #55350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
