### PR TITLE
fix: add missing space before optimize/identity/connectors image-tag helm args

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -677,7 +677,7 @@ jobs:
           if [[ "${ENABLE_OPTIMIZE}" == "true" ]]; then
             if [[ -n "${OPTIMIZE_TAG}" ]]; then
               # Explicit optimize tag provided: use it directly (Docker Hub image)
-              additional_platform_config+="--set optimize.image.tag=${OPTIMIZE_TAG}"
+              additional_platform_config+=" --set optimize.image.tag=${OPTIMIZE_TAG}"
             elif [[ -z "${ORCHESTRATION_TAG}" ]]; then
               # Custom build without explicit optimize tag: use the built image from internal registry
               additional_platform_config+=" \
@@ -689,12 +689,12 @@ jobs:
 
           # Append identity image config if a dedicated tag is provided
           if [[ -n "${IDENTITY_TAG}" ]]; then
-            additional_platform_config+="--set identity.image.tag=${IDENTITY_TAG}"
+            additional_platform_config+=" --set identity.image.tag=${IDENTITY_TAG}"
           fi
 
           # Append connectors image config if a dedicated tag is provided
           if [[ -n "${CONNECTORS_TAG}" ]]; then
-            additional_platform_config+="--set connectors.image.tag=${CONNECTORS_TAG}"
+            additional_platform_config+=" --set connectors.image.tag=${CONNECTORS_TAG}"
           fi
 
           # Append user-provided helm values if present


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In the load-test deploy step, the optimize/identity/connectors image-tag `--set` flags were appended to `additional_platform_config` with no leading space.
When combined with `orchestration-tag` (whose block ends at `--set orchestration.image.tag=<tag>` without a trailing space), the tokens fused into `...image.tag=8.8.28--set optimize.image.tag=8.8.28`, so `helm upgrade`
received a mangled argument list and failed with `"helm upgrade" requires 2 arguments`. This broke any run that combined `orchestration-tag` with `optimize-tag`, `identity-tag`, or `connectors-tag`.

Prefix each append with a space, matching the existing `platform-helm-values` append.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
