### PR TITLE
feat: add Aurora MySQL support to async replication acceptance test

### DIFF
--- a/.github/terraform/aurora-replication-it/main.tf
+++ b/.github/terraform/aurora-replication-it/main.tf
@@ -68,6 +68,29 @@ variable "instance_class" {
   default = "db.r6g.large"
 }
 
+# The aurora-global module also defaults to aurora-postgresql/18.3; both must be overridden
+# together when switching engine, since the module's own engine_version default is a Postgres
+# version regardless of which engine is selected.
+variable "engine" {
+  type    = string
+  default = "aurora-postgresql"
+}
+
+variable "engine_version" {
+  type    = string
+  default = "18.3"
+}
+
+# Database port used by both the Aurora cluster (implicitly, via its engine default) and the
+# bastion's egress rule below. NOTE: the aurora-global module's own security groups (in
+# camunda-deployment-references) additionally hardcode 5432 for both the primary and secondary
+# clusters — until that is parameterized upstream, setting engine to aurora-mysql here alone is
+# not sufficient for end-to-end connectivity on port 3306.
+variable "port" {
+  type    = number
+  default = 5432
+}
+
 # Scaled 1 -> 0 -> 1 by the test to remove/restore the replica instance while
 # keeping the secondary cluster (and storage replication) in place.
 variable "secondary_num_instances" {
@@ -115,6 +138,8 @@ module "aurora" {
   }
 
   global_cluster_identifier = "${var.name_prefix}-global"
+  engine                    = var.engine
+  engine_version            = var.engine_version
   master_username           = var.master_username
   master_password           = var.master_password
   instance_class            = var.instance_class
@@ -202,7 +227,7 @@ resource "aws_security_group" "bastion" {
     Purpose = "aurora-async-replication-it"
   }
 
-  # outbound only: 443 for the SSM agent, 5432 towards Aurora
+  # outbound only: 443 for the SSM agent, var.port towards Aurora
   egress {
     from_port   = 443
     to_port     = 443
@@ -212,11 +237,11 @@ resource "aws_security_group" "bastion" {
   }
 
   egress {
-    from_port   = 5432
-    to_port     = 5432
+    from_port   = var.port
+    to_port     = var.port
     protocol    = "TCP"
     cidr_blocks = [data.aws_vpc.primary.cidr_block]
-    description = "PostgreSQL to Aurora"
+    description = "Aurora database port"
   }
 }
 

--- a/.github/terraform/aurora-replication-it/main.tf
+++ b/.github/terraform/aurora-replication-it/main.tf
@@ -68,27 +68,16 @@ variable "instance_class" {
   default = "db.r6g.large"
 }
 
-# The aurora-global module also defaults to aurora-postgresql/18.3; both must be overridden
-# together when switching engine, since the module's own engine_version default is a Postgres
-# version regardless of which engine is selected.
 variable "engine" {
   type    = string
   default = "aurora-postgresql"
 }
 
+# Left null so the module picks its own per-engine default (postgresql_engine_version /
+# mysql_engine_version). Set explicitly here only to pin a specific version.
 variable "engine_version" {
   type    = string
-  default = "18.3"
-}
-
-# Database port used by both the Aurora cluster (implicitly, via its engine default) and the
-# bastion's egress rule below. NOTE: the aurora-global module's own security groups (in
-# camunda-deployment-references) additionally hardcode 5432 for both the primary and secondary
-# clusters — until that is parameterized upstream, setting engine to aurora-mysql here alone is
-# not sufficient for end-to-end connectivity on port 3306.
-variable "port" {
-  type    = number
-  default = 5432
+  default = null
 }
 
 # Scaled 1 -> 0 -> 1 by the test to remove/restore the replica instance while
@@ -227,7 +216,7 @@ resource "aws_security_group" "bastion" {
     Purpose = "aurora-async-replication-it"
   }
 
-  # outbound only: 443 for the SSM agent, var.port towards Aurora
+  # outbound only: 443 for the SSM agent, module.aurora.db_port towards Aurora
   egress {
     from_port   = 443
     to_port     = 443
@@ -237,8 +226,8 @@ resource "aws_security_group" "bastion" {
   }
 
   egress {
-    from_port   = var.port
-    to_port     = var.port
+    from_port   = module.aurora.db_port
+    to_port     = module.aurora.db_port
     protocol    = "TCP"
     cidr_blocks = [data.aws_vpc.primary.cidr_block]
     description = "Aurora database port"
@@ -276,4 +265,8 @@ output "primary_cluster_endpoint" {
 
 output "bastion_instance_id" {
   value = aws_instance.bastion.id
+}
+
+output "db_port" {
+  value = module.aurora.db_port
 }

--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -1,7 +1,8 @@
 ---
 # description: Provisions an ephemeral AWS Aurora Global Database (two regions) using the
 # aurora-global Terraform module from camunda/camunda-deployment-references and runs the
-# AuroraAsyncReplicationIT acceptance test against it through an SSM port-forwarding tunnel.
+# AuroraAsyncReplicationIT (or AuroraMysqlAsyncReplicationIT, via the db_engine input)
+# acceptance test against it through an SSM port-forwarding tunnel.
 # The infrastructure is destroyed at the end of the run.
 # test location: qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication
 # type: CI
@@ -17,6 +18,11 @@ on:
         type: string
         required: false
         default: 'main'
+      db_engine:
+        description: 'Aurora engine to provision (postgresql or mysql)'
+        type: string
+        required: false
+        default: 'postgresql'
       skip_destroy:
         description: 'Keep the Aurora infrastructure after the run (for debugging; destroy manually!)'
         type: boolean
@@ -29,6 +35,14 @@ on:
         type: string
         required: false
         default: 'main'
+      db_engine:
+        description: 'Aurora engine to provision'
+        type: choice
+        options:
+          - postgresql
+          - mysql
+        required: false
+        default: 'postgresql'
       skip_destroy:
         description: 'Keep the Aurora infrastructure after the run (for debugging; destroy manually!)'
         type: boolean
@@ -38,7 +52,7 @@ on:
     types: [labeled, synchronize]
 
 concurrency:
-  group: aurora-async-replication-test
+  group: aurora-async-replication-test-${{ inputs.db_engine || 'postgresql' }}
   cancel-in-progress: false
 
 defaults:
@@ -54,10 +68,17 @@ env:
   TF_VAR_secondary_region: eu-west-2
   LOCAL_DB_PORT: '15432'
   TF_STATE_BUCKET_REGION: eu-west-1
+  # engine-derived config: keep all engine differences here so the steps below stay generic.
+  # NOTE: aurora-mysql connectivity additionally requires the aurora-global module (in
+  # camunda-deployment-references) to stop hardcoding port 5432 in its own security groups —
+  # see the `port` variable comment in .github/terraform/aurora-replication-it/main.tf.
+  TF_VAR_engine: ${{ (inputs.db_engine || 'postgresql') == 'mysql' && 'aurora-mysql' || 'aurora-postgresql' }}
+  TF_VAR_engine_version: ${{ (inputs.db_engine || 'postgresql') == 'mysql' && '8.0.mysql_aurora.3.05.2' || '18.3' }}
+  TF_VAR_port: ${{ (inputs.db_engine || 'postgresql') == 'mysql' && '3306' || '5432' }}
 
 jobs:
   aurora-it:
-    name: Provision Aurora and run AuroraAsyncReplicationIT
+    name: Provision Aurora (${{ inputs.db_engine || 'postgresql' }}) and run async replication IT
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions: {}
@@ -204,7 +225,7 @@ jobs:
               aws ssm start-session \
                 --target "$(cat /tmp/ssm-bastion-id)" \
                 --document-name AWS-StartPortForwardingSessionToRemoteHost \
-                --parameters "host=$(cat /tmp/ssm-endpoint),portNumber=5432,localPortNumber=${LOCAL_DB_PORT}" \
+                --parameters "host=$(cat /tmp/ssm-endpoint),portNumber=${TF_VAR_port},localPortNumber=${LOCAL_DB_PORT}" \
                 2>&1 | stamp
               echo "SSM session ended — restarting in 2s" | stamp
               sleep 2
@@ -230,20 +251,24 @@ jobs:
         with:
           parameters: install -pl qa/acceptance-tests -am -Dquickly
 
-      - name: Run AuroraAsyncReplicationIT
+      - name: Run Aurora async replication IT
         env:
-          TEST_AURORA_JDBC_URL: jdbc:postgresql://localhost:${{ env.LOCAL_DB_PORT }}/postgres
+          TEST_AURORA_JDBC_URL: >-
+            ${{ (inputs.db_engine || 'postgresql') == 'mysql'
+              && format('jdbc:mysql://localhost:{0}/mysql', env.LOCAL_DB_PORT)
+              || format('jdbc:postgresql://localhost:{0}/postgres', env.LOCAL_DB_PORT) }}
           TEST_AURORA_USERNAME: camunda_admin
           TEST_AURORA_PASSWORD: ${{ env.TF_VAR_master_password }}
           # Replica loss is simulated by DELETING the secondary instance, not by rebooting or
           # scaling it. Aurora Global Database replication is storage-level and independent of the
           # secondary DB instance, so a reboot never freezes the replica's durable_lsn nor removes
-          # its row from aurora_global_db_instance_status() — the row the test waits to disappear.
-          # Deleting the instance makes the secondary cluster headless: its row vanishes from the
-          # status function (so the exporter loses its sync quorum and pauses) while the secondary
-          # cluster and its already-replicated storage volume survive. Recovery re-creates the
-          # instance into that surviving cluster, so it reattaches to the replicated volume and
-          # catches up quickly instead of re-seeding from scratch.
+          # its row from the Aurora Global Database instance status (the row the test waits to
+          # disappear — see AbstractAuroraReplicationCluster). Deleting the instance makes the
+          # secondary cluster headless: its row vanishes from that status (so the exporter loses
+          # its sync quorum and pauses) while the secondary cluster and its already-replicated
+          # storage volume survive. Recovery re-creates the instance into that surviving cluster,
+          # so it reattaches to the replicated volume and catches up quickly instead of
+          # re-seeding from scratch.
           TEST_AURORA_STOP_REPLICA_CMD: >-
             aws rds delete-db-instance
             --region ${{ env.TF_VAR_secondary_region }}
@@ -257,7 +282,7 @@ jobs:
             --region ${{ env.TF_VAR_secondary_region }}
             --db-cluster-identifier ${{ env.TF_VAR_name_prefix }}-secondary
             --db-instance-identifier ${{ env.TF_VAR_name_prefix }}-secondary-0
-            --engine aurora-postgresql
+            --engine ${{ env.TF_VAR_engine }}
             --db-instance-class db.r6g.large
             && aws rds wait db-instance-available
             --region ${{ env.TF_VAR_secondary_region }}
@@ -267,7 +292,7 @@ jobs:
           threads: '1'
           parameters: >-
             verify -pl qa/acceptance-tests
-            -Prdbms-aurora
+            ${{ (inputs.db_engine || 'postgresql') == 'mysql' && '-Prdbms-aurora-mysql' || '-Prdbms-aurora' }}
             -DskipUTs -DskipChecks -DskipTests=false
 
       - name: Upload test reports and SSM logs

--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -21,8 +21,7 @@ on:
       db_engine:
         description: 'Aurora engine to provision (postgresql or mysql)'
         type: string
-        required: false
-        default: 'postgresql'
+        required: true
       skip_destroy:
         description: 'Keep the Aurora infrastructure after the run (for debugging; destroy manually!)'
         type: boolean
@@ -41,8 +40,7 @@ on:
         options:
           - postgresql
           - mysql
-        required: false
-        default: 'postgresql'
+        required: true
       skip_destroy:
         description: 'Keep the Aurora infrastructure after the run (for debugging; destroy manually!)'
         type: boolean

--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -172,7 +172,9 @@ jobs:
         run: |
           set -euo pipefail
           NAME_PREFIX="aurora-it-${{ github.run_id }}"
-          MASTER_PASSWORD="$(openssl rand -hex 24)"
+          # 32 hex chars (128 bits of entropy) stays under RDS's 41-character master
+          # password limit for MySQL/MariaDB engines (PostgreSQL allows up to 128).
+          MASTER_PASSWORD="$(openssl rand -hex 16)"
           echo "::add-mask::${MASTER_PASSWORD}"
           {
             echo "TF_VAR_name_prefix=${NAME_PREFIX}"

--- a/.github/workflows/aurora-async-replication-test.yml
+++ b/.github/workflows/aurora-async-replication-test.yml
@@ -17,7 +17,9 @@ on:
         description: 'Ref of camunda/camunda-deployment-references to use'
         type: string
         required: false
-        default: 'main'
+        # TODO: revert to 'main' once the aurora-mysql-engine-option branch
+        # (engine/port parameterization for Aurora MySQL) is merged there.
+        default: 'aurora-mysql-engine-option'
       db_engine:
         description: 'Aurora engine to provision (postgresql or mysql)'
         type: string
@@ -33,7 +35,9 @@ on:
         description: 'Ref of camunda/camunda-deployment-references to use'
         type: string
         required: false
-        default: 'main'
+        # TODO: revert to 'main' once the aurora-mysql-engine-option branch
+        # (engine/port parameterization for Aurora MySQL) is merged there.
+        default: 'aurora-mysql-engine-option'
       db_engine:
         description: 'Aurora engine to provision'
         type: choice
@@ -67,12 +71,10 @@ env:
   LOCAL_DB_PORT: '15432'
   TF_STATE_BUCKET_REGION: eu-west-1
   # engine-derived config: keep all engine differences here so the steps below stay generic.
-  # NOTE: aurora-mysql connectivity additionally requires the aurora-global module (in
-  # camunda-deployment-references) to stop hardcoding port 5432 in its own security groups —
-  # see the `port` variable comment in .github/terraform/aurora-replication-it/main.tf.
+  # engine_version and the database port are intentionally NOT set here — the aurora-global
+  # module (via the aurora-mysql-engine-option branch) derives both from TF_VAR_engine itself
+  # (per-engine version defaults, and a `db_port` output used for the SSM tunnel below).
   TF_VAR_engine: ${{ (inputs.db_engine || 'postgresql') == 'mysql' && 'aurora-mysql' || 'aurora-postgresql' }}
-  TF_VAR_engine_version: ${{ (inputs.db_engine || 'postgresql') == 'mysql' && '8.0.mysql_aurora.3.05.2' || '18.3' }}
-  TF_VAR_port: ${{ (inputs.db_engine || 'postgresql') == 'mysql' && '3306' || '5432' }}
 
 jobs:
   aurora-it:
@@ -194,8 +196,10 @@ jobs:
           set -euo pipefail
           ENDPOINT="$(terraform output -raw primary_cluster_endpoint)"
           BASTION_ID="$(terraform output -raw bastion_instance_id)"
+          DB_PORT="$(terraform output -raw db_port)"
           echo "${ENDPOINT}"   > /tmp/ssm-endpoint
           echo "${BASTION_ID}" > /tmp/ssm-bastion-id
+          echo "${DB_PORT}"    > /tmp/ssm-db-port
 
           # Supervise the tunnel: `aws ssm start-session` blocks until the session ends,
           # then we restart it. Over a 90+ min run the session can drop from an SSM idle
@@ -223,7 +227,7 @@ jobs:
               aws ssm start-session \
                 --target "$(cat /tmp/ssm-bastion-id)" \
                 --document-name AWS-StartPortForwardingSessionToRemoteHost \
-                --parameters "host=$(cat /tmp/ssm-endpoint),portNumber=${TF_VAR_port},localPortNumber=${LOCAL_DB_PORT}" \
+                --parameters "host=$(cat /tmp/ssm-endpoint),portNumber=$(cat /tmp/ssm-db-port),localPortNumber=${LOCAL_DB_PORT}" \
                 2>&1 | stamp
               echo "SSM session ended — restarting in 2s" | stamp
               sleep 2

--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -152,11 +152,27 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   aurora-async-replication:
-    name: "Aurora Async Replication IT"
+    name: "Aurora Async Replication IT (PostgreSQL)"
     concurrency:
-      group: aurora-async-replication-test
+      group: aurora-async-replication-test-postgresql
       cancel-in-progress: false
     uses: ./.github/workflows/aurora-async-replication-test.yml
+    with:
+      db_engine: postgresql
+    secrets: inherit
+    permissions: { }
+    if: |
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch'
+
+  aurora-async-replication-mysql:
+    name: "Aurora Async Replication IT (MySQL)"
+    concurrency:
+      group: aurora-async-replication-test-mysql
+      cancel-in-progress: false
+    uses: ./.github/workflows/aurora-async-replication-test.yml
+    with:
+      db_engine: mysql
     secrets: inherit
     permissions: { }
     if: |

--- a/db/rdbms/src/main/resources/mapper/ReplicationStatusMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ReplicationStatusMapper.xml
@@ -62,11 +62,18 @@
   </select>
 
   <!--
-    Detects whether the connected MySQL instance is AWS Aurora MySQL. Aurora MySQL exposes the
-    aurora_version() function; plain MySQL does not. Safe to run on any MySQL-compatible database; never throws.
+    Detects whether the connected MySQL instance is AWS Aurora MySQL. aurora_version() is a native
+    engine function on Aurora MySQL, not a user routine, so it never appears in
+    information_schema.ROUTINES (unlike PostgreSQL, where aurora_version() is a real catalog
+    function). information_schema.replica_host_status is documented by AWS to exist on every
+    Aurora MySQL cluster regardless of version or Global Database status, so check for that table
+    instead. Safe to run on any MySQL-compatible database; never throws.
   -->
   <select id="isAurora" resultType="boolean" databaseId="mysql">
-    SELECT EXISTS(SELECT 1 FROM information_schema.ROUTINES WHERE ROUTINE_NAME = 'aurora_version')
+    SELECT EXISTS(SELECT 1
+                  FROM information_schema.TABLES
+                  WHERE TABLE_SCHEMA = 'information_schema'
+                    AND TABLE_NAME = 'REPLICA_HOST_STATUS')
   </select>
 
   <!--

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -751,7 +751,7 @@
           <systemPropertyVariables>
             <identity.docker.image.version>${version.identity}</identity.docker.image.version>
           </systemPropertyVariables>
-          <excludedGroups>rdbms, rdbms-aurora, multi-db-test, compatibility-test, dl-nightly</excludedGroups>
+          <excludedGroups>rdbms, rdbms-aurora, rdbms-aurora-mysql, multi-db-test, compatibility-test, dl-nightly</excludedGroups>
         </configuration>
         <dependencies>
           <dependency>
@@ -815,7 +815,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <groups>rdbms</groups>
-              <excludedGroups>rdbms-aurora, multi-db-test, compatibility-test, history</excludedGroups>
+              <excludedGroups>rdbms-aurora, rdbms-aurora-mysql, multi-db-test, compatibility-test, history</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -835,6 +835,26 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <groups>rdbms-aurora</groups>
+              <excludedGroups>multi-db-test, compatibility-test, history</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+    This profile runs the Aurora MySQL async replication IT against a pre-provisioned AWS Aurora
+    MySQL Global Database. Requires TEST_AURORA_* environment variables to be set.
+    -->
+    <profile>
+      <id>rdbms-aurora-mysql</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <groups>rdbms-aurora-mysql</groups>
               <excludedGroups>multi-db-test, compatibility-test, history</excludedGroups>
             </configuration>
           </plugin>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AuroraAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AuroraAsyncReplicationIT.java
@@ -7,20 +7,20 @@
  */
 package io.camunda.it.rdbms.db.asyncreplication;
 
-import io.camunda.it.rdbms.db.util.AuroraReplicationCluster;
+import io.camunda.it.rdbms.db.util.AuroraPostgresReplicationCluster;
 import java.time.Duration;
 import org.junit.jupiter.api.Tag;
 
 /**
- * Runs the {@link AsyncReplicationIT} suite against a pre-provisioned AWS Aurora Global Database
- * instead of local containers (see {@link AuroraReplicationCluster}).
+ * Runs the {@link AsyncReplicationIT} suite against a pre-provisioned AWS Aurora <b>PostgreSQL</b>
+ * Global Database instead of local containers (see {@link AuroraPostgresReplicationCluster}).
  */
 @Tag("rdbms-aurora")
-public class AuroraAsyncReplicationIT extends AsyncReplicationIT<AuroraReplicationCluster> {
+public class AuroraAsyncReplicationIT extends AsyncReplicationIT<AuroraPostgresReplicationCluster> {
 
   @Override
-  protected AuroraReplicationCluster createCluster() {
-    return new AuroraReplicationCluster();
+  protected AuroraPostgresReplicationCluster createCluster() {
+    return new AuroraPostgresReplicationCluster();
   }
 
   @Override

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AuroraMysqlAsyncReplicationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/asyncreplication/AuroraMysqlAsyncReplicationIT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.asyncreplication;
+
+import io.camunda.it.rdbms.db.util.AuroraMysqlReplicationCluster;
+import java.time.Duration;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Runs the {@link AsyncReplicationIT} suite against a pre-provisioned AWS Aurora <b>MySQL</b>
+ * Global Database instead of local containers (see {@link AuroraMysqlReplicationCluster}).
+ */
+@Tag("rdbms-aurora-mysql")
+public class AuroraMysqlAsyncReplicationIT
+    extends AsyncReplicationIT<AuroraMysqlReplicationCluster> {
+
+  @Override
+  protected AuroraMysqlReplicationCluster createCluster() {
+    return new AuroraMysqlReplicationCluster();
+  }
+
+  @Override
+  protected Duration getMaxLag() {
+    return Duration.ofMinutes(5);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AbstractAuroraReplicationCluster.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AbstractAuroraReplicationCluster.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.util;
+
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.util.Unit;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link ReplicationClusterContainer} backed by a pre-provisioned AWS Aurora Global Database
+ * instead of local containers.
+ *
+ * <p>An Aurora cluster cannot be spawned in CI; it is assumed to be set up beforehand and reachable
+ * via the following environment variables:
+ *
+ * <ul>
+ *   <li>{@value #ENV_JDBC_URL} – JDBC URL of the primary cluster endpoint (any maintenance
+ *       database)
+ *   <li>{@value #ENV_USERNAME} – database user with privileges to create/drop databases
+ *   <li>{@value #ENV_PASSWORD} – password of that user
+ *   <li>{@value #ENV_STOP_REPLICA_CMD} – shell command that removes the replica (e.g. a {@code
+ *       terraform apply} scaling the secondary instance count to 0)
+ *   <li>{@value #ENV_START_REPLICA_CMD} – shell command that restores the replica
+ * </ul>
+ *
+ * <p>{@link #start()} creates a uniquely named scratch database on the cluster so each test run is
+ * isolated; {@link #stop()} drops it again, leaving the cluster in a clean state. Replica removal
+ * and recovery are delegated to the infrastructure-provided commands, since a managed Aurora Global
+ * Database cannot be manipulated directly from a test; after {@link #startReplica()} the cluster
+ * waits until the replica reports a position via the engine-specific Aurora Global Database status
+ * query (see {@link #replicaStatusQuery()}).
+ *
+ * <p>Subclasses only need to supply the engine-specific SQL: Aurora PostgreSQL exposes replica
+ * status via the {@code aurora_global_db_instance_status()} table function, while Aurora MySQL
+ * exposes the same information as the {@code information_schema.aurora_global_db_instance_status}
+ * table.
+ */
+public abstract class AbstractAuroraReplicationCluster implements ReplicationClusterContainer {
+
+  public static final String ENV_JDBC_URL = "TEST_AURORA_JDBC_URL";
+  public static final String ENV_USERNAME = "TEST_AURORA_USERNAME";
+  public static final String ENV_PASSWORD = "TEST_AURORA_PASSWORD";
+  public static final String ENV_STOP_REPLICA_CMD = "TEST_AURORA_STOP_REPLICA_CMD";
+  public static final String ENV_START_REPLICA_CMD = "TEST_AURORA_START_REPLICA_CMD";
+
+  private static final Duration REPLICA_COMMAND_TIMEOUT = Duration.ofMinutes(30);
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractAuroraReplicationCluster.class);
+
+  private final String adminJdbcUrl = requireEnv(ENV_JDBC_URL);
+  private final String username = requireEnv(ENV_USERNAME);
+  private final String password = requireEnv(ENV_PASSWORD);
+  private final String stopReplicaCommand = requireEnv(ENV_STOP_REPLICA_CMD);
+  private final String startReplicaCommand = requireEnv(ENV_START_REPLICA_CMD);
+  private final String databaseName = "camunda_it_" + UUID.randomUUID().toString().replace("-", "");
+  private final ExecutorService processExecutor =
+      Executors.newSingleThreadExecutor(r -> new Thread(r, "aurora-cluster"));
+
+  /** Returns the engine-specific statement used to drop the scratch database in {@link #stop()}. */
+  protected abstract String dropDatabaseStatement(String databaseName);
+
+  /**
+   * Returns the engine-specific query selecting {@code server_id}, {@code session_id} and {@code
+   * durable_lsn} from the Aurora Global Database instance status, used to detect that a replica has
+   * gone offline.
+   */
+  protected abstract String replicaUnreachableQuery();
+
+  /**
+   * Returns the engine-specific query selecting {@code server_id}, {@code session_id}, {@code
+   * aws_region}, {@code durable_lsn} and {@code visibility_lag_in_msec} from the Aurora Global
+   * Database instance status, used to detect that a replica has caught up.
+   */
+  protected abstract String replicaStatusQuery();
+
+  @Override
+  public void start() {
+    LOG.info("Creating scratch database '{}' on Aurora cluster", databaseName);
+    executeAdminStatement("CREATE DATABASE " + databaseName);
+  }
+
+  @Override
+  public void stop() {
+    LOG.info("Dropping scratch database '{}' on Aurora cluster", databaseName);
+    executeAdminStatement(dropDatabaseStatement(databaseName));
+  }
+
+  @Override
+  public String getJdbcUrl() {
+    // replace the maintenance database in the admin URL with the scratch database
+    final int lastSlash = adminJdbcUrl.lastIndexOf('/');
+    final int queryStart = adminJdbcUrl.indexOf('?', lastSlash);
+    final String query = queryStart < 0 ? "" : adminJdbcUrl.substring(queryStart);
+    return adminJdbcUrl.substring(0, lastSlash + 1) + databaseName + query;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public Future<Void> stopReplica() {
+    LOG.info("Triggering Aurora replica outage via external command");
+    final var future = executeReplicaCommand(stopReplicaCommand);
+    waitForReplicaUnreachable();
+    LOG.info("Aurora replica is unreachable");
+    return future;
+  }
+
+  @Override
+  public Future<Void> startReplica() {
+    LOG.info("Restoring Aurora replica via external command");
+    final var future = executeReplicaCommand(startReplicaCommand);
+    waitForReplication();
+    LOG.info("Aurora replica is in sync with primary");
+    return future;
+  }
+
+  /**
+   * Waits until no replica instance reports a position on the primary, i.e. the secondary has
+   * actually gone offline. The stop command (e.g. a reboot) returns before the instance is down, so
+   * without this the test would proceed while the replica is still reachable and exporting would
+   * not yet be paused.
+   */
+  private void waitForReplicaUnreachable() {
+    await()
+        .atMost(Duration.ofMinutes(5))
+        .pollInterval(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              try (final Connection connection =
+                      DriverManager.getConnection(adminJdbcUrl, username, password);
+                  final Statement statement = connection.createStatement();
+                  final ResultSet rs = statement.executeQuery(replicaUnreachableQuery())) {
+                int replicaCount = 0;
+                while (rs.next()) {
+                  final String sessionId = rs.getString("session_id");
+                  if (!"MASTER_SESSION_ID".equals(sessionId)) {
+                    replicaCount++;
+                    LOG.info(
+                        "Replica still reachable: server_id={}, session_id={}, durable_lsn={}",
+                        rs.getString("server_id"),
+                        sessionId,
+                        rs.getLong("durable_lsn"));
+                  }
+                }
+                if (replicaCount > 0) {
+                  throw new AssertionError(
+                      "Replica still reachable (replicas visible: " + replicaCount + ")");
+                }
+              }
+            });
+    LOG.info("Replica is unreachable now");
+  }
+
+  private Future<Void> executeReplicaCommand(final String command) {
+    LOG.info("Executing replica command: {}", command);
+    try {
+      final Process process =
+          new ProcessBuilder("sh", "-c", command).redirectErrorStream(true).start();
+      final String output;
+      try (final InputStream is = process.getInputStream()) {
+        output = new String(is.readAllBytes());
+        return processExecutor.submit(
+            () -> {
+              try {
+                final boolean finished =
+                    process.waitFor(REPLICA_COMMAND_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+                if (!finished) {
+                  process.destroyForcibly();
+                  LOG.error("Replica command timed out. Output:\n{}", output);
+                  throw new IllegalStateException("Replica command timed out: " + command);
+                }
+                final int exitCode = process.exitValue();
+                LOG.info(
+                    "Replica command finished with exit code {}. Output:\n{}", exitCode, output);
+                if (exitCode != 0) {
+                  throw new IllegalStateException(
+                      "Replica command failed with exit code %d: %s".formatted(exitCode, command));
+                }
+                return Unit.unit();
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(
+                    "Interrupted while running replica command: " + command, e);
+              }
+            });
+      }
+    } catch (final IOException e) {
+      throw new IllegalStateException("Failed to run replica command: " + command, e);
+    }
+  }
+
+  /** Waits until a replica instance reports a replicated position on the primary endpoint. */
+  private void waitForReplication() {
+    await()
+        .atMost(Duration.ofMinutes(45))
+        .pollInterval(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              try (final Connection connection =
+                      DriverManager.getConnection(adminJdbcUrl, username, password);
+                  final Statement statement = connection.createStatement();
+                  final ResultSet rs = statement.executeQuery(replicaStatusQuery())) {
+                int replicaCount = 0;
+                boolean replicaInSync = false;
+                while (rs.next()) {
+                  final String sessionId = rs.getString("session_id");
+                  final long durableLsn = rs.getLong("durable_lsn");
+                  // NULL session_id is treated as non-master (a recovering secondary may report a
+                  // NULL session before it establishes a streaming session); equals() is NULL-safe.
+                  final boolean isMaster = "MASTER_SESSION_ID".equals(sessionId);
+                  LOG.info(
+                      "Instance status: server_id={}, session_id={}, aws_region={}, durable_lsn={}, visibility_lag_in_msec={}",
+                      rs.getString("server_id"),
+                      sessionId,
+                      rs.getString("aws_region"),
+                      durableLsn,
+                      rs.getLong("visibility_lag_in_msec"));
+                  if (!isMaster) {
+                    replicaCount++;
+                    if (durableLsn > 0) {
+                      replicaInSync = true;
+                    }
+                  }
+                }
+                if (replicaInSync) {
+                  return;
+                }
+                throw new AssertionError(
+                    "No replica instance reporting a durable_lsn yet (replicas visible: "
+                        + replicaCount
+                        + ")");
+              }
+            });
+  }
+
+  private void executeAdminStatement(final String sql) {
+    try (final Connection connection =
+            DriverManager.getConnection(adminJdbcUrl, username, password);
+        final Statement statement = connection.createStatement()) {
+      statement.execute(sql);
+    } catch (final SQLException e) {
+      throw new IllegalStateException("Failed to execute on Aurora cluster: " + sql, e);
+    }
+  }
+
+  private static String requireEnv(final String name) {
+    final String value = System.getenv(name);
+    if (value == null || value.isBlank()) {
+      throw new IllegalStateException("Missing required environment variable: " + name);
+    }
+    return value;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraMysqlReplicationCluster.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraMysqlReplicationCluster.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.util;
+
+/**
+ * {@link AbstractAuroraReplicationCluster} for an Aurora <b>MySQL</b> Global Database.
+ *
+ * <p>The admin JDBC URL (see {@value AbstractAuroraReplicationCluster#ENV_JDBC_URL}) is expected to
+ * be a {@code jdbc:mysql://<endpoint>:3306/mysql}-style URL.
+ *
+ * <p>Aurora MySQL exposes Global Database instance status as the {@code
+ * information_schema.aurora_global_db_instance_status} table rather than the {@code
+ * aurora_global_db_instance_status()} table function used by Aurora PostgreSQL (see {@link
+ * AuroraReplicationCluster}). Column name case differs (upper-case on MySQL) but JDBC {@code
+ * ResultSet} column-label lookups are case-insensitive, so the shared parsing logic in {@link
+ * AbstractAuroraReplicationCluster} works unchanged.
+ */
+public final class AuroraMysqlReplicationCluster extends AbstractAuroraReplicationCluster {
+
+  @Override
+  protected String dropDatabaseStatement(final String databaseName) {
+    // unlike PostgreSQL, MySQL does not require terminating open sessions to drop a database
+    return "DROP DATABASE IF EXISTS " + databaseName;
+  }
+
+  @Override
+  protected String replicaUnreachableQuery() {
+    return """
+        SELECT SERVER_ID, SESSION_ID, DURABLE_LSN
+        FROM information_schema.aurora_global_db_instance_status
+        """;
+  }
+
+  @Override
+  protected String replicaStatusQuery() {
+    return """
+        SELECT SERVER_ID, SESSION_ID, AWS_REGION, DURABLE_LSN, VISIBILITY_LAG_IN_MSEC
+        FROM information_schema.aurora_global_db_instance_status
+        """;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraMysqlReplicationCluster.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraMysqlReplicationCluster.java
@@ -16,9 +16,9 @@ package io.camunda.it.rdbms.db.util;
  * <p>Aurora MySQL exposes Global Database instance status as the {@code
  * information_schema.aurora_global_db_instance_status} table rather than the {@code
  * aurora_global_db_instance_status()} table function used by Aurora PostgreSQL (see {@link
- * AuroraReplicationCluster}). Column name case differs (upper-case on MySQL) but JDBC {@code
- * ResultSet} column-label lookups are case-insensitive, so the shared parsing logic in {@link
- * AbstractAuroraReplicationCluster} works unchanged.
+ * AuroraPostgresReplicationCluster}). Column name case differs (upper-case on MySQL) but JDBC
+ * {@code ResultSet} column-label lookups are case-insensitive, so the shared parsing logic in
+ * {@link AbstractAuroraReplicationCluster} works unchanged.
  */
 public final class AuroraMysqlReplicationCluster extends AbstractAuroraReplicationCluster {
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraPostgresReplicationCluster.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraPostgresReplicationCluster.java
@@ -13,7 +13,7 @@ package io.camunda.it.rdbms.db.util;
  * <p>The admin JDBC URL (see {@value AbstractAuroraReplicationCluster#ENV_JDBC_URL}) is expected to
  * be a {@code jdbc:postgresql://<endpoint>:5432/postgres}-style URL.
  */
-public final class AuroraReplicationCluster extends AbstractAuroraReplicationCluster {
+public final class AuroraPostgresReplicationCluster extends AbstractAuroraReplicationCluster {
 
   @Override
   protected String dropDatabaseStatement(final String databaseName) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraReplicationCluster.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/util/AuroraReplicationCluster.java
@@ -7,264 +7,32 @@
  */
 package io.camunda.it.rdbms.db.util;
 
-import static org.awaitility.Awaitility.await;
-
-import io.camunda.zeebe.util.Unit;
-import java.io.IOException;
-import java.io.InputStream;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.time.Duration;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
- * {@link ReplicationClusterContainer} backed by a pre-provisioned AWS Aurora Global Database
- * instead of local containers.
+ * {@link AbstractAuroraReplicationCluster} for an Aurora <b>PostgreSQL</b> Global Database.
  *
- * <p>An Aurora cluster cannot be spawned in CI; it is assumed to be set up beforehand and reachable
- * via the following environment variables:
- *
- * <ul>
- *   <li>{@value #ENV_JDBC_URL} – JDBC URL of the primary cluster endpoint (any maintenance
- *       database, e.g. {@code jdbc:postgresql://<endpoint>:5432/postgres})
- *   <li>{@value #ENV_USERNAME} – database user with {@code CREATEDB} privilege
- *   <li>{@value #ENV_PASSWORD} – password of that user
- *   <li>{@value #ENV_STOP_REPLICA_CMD} – shell command that removes the replica (e.g. a {@code
- *       terraform apply} scaling the secondary instance count to 0)
- *   <li>{@value #ENV_START_REPLICA_CMD} – shell command that restores the replica
- * </ul>
- *
- * <p>{@link #start()} creates a uniquely named scratch database on the cluster so each test run is
- * isolated; {@link #stop()} drops it again, leaving the cluster in a clean state. Replica removal
- * and recovery are delegated to the infrastructure-provided commands, since a managed Aurora Global
- * Database cannot be manipulated directly from a test; after {@link #startReplica()} the cluster
- * waits until the replica reports a position via {@code aurora_global_db_instance_status()}.
+ * <p>The admin JDBC URL (see {@value AbstractAuroraReplicationCluster#ENV_JDBC_URL}) is expected to
+ * be a {@code jdbc:postgresql://<endpoint>:5432/postgres}-style URL.
  */
-public final class AuroraReplicationCluster implements ReplicationClusterContainer {
-
-  public static final String ENV_JDBC_URL = "TEST_AURORA_JDBC_URL";
-  public static final String ENV_USERNAME = "TEST_AURORA_USERNAME";
-  public static final String ENV_PASSWORD = "TEST_AURORA_PASSWORD";
-  public static final String ENV_STOP_REPLICA_CMD = "TEST_AURORA_STOP_REPLICA_CMD";
-  public static final String ENV_START_REPLICA_CMD = "TEST_AURORA_START_REPLICA_CMD";
-
-  private static final Duration REPLICA_COMMAND_TIMEOUT = Duration.ofMinutes(30);
-
-  private static final Logger LOG = LoggerFactory.getLogger(AuroraReplicationCluster.class);
-
-  private final String adminJdbcUrl = requireEnv(ENV_JDBC_URL);
-  private final String username = requireEnv(ENV_USERNAME);
-  private final String password = requireEnv(ENV_PASSWORD);
-  private final String stopReplicaCommand = requireEnv(ENV_STOP_REPLICA_CMD);
-  private final String startReplicaCommand = requireEnv(ENV_START_REPLICA_CMD);
-  private final String databaseName = "camunda_it_" + UUID.randomUUID().toString().replace("-", "");
-  private final ExecutorService processExecutor =
-      Executors.newSingleThreadExecutor(r -> new Thread(r, "aurora-cluster"));
+public final class AuroraReplicationCluster extends AbstractAuroraReplicationCluster {
 
   @Override
-  public void start() {
-    LOG.info("Creating scratch database '{}' on Aurora cluster", databaseName);
-    executeAdminStatement("CREATE DATABASE " + databaseName);
+  protected String dropDatabaseStatement(final String databaseName) {
+    return "DROP DATABASE IF EXISTS " + databaseName + " WITH (FORCE)";
   }
 
   @Override
-  public void stop() {
-    LOG.info("Dropping scratch database '{}' on Aurora cluster", databaseName);
-    executeAdminStatement("DROP DATABASE IF EXISTS " + databaseName + " WITH (FORCE)");
+  protected String replicaUnreachableQuery() {
+    return """
+        SELECT server_id, session_id, durable_lsn
+        FROM aurora_global_db_instance_status()
+        """;
   }
 
   @Override
-  public String getJdbcUrl() {
-    // replace the maintenance database in the admin URL with the scratch database
-    final int lastSlash = adminJdbcUrl.lastIndexOf('/');
-    final int queryStart = adminJdbcUrl.indexOf('?', lastSlash);
-    final String query = queryStart < 0 ? "" : adminJdbcUrl.substring(queryStart);
-    return adminJdbcUrl.substring(0, lastSlash + 1) + databaseName + query;
-  }
-
-  @Override
-  public String getUsername() {
-    return username;
-  }
-
-  @Override
-  public String getPassword() {
-    return password;
-  }
-
-  @Override
-  public Future<Void> stopReplica() {
-    LOG.info("Triggering Aurora replica outage via external command");
-    final var future = executeReplicaCommand(stopReplicaCommand);
-    waitForReplicaUnreachable();
-    LOG.info("Aurora replica is unreachable");
-    return future;
-  }
-
-  @Override
-  public Future<Void> startReplica() {
-    LOG.info("Restoring Aurora replica via external command");
-    final var future = executeReplicaCommand(startReplicaCommand);
-    waitForReplication();
-    LOG.info("Aurora replica is in sync with primary");
-    return future;
-  }
-
-  /**
-   * Waits until no replica instance reports a position on the primary, i.e. the secondary has
-   * actually gone offline. The stop command (e.g. a reboot) returns before the instance is down, so
-   * without this the test would proceed while the replica is still reachable and exporting would
-   * not yet be paused.
-   */
-  private void waitForReplicaUnreachable() {
-    await()
-        .atMost(Duration.ofMinutes(5))
-        .pollInterval(Duration.ofSeconds(5))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              try (final Connection connection =
-                      DriverManager.getConnection(adminJdbcUrl, username, password);
-                  final Statement statement = connection.createStatement();
-                  final ResultSet rs =
-                      statement.executeQuery(
-                          """
-                          SELECT server_id, session_id, durable_lsn
-                          FROM aurora_global_db_instance_status()
-                          """)) {
-                int replicaCount = 0;
-                while (rs.next()) {
-                  final String sessionId = rs.getString("session_id");
-                  if (!"MASTER_SESSION_ID".equals(sessionId)) {
-                    replicaCount++;
-                    LOG.info(
-                        "Replica still reachable: server_id={}, session_id={}, durable_lsn={}",
-                        rs.getString("server_id"),
-                        sessionId,
-                        rs.getLong("durable_lsn"));
-                  }
-                }
-                if (replicaCount > 0) {
-                  throw new AssertionError(
-                      "Replica still reachable (replicas visible: " + replicaCount + ")");
-                }
-              }
-            });
-    LOG.info("Replica is unreachable now");
-  }
-
-  private Future<Void> executeReplicaCommand(final String command) {
-    LOG.info("Executing replica command: {}", command);
-    try {
-      final Process process =
-          new ProcessBuilder("sh", "-c", command).redirectErrorStream(true).start();
-      final String output;
-      try (final InputStream is = process.getInputStream()) {
-        output = new String(is.readAllBytes());
-        return processExecutor.submit(
-            () -> {
-              try {
-                final boolean finished =
-                    process.waitFor(REPLICA_COMMAND_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
-                if (!finished) {
-                  process.destroyForcibly();
-                  LOG.error("Replica command timed out. Output:\n{}", output);
-                  throw new IllegalStateException("Replica command timed out: " + command);
-                }
-                final int exitCode = process.exitValue();
-                LOG.info(
-                    "Replica command finished with exit code {}. Output:\n{}", exitCode, output);
-                if (exitCode != 0) {
-                  throw new IllegalStateException(
-                      "Replica command failed with exit code %d: %s".formatted(exitCode, command));
-                }
-                return Unit.unit();
-              } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(
-                    "Interrupted while running replica command: " + command, e);
-              }
-            });
-      }
-    } catch (final IOException e) {
-      throw new IllegalStateException("Failed to run replica command: " + command, e);
-    }
-  }
-
-  /** Waits until a replica instance reports a replicated position on the primary endpoint. */
-  private void waitForReplication() {
-    await()
-        .atMost(Duration.ofMinutes(45))
-        .pollInterval(Duration.ofSeconds(30))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              try (final Connection connection =
-                      DriverManager.getConnection(adminJdbcUrl, username, password);
-                  final Statement statement = connection.createStatement();
-                  final ResultSet rs =
-                      statement.executeQuery(
-                          """
-                          SELECT server_id, session_id, aws_region, durable_lsn, visibility_lag_in_msec
-                          FROM aurora_global_db_instance_status()
-                          """)) {
-                int replicaCount = 0;
-                boolean replicaInSync = false;
-                while (rs.next()) {
-                  final String sessionId = rs.getString("session_id");
-                  final long durableLsn = rs.getLong("durable_lsn");
-                  // NULL session_id is treated as non-master (a recovering secondary may report a
-                  // NULL session before it establishes a streaming session); equals() is NULL-safe.
-                  final boolean isMaster = "MASTER_SESSION_ID".equals(sessionId);
-                  LOG.info(
-                      "Instance status: server_id={}, session_id={}, aws_region={}, durable_lsn={}, visibility_lag_in_msec={}",
-                      rs.getString("server_id"),
-                      sessionId,
-                      rs.getString("aws_region"),
-                      durableLsn,
-                      rs.getLong("visibility_lag_in_msec"));
-                  if (!isMaster) {
-                    replicaCount++;
-                    if (durableLsn > 0) {
-                      replicaInSync = true;
-                    }
-                  }
-                }
-                if (replicaInSync) {
-                  return;
-                }
-                throw new AssertionError(
-                    "No replica instance reporting a durable_lsn yet (replicas visible: "
-                        + replicaCount
-                        + ")");
-              }
-            });
-  }
-
-  private void executeAdminStatement(final String sql) {
-    try (final Connection connection =
-            DriverManager.getConnection(adminJdbcUrl, username, password);
-        final Statement statement = connection.createStatement()) {
-      statement.execute(sql);
-    } catch (final SQLException e) {
-      throw new IllegalStateException("Failed to execute on Aurora cluster: " + sql, e);
-    }
-  }
-
-  private static String requireEnv(final String name) {
-    final String value = System.getenv(name);
-    if (value == null || value.isBlank()) {
-      throw new IllegalStateException("Missing required environment variable: " + name);
-    }
-    return value;
+  protected String replicaStatusQuery() {
+    return """
+        SELECT server_id, session_id, aws_region, durable_lsn, visibility_lag_in_msec
+        FROM aurora_global_db_instance_status()
+        """;
   }
 }


### PR DESCRIPTION
## Description

`AuroraAsyncReplicationIT` and the `aurora-async-replication-test.yml` workflow previously only
covered an AWS Aurora **PostgreSQL** Global Database, even though the RDBMS exporter's
Aurora Global Database replication-status querying (`ReplicationStatusMapper.xml`,
`ReplicationLogStatusProviderFactory`) already fully supports Aurora **MySQL** and is unit-tested
for it. This PR adds equivalent MySQL coverage on the qa/acceptance-tests and CI side:

- Extracts the reusable parts of `AuroraReplicationCluster` (scratch-DB lifecycle, replica command
  execution, Awaitility polling) into a new `AbstractAuroraReplicationCluster`, leaving only the
  engine-specific SQL/DROP statement in each subclass (separate refactor commit, no behavior
  change).
- Adds `AuroraMysqlReplicationCluster` and `AuroraMysqlAsyncReplicationIT` (tagged
  `rdbms-aurora-mysql`), supplying the Aurora MySQL variant of the Global Database status query
  (`information_schema.aurora_global_db_instance_status` table vs. the Postgres
  `aurora_global_db_instance_status()` function).
- Adds a matching `rdbms-aurora-mysql` Maven profile in `qa/acceptance-tests/pom.xml`.
- Parameterizes `.github/terraform/aurora-replication-it/main.tf` with `engine`/`engine_version`/
  `port` variables (defaulting to today's Postgres values) and wires them into the `aurora-global`
  module call and the bastion's egress rule.
- Adds a `db_engine` input (`postgresql`/`mysql`) to
  `.github/workflows/aurora-async-replication-test.yml`, deriving the JDBC URL scheme, tunnel port,
  RDS `--engine` flag, and Maven profile from it, and including the engine in the concurrency group
  so the two flavors don't queue behind each other.

### Known limitation (not fixed in this PR)

The upstream `aws/modules/aurora-global` Terraform module (in
`camunda/camunda-deployment-references`) already exposes an `engine`/`engine_version` variable, but
its own security groups still hardcode port 5432 for both the primary and secondary clusters.
Until that's parameterized in that separate repository, running this workflow with
`db_engine: mysql` will provision an Aurora MySQL cluster whose port 3306 is unreachable through
the bastion. The changes here are ready to exercise end-to-end as soon as that upstream fix lands.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

N/A — no linked issue.