### PR TITLE
feat: add Operate shared DeleteDefinitionModal and StructuredList components

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
@@ -30,6 +30,8 @@ const config: KnipConfig = {
 		'src/operate/shared/PanelHeader/**',
 		'src/operate/shared/DiagramShell/**',
 		'src/operate/shared/FiltersPanel/**',
+		'src/operate/shared/DeleteDefinition/**',
+		'src/operate/shared/StructuredList/**',
 		// TODO(#55642): remove when BatchOperation detail page is migrated
 		'src/operate/shared/PaginatedSortableTable/**',
 		// TODO(#56029, #56026): remove when Process Instance / Decision Instance shells are migrated

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinition/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinition/styled.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const DeleteButtonContainer = styled.div`
+	display: flex;
+	align-items: center;
+	margin-left: auto;
+`;
+
+export {DeleteButtonContainer};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinitionModal/DeleteDefinitionModal.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinitionModal/DeleteDefinitionModal.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {DeleteDefinitionModal} from './DeleteDefinitionModal';
+
+describe('<DeleteDefinitionModal />', () => {
+	it('starts with an unchecked confirmation checkbox', async () => {
+		const screen = await render(
+			<DeleteDefinitionModal
+				isVisible
+				title="warning"
+				description="description"
+				bodyContent={<div>body</div>}
+				confirmationText="confirm"
+				onClose={() => {}}
+				onDelete={() => {}}
+			/>,
+		);
+
+		await expect.element(screen.getByRole('checkbox')).not.toBeChecked();
+	});
+
+	it('shows a validation error and does not delete when submitted unconfirmed', async () => {
+		const onDelete = vi.fn();
+		const screen = await render(
+			<DeleteDefinitionModal
+				isVisible
+				title="warning"
+				description="description"
+				bodyContent={<div>body</div>}
+				confirmationText="confirm"
+				onClose={() => {}}
+				onDelete={onDelete}
+			/>,
+		);
+
+		await screen.getByRole('button', {name: 'Delete'}).click();
+
+		await expect.element(screen.getByText('Please tick this box if you want to proceed.')).toBeVisible();
+		expect(onDelete).not.toHaveBeenCalled();
+	});
+
+	it('deletes once the checkbox is confirmed', async () => {
+		const onDelete = vi.fn();
+		const screen = await render(
+			<DeleteDefinitionModal
+				isVisible
+				title="warning"
+				description="description"
+				bodyContent={<div>body</div>}
+				confirmationText="confirm"
+				onClose={() => {}}
+				onDelete={onDelete}
+			/>,
+		);
+
+		// the checkbox's native input is visually covered by its own label, which fails
+		// real-browser hover actionability - click the visible label text instead.
+		await screen.getByText('confirm').click();
+		await screen.getByRole('button', {name: 'Delete'}).click();
+
+		expect(onDelete).toHaveBeenCalledTimes(1);
+	});
+
+	it('calls onClose when cancelled', async () => {
+		const onClose = vi.fn();
+		const screen = await render(
+			<DeleteDefinitionModal
+				isVisible
+				title="warning"
+				description="description"
+				bodyContent={<div>body</div>}
+				confirmationText="confirm"
+				onClose={onClose}
+				onDelete={() => {}}
+			/>,
+		);
+
+		await screen.getByRole('button', {name: 'Cancel'}).click();
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders the warning content when provided', async () => {
+		const screen = await render(
+			<DeleteDefinitionModal
+				isVisible
+				title="warning"
+				description="description"
+				bodyContent={<div>body</div>}
+				confirmationText="confirm"
+				warningTitle="Careful"
+				warningContent={<div>this cannot be undone</div>}
+				onClose={() => {}}
+				onDelete={() => {}}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Careful')).toBeVisible();
+		await expect.element(screen.getByText('this cannot be undone')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinitionModal/DeleteDefinitionModal.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinitionModal/DeleteDefinitionModal.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useId, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {Modal, Stack, ActionableNotification, Checkbox} from '@carbon/react';
+import {Description, WarningContainer} from './styled';
+
+type Props = {
+	isVisible: boolean;
+	title: string;
+	description: string;
+	bodyContent: React.ReactNode;
+	confirmationText: string;
+	warningTitle?: string;
+	warningContent?: React.ReactNode;
+	onClose: () => void;
+	onDelete: () => void;
+};
+
+const DeleteDefinitionModal: React.FC<Props> = ({
+	isVisible,
+	title,
+	description,
+	bodyContent,
+	warningTitle,
+	confirmationText,
+	warningContent,
+	onClose,
+	onDelete,
+}) => {
+	const {t} = useTranslation();
+	const confirmationCheckboxId = useId();
+	const [isConfirmed, setIsConfirmed] = useState(false);
+	const [hasConfirmationError, setHasConfirmationError] = useState(false);
+
+	return (
+		<Modal
+			open={isVisible}
+			danger
+			preventCloseOnClickOutside
+			modalHeading={title}
+			primaryButtonText={t('operate.shared.deleteDefinitionModal.deleteButton')}
+			secondaryButtonText={t('operate.shared.deleteDefinitionModal.cancelButton')}
+			onRequestSubmit={() => {
+				if (!isConfirmed) {
+					setHasConfirmationError(true);
+					return;
+				}
+
+				onDelete();
+				setIsConfirmed(false);
+			}}
+			onRequestClose={() => {
+				setHasConfirmationError(false);
+				onClose();
+				setIsConfirmed(false);
+			}}
+			size="md"
+		>
+			<Stack gap={6}>
+				<Description>{description}</Description>
+				{bodyContent}
+				{warningContent && (
+					<ActionableNotification
+						kind="warning"
+						inline
+						hideCloseButton
+						lowContrast
+						title={warningTitle}
+						children={<WarningContainer>{warningContent}</WarningContainer>}
+						actionButtonLabel=""
+					/>
+				)}
+				<Checkbox
+					checked={isConfirmed}
+					id={confirmationCheckboxId}
+					labelText={confirmationText}
+					invalid={hasConfirmationError}
+					invalidText={t('operate.shared.deleteDefinitionModal.confirmationError')}
+					warnText=""
+					onChange={(_, {checked}) => {
+						if (checked && hasConfirmationError) {
+							setHasConfirmationError(false);
+						}
+
+						setIsConfirmed(checked);
+					}}
+				/>
+			</Stack>
+		</Modal>
+	);
+};
+
+export {DeleteDefinitionModal};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinitionModal/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DeleteDefinitionModal/styled.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {styles} from '@carbon/type';
+
+const Description = styled.p`
+	margin: 0;
+	${styles.bodyShort01};
+`;
+
+const WarningContainer = styled.section`
+	margin-top: var(--cds-spacing-06);
+`;
+
+export {Description, WarningContainer};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StructuredList/StructuredList.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StructuredList/StructuredList.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render} from 'vitest-browser-react';
+import {StructuredList} from './StructuredList';
+
+describe('<StructuredList />', () => {
+	it('renders header and row columns', async () => {
+		const screen = await render(
+			<StructuredList
+				label="Process Details"
+				headerColumns={[{cellContent: 'Process Definition'}]}
+				rows={[{key: 'order-process-v2', columns: [{cellContent: 'Order Process - Version 2'}]}]}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Process Definition')).toBeVisible();
+		await expect.element(screen.getByText('Order Process - Version 2')).toBeVisible();
+	});
+
+	it('renders dynamic rows alongside the static rows', async () => {
+		const screen = await render(
+			<StructuredList
+				label="Process Details"
+				headerColumns={[{cellContent: 'Name'}]}
+				rows={[{key: 'static-row', columns: [{cellContent: 'Static'}]}]}
+				dynamicRows={<div>Dynamic content</div>}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Dynamic content')).toBeVisible();
+		await expect.element(screen.getByText('Static')).toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StructuredList/StructuredList.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StructuredList/StructuredList.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React, {useRef} from 'react';
+import {StructuredListHead, StructuredListRow, StructuredListWrapper} from '@carbon/react';
+import {InfiniteScroller} from '#/operate/shared/InfiniteScroller/InfiniteScroller';
+import {Container, StructuredListCell} from './styled';
+
+type Column = {
+	cellContent: React.ReactNode;
+	width?: string;
+};
+
+type RowProps = {
+	columns: Column[];
+	dataTestId?: string;
+	key: string;
+};
+
+type Props = {
+	label: string;
+	headerSize?: 'sm' | 'md';
+	headerColumns: Column[];
+	rows: RowProps[];
+	className?: string;
+	dynamicRows?: React.ReactNode;
+	verticalCellPadding?: string;
+	dataTestId?: string;
+	isFlush?: boolean;
+} & Pick<React.ComponentProps<typeof InfiniteScroller>, 'onVerticalScrollStartReach' | 'onVerticalScrollEndReach'>;
+
+const StructuredRows: React.FC<Pick<Props, 'rows' | 'verticalCellPadding'>> = ({rows, verticalCellPadding}) => {
+	return (
+		<>
+			{rows.map(({key, dataTestId, columns}) => (
+				<StructuredListRow key={key} data-testid={dataTestId}>
+					{columns.map(({cellContent, width}, index) => {
+						return (
+							<StructuredListCell
+								key={index}
+								$verticalCellPadding={verticalCellPadding}
+								$width={width}
+								onFocus={(e) => {
+									e.stopPropagation();
+								}}
+							>
+								{cellContent}
+							</StructuredListCell>
+						);
+					})}
+				</StructuredListRow>
+			))}
+		</>
+	);
+};
+
+const StructuredList: React.FC<Props> = ({
+	label,
+	headerSize = 'md',
+	headerColumns,
+	rows,
+	className,
+	dynamicRows,
+	verticalCellPadding,
+	dataTestId,
+	onVerticalScrollStartReach,
+	onVerticalScrollEndReach,
+	isFlush = true,
+}) => {
+	const scrollableContentRef = useRef<HTMLDivElement | null>(null);
+
+	return (
+		<Container className={className} data-testid={dataTestId} ref={scrollableContentRef}>
+			<StructuredListWrapper aria-label={label} isCondensed isFlush={isFlush}>
+				<StructuredListHead>
+					<StructuredListRow head tabIndex={0}>
+						{headerColumns.map(({cellContent, width}, index) => {
+							return (
+								<StructuredListCell $width={width} $size={headerSize} head key={index}>
+									{cellContent}
+								</StructuredListCell>
+							);
+						})}
+					</StructuredListRow>
+				</StructuredListHead>
+				<InfiniteScroller
+					onVerticalScrollStartReach={onVerticalScrollStartReach}
+					onVerticalScrollEndReach={onVerticalScrollEndReach}
+					scrollableContainerRef={scrollableContentRef}
+				>
+					<div className="cds--structured-list-tbody" role="rowgroup">
+						{dynamicRows}
+						<StructuredRows rows={rows} verticalCellPadding={verticalCellPadding} />
+					</div>
+				</InfiniteScroller>
+			</StructuredListWrapper>
+		</Container>
+	);
+};
+
+export {StructuredList, StructuredRows};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StructuredList/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StructuredList/styled.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled, {css} from 'styled-components';
+import {styles} from '@carbon/type';
+import {StructuredListCell as BaseStructuredListCell} from '@carbon/react';
+
+const Container = styled.div`
+	overflow-y: auto;
+`;
+
+type StructuredListCellProps = {
+	$size?: 'sm' | 'md';
+	$width?: string;
+	$verticalCellPadding?: string;
+};
+
+const StructuredListCell = styled(BaseStructuredListCell)<StructuredListCellProps>`
+	${({$size = 'md', $width, $verticalCellPadding}) => css`
+		vertical-align: top;
+		${
+			$size === 'sm' &&
+			css`
+				${styles.label01};
+			`
+		}
+		${
+			$width &&
+			css`
+				width: ${$width};
+			`
+		}
+		${
+			$verticalCellPadding &&
+			css`
+				padding-top: ${$verticalCellPadding} !important;
+				padding-bottom: ${$verticalCellPadding} !important;
+			`
+		}
+	`}
+`;
+
+export {Container, StructuredListCell};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -524,6 +524,11 @@
 					"copied": "Kopiert",
 					"copyToClipboard": "In die Zwischenablage kopieren",
 					"copiedToClipboard": "In die Zwischenablage kopiert"
+				},
+				"deleteDefinitionModal": {
+					"deleteButton": "Löschen",
+					"cancelButton": "Abbrechen",
+					"confirmationError": "Bitte aktivieren Sie dieses Kästchen, wenn Sie fortfahren möchten."
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -538,6 +538,11 @@
 					"copied": "Copied",
 					"copyToClipboard": "Copy to clipboard",
 					"copiedToClipboard": "Copied to clipboard"
+				},
+				"deleteDefinitionModal": {
+					"deleteButton": "Delete",
+					"cancelButton": "Cancel",
+					"confirmationError": "Please tick this box if you want to proceed."
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -524,6 +524,11 @@
 					"copied": "Copiado",
 					"copyToClipboard": "Copiar al portapapeles",
 					"copiedToClipboard": "Copiado al portapapeles"
+				},
+				"deleteDefinitionModal": {
+					"deleteButton": "Eliminar",
+					"cancelButton": "Cancelar",
+					"confirmationError": "Marque esta casilla si desea continuar."
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -527,6 +527,11 @@
 					"copied": "Copié",
 					"copyToClipboard": "Copier dans le presse-papiers",
 					"copiedToClipboard": "Copié dans le presse-papiers"
+				},
+				"deleteDefinitionModal": {
+					"deleteButton": "Supprimer",
+					"cancelButton": "Annuler",
+					"confirmationError": "Veuillez cocher cette case si vous souhaitez continuer."
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Ports `DeleteDefinitionModal`, `DeleteDefinition` (`DeleteButtonContainer`), and `StructuredList` from legacy Operate to `operate/shared/`, ahead of their consumer (`ProcessOperations`, #55987). Uses `@carbon/type` (already a dependency) instead of the legacy `@carbon/elements` for typography tokens.

Closes #57679

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #57679
