### PR TITLE
test: in ListLogStorage delete data before oldest reader

### DIFF
--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -93,22 +93,25 @@ public class ListLogStorage implements LogStorage {
 
   public void reset() {
     final Integer lastIndex =
-        listLogStorageReaders.stream().map(r -> r.currentIndex).min(Integer::compareTo).orElse(0);
+        listLogStorageReaders.stream()
+            .map(r -> r.currentIndex.get())
+            .min(Integer::compareTo)
+            .orElse(0);
     entries.headMap(lastIndex).clear();
   }
 
   private record Entry(ByteBuffer data) {}
 
   private final class ListLogStorageReader implements LogStorageReader {
-    volatile int currentIndex;
+    AtomicInteger currentIndex;
 
     @Override
     public void seek(final long position) {
-      currentIndex =
+      currentIndex.set(
           Optional.ofNullable(positionIndexMapping.lowerEntry(position))
               .map(Map.Entry::getValue)
               //              .map(index -> index - 1)
-              .orElse(0);
+              .orElse(0));
     }
 
     @Override
@@ -118,8 +121,8 @@ public class ListLogStorage implements LogStorage {
 
     @Override
     public boolean hasNext() {
-      return currentIndex >= 0
-          && !entries.tailMap(currentIndex).isEmpty(); // && currentIndex < entries.size();
+      return currentIndex.get() >= 0
+          && !entries.tailMap(currentIndex.get()).isEmpty(); // && currentIndex < entries.size();
     }
 
     @Override
@@ -128,10 +131,11 @@ public class ListLogStorage implements LogStorage {
         throw new NoSuchElementException();
       }
 
-      final int index = currentIndex;
-      currentIndex++;
+      final int index = currentIndex.get();
 
-      return new UnsafeBuffer(entries.get(index).data);
+      final var buffer = new UnsafeBuffer(entries.get(index).data);
+      currentIndex.incrementAndGet();
+      return buffer;
     }
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -103,7 +103,7 @@ public class ListLogStorage implements LogStorage {
   private record Entry(ByteBuffer data) {}
 
   private final class ListLogStorageReader implements LogStorageReader {
-    AtomicInteger currentIndex;
+    final AtomicInteger currentIndex = new AtomicInteger(0);
 
     @Override
     public void seek(final long position) {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -24,12 +24,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongConsumer;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public class ListLogStorage implements LogStorage {
 
   private final ConcurrentNavigableMap<Long, Integer> positionIndexMapping;
   private final ConcurrentSkipListMap<Integer, Entry> entries;
-  private LongConsumer positionListener;
+  private @Nullable LongConsumer positionListener;
   private final Set<CommitListener> commitListeners = new HashSet<>();
   private final List<ListLogStorageReader> listLogStorageReaders;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
@@ -121,8 +124,8 @@ public class ListLogStorage implements LogStorage {
 
     @Override
     public boolean hasNext() {
-      return currentIndex.get() >= 0
-          && !entries.tailMap(currentIndex.get()).isEmpty(); // && currentIndex < entries.size();
+      final var index = currentIndex.get();
+      return index >= 0 && !entries.tailMap(index).isEmpty(); // && currentIndex < entries.size();
     }
 
     @Override
@@ -131,9 +134,11 @@ public class ListLogStorage implements LogStorage {
         throw new NoSuchElementException();
       }
 
-      final int index = currentIndex.get();
-
-      final var buffer = new UnsafeBuffer(entries.get(index).data);
+      final var entry = entries.get(currentIndex.get());
+      if (entry == null) {
+        throw new NoSuchElementException();
+      }
+      final var buffer = new UnsafeBuffer(entry.data);
       currentIndex.incrementAndGet();
       return buffer;
     }


### PR DESCRIPTION
## Description
In EngineLargeStatePerformanceTest we are continuously calling `log.resetLog` to maintain the memory usage bounded, but there's a race condition between `reset()` and `hasNext()` as `currentIndex` in a reader is still used by `next()`, but it was incremented before being used to get the data from the list.
This resulted in test failures with this stacktrace:

```
java.lang.NullPointerException: Cannot read field "data" because the return value of "java.util.concurrent.ConcurrentSkipListMap.get(Object)" is null
	at io.camunda.zeebe.logstreams.util.ListLogStorage$ListLogStorageReader.next(ListLogStorage.java:134)
	at io.camunda.zeebe.logstreams.util.ListLogStorage$ListLogStorageReader.next(ListLogStorage.java:102)
	at io.camunda.zeebe.logstreams.impl.log.LogStreamReaderImpl.readNextBlock(LogStreamReaderImpl.java:196)
	at io.camunda.zeebe.logstreams.impl.log.LogStreamReaderImpl.hasNext(LogStreamReaderImpl.java:46)
	at io.camunda.zeebe.stream.impl.ProcessingStateMachine.tryToReadNextRecord(ProcessingStateMachine.java:249)
	at io.camunda.zeebe.scheduler.ActorJob.invoke(ActorJob.java:84)
	at io.camunda.zeebe.scheduler.ActorJob.execute(ActorJob.java:43)
	at io.camunda.zeebe.scheduler.ActorTask.execute(ActorTask.java:125)
	at io.camunda.zeebe.scheduler.ActorThread.executeCurrentTask(ActorThread.java:129)
	at io.camunda.zeebe.scheduler.ActorThread.doWork(ActorThread.java:106)
	at io.camunda.zeebe.scheduler.ActorThread.run(ActorThread.java:226)
```

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
