### PR TITLE
Rename TypedResponseWriter methods to remove a naming trap

### DIFF
--- a/.claude/skills/engine-expert/processors.md
+++ b/.claude/skills/engine-expert/processors.md
@@ -7,7 +7,7 @@ Processors are where the engine's logic lives. They consume commands and produce
 - **Bulk of logic lives here**, not in event appliers. Processors are easier to fix when bugs are found or behavior must be adjusted.
 - **Read-only state access only.** Mutation goes through events + appliers. Use the `*State` (read-only) interface from a processor, never the `Mutable*State` interface.
 - **Composition over inheritance.** Reuse logic via `Behavior` classes (e.g., `BpmnJobActivationBehavior`), not via subclasses.
-- **A processor must always end the command's processing by appending an event or a rejection.** A command is considered processed (after replay) when a follow-up record points to it.
+- **A processor must always end the command's processing by appending an event or a rejection** — either directly via `StateWriter.appendFollowUpEvent(...)` / `TypedRejectionWriter.appendRejection(...)`, or transitively through a behavior class that wraps one of these calls. A command is considered processed (after replay) when a follow-up record points to it. A call to `TypedResponseWriter` does not satisfy this: it only sends the response to the client, via gRPC or REST — it never appends anything to the log.
 - **Exceptions are a last-resort rollback mechanism**, not a control-flow tool. They are expensive at engine throughput.
   - Prefer pre-validation: validate the command before appending any events.
   - Throw only when validation is only possible mid-processing, after some events have already been appended. The stream processor will roll back the appended records and call `tryHandleError`, where the processor typically appends a command rejection to recover.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -262,7 +262,7 @@ public class Engine implements RecordProcessor {
     writers.rejection().appendRejection(typedCommand, RejectionType.INVALID_STATE, rejectionReason);
     writers
         .response()
-        .writeRejectionOnCommand(typedCommand, RejectionType.INVALID_STATE, rejectionReason);
+        .writeRejectedResponseOnCommand(typedCommand, RejectionType.INVALID_STATE, rejectionReason);
   }
 
   private void handleUnexpectedError(
@@ -280,12 +280,12 @@ public class Engine implements RecordProcessor {
       writers.rejection().appendRejection(record, RejectionType.EXCEEDED_BATCH_RECORD_SIZE, "");
       writers
           .response()
-          .writeRejectionOnCommand(record, RejectionType.EXCEEDED_BATCH_RECORD_SIZE, "");
+          .writeRejectedResponseOnCommand(record, RejectionType.EXCEEDED_BATCH_RECORD_SIZE, "");
     } else {
       writers.rejection().appendRejection(record, RejectionType.PROCESSING_ERROR, errorMessage);
       writers
           .response()
-          .writeRejectionOnCommand(
+          .writeRejectedResponseOnCommand(
               record,
               RejectionType.PROCESSING_ERROR,
               """

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -182,7 +182,7 @@ public class AdHocSubProcessInstructionActivateProcessor
       final RejectionType rejectionType,
       final String errorMessage) {
     rejectionWriter.appendRejection(command, rejectionType, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, errorMessage);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, errorMessage);
   }
 
   private Either<Rejection, Void> authorize(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessInstructionActivateProcessor.java
@@ -173,7 +173,7 @@ public class AdHocSubProcessInstructionActivateProcessor
     stateWriter.appendFollowUpEvent(
         command.getKey(), AdHocSubProcessInstructionIntent.ACTIVATED, command.getValue());
 
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), AdHocSubProcessInstructionIntent.ACTIVATED, command.getValue(), command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -146,6 +146,6 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
       final RejectionType rejectionType,
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -137,7 +137,8 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
         .setDurationMs(commandValue.getMetrics().getDurationMs());
 
     stateWriter.appendFollowUpEvent(historyKey, AgentHistoryIntent.CREATED, event);
-    responseWriter.writeEventOnCommand(historyKey, AgentHistoryIntent.CREATED, event, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        historyKey, AgentHistoryIntent.CREATED, event, command);
   }
 
   private void writeRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -184,6 +184,6 @@ public final class AgentInstanceCreateProcessor
       final RejectionType rejectionType,
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceCreateProcessor.java
@@ -119,7 +119,7 @@ public final class AgentInstanceCreateProcessor
           RejectionType.ALREADY_EXISTS,
           ERROR_MSG_AGENT_INSTANCE_ALREADY_EXISTS.formatted(
               elementInstanceKey, existingAgentInstanceKey));
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           existingAgentInstanceKey, AgentInstanceIntent.CREATED, existingRecord, command);
       return;
     }
@@ -175,7 +175,7 @@ public final class AgentInstanceCreateProcessor
         .setMaxToolCalls(commandValue.getLimits().getMaxToolCalls());
 
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.CREATED, event);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.CREATED, event, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -227,7 +227,7 @@ public final class AgentInstanceUpdateProcessor
     current.setChangedAttributes(applyPatch(current, commandValue, changed));
 
     stateWriter.appendFollowUpEvent(agentInstanceKey, AgentInstanceIntent.UPDATED, current);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         agentInstanceKey, AgentInstanceIntent.UPDATED, current, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agentinstance/AgentInstanceUpdateProcessor.java
@@ -345,6 +345,6 @@ public final class AgentInstanceUpdateProcessor
       final RejectionType rejectionType,
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
@@ -135,7 +135,8 @@ public final class BatchOperationCreationCreateProcessor
         BatchOperationIntent.CREATED,
         recordWithKey,
         FollowUpEventMetadata.of(b -> b.batchOperationReference(key)));
-    responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        key, BatchOperationIntent.CREATED, recordWithKey, command);
     commandDistributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.BATCH_OPERATION)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreationCreateProcessor.java
@@ -89,7 +89,7 @@ public final class BatchOperationCreationCreateProcessor
     if (isEmptyOrNullFilter(command)) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_ARGUMENT, MESSAGE_GIVEN_FILTER_IS_EMPTY);
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.INVALID_ARGUMENT, MESSAGE_GIVEN_FILTER_IS_EMPTY);
       return;
     }
@@ -97,7 +97,7 @@ public final class BatchOperationCreationCreateProcessor
     if (isEmptyJobUpdateChangeset(command)) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_ARGUMENT, MESSAGE_JOB_UPDATE_CHANGESET_IS_EMPTY);
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.INVALID_ARGUMENT, MESSAGE_JOB_UPDATE_CHANGESET_IS_EMPTY);
       return;
     }
@@ -106,7 +106,7 @@ public final class BatchOperationCreationCreateProcessor
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
@@ -87,7 +87,7 @@ public final class BatchOperationLifecycleManagementCancelProcessor
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -112,7 +112,7 @@ public final class BatchOperationLifecycleManagementCancelProcessor
           command,
           RejectionType.NOT_FOUND,
           String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command,
           RejectionType.NOT_FOUND,
           String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementCancelProcessor.java
@@ -99,7 +99,7 @@ public final class BatchOperationLifecycleManagementCancelProcessor
     final var batchOperation = batchOperationState.get(batchOperationKey);
     if (batchOperation.isPresent() && batchOperation.get().canCancel()) {
       cancelBatchOperationEvent(cancelKey, recordValue);
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           cancelKey, BatchOperationIntent.CANCELED, command.getValue(), command);
       commandDistributionBehavior
           .withKey(cancelKey)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
@@ -122,7 +122,7 @@ public final class BatchOperationLifecycleManagementResumeProcessor
     }
 
     resumeBatchOperation(resumeKey, batchOperation.get(), command.getValue());
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         resumeKey, BatchOperationIntent.RESUMED, command.getValue(), command);
     commandDistributionBehavior
         .withKey(resumeKey)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementResumeProcessor.java
@@ -98,7 +98,7 @@ public final class BatchOperationLifecycleManagementResumeProcessor
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -192,7 +192,7 @@ public final class BatchOperationLifecycleManagementResumeProcessor
         RejectionType.INVALID_STATE,
         String.format(
             BATCH_OPERATION_INVALID_STATE_MESSAGE, batchOperationKey, batchOperationStatus));
-    responseWriter.writeRejectionOnCommand(
+    responseWriter.writeRejectedResponseOnCommand(
         command,
         RejectionType.INVALID_STATE,
         String.format(
@@ -211,7 +211,7 @@ public final class BatchOperationLifecycleManagementResumeProcessor
         command,
         RejectionType.NOT_FOUND,
         String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
-    responseWriter.writeRejectionOnCommand(
+    responseWriter.writeRejectedResponseOnCommand(
         command,
         RejectionType.NOT_FOUND,
         String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessor.java
@@ -114,7 +114,7 @@ public final class BatchOperationLifecycleManagementSuspendProcessor
     }
 
     suspendBatchOperation(suspendKey, recordValue);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         suspendKey, BatchOperationIntent.SUSPENDED, command.getValue(), command);
     commandDistributionBehavior
         .withKey(suspendKey)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationLifecycleManagementSuspendProcessor.java
@@ -89,7 +89,7 @@ public final class BatchOperationLifecycleManagementSuspendProcessor
     if (authorizationResult.isLeft()) {
       final Rejection rejection = authorizationResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -173,7 +173,7 @@ public final class BatchOperationLifecycleManagementSuspendProcessor
         RejectionType.INVALID_STATE,
         String.format(
             BATCH_OPERATION_INVALID_STATE_MESSAGE, batchOperationKey, batchOperationStatus));
-    responseWriter.writeRejectionOnCommand(
+    responseWriter.writeRejectedResponseOnCommand(
         command,
         RejectionType.INVALID_STATE,
         String.format(
@@ -192,7 +192,7 @@ public final class BatchOperationLifecycleManagementSuspendProcessor
         command,
         RejectionType.NOT_FOUND,
         String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));
-    responseWriter.writeRejectionOnCommand(
+    responseWriter.writeRejectedResponseOnCommand(
         command,
         RejectionType.NOT_FOUND,
         String.format(BATCH_OPERATION_NOT_FOUND_MESSAGE, batchOperationKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnProcessResultSenderBehavior.java
@@ -70,7 +70,7 @@ public final class BpmnProcessResultSenderBehavior {
         .setTags(context.getTags())
         .setBusinessId(context.getBusinessId());
 
-    responseWriter.writeResponse(
+    responseWriter.writeAcceptedResponse(
         context.getProcessInstanceKey(),
         ProcessInstanceResultIntent.COMPLETED,
         resultRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -468,7 +468,7 @@ public final class BpmnUserTaskBehavior {
             request -> {
               switch (request.valueType()) {
                 case USER_TASK ->
-                    responseWriter.writeRejection(
+                    responseWriter.writeRejectedResponse(
                         userTask.getUserTaskKey(),
                         request.intent(),
                         userTask,
@@ -482,7 +482,7 @@ public final class BpmnUserTaskBehavior {
                         .findVariableDocumentState(userTaskElementInstanceKey)
                         .ifPresent(
                             variableDocument -> {
-                              responseWriter.writeRejection(
+                              responseWriter.writeRejectedResponse(
                                   variableDocument.getKey(),
                                   request.intent(),
                                   variableDocument.getRecord(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
@@ -87,7 +87,8 @@ public final class ClockPinProcessor implements DistributedTypedRecordProcessor<
     final long eventKey = keyGenerator.nextKey();
     applyClockModification(eventKey, clockRecord);
     if (command.hasRequestMetadata()) {
-      responseWriter.writeEventOnCommand(eventKey, ClockIntent.PINNED, clockRecord, command);
+      responseWriter.writeAcceptedResponseOnCommand(
+          eventKey, ClockIntent.PINNED, clockRecord, command);
     }
 
     // Distribute to other partitions

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
@@ -67,7 +67,7 @@ public final class ClockPinProcessor implements DistributedTypedRecordProcessor<
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -78,7 +78,7 @@ public final class ClockPinProcessor implements DistributedTypedRecordProcessor<
           "Expected pin time to be not negative but it was %d".formatted(clockRecord.getTime());
 
       rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, rejectionMessage);
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.INVALID_ARGUMENT, rejectionMessage);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
@@ -65,7 +65,7 @@ public final class ClockResetProcessor implements DistributedTypedRecordProcesso
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockResetProcessor.java
@@ -74,7 +74,8 @@ public final class ClockResetProcessor implements DistributedTypedRecordProcesso
     final long eventKey = keyGenerator.nextKey();
     applyClockModification(eventKey, clockRecord);
     if (command.hasRequestMetadata()) {
-      responseWriter.writeEventOnCommand(eventKey, ClockIntent.RESETTED, clockRecord, command);
+      responseWriter.writeAcceptedResponseOnCommand(
+          eventKey, ClockIntent.RESETTED, clockRecord, command);
     }
 
     // Distribute to other partitions

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -76,7 +76,7 @@ public class ClusterVariableCreateProcessor
               writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
               writers
                   .response()
-                  .writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+                  .writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableCreateProcessor.java
@@ -65,7 +65,7 @@ public class ClusterVariableCreateProcessor
                   .appendFollowUpEvent(key, ClusterVariableIntent.CREATED, clusterVariableRecord);
               writers
                   .response()
-                  .writeEventOnCommand(
+                  .writeAcceptedResponseOnCommand(
                       key, ClusterVariableIntent.CREATED, clusterVariableRecord, command);
               commandDistributionBehavior
                   .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -64,7 +64,7 @@ public class ClusterVariableDeleteProcessor
                   .appendFollowUpEvent(key, ClusterVariableIntent.DELETED, clusterVariableRecord);
               writers
                   .response()
-                  .writeEventOnCommand(
+                  .writeAcceptedResponseOnCommand(
                       key, ClusterVariableIntent.DELETED, clusterVariableRecord, command);
               commandDistributionBehavior
                   .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableDeleteProcessor.java
@@ -75,7 +75,7 @@ public class ClusterVariableDeleteProcessor
               writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
               writers
                   .response()
-                  .writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+                  .writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -75,7 +75,7 @@ public class ClusterVariableUpdateProcessor
               writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
               writers
                   .response()
-                  .writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+                  .writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clustervariable/ClusterVariableUpdateProcessor.java
@@ -64,7 +64,7 @@ public class ClusterVariableUpdateProcessor
                   .appendFollowUpEvent(key, ClusterVariableIntent.UPDATED, clusterVariableRecord);
               writers
                   .response()
-                  .writeEventOnCommand(
+                  .writeAcceptedResponseOnCommand(
                       key, ClusterVariableIntent.UPDATED, clusterVariableRecord, command);
               commandDistributionBehavior
                   .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -134,7 +134,7 @@ public class ConditionalEvaluationEvaluateProcessor
     final long eventKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(eventKey, ConditionalEvaluationIntent.EVALUATED, record);
 
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         eventKey, ConditionalEvaluationIntent.EVALUATED, record, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -93,7 +93,8 @@ public class ConditionalEvaluationEvaluateProcessor
       final var failureMessage =
           USER_NOT_ASSIGNED_TO_TENANT_MESSAGE.formatted(record.getTenantId());
       rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, failureMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, failureMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.FORBIDDEN, failureMessage);
       return;
     }
 
@@ -104,7 +105,8 @@ public class ConditionalEvaluationEvaluateProcessor
       final var failureMessage =
           NO_PROCESS_DEFINITION_FOUND_MESSAGE.formatted(processDefinitionKey);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, failureMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, failureMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.NOT_FOUND, failureMessage);
       return;
     }
 
@@ -144,7 +146,7 @@ public class ConditionalEvaluationEvaluateProcessor
     if (error instanceof final ForbiddenException exception) {
       rejectionWriter.appendRejection(
           command, exception.getRejectionType(), exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, exception.getRejectionType(), exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -239,7 +239,7 @@ public final class DeploymentCreateProcessor
     }
 
     final var recordWithoutResource = createDeploymentWithoutResources(deploymentEvent);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         key, DeploymentIntent.CREATED, recordWithoutResource, command);
     stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, recordWithoutResource);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -156,7 +156,7 @@ public final class DeploymentCreateProcessor
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -190,13 +190,13 @@ public final class DeploymentCreateProcessor
     if (error instanceof final ResourceTransformationFailedException exception) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_ARGUMENT, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     } else if (error instanceof final TimerCreationFailedException exception) {
       rejectionWriter.appendRejection(
           command, RejectionType.PROCESSING_ERROR, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.PROCESSING_ERROR, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateProcessor.java
@@ -83,7 +83,7 @@ public class DecisionEvaluationEvaluateProcessor
                 ? AuthorizationCheckBehavior.NOT_FOUND_ERROR_MESSAGE.formatted(
                     "evaluate a decision", record.getDecisionKey(), "such decision")
                 : rejection.reason();
-        responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+        responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), errorMessage);
         rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
         return;
       }
@@ -121,7 +121,7 @@ public class DecisionEvaluationEvaluateProcessor
             },
             rejection -> {
               final String reason = rejection.reason();
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), reason);
+              responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), reason);
               rejectionWriter.appendRejection(command, rejection.type(), reason);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateProcessor.java
@@ -113,7 +113,7 @@ public class DecisionEvaluationEvaluateProcessor
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),
                   evaluationRecordTuple.getRight());
-              responseWriter.writeEventOnCommand(
+              responseWriter.writeAcceptedResponseOnCommand(
                   evaluationRecordKey,
                   evaluationRecordTuple.getLeft(),
                   evaluationRecordTuple.getRight(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -145,6 +145,7 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
       final TypedRecord<ExpressionRecord> command, final ExpressionRecord resolvedValue) {
     final var key = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(key, ExpressionIntent.EVALUATED, resolvedValue);
-    responseWriter.writeEventOnCommand(key, ExpressionIntent.EVALUATED, resolvedValue, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        key, ExpressionIntent.EVALUATED, resolvedValue, command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/ExpressionEvaluateProcessor.java
@@ -138,7 +138,7 @@ public final class ExpressionEvaluateProcessor implements TypedRecordProcessor<E
   private void rejectCommand(
       final TypedRecord<ExpressionRecord> command, final Rejection rejection) {
     rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-    responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+    responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
   }
 
   private void acceptCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
@@ -71,7 +71,7 @@ public final class GlobalListenerCreateProcessor
 
     writers
         .response()
-        .writeEventOnCommand(
+        .writeAcceptedResponseOnCommand(
             record.getGlobalListenerKey(), GlobalListenerIntent.CREATED, record, command);
 
     // Note: the configuration key is used as the command key for distribution, ensuring

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerCreateProcessor.java
@@ -56,7 +56,9 @@ public final class GlobalListenerCreateProcessor
     if (validRecord.isLeft()) {
       final var rejection = validRecord.getLeft();
       writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
-      writers.response().writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      writers
+          .response()
+          .writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
@@ -56,7 +56,9 @@ public final class GlobalListenerDeleteProcessor
     if (validRecord.isLeft()) {
       final var rejection = validRecord.getLeft();
       writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
-      writers.response().writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      writers
+          .response()
+          .writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerDeleteProcessor.java
@@ -69,7 +69,7 @@ public final class GlobalListenerDeleteProcessor
 
     writers
         .response()
-        .writeEventOnCommand(
+        .writeAcceptedResponseOnCommand(
             record.getGlobalListenerKey(), GlobalListenerIntent.DELETED, record, command);
 
     // Note: the configuration key is used as the command key for distribution, ensuring

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
@@ -56,7 +56,9 @@ public final class GlobalListenerUpdateProcessor
     if (validRecord.isLeft()) {
       final var rejection = validRecord.getLeft();
       writers.rejection().appendRejection(command, rejection.type(), rejection.reason());
-      writers.response().writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      writers
+          .response()
+          .writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/globallistener/GlobalListenerUpdateProcessor.java
@@ -69,7 +69,7 @@ public final class GlobalListenerUpdateProcessor
 
     writers
         .response()
-        .writeEventOnCommand(
+        .writeAcceptedResponseOnCommand(
             record.getGlobalListenerKey(), GlobalListenerIntent.UPDATED, record, command);
 
     // Note: the configuration key is used as the command key for distribution, ensuring

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -146,7 +146,7 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
       final HistoryDeletionRecord recordValue, final TypedRecord<HistoryDeletionRecord> command) {
     stateWriter.appendFollowUpEvent(
         recordValue.getResourceKey(), HistoryDeletionIntent.DELETED, recordValue);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         recordValue.getResourceKey(), HistoryDeletionIntent.DELETED, recordValue, command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/historydeletion/HistoryDeletionDeleteProcessor.java
@@ -74,7 +74,8 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
             validRecord -> writeHistoryDeletionEvent(recordValue, command),
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 
@@ -95,7 +96,8 @@ public class HistoryDeletionDeleteProcessor implements TypedRecordProcessor<Hist
             validRecord -> writeHistoryDeletionEvent(recordValue, command),
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -128,7 +128,7 @@ public class AuthorizationCreateProcessor
         authorizationRecord.getResourceType());
     authorizationRecord.setAuthorizationKey(key);
     stateWriter.appendFollowUpEvent(key, AuthorizationIntent.CREATED, authorizationRecord);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         key, AuthorizationIntent.CREATED, authorizationRecord, command);
     distributionBehavior
         .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -88,7 +88,8 @@ public class AuthorizationCreateProcessor
             (rejection) -> {
               LOG.debug("Rejecting CREATE authorization command: {}", rejection.reason());
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -154,7 +154,7 @@ public class AuthorizationDeleteProcessor
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
         .distribute(command);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         authorizationKey, AuthorizationIntent.DELETED, command.getValue(), command);
     sideEffectWriter.appendSideEffect(
         () -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -94,7 +94,8 @@ public class AuthorizationDeleteProcessor
             (rejection) -> {
               LOG.debug("Rejecting DELETE authorization command: {}", rejection.reason());
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -93,7 +93,8 @@ public class AuthorizationUpdateProcessor
             (rejection) -> {
               LOG.debug("Rejecting UPDATE authorization command: {}", rejection.reason());
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -137,7 +137,7 @@ public class AuthorizationUpdateProcessor
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
         .distribute(command);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         authorizationRecord.getAuthorizationKey(),
         AuthorizationIntent.UPDATED,
         authorizationRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -114,7 +114,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     }
 
     stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_ADDED, record);
-    responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_ADDED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        groupKey, GroupIntent.ENTITY_ADDED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -77,7 +77,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -88,7 +88,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
           "Expected to update group with ID '%s', but a group with this ID does not exist."
               .formatted(groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -100,7 +100,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
           "Expected to add an entity with ID '%s' and type '%s' to group with ID '%s', but the entity does not exist."
               .formatted(entityId, entityType, groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -109,7 +109,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
           ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(
               record.getEntityId(), record.getGroupId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -61,7 +61,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -71,7 +71,8 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
     if (persistedGroup.isPresent()) {
       final var errorMessage = GROUP_ALREADY_EXISTS_ERROR_MESSAGE.formatted(groupId);
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -79,7 +79,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
     record.setGroupKey(key);
 
     stateWriter.appendFollowUpEvent(key, GroupIntent.CREATED, record);
-    responseWriter.writeEventOnCommand(key, GroupIntent.CREATED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(key, GroupIntent.CREATED, record, command);
 
     commandDistributionBehavior
         .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -94,7 +94,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
     deleteAuthorizations(record);
 
     stateWriter.appendFollowUpEvent(groupKey, GroupIntent.DELETED, record);
-    responseWriter.writeEventOnCommand(groupKey, GroupIntent.DELETED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(groupKey, GroupIntent.DELETED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -74,7 +74,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -82,7 +82,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
     if (persistedRecord.isEmpty()) {
       final var errorMessage = GROUP_NOT_FOUND_ERROR_MESSAGE.formatted(groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -71,7 +71,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -81,7 +81,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
           "Expected to update group with ID '%s', but a group with this ID does not exist."
               .formatted(groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -92,7 +92,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
           "Expected to remove an entity with ID '%s' and type '%s' from group with ID '%s', but the entity does not exist."
               .formatted(entityId, entityType, groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -100,7 +100,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
       final var errorMessage =
           ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getGroupId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -106,7 +106,8 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
     final var groupKey = persistedRecord.get().getGroupKey();
     stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_REMOVED, record);
-    responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_REMOVED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        groupKey, GroupIntent.ENTITY_REMOVED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -115,7 +115,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
 
     stateWriter.appendFollowUpEvent(
         persistedGroup.getGroupKey(), GroupIntent.UPDATED, updatedRecord);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         persistedGroup.getGroupKey(), GroupIntent.UPDATED, updatedRecord, command);
     commandDistributionBehavior.acknowledgeCommand(command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -62,7 +62,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -72,7 +72,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
           "Expected to update group with ID '%s', but a group with this ID does not exist."
               .formatted(groupId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -66,7 +66,7 @@ public class MappingRuleCreateProcessor
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -86,7 +86,7 @@ public class MappingRuleCreateProcessor
               record.getName(),
               record.getMappingRuleId());
       rejectionWriter.appendRejection(command, RejectionType.NULL_VAL, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NULL_VAL, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NULL_VAL, errorMessage);
       return;
     }
 
@@ -97,7 +97,8 @@ public class MappingRuleCreateProcessor
           MAPPING_RULE_SAME_CLAIM_ALREADY_EXISTS_ERROR_MESSAGE.formatted(
               record.getClaimName(), record.getClaimValue());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 
@@ -106,7 +107,8 @@ public class MappingRuleCreateProcessor
       final var errorMessage =
           MAPPING_RULE_SAME_ID_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getMappingRuleId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -114,7 +114,7 @@ public class MappingRuleCreateProcessor
     record.setMappingRuleKey(key);
 
     stateWriter.appendFollowUpEvent(key, MappingRuleIntent.CREATED, record);
-    responseWriter.writeEventOnCommand(key, MappingRuleIntent.CREATED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(key, MappingRuleIntent.CREATED, record, command);
 
     commandDistributionBehavior
         .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -90,7 +90,7 @@ public class MappingRuleDeleteProcessor
     if (persistedMappingRuleOptional.isEmpty()) {
       final var errorMessage = MAPPING_RULE_NOT_FOUND_ERROR_MESSAGE.formatted(id);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -100,7 +100,7 @@ public class MappingRuleDeleteProcessor
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
     final long key = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -105,7 +105,7 @@ public class MappingRuleDeleteProcessor
     }
     final long key = keyGenerator.nextKey();
     deleteMappingRule(persistedMappingRuleOptional.get(), key);
-    responseWriter.writeEventOnCommand(key, MappingRuleIntent.DELETED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(key, MappingRuleIntent.DELETED, record, command);
 
     commandDistributionBehavior
         .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -113,7 +113,7 @@ public class MappingRuleUpdateProcessor
     }
 
     stateWriter.appendFollowUpEvent(record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         record.getMappingRuleKey(), MappingRuleIntent.UPDATED, record, command);
 
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -77,7 +77,7 @@ public class MappingRuleUpdateProcessor
               record.getName(),
               record.getMappingRuleId());
       rejectionWriter.appendRejection(command, RejectionType.NULL_VAL, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NULL_VAL, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NULL_VAL, errorMessage);
       return;
     }
 
@@ -86,7 +86,7 @@ public class MappingRuleUpdateProcessor
       final var errorMessage =
           MAPPING_RULE_ID_DOES_NOT_EXIST_ERROR_MESSAGE.formatted(mappingRuleId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -96,7 +96,7 @@ public class MappingRuleUpdateProcessor
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -108,7 +108,8 @@ public class MappingRuleUpdateProcessor
           MAPPING_RULE_SAME_CLAIM_ALREADY_EXISTS_ERROR_MESSAGE.formatted(
               record.getClaimName(), record.getClaimValue());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -116,7 +116,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     }
 
     stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.ENTITY_ADDED, record);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         record.getRoleKey(), RoleIntent.ENTITY_ADDED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -85,7 +85,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -93,7 +93,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     if (persistedRecord.isEmpty()) {
       final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -103,7 +103,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       final var errorMessage =
           ENTITY_NOT_FOUND_ERROR_MESSAGE.formatted(entityId, entityType, record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -111,7 +111,8 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
       final var errorMessage =
           ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -60,7 +60,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -69,7 +69,8 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
     if (persistedRole.isPresent()) {
       final var errorMessage = ROLE_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
     }
     final long key = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -76,7 +76,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
     record.setRoleKey(key);
 
     stateWriter.appendFollowUpEvent(key, RoleIntent.CREATED, record);
-    responseWriter.writeEventOnCommand(key, RoleIntent.CREATED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(key, RoleIntent.CREATED, record, command);
 
     commandDistributionBehavior
         .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -105,7 +105,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     deleteAuthorizations(record);
 
     stateWriter.appendFollowUpEvent(roleKey, RoleIntent.DELETED, record);
-    responseWriter.writeEventOnCommand(roleKey, RoleIntent.DELETED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(roleKey, RoleIntent.DELETED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -78,14 +78,15 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
     if (roleId != null && DefaultRole.ids().contains(roleId)) {
       final var errorMessage = ROLE_PROTECTED_ERROR_MESSAGE.formatted(roleId);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.INVALID_STATE, errorMessage);
       return;
     }
 
@@ -93,7 +94,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     if (persistedRecord.isEmpty()) {
       final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(roleId);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -79,7 +79,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -87,7 +87,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     if (persistedRecord.isEmpty()) {
       final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -97,7 +97,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
       final var errorMessage =
           ENTITY_NOT_FOUND_ERROR_MESSAGE.formatted(entityId, entityType, record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 
@@ -105,7 +105,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
       final var errorMessage =
           ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(record.getEntityId(), record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -110,7 +110,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     }
 
     stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         record.getRoleKey(), RoleIntent.ENTITY_REMOVED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -87,7 +87,8 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
     final var persistedRole = persistedRecord.get();
     record.setRoleKey(persistedRole.getRoleKey());
     stateWriter.appendFollowUpEvent(record.getRoleKey(), RoleIntent.UPDATED, record);
-    responseWriter.writeEventOnCommand(record.getRoleKey(), RoleIntent.UPDATED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        record.getRoleKey(), RoleIntent.UPDATED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -65,14 +65,15 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
     if (roleId != null && DefaultRole.ids().contains(roleId)) {
       final var errorMessage = ROLE_PROTECTED_ERROR_MESSAGE.formatted(record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.INVALID_STATE, errorMessage);
       return;
     }
 
@@ -80,7 +81,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
     if (persistedRecord.isEmpty()) {
       final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -135,7 +135,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
     }
 
     stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
-    responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
+    responseWriter.writeAcceptedResponseOnCommand(key, IncidentIntent.RESOLVED, incident, command);
     incidentMetrics.incidentResolved();
 
     publishIncidentRelatedJob(jobKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -150,7 +150,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
       final RejectionType rejectionType) {
 
     rejectionWriter.appendRejection(command, rejectionType, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, errorMessage);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, errorMessage);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -183,7 +183,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
   private void rejectCommand(final TypedRecord<JobBatchRecord> record, final Rejection rejection) {
     rejectionWriter.appendRejection(record, rejection.type(), rejection.reason());
-    responseWriter.writeRejectionOnCommand(record, rejection.type(), rejection.reason());
+    responseWriter.writeRejectedResponseOnCommand(record, rejection.type(), rejection.reason());
   }
 
   private void activateJobBatch(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -192,7 +192,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final long jobBatchKey,
       final Map<JobKind, Integer> activatedJobsCountPerJobKind) {
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
-    responseWriter.writeEventOnCommand(jobBatchKey, JobBatchIntent.ACTIVATED, value, record);
+    responseWriter.writeAcceptedResponseOnCommand(
+        jobBatchKey, JobBatchIntent.ACTIVATED, value, record);
     activatedJobsCountPerJobKind.forEach(
         (jobKind, count) ->
             jobMetrics.countJobEvent(JobAction.ACTIVATED, jobKind, value.getType(), count));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -219,7 +219,8 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     job.setResult(command.getValue().getResult());
 
     stateWriter.appendFollowUpEvent(command.getKey(), JobIntent.COMPLETED, job);
-    responseWriter.writeEventOnCommand(command.getKey(), JobIntent.COMPLETED, job, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        command.getKey(), JobIntent.COMPLETED, job, command);
 
     if (job.isAgentic()) {
       commandWriter.appendFollowUpCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -201,7 +201,8 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
             job -> completeJob(record, job, session),
             rejection -> {
               rejectionWriter.appendRejection(record, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(record, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  record, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -140,7 +140,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
           });
     }
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.FAILED, failedJob);
-    responseWriter.writeEventOnCommand(jobKey, JobIntent.FAILED, failedJob, record);
+    responseWriter.writeAcceptedResponseOnCommand(jobKey, JobIntent.FAILED, failedJob, record);
     jobMetrics.countJobEvent(JobAction.FAILED, failedJob.getJobKind(), failedJob.getType());
 
     setFailedVariables(failedJob);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -114,7 +114,8 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
             failedJob -> failJob(record, failedJob),
             rejection -> {
               rejectionWriter.appendRejection(record, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(record, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  record, rejection.type(), rejection.reason());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -217,7 +217,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
   private void writeThrowErrorEvent(
       final long jobKey, final JobRecord job, final TypedRecord<JobRecord> command) {
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.ERROR_THROWN, job);
-    responseWriter.writeEventOnCommand(jobKey, JobIntent.ERROR_THROWN, job, command);
+    responseWriter.writeAcceptedResponseOnCommand(jobKey, JobIntent.ERROR_THROWN, job, command);
     jobMetrics.countJobEvent(JobAction.ERROR_THROWN, job.getJobKind(), job.getType());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -140,7 +140,8 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
             job -> throwError(record, job),
             rejection -> {
               rejectionWriter.appendRejection(record, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(record, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  record, rejection.type(), rejection.reason());
             });
   }
 
@@ -159,7 +160,8 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
       final var errorMessage =
           ERROR_REJECTION_MESSAGE.formatted(jobKind, jobKey, job.getType(), processInstanceKey);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.INVALID_STATE, errorMessage);
       return;
     }
 
@@ -185,7 +187,8 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
       final var errorMessage =
           "Expected to find active element instance, but was %s".formatted(elementInstance);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.INVALID_STATE, errorMessage);
     } else if (!eventScopeInstanceState.canTriggerEvent(
         foundCatchEvent.get().getElementInstance().getKey(),
         foundCatchEvent.get().getCatchEvent().getId())) {
@@ -194,7 +197,8 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
           "Expected to find event scope that is accepting events, but was %s"
               .formatted(catchEventInstance);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.INVALID_STATE, errorMessage);
     } else {
       writeThrowErrorEvent(jobKey, job, command);
       eventPublicationBehavior.throwErrorEvent(foundCatchEvent.get(), job.getVariablesBuffer());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -72,7 +72,8 @@ public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
               }
 
               stateWriter.appendFollowUpEvent(jobKey, JobIntent.UPDATED, job);
-              responseWriter.writeEventOnCommand(jobKey, JobIntent.UPDATED, job, command);
+              responseWriter.writeAcceptedResponseOnCommand(
+                  jobKey, JobIntent.UPDATED, job, command);
             },
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -77,13 +77,15 @@ public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
             },
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 
   private void handleRejection(final List<String> errors, final TypedRecord<JobRecord> command) {
     final String errorMessage = String.join(", ", errors);
     rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, errorMessage);
+    responseWriter.writeRejectedResponseOnCommand(
+        command, RejectionType.INVALID_ARGUMENT, errorMessage);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -47,7 +47,7 @@ public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<Job
                         errorMessage -> {
                           rejectionWriter.appendRejection(
                               command, RejectionType.INVALID_ARGUMENT, errorMessage);
-                          responseWriter.writeRejectionOnCommand(
+                          responseWriter.writeRejectedResponseOnCommand(
                               command, RejectionType.INVALID_ARGUMENT, errorMessage);
                         },
                         () ->
@@ -55,7 +55,8 @@ public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<Job
                                 jobKey, JobIntent.RETRIES_UPDATED, job, command)),
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -51,7 +51,7 @@ public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<Job
                               command, RejectionType.INVALID_ARGUMENT, errorMessage);
                         },
                         () ->
-                            responseWriter.writeEventOnCommand(
+                            responseWriter.writeAcceptedResponseOnCommand(
                                 jobKey, JobIntent.RETRIES_UPDATED, job, command)),
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -51,7 +51,7 @@ public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord
                               command, RejectionType.INVALID_STATE, errorMessage);
                         },
                         () ->
-                            responseWriter.writeEventOnCommand(
+                            responseWriter.writeAcceptedResponseOnCommand(
                                 jobKey, JobIntent.TIMEOUT_UPDATED, job, command)),
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -47,7 +47,7 @@ public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord
                         errorMessage -> {
                           rejectionWriter.appendRejection(
                               command, RejectionType.INVALID_STATE, errorMessage);
-                          responseWriter.writeRejectionOnCommand(
+                          responseWriter.writeRejectedResponseOnCommand(
                               command, RejectionType.INVALID_STATE, errorMessage);
                         },
                         () ->
@@ -55,7 +55,8 @@ public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord
                                 jobKey, JobIntent.TIMEOUT_UPDATED, job, command)),
             rejection -> {
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, rejection.type(), rejection.reason());
             });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -194,7 +194,7 @@ public final class MessageCorrelationCorrelateProcessor
 
               stateWriter.appendFollowUpEvent(
                   messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
-              responseWriter.writeEventOnCommand(
+              responseWriter.writeAcceptedResponseOnCommand(
                   messageKey,
                   MessageCorrelationIntent.CORRELATED,
                   messageCorrelationRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -116,7 +116,7 @@ public final class MessageCorrelationCorrelateProcessor
             "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
                 .formatted(messageCorrelationRecord.getTenantId());
         rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
-        responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
+        responseWriter.writeRejectedResponseOnCommand(command, RejectionType.FORBIDDEN, message);
         return;
       }
     }
@@ -144,7 +144,7 @@ public final class MessageCorrelationCorrelateProcessor
     if (authorizationRejectionOptional.isPresent()) {
       final var rejection = authorizationRejectionOptional.get();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -181,7 +181,7 @@ public final class MessageCorrelationCorrelateProcessor
                 command.getValue().getName(), command.getValue().getCorrelationKey());
       }
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -173,7 +173,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     messageRecord.setDeadline(command.getTimestamp() + messageRecord.getTimeToLive());
 
     stateWriter.appendFollowUpEvent(messageKey, MessageIntent.PUBLISHED, command.getValue());
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         messageKey, MessageIntent.PUBLISHED, command.getValue(), command);
 
     final var correlatingSubscriptions = new Subscriptions();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -123,7 +123,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       if (isAuthorized.isLeft()) {
         final var rejection = isAuthorized.getLeft();
         rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-        responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+        responseWriter.writeRejectedResponseOnCommand(
+            command, rejection.type(), rejection.reason());
         return;
       }
     }
@@ -135,7 +136,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       if (validation.isLeft()) {
         final String reason = validation.getLeft().reason();
         rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
-        responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
+        responseWriter.writeRejectedResponseOnCommand(
+            command, RejectionType.INVALID_ARGUMENT, reason);
         return;
       }
     }
@@ -144,7 +146,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
       final var reason =
           "The message has not been routed to the right partition. This is probably a temporary issue, please retry in a few seconds";
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, reason);
       return;
     }
 
@@ -159,7 +161,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
               ALREADY_PUBLISHED_MESSAGE, bufferAsString(messageRecord.getMessageIdBuffer()));
 
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, rejectionReason);
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.ALREADY_EXISTS, rejectionReason);
     } else {
       handleNewMessage(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -152,7 +152,7 @@ public final class MessageSubscriptionCorrelateProcessor
 
       stateWriter.appendFollowUpEvent(
           messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
-      responseWriter.writeResponse(
+      responseWriter.writeAcceptedResponse(
           record.getValue().getMessageKey(),
           MessageCorrelationIntent.CORRELATED,
           messageCorrelationRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -138,7 +138,7 @@ public final class MessageSubscriptionRejectProcessor
 
       stateWriter.appendFollowUpEvent(
           messageKey, MessageCorrelationIntent.NOT_CORRELATED, messageCorrelationRecord);
-      responseWriter.writeRejection(
+      responseWriter.writeRejectedResponseOnCommand(
           record,
           RejectionType.NOT_FOUND,
           SUBSCRIPTION_NOT_FOUND.formatted(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -89,7 +89,7 @@ public class ProcessInstanceBusinessIdAssignProcessor
             decision -> {
               assignmentBehavior.enrich(value, processInstanceRecord);
               assignmentBehavior.appendAssignedEvent(processInstanceKey, value);
-              responseWriter.writeEventOnCommand(
+              responseWriter.writeAcceptedResponseOnCommand(
                   processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
             },
             rejection -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -132,7 +132,7 @@ public class ProcessInstanceBusinessIdAssignProcessor
       final RejectionType rejectionType,
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -97,7 +97,7 @@ public final class ProcessInstanceCancelProcessor
           command,
           RejectionType.NOT_FOUND,
           String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command,
           RejectionType.NOT_FOUND,
           String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
@@ -124,7 +124,7 @@ public final class ProcessInstanceCancelProcessor
               : rejection.reason();
       enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), errorMessage);
       return false;
     }
 
@@ -138,7 +138,7 @@ public final class ProcessInstanceCancelProcessor
           command,
           RejectionType.INVALID_STATE,
           String.format(PROCESS_NOT_ROOT_MESSAGE, command.getKey(), rootProcessInstanceKey));
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command,
           RejectionType.INVALID_STATE,
           String.format(PROCESS_NOT_ROOT_MESSAGE, command.getKey(), rootProcessInstanceKey));
@@ -152,7 +152,7 @@ public final class ProcessInstanceCancelProcessor
       final String reason = String.format(PROCESS_CANCEL_IN_PROGRESS_MESSAGE, command.getKey());
       enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, reason);
       return false;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -83,7 +83,7 @@ public final class ProcessInstanceCancelProcessor
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.CANCELING, value);
     commandWriter.appendFollowUpCommand(
         command.getKey(), ProcessInstanceIntent.TERMINATE_ELEMENT, value);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.ELEMENT_TERMINATING, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCommandContext.java
@@ -61,7 +61,7 @@ public final class ProcessInstanceCommandContext {
 
   public void reject(final RejectionType rejectionType, final String reason) {
     writers.rejection().appendRejection(record, rejectionType, reason);
-    writers.response().writeRejectionOnCommand(record, rejectionType, reason);
+    writers.response().writeRejectedResponseOnCommand(record, rejectionType, reason);
   }
 
   public TypedCommandWriter getCommandWriter() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -137,7 +137,7 @@ public final class ProcessInstanceCreationCreateProcessor
     if (command.hasRequestMetadata()) {
       // set variables back to return them in the response
       record.setVariables(variablesBuffer);
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           entityKey, ProcessInstanceCreationIntent.CREATED, record, command);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -82,7 +82,7 @@ public final class ProcessInstanceCreationCreateProcessor
       // This exception is only thrown for ProcessInstanceCreationRecord with start instructions
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
@@ -95,7 +95,7 @@ public final class ProcessInstanceCreationCreateProcessor
       final String reason) {
     rejectionWriter.appendRejection(command, type, reason);
     if (command.hasRequestMetadata()) {
-      responseWriter.writeRejectionOnCommand(command, type, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, type, reason);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithAwaitingResultProcessor.java
@@ -86,7 +86,7 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
       // This exception is only thrown for ProcessInstanceCreationRecord with start instructions
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
@@ -99,7 +99,7 @@ public final class ProcessInstanceCreationCreateWithAwaitingResultProcessor
       final String reason) {
     rejectionWriter.appendRejection(command, type, reason);
     if (command.hasRequestMetadata()) {
-      responseWriter.writeRejectionOnCommand(command, type, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, type, reason);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -160,7 +160,7 @@ public class ProcessInstanceMigrationMigrateProcessor
               : rejection.reason();
       enrichRejectionCommand(command, processInstanceRecord);
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), errorMessage);
       return;
     }
 
@@ -212,14 +212,14 @@ public class ProcessInstanceMigrationMigrateProcessor
     if (error instanceof final ProcessInstanceMigrationPreconditionFailedException e) {
       enrichRejectionCommand(command);
       rejectionWriter.appendRejection(command, e.getRejectionType(), e.getMessage());
-      responseWriter.writeRejectionOnCommand(command, e.getRejectionType(), e.getMessage());
+      responseWriter.writeRejectedResponseOnCommand(command, e.getRejectionType(), e.getMessage());
       return ProcessingError.EXPECTED_ERROR;
 
     } else if (error instanceof final SafetyCheckFailedException e) {
       LOG.error(e.getMessage(), e);
       enrichRejectionCommand(command);
       rejectionWriter.appendRejection(command, RejectionType.PROCESSING_ERROR, e.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.PROCESSING_ERROR, e.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -201,7 +201,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     value.setBpmnProcessId(processInstanceRecord.getBpmnProcessId());
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -237,7 +237,7 @@ public final class ProcessInstanceModificationModifyProcessor
 
     if (processInstance == null) {
       final String reason = String.format(ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND, eventKey);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, reason);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
       return;
     }
@@ -261,7 +261,7 @@ public final class ProcessInstanceModificationModifyProcessor
                   "such process instance")
               : rejection.reason();
       enrichRejectionCommand(command, processInstance.getValue());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), errorMessage);
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
       return;
     }
@@ -280,7 +280,7 @@ public final class ProcessInstanceModificationModifyProcessor
     if (commandValidationResult.isLeft()) {
       final var rejection = commandValidationResult.getLeft();
       enrichRejectionCommand(command, processInstance.getValue());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       return;
     }
@@ -302,7 +302,7 @@ public final class ProcessInstanceModificationModifyProcessor
     if (moveByKeyValidationResult.isLeft()) {
       final var rejection = moveByKeyValidationResult.getLeft();
       enrichRejectionCommand(command, processInstance.getValue());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       return;
     }
@@ -331,7 +331,7 @@ public final class ProcessInstanceModificationModifyProcessor
     if (instructionsValidationResult.isLeft()) {
       final var rejection = instructionsValidationResult.getLeft();
       enrichRejectionCommand(command, processInstance.getValue());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       return;
     }
@@ -404,7 +404,7 @@ public final class ProcessInstanceModificationModifyProcessor
       enrichRejectionCommand(typedCommand);
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
 
@@ -415,7 +415,7 @@ public final class ProcessInstanceModificationModifyProcessor
       enrichRejectionCommand(typedCommand);
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, rejectionReason);
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           typedCommand, RejectionType.INVALID_ARGUMENT, rejectionReason);
       return ProcessingError.EXPECTED_ERROR;
 
@@ -424,14 +424,15 @@ public final class ProcessInstanceModificationModifyProcessor
           ERROR_COMMAND_TOO_LARGE.formatted(typedCommand.getValue().getProcessInstanceKey());
       enrichRejectionCommand(typedCommand);
       rejectionWriter.appendRejection(typedCommand, RejectionType.INVALID_ARGUMENT, message);
-      responseWriter.writeRejectionOnCommand(typedCommand, RejectionType.INVALID_ARGUMENT, message);
+      responseWriter.writeRejectedResponseOnCommand(
+          typedCommand, RejectionType.INVALID_ARGUMENT, message);
       return ProcessingError.EXPECTED_ERROR;
 
     } else if (error instanceof final TerminatedChildProcessException exception) {
       enrichRejectionCommand(typedCommand);
       rejectionWriter.appendRejection(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           typedCommand, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
 
@@ -441,7 +442,8 @@ public final class ProcessInstanceModificationModifyProcessor
               exception.getBpmnProcessId(), exception.getMultiInstanceId());
       enrichRejectionCommand(typedCommand);
       rejectionWriter.appendRejection(typedCommand, RejectionType.INVALID_ARGUMENT, message);
-      responseWriter.writeRejectionOnCommand(typedCommand, RejectionType.INVALID_ARGUMENT, message);
+      responseWriter.writeRejectedResponseOnCommand(
+          typedCommand, RejectionType.INVALID_ARGUMENT, message);
       return ProcessingError.EXPECTED_ERROR;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -393,7 +393,7 @@ public final class ProcessInstanceModificationModifyProcessor
     stateWriter.appendFollowUpEvent(
         eventKey, ProcessInstanceModificationIntent.MODIFIED, extendedRecord);
 
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         eventKey, ProcessInstanceModificationIntent.MODIFIED, extendedRecord, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -65,7 +65,7 @@ public final class ProcessInstanceResumeProcessor
     // TODO(#57792): append a DRAIN command instead of writing RESUMED directly, once chunked
     // draining of buffered commands is implemented.
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.RESUMED, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -77,7 +77,7 @@ public final class ProcessInstanceResumeProcessor
           command,
           RejectionType.NOT_FOUND,
           String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command,
           RejectionType.NOT_FOUND,
           String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey()));
@@ -104,7 +104,7 @@ public final class ProcessInstanceResumeProcessor
               : rejection.reason();
       enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), errorMessage);
       return false;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -76,7 +76,7 @@ public final class ProcessInstanceSuspendProcessor
     if (elementInstance == null || elementInstance.isTerminating()) {
       final var reason = String.format(PROCESS_NOT_FOUND_MESSAGE, command.getKey());
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, reason);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.NOT_FOUND, reason);
       return false;
     }
 
@@ -100,7 +100,7 @@ public final class ProcessInstanceSuspendProcessor
               : rejection.reason();
       enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), errorMessage);
       return false;
     }
 
@@ -111,7 +111,7 @@ public final class ProcessInstanceSuspendProcessor
       final var reason = String.format(PROCESS_CANCEL_IN_PROGRESS_MESSAGE, command.getKey());
       enrichRejectionCommand(command, elementInstance.getValue());
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, reason);
       return false;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -66,7 +66,7 @@ public final class ProcessInstanceSuspendProcessor
 
     final ProcessInstanceRecord value = elementInstance.getValue();
     stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.SUSPENDED, value);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         command.getKey(), ProcessInstanceIntent.SUSPENDED, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -147,12 +147,12 @@ public class ResourceDeletionDeleteProcessor
     if (error instanceof final ForbiddenException exception) {
       rejectionWriter.appendRejection(
           command, exception.getRejectionType(), exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, exception.getRejectionType(), exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     } else if (error instanceof final NoSuchResourceException exception) {
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.NOT_FOUND, exception.getMessage());
 
       if (command.isCommandDistributed()) {
@@ -164,7 +164,7 @@ public class ResourceDeletionDeleteProcessor
       return ProcessingError.EXPECTED_ERROR;
     } else if (error instanceof final ActiveProcessInstancesException exception) {
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, RejectionType.INVALID_STATE, exception.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -127,7 +127,8 @@ public class ResourceDeletionDeleteProcessor
         .withKey(eventKey)
         .inQueue(DistributionQueue.DEPLOYMENT)
         .distribute(command);
-    responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETED, value, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        eventKey, ResourceDeletionIntent.DELETED, value, command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
@@ -154,7 +154,7 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
       final RejectionType rejectionType,
       final String reason) {
     rejectionWriter.appendRejection(command, rejectionType, reason);
-    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+    responseWriter.writeRejectedResponseOnCommand(command, rejectionType, reason);
     return ProcessingError.EXPECTED_ERROR;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
@@ -61,7 +61,7 @@ public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceReco
               checkAuthorization(command, resource);
               final var record = asResourceRecord(resource);
               stateWriter.appendFollowUpEvent(resourceKey, ResourceIntent.FETCHED, record);
-              responseWriter.writeEventOnCommand(
+              responseWriter.writeAcceptedResponseOnCommand(
                   resourceKey, ResourceIntent.FETCHED, record, command);
             },
             () -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
@@ -155,6 +155,6 @@ public class ScaleMarkPartitionBootstrappedProcessor
   private void rejectWith(
       final TypedRecord<ScaleRecord> command, final RejectionType type, final String reason) {
     rejectionWriter.appendRejection(command, type, reason);
-    responseWriter.writeRejectionOnCommand(command, type, reason);
+    responseWriter.writeRejectedResponseOnCommand(command, type, reason);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleMarkPartitionBootstrappedProcessor.java
@@ -78,7 +78,7 @@ public class ScaleMarkPartitionBootstrappedProcessor
         final var scalingKey = keyGenerator.nextKey();
         final var wasAlreadyBootstrapped = areAllPartitionsBootstrapped();
         stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp);
-        responseWriter.writeEventOnCommand(
+        responseWriter.writeAcceptedResponseOnCommand(
             scalingKey, ScaleIntent.PARTITION_BOOTSTRAPPED, scaleUp, command);
 
         // now the PARTITION_BOOTSTRAPPED event has been applied to the state, let's check if

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleScaleUpProcessor.java
@@ -63,7 +63,8 @@ public class ScaleScaleUpProcessor implements DistributedTypedRecordProcessor<Sc
     final var scalingKey = keyGenerator.nextKey();
     scaleUp.setScalingPosition(command.getPosition());
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALING_UP, scaleUp);
-    responseWriter.writeEventOnCommand(scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);
     commandDistributionBehavior
         .withKey(scalingKey)
         .inQueue(DistributionQueue.SCALING)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleScaleUpProcessor.java
@@ -57,7 +57,7 @@ public class ScaleScaleUpProcessor implements DistributedTypedRecordProcessor<Sc
     if (optionalRejection.isPresent()) {
       final var rejection = optionalRejection.get();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
     final var scalingKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleStatusProcessor.java
@@ -46,7 +46,9 @@ public class ScaleStatusProcessor implements TypedRecordProcessor<ScaleRecord> {
       final var reason =
           "Scaling has not started for the desired partition count " + desiredPartitionCount;
       writers.rejection().appendRejection(command, RejectionType.INVALID_STATE, reason);
-      writers.response().writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
+      writers
+          .response()
+          .writeRejectedResponseOnCommand(command, RejectionType.INVALID_STATE, reason);
     }
     response.statusResponse(
         desiredPartitions.size(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleStatusProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scaling/ScaleStatusProcessor.java
@@ -54,6 +54,8 @@ public class ScaleStatusProcessor implements TypedRecordProcessor<ScaleRecord> {
         routingState.messageCorrelation().partitionCount(),
         routingState.scalingStartedAt(desiredPartitionCount));
     writers.state().appendFollowUpEvent(key, ScaleIntent.STATUS_RESPONSE, response);
-    writers.response().writeEventOnCommand(key, ScaleIntent.STATUS_RESPONSE, response, command);
+    writers
+        .response()
+        .writeAcceptedResponseOnCommand(key, ScaleIntent.STATUS_RESPONSE, response, command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -98,7 +98,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
             "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
                 .formatted(signalRecord.getTenantId());
         rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
-        responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
+        responseWriter.writeRejectedResponseOnCommand(command, RejectionType.FORBIDDEN, message);
         return;
       }
     }
@@ -109,7 +109,8 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
       if (validation.isLeft()) {
         final String reason = validation.getLeft().reason();
         rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
-        responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
+        responseWriter.writeRejectedResponseOnCommand(
+            command, RejectionType.INVALID_ARGUMENT, reason);
         return;
       }
     }
@@ -187,7 +188,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     if (error instanceof final ForbiddenException exception) {
       rejectionWriter.appendRejection(
           command, exception.getRejectionType(), exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
+      responseWriter.writeRejectedResponseOnCommand(
           command, exception.getRejectionType(), exception.getMessage());
       if (command.isCommandDistributed()) {
         // If the command was distributed but doesn't pass auth checks on this partition, we still

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -237,7 +237,8 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
         });
 
     if (command.hasRequestMetadata()) {
-      responseWriter.writeEventOnCommand(eventKey, SignalIntent.BROADCASTED, signalRecord, command);
+      responseWriter.writeAcceptedResponseOnCommand(
+          eventKey, SignalIntent.BROADCASTED, signalRecord, command);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -28,11 +28,12 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   @Override
   public void writeRejectedResponseOnCommand(
       final TypedRecord<?> command, final RejectionType type, final String reason) {
-    writeRejection(command, type, reason, command.getRequestId(), command.getRequestStreamId());
+    writeRejectedResponseOnCommand(
+        command, type, reason, command.getRequestId(), command.getRequestStreamId());
   }
 
   @Override
-  public void writeRejection(
+  public void writeRejectedResponseOnCommand(
       final TypedRecord<?> command,
       final RejectionType type,
       final String reason,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -53,7 +53,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   }
 
   @Override
-  public void writeRejection(
+  public void writeRejectedResponse(
       final long key,
       final Intent intent,
       final UnifiedRecordValue value,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -76,7 +76,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
 
   @Override
   public void writeAcceptedResponse(final TypedRecord<?> event) {
-    writeResponse(
+    writeAcceptedResponse(
         event.getKey(),
         event.getIntent(),
         event.getValue(),
@@ -91,7 +91,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
       final Intent eventState,
       final UnpackedObject eventValue,
       final TypedRecord<?> command) {
-    writeResponse(
+    writeAcceptedResponse(
         eventKey,
         eventState,
         eventValue,
@@ -101,7 +101,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   }
 
   @Override
-  public void writeResponse(
+  public void writeAcceptedResponse(
       final long eventKey,
       final Intent eventState,
       final UnpackedObject eventValue,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -75,7 +75,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   }
 
   @Override
-  public void writeEvent(final TypedRecord<?> event) {
+  public void writeAcceptedResponse(final TypedRecord<?> event) {
     writeResponse(
         event.getKey(),
         event.getIntent(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -86,7 +86,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   }
 
   @Override
-  public void writeEventOnCommand(
+  public void writeAcceptedResponseOnCommand(
       final long eventKey,
       final Intent eventState,
       final UnpackedObject eventValue,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -26,7 +26,7 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   }
 
   @Override
-  public void writeRejectionOnCommand(
+  public void writeRejectedResponseOnCommand(
       final TypedRecord<?> command, final RejectionType type, final String reason) {
     writeRejection(command, type, reason, command.getRequestId(), command.getRequestStreamId());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public interface TypedResponseWriter {
 
-  void writeRejectionOnCommand(TypedRecord<?> command, RejectionType type, String reason);
+  void writeRejectedResponseOnCommand(TypedRecord<?> command, RejectionType type, String reason);
 
   void writeRejection(
       final TypedRecord<?> command,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -25,7 +25,7 @@ public interface TypedResponseWriter {
       final long requestId,
       final int requestStreamId);
 
-  void writeRejection(
+  void writeRejectedResponse(
       final long key,
       final Intent intent,
       final UnifiedRecordValue value,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -37,7 +37,7 @@ public interface TypedResponseWriter {
 
   void writeAcceptedResponse(TypedRecord<?> event);
 
-  void writeEventOnCommand(
+  void writeAcceptedResponseOnCommand(
       long eventKey, Intent eventState, UnpackedObject eventValue, TypedRecord<?> command);
 
   void writeAcceptedResponse(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -35,7 +35,7 @@ public interface TypedResponseWriter {
       final long requestId,
       final int requestStreamId);
 
-  void writeEvent(TypedRecord<?> event);
+  void writeAcceptedResponse(TypedRecord<?> event);
 
   void writeEventOnCommand(
       long eventKey, Intent eventState, UnpackedObject eventValue, TypedRecord<?> command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -18,7 +18,7 @@ public interface TypedResponseWriter {
 
   void writeRejectedResponseOnCommand(TypedRecord<?> command, RejectionType type, String reason);
 
-  void writeRejection(
+  void writeRejectedResponseOnCommand(
       final TypedRecord<?> command,
       final RejectionType type,
       final String reason,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -40,7 +40,7 @@ public interface TypedResponseWriter {
   void writeEventOnCommand(
       long eventKey, Intent eventState, UnpackedObject eventValue, TypedRecord<?> command);
 
-  void writeResponse(
+  void writeAcceptedResponse(
       long eventKey,
       Intent eventState,
       UnpackedObject eventValue,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -224,7 +224,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final String errorMessage) {
     rejectionWriter.appendRejection(command, type, errorMessage);
     if (command.hasRequestMetadata()) {
-      responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, type, errorMessage);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -118,7 +118,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     }
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_ADDED, record);
-    responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_ADDED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        tenantKey, TenantIntent.ENTITY_ADDED, record, command);
     invalidateMembershipCache();
 
     distributeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -127,6 +127,6 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
       final RejectionType type,
       final String errorMessage) {
     rejectionWriter.appendRejection(command, type, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+    responseWriter.writeRejectedResponseOnCommand(command, type, errorMessage);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -105,7 +105,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
     final long key = keyGenerator.nextKey();
     record.setTenantKey(key);
     stateWriter.appendFollowUpEvent(key, TenantIntent.CREATED, record);
-    responseWriter.writeEventOnCommand(key, TenantIntent.CREATED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(key, TenantIntent.CREATED, record, command);
   }
 
   private void distributeCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -149,7 +149,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
       final RejectionType type,
       final String errorMessage) {
     rejectionWriter.appendRejection(command, type, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+    responseWriter.writeRejectedResponseOnCommand(command, type, errorMessage);
   }
 
   private void distributeCommand(final TypedRecord<TenantRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -111,7 +111,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
     deleteAuthorizations(record);
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.DELETED, record);
-    responseWriter.writeEventOnCommand(tenantKey, TenantIntent.DELETED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(tenantKey, TenantIntent.DELETED, record, command);
     invalidateAuthorizationCaches();
 
     distributeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -197,7 +197,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
       final String errorMessage) {
     rejectionWriter.appendRejection(command, type, errorMessage);
     if (command.hasRequestMetadata()) {
-      responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+      responseWriter.writeRejectedResponseOnCommand(command, type, errorMessage);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -99,7 +99,8 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
 
     final var tenantKey = persistedTenant.get().getTenantKey();
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_REMOVED, record);
-    responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_REMOVED, record, command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        tenantKey, TenantIntent.ENTITY_REMOVED, record, command);
     invalidateMembershipCache();
 
     distributeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -121,7 +121,7 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
 
     stateWriter.appendFollowUpEvent(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
 
     final long distributionKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -141,6 +141,6 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
       final RejectionType type,
       final String errorMessage) {
     rejectionWriter.appendRejection(command, type, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+    responseWriter.writeRejectedResponseOnCommand(command, type, errorMessage);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -89,7 +89,7 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
                       .setEntityId(record.getUsername())
                       .setEntityType(EntityType.USER));
               stateWriter.appendFollowUpEvent(key, UserIntent.INITIAL_ADMIN_CREATED, record);
-              responseWriter.writeEventOnCommand(
+              responseWriter.writeAcceptedResponseOnCommand(
                   key, UserIntent.INITIAL_ADMIN_CREATED, record, command);
             },
             message -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -95,7 +95,8 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
             message -> {
               // For this command we always want to reject with FORBIDDEN
               rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
-              responseWriter.writeRejectionOnCommand(command, RejectionType.FORBIDDEN, message);
+              responseWriter.writeRejectedResponseOnCommand(
+                  command, RejectionType.FORBIDDEN, message);
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -87,7 +87,8 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
 
     stateWriter.appendFollowUpEvent(key, UserIntent.CREATED, command.getValue());
     addUserPermissions(key, username);
-    responseWriter.writeEventOnCommand(key, UserIntent.CREATED, command.getValue(), command);
+    responseWriter.writeAcceptedResponseOnCommand(
+        key, UserIntent.CREATED, command.getValue(), command);
 
     distributionBehavior
         .withKey(key)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -68,7 +68,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -78,7 +78,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     if (user.isPresent()) {
       final var message = USER_ALREADY_EXISTS_ERROR_MESSAGE.formatted(user.get().getUsername());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, message);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, message);
+      responseWriter.writeRejectedResponseOnCommand(command, RejectionType.ALREADY_EXISTS, message);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -106,7 +106,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     }
 
     deleteUser(user);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         user.getUserKey(), UserIntent.DELETED, command.getValue(), command);
 
     final long distributionKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -90,7 +90,8 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
       final var rejectionMessage = USER_DOES_NOT_EXIST_ERROR_MESSAGE.formatted(username);
 
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, rejectionMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, rejectionMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.NOT_FOUND, rejectionMessage);
       return;
     }
 
@@ -101,7 +102,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -62,7 +62,8 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
               .formatted(username);
 
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, rejectionMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, rejectionMessage);
+      responseWriter.writeRejectedResponseOnCommand(
+          command, RejectionType.NOT_FOUND, rejectionMessage);
       return;
     }
 
@@ -74,7 +75,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -81,7 +81,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     final var updatedUser = overlayUser(persistedUser.getUser(), record);
 
     stateWriter.appendFollowUpEvent(persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser);
-    responseWriter.writeEventOnCommand(
+    responseWriter.writeAcceptedResponseOnCommand(
         persistedUser.getUserKey(), UserIntent.UPDATED, updatedUser, command);
 
     final long distributionKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -228,7 +228,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   private void handleCommandRejection(
       final TypedRecord<UserTaskRecord> command, final Rejection rejection) {
     rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
-    responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+    responseWriter.writeRejectedResponseOnCommand(command, rejection.type(), rejection.reason());
   }
 
   private Optional<TaskListener> findNextTaskListener(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -264,7 +264,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
             request -> {
               switch (request.valueType()) {
                 case USER_TASK ->
-                    responseWriter.writeRejection(
+                    responseWriter.writeRejectedResponse(
                         command.getKey(),
                         mapDeniedIntentToResponseIntent(intentToWrite),
                         command.getValue(),
@@ -292,7 +292,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
                               final var deniedReason =
                                   USER_TASK_VARIABLE_UPDATE_REJECTION.formatted(
                                       userTaskInstanceKey, command.getValue().getDeniedReason());
-                              responseWriter.writeRejection(
+                              responseWriter.writeRejectedResponse(
                                   variableDocumentKey,
                                   VariableDocumentIntent.UPDATE,
                                   variableDocumentRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -97,7 +97,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
       // Async request might be absent if the assignment transition was triggered internally
       // by Zeebe due to an assignee configured in the process model.
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -104,7 +104,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
 
     final var request = asyncRequest.get();
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-    responseWriter.writeResponse(
+    responseWriter.writeAcceptedResponse(
         userTaskKey,
         UserTaskIntent.ASSIGNED,
         userTaskRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -111,7 +111,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
 
     final var request = asyncRequest.get();
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-    responseWriter.writeResponse(
+    responseWriter.writeAcceptedResponse(
         userTaskKey,
         UserTaskIntent.ASSIGNED,
         userTaskRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -104,7 +104,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
 
     if (asyncRequest.isEmpty()) {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -102,7 +102,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord);
       completeElementInstance(userTaskRecord);
 
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord, command);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -110,7 +110,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
     final var request = asyncRequest.get();
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord);
     completeElementInstance(userTaskRecord);
-    responseWriter.writeResponse(
+    responseWriter.writeAcceptedResponse(
         userTaskKey,
         UserTaskIntent.COMPLETED,
         userTaskRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -125,7 +125,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
     switch (request.valueType()) {
       case USER_TASK -> {
         stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-        responseWriter.writeResponse(
+        responseWriter.writeAcceptedResponse(
             userTaskKey,
             UserTaskIntent.UPDATED,
             userTaskRecord,
@@ -170,7 +170,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
             variableDocumentRecord,
             m -> m.operationReference(request.operationReference()));
 
-        responseWriter.writeResponse(
+        responseWriter.writeAcceptedResponse(
             variableDocumentKey,
             VariableDocumentIntent.UPDATED,
             variableDocumentRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -116,7 +116,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
               + "Please report this as a bug.",
           userTaskKey);
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, userTaskRecord);
-      responseWriter.writeEventOnCommand(
+      responseWriter.writeAcceptedResponseOnCommand(
           userTaskKey, UserTaskIntent.UPDATED, userTaskRecord, command);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -95,7 +95,7 @@ public final class VariableDocumentUpdateProcessor
     if (scope == null || scope.isTerminating() || scope.isInFinalState()) {
       final String reason = String.format(ERROR_MESSAGE_SCOPE_NOT_FOUND, value.getScopeKey());
       writers.rejection().appendRejection(record, RejectionType.NOT_FOUND, reason);
-      writers.response().writeRejectionOnCommand(record, RejectionType.NOT_FOUND, reason);
+      writers.response().writeRejectedResponseOnCommand(record, RejectionType.NOT_FOUND, reason);
       return;
     }
 
@@ -104,7 +104,9 @@ public final class VariableDocumentUpdateProcessor
     if (bannedInstanceCheckResult.isLeft()) {
       final var rejection = bannedInstanceCheckResult.getLeft();
       writers.rejection().appendRejection(record, rejection.type(), rejection.reason());
-      writers.response().writeRejectionOnCommand(record, rejection.type(), rejection.reason());
+      writers
+          .response()
+          .writeRejectedResponseOnCommand(record, rejection.type(), rejection.reason());
       return;
     }
 
@@ -127,7 +129,7 @@ public final class VariableDocumentUpdateProcessor
                   "such element")
               : rejection.reason();
       writers.rejection().appendRejection(record, rejection.type(), errorMessage);
-      writers.response().writeRejectionOnCommand(record, rejection.type(), errorMessage);
+      writers.response().writeRejectedResponseOnCommand(record, rejection.type(), errorMessage);
       return;
     }
 
@@ -139,7 +141,9 @@ public final class VariableDocumentUpdateProcessor
       if (lifecycleState != LifecycleState.CREATED) {
         final var reason = INVALID_USER_TASK_STATE_MESSAGE.formatted(userTaskKey, lifecycleState);
         writers.rejection().appendRejection(record, RejectionType.INVALID_STATE, reason);
-        writers.response().writeRejectionOnCommand(record, RejectionType.INVALID_STATE, reason);
+        writers
+            .response()
+            .writeRejectedResponseOnCommand(record, RejectionType.INVALID_STATE, reason);
         return;
       }
 
@@ -180,7 +184,7 @@ public final class VariableDocumentUpdateProcessor
         writers.rejection().appendRejection(record, RejectionType.INVALID_ARGUMENT, e.getMessage());
         writers
             .response()
-            .writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, e.getMessage());
+            .writeRejectedResponseOnCommand(record, RejectionType.INVALID_ARGUMENT, e.getMessage());
         return;
       }
 
@@ -230,13 +234,15 @@ public final class VariableDocumentUpdateProcessor
               "Expected document to be valid msgpack, but it could not be read: '%s'",
               e.getMessage());
       writers.rejection().appendRejection(record, RejectionType.INVALID_ARGUMENT, reason);
-      writers.response().writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, reason);
+      writers
+          .response()
+          .writeRejectedResponseOnCommand(record, RejectionType.INVALID_ARGUMENT, reason);
       return;
     } catch (final ValidationException e) {
       writers.rejection().appendRejection(record, RejectionType.INVALID_ARGUMENT, e.getMessage());
       writers
           .response()
-          .writeRejectionOnCommand(record, RejectionType.INVALID_ARGUMENT, e.getMessage());
+          .writeRejectedResponseOnCommand(record, RejectionType.INVALID_ARGUMENT, e.getMessage());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -190,7 +190,8 @@ public final class VariableDocumentUpdateProcessor
       writers.state().appendFollowUpEvent(variableDocKey, VariableDocumentIntent.UPDATED, value);
       writers
           .response()
-          .writeEventOnCommand(variableDocKey, VariableDocumentIntent.UPDATED, value, record);
+          .writeAcceptedResponseOnCommand(
+              variableDocKey, VariableDocumentIntent.UPDATED, value, record);
       writers
           .state()
           .appendFollowUpEvent(
@@ -242,7 +243,9 @@ public final class VariableDocumentUpdateProcessor
     final long key = keyGenerator.nextKey();
 
     writers.state().appendFollowUpEvent(key, VariableDocumentIntent.UPDATED, value);
-    writers.response().writeEventOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
+    writers
+        .response()
+        .writeAcceptedResponseOnCommand(key, VariableDocumentIntent.UPDATED, value, record);
   }
 
   public static void mergeVariables(


### PR DESCRIPTION
## Description

Review on #58000 found a processor branch that called only `responseWriter.writeEventOnCommand(...)` and returned, producing no follow-up record at all. The bug wasn't caught by the engine-expert skill's iron rule ("a processor must always end by appending an event or a rejection") because `writeEventOnCommand` reads like an append, even though `TypedResponseWriter` only builds the client's gRPC/REST response and never touches the log.

This PR removes the naming trap at its source instead of only patching the one call site: the whole `TypedResponseWriter` interface is renamed so every method name states both the outcome (accepted/rejected) and that it's response-only.

- `writeEvent` / `writeResponse` → `writeAcceptedResponse` (overloads)
- `writeEventOnCommand` → `writeAcceptedResponseOnCommand`
- `writeRejectionOnCommand`, plus the `TypedRecord`-based `writeRejection` overload → `writeRejectedResponseOnCommand`
- the primitive key-based `writeRejection` overload → `writeRejectedResponse`

Pure rename, no behavior change — verified by compiling `zeebe/engine` and running targeted tests covering every call site where an overload had to be disambiguated by argument shape.

A second commit updates the `engine-expert` skill's `processors.md` so the iron rule explicitly excludes `TypedResponseWriter` calls and covers appending transitively through a behavior class, closing the review gap independent of naming.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

None — internal naming/documentation cleanup following review feedback on #58000.