### PR TITLE
feat: include partitionstate in the topology rest response

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -61,6 +61,7 @@ import io.camunda.gateway.protocol.model.MessageCorrelationResult;
 import io.camunda.gateway.protocol.model.MessagePublicationResult;
 import io.camunda.gateway.protocol.model.Partition.HealthEnum;
 import io.camunda.gateway.protocol.model.Partition.RoleEnum;
+import io.camunda.gateway.protocol.model.Partition.StateEnum;
 import io.camunda.gateway.protocol.model.ProcessInstanceReference;
 import io.camunda.gateway.protocol.model.ResourceResult;
 import io.camunda.gateway.protocol.model.RoleCreateResult;
@@ -910,6 +911,7 @@ public final class ResponseMapper {
                     .partitionId(partition.partitionId())
                     .role(EnumUtil.convert(partition.role(), RoleEnum.class))
                     .health(EnumUtil.convert(partition.health(), HealthEnum.class))
+                    .state(EnumUtil.convert(partition.state(), StateEnum.class))
                     .build())
         .toList();
   }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -125,6 +125,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                                       .partitionId(1)
                                       .role(RoleEnum.LEADER)
                                       .health(HealthEnum.HEALTHY)
+                                      .state(null)
                                       .build()))
                           .version(version)
                           .build(),
@@ -138,6 +139,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                                       .partitionId(1)
                                       .role(RoleEnum.FOLLOWER)
                                       .health(HealthEnum.HEALTHY)
+                                      .state(null)
                                       .build()))
                           .version(version)
                           .build(),
@@ -151,6 +153,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                                       .partitionId(1)
                                       .role(RoleEnum.INACTIVE)
                                       .health(HealthEnum.UNHEALTHY)
+                                      .state(null)
                                       .build()))
                           .version(version)
                           .build()))
@@ -169,21 +172,23 @@ class ClusterToolsTest extends OperationalToolsTest {
                       0,
                       "localhost",
                       26501,
-                      List.of(new TopologyServices.Partition(1, Role.LEADER, Health.HEALTHY)),
+                      List.of(new TopologyServices.Partition(1, Role.LEADER, Health.HEALTHY, null)),
                       version),
                   new Broker(
                       null,
                       1,
                       "localhost",
                       26502,
-                      List.of(new TopologyServices.Partition(1, Role.FOLLOWER, Health.HEALTHY)),
+                      List.of(
+                          new TopologyServices.Partition(1, Role.FOLLOWER, Health.HEALTHY, null)),
                       version),
                   new Broker(
                       null,
                       2,
                       "localhost",
                       26503,
-                      List.of(new TopologyServices.Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
+                      List.of(
+                          new TopologyServices.Partition(1, Role.INACTIVE, Health.UNHEALTHY, null)),
                       version)),
               "cluster-id",
               3,

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/cluster/ClusterToolsTest.java
@@ -17,6 +17,7 @@ import io.camunda.gateway.protocol.model.BrokerInfo;
 import io.camunda.gateway.protocol.model.Partition;
 import io.camunda.gateway.protocol.model.Partition.HealthEnum;
 import io.camunda.gateway.protocol.model.Partition.RoleEnum;
+import io.camunda.gateway.protocol.model.Partition.StateEnum;
 import io.camunda.gateway.protocol.model.TopologyResponse;
 import io.camunda.service.TopologyServices;
 import io.camunda.service.TopologyServices.Broker;
@@ -125,7 +126,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                                       .partitionId(1)
                                       .role(RoleEnum.LEADER)
                                       .health(HealthEnum.HEALTHY)
-                                      .state(null)
+                                      .state(StateEnum.UNKNOWN)
                                       .build()))
                           .version(version)
                           .build(),
@@ -139,7 +140,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                                       .partitionId(1)
                                       .role(RoleEnum.FOLLOWER)
                                       .health(HealthEnum.HEALTHY)
-                                      .state(null)
+                                      .state(StateEnum.UNKNOWN)
                                       .build()))
                           .version(version)
                           .build(),
@@ -153,7 +154,7 @@ class ClusterToolsTest extends OperationalToolsTest {
                                       .partitionId(1)
                                       .role(RoleEnum.INACTIVE)
                                       .health(HealthEnum.UNHEALTHY)
-                                      .state(null)
+                                      .state(StateEnum.UNKNOWN)
                                       .build()))
                           .version(version)
                           .build()))
@@ -172,7 +173,9 @@ class ClusterToolsTest extends OperationalToolsTest {
                       0,
                       "localhost",
                       26501,
-                      List.of(new TopologyServices.Partition(1, Role.LEADER, Health.HEALTHY, null)),
+                      List.of(
+                          new TopologyServices.Partition(
+                              1, Role.LEADER, Health.HEALTHY, TopologyServices.State.UNKNOWN)),
                       version),
                   new Broker(
                       null,
@@ -180,7 +183,8 @@ class ClusterToolsTest extends OperationalToolsTest {
                       "localhost",
                       26502,
                       List.of(
-                          new TopologyServices.Partition(1, Role.FOLLOWER, Health.HEALTHY, null)),
+                          new TopologyServices.Partition(
+                              1, Role.FOLLOWER, Health.HEALTHY, TopologyServices.State.UNKNOWN)),
                       version),
                   new Broker(
                       null,
@@ -188,7 +192,8 @@ class ClusterToolsTest extends OperationalToolsTest {
                       "localhost",
                       26503,
                       List.of(
-                          new TopologyServices.Partition(1, Role.INACTIVE, Health.UNHEALTHY, null)),
+                          new TopologyServices.Partition(
+                              1, Role.INACTIVE, Health.UNHEALTHY, TopologyServices.State.UNKNOWN)),
                       version)),
               "cluster-id",
               3,

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -138,7 +138,7 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
       final Broker.Builder broker,
       final BrokerMemberId brokerId,
       final BrokerClusterState topology,
-      final @Nullable ClusterConfiguration clusterConfiguration) {
+      final ClusterConfiguration clusterConfiguration) {
     topology
         .getPartitions()
         .forEach(
@@ -172,12 +172,8 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
   private void setState(
       final BrokerMemberId brokerId,
       final Integer partitionId,
-      final @Nullable ClusterConfiguration clusterConfiguration,
+      final ClusterConfiguration clusterConfiguration,
       final Partition.Builder partition) {
-    if (clusterConfiguration == null) {
-      return;
-    }
-
     final var memberState = clusterConfiguration.members().get(brokerId.memberId());
     if (memberState == null) {
       return;

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -16,6 +16,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.ArrayList;
@@ -100,13 +101,15 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
           .replicationFactor(clusterState.getReplicationFactor())
           .lastCompletedChangeId(clusterState.getLastCompletedChangeId());
 
+      final var clusterConfiguration = brokerClient.getTopologyManager().getClusterConfiguration();
+
       clusterState
           .getBrokers()
           .forEach(
               brokerId -> {
                 final var broker = Broker.Builder.create();
                 addBrokerInfo(broker, brokerId, clusterState);
-                addPartitionInfoToBrokerInfo(broker, brokerId, clusterState);
+                addPartitionInfoToBrokerInfo(broker, brokerId, clusterState, clusterConfiguration);
 
                 topology.addBroker(broker.build());
               });
@@ -134,7 +137,8 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
   private void addPartitionInfoToBrokerInfo(
       final Broker.Builder broker,
       final BrokerMemberId brokerId,
-      final BrokerClusterState topology) {
+      final BrokerClusterState topology,
+      final @Nullable ClusterConfiguration clusterConfiguration) {
     topology
         .getPartitions()
         .forEach(
@@ -160,8 +164,42 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
                             .map(PartitionHealthStatus::name)
                             .orElse("null"));
               }
+              setState(brokerId, partitionId, clusterConfiguration, partition);
               broker.addPartition(partition.build());
             });
+  }
+
+  private void setState(
+      final BrokerMemberId brokerId,
+      final Integer partitionId,
+      final @Nullable ClusterConfiguration clusterConfiguration,
+      final Partition.Builder partition) {
+    if (clusterConfiguration == null) {
+      return;
+    }
+
+    final var memberState = clusterConfiguration.members().get(brokerId.memberId());
+    if (memberState == null) {
+      return;
+    }
+
+    final var partitionState = memberState.getPartition(partitionId);
+    if (partitionState == null) {
+      return;
+    }
+
+    partition.state(mapState(partitionState.state()));
+  }
+
+  private static State mapState(
+      final io.camunda.zeebe.dynamic.config.state.PartitionState.State state) {
+    return switch (state) {
+      case UNKNOWN, BOOTSTRAPPING -> State.UNKNOWN;
+      case JOINING -> State.JOINING;
+      case ACTIVE -> State.ACTIVE;
+      case LEAVING -> State.LEAVING;
+      case RECOVERING -> State.RECOVERING;
+    };
   }
 
   private boolean setRole(
@@ -331,11 +369,12 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
     }
   }
 
-  public record Partition(Integer partitionId, Role role, Health health) {
+  public record Partition(Integer partitionId, Role role, Health health, @Nullable State state) {
     static class Builder {
       Integer partitionId;
       Role role;
       Health health;
+      @Nullable State state;
 
       public static Builder create() {
         return new Builder();
@@ -356,8 +395,13 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
         return this;
       }
 
+      public Builder state(final @Nullable State state) {
+        this.state = state;
+        return this;
+      }
+
       public Partition build() {
-        return new Partition(partitionId, role, health);
+        return new Partition(partitionId, role, health, state);
       }
     }
   }
@@ -374,6 +418,15 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
     HEALTHY,
     UNHEALTHY,
     DEAD
+  }
+
+  /** Describes the current operational state of the partition in the cluster configuration. */
+  public enum State {
+    UNKNOWN,
+    JOINING,
+    ACTIVE,
+    LEAVING,
+    RECOVERING
   }
 
   public enum ClusterStatus {

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -16,7 +16,6 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
@@ -102,15 +101,13 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
           .replicationFactor(clusterState.getReplicationFactor())
           .lastCompletedChangeId(clusterState.getLastCompletedChangeId());
 
-      final var clusterConfiguration = brokerClient.getTopologyManager().getClusterConfiguration();
-
       clusterState
           .getBrokers()
           .forEach(
               brokerId -> {
                 final var broker = Broker.Builder.create();
                 addBrokerInfo(broker, brokerId, clusterState);
-                addPartitionInfoToBrokerInfo(broker, brokerId, clusterState, clusterConfiguration);
+                addPartitionInfoToBrokerInfo(broker, brokerId, clusterState);
 
                 topology.addBroker(broker.build());
               });
@@ -138,8 +135,7 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
   private void addPartitionInfoToBrokerInfo(
       final Broker.Builder broker,
       final BrokerMemberId brokerId,
-      final BrokerClusterState topology,
-      final ClusterConfiguration clusterConfiguration) {
+      final BrokerClusterState topology) {
     topology
         .getPartitions()
         .forEach(
@@ -165,7 +161,7 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
                             .map(PartitionHealthStatus::name)
                             .orElse("null"));
               }
-              setState(brokerId, partitionId, clusterConfiguration, partition);
+              partition.state(mapState(topology.getPartitionState(brokerId, partitionId)));
               broker.addPartition(partition.build());
             });
   }
@@ -190,26 +186,6 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
     }
 
     return true;
-  }
-
-  private void setState(
-      final BrokerMemberId brokerId,
-      final Integer partitionId,
-      final ClusterConfiguration clusterConfiguration,
-      final Partition.Builder partition) {
-    final var memberState = clusterConfiguration.members().get(brokerId.memberId());
-    if (memberState == null) {
-      partition.state(State.UNKNOWN);
-      return;
-    }
-
-    final var partitionState = memberState.getPartition(partitionId);
-    if (partitionState == null) {
-      partition.state(State.UNKNOWN);
-      return;
-    }
-
-    partition.state(mapState(partitionState.state()));
   }
 
   private static State mapState(final PartitionState.State state) {

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -17,6 +17,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.ArrayList;
@@ -169,35 +170,6 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
             });
   }
 
-  private void setState(
-      final BrokerMemberId brokerId,
-      final Integer partitionId,
-      final ClusterConfiguration clusterConfiguration,
-      final Partition.Builder partition) {
-    final var memberState = clusterConfiguration.members().get(brokerId.memberId());
-    if (memberState == null) {
-      return;
-    }
-
-    final var partitionState = memberState.getPartition(partitionId);
-    if (partitionState == null) {
-      return;
-    }
-
-    partition.state(mapState(partitionState.state()));
-  }
-
-  private static State mapState(
-      final io.camunda.zeebe.dynamic.config.state.PartitionState.State state) {
-    return switch (state) {
-      case UNKNOWN, BOOTSTRAPPING -> State.UNKNOWN;
-      case JOINING -> State.JOINING;
-      case ACTIVE -> State.ACTIVE;
-      case LEAVING -> State.LEAVING;
-      case RECOVERING -> State.RECOVERING;
-    };
-  }
-
   private boolean setRole(
       final BrokerMemberId brokerId,
       final Integer partitionId,
@@ -218,6 +190,36 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
     }
 
     return true;
+  }
+
+  private void setState(
+      final BrokerMemberId brokerId,
+      final Integer partitionId,
+      final ClusterConfiguration clusterConfiguration,
+      final Partition.Builder partition) {
+    final var memberState = clusterConfiguration.members().get(brokerId.memberId());
+    if (memberState == null) {
+      partition.state(State.UNKNOWN);
+      return;
+    }
+
+    final var partitionState = memberState.getPartition(partitionId);
+    if (partitionState == null) {
+      partition.state(State.UNKNOWN);
+      return;
+    }
+
+    partition.state(mapState(partitionState.state()));
+  }
+
+  private static State mapState(final PartitionState.State state) {
+    return switch (state) {
+      case UNKNOWN, BOOTSTRAPPING -> State.UNKNOWN;
+      case JOINING -> State.JOINING;
+      case ACTIVE -> State.ACTIVE;
+      case LEAVING -> State.LEAVING;
+      case RECOVERING -> State.RECOVERING;
+    };
   }
 
   public record Topology(
@@ -365,12 +367,12 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
     }
   }
 
-  public record Partition(Integer partitionId, Role role, Health health, @Nullable State state) {
+  public record Partition(Integer partitionId, Role role, Health health, State state) {
     static class Builder {
       Integer partitionId;
       Role role;
       Health health;
-      @Nullable State state;
+      State state;
 
       public static Builder create() {
         return new Builder();
@@ -391,7 +393,7 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
         return this;
       }
 
-      public Builder state(final @Nullable State state) {
+      public Builder state(final State state) {
         this.state = state;
         return this;
       }

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -67,7 +67,8 @@ public class TopologyServiceTest {
     topologyManager = mock(BrokerTopologyManager.class);
     when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
     when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(clusterState);
-    when(topologyManager.getClusterConfiguration()).thenReturn(ClusterConfiguration.uninitialized());
+    when(topologyManager.getClusterConfiguration())
+        .thenReturn(ClusterConfiguration.uninitialized());
     services =
         new TopologyServices(
             PHYSICAL_TENANT_ID,
@@ -215,21 +216,21 @@ public class TopologyServiceTest {
                     0,
                     "localhost",
                     26501,
-                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, null)),
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, State.UNKNOWN)),
                     version),
                 new Broker(
                     zone,
                     1,
                     "localhost",
                     26502,
-                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY, null)),
+                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY, State.UNKNOWN)),
                     version),
                 new Broker(
                     zone,
                     2,
                     "localhost",
                     26503,
-                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY, null)),
+                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY, State.UNKNOWN)),
                     version)),
             "cluster-id",
             3,

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -18,14 +18,20 @@ import io.camunda.service.TopologyServices.ClusterStatus;
 import io.camunda.service.TopologyServices.Health;
 import io.camunda.service.TopologyServices.Partition;
 import io.camunda.service.TopologyServices.Role;
+import io.camunda.service.TopologyServices.State;
 import io.camunda.service.TopologyServices.Topology;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -208,21 +214,21 @@ public class TopologyServiceTest {
                     0,
                     "localhost",
                     26501,
-                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY)),
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, null)),
                     version),
                 new Broker(
                     zone,
                     1,
                     "localhost",
                     26502,
-                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY)),
+                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY, null)),
                     version),
                 new Broker(
                     zone,
                     2,
                     "localhost",
                     26503,
-                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
+                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY, null)),
                     version)),
             "cluster-id",
             3,
@@ -236,6 +242,53 @@ public class TopologyServiceTest {
 
     // then
     Assertions.assertThat(topology).isEqualTo(expectedTopology);
+  }
+
+  @ParameterizedTest
+  @EnumSource(PartitionState.State.class)
+  public void shouldExposePartitionOperationalState(final PartitionState.State dynamicConfigState) {
+    // given
+    final var version = VersionUtil.getVersion();
+    when(topologyManager.getTopology(PHYSICAL_TENANT_ID))
+        .thenReturn(new TestBrokerClusterState(null, version, "cluster-id"));
+
+    final var leaderMemberId = BrokerMemberId.from(null, 0).memberId();
+    final var clusterConfiguration =
+        ClusterConfiguration.builder()
+            .members(
+                Map.of(
+                    leaderMemberId,
+                    MemberState.initializeAsActive(
+                        Map.of(
+                            1,
+                            new PartitionState(
+                                dynamicConfigState, 1, DynamicPartitionConfig.init())))))
+            .build();
+    when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
+
+    // when
+    final var topology = services.getTopology().join();
+
+    // then
+    final var leaderPartitionState =
+        topology.brokers().stream()
+            .filter(broker -> broker.nodeIdx() == 0)
+            .findFirst()
+            .orElseThrow()
+            .partitions()
+            .getFirst()
+            .state();
+    Assertions.assertThat(leaderPartitionState).isEqualTo(expectedState(dynamicConfigState));
+  }
+
+  private static State expectedState(final PartitionState.State dynamicConfigState) {
+    return switch (dynamicConfigState) {
+      case UNKNOWN, BOOTSTRAPPING -> State.UNKNOWN;
+      case JOINING -> State.JOINING;
+      case ACTIVE -> State.ACTIVE;
+      case LEAVING -> State.LEAVING;
+      case RECOVERING -> State.RECOVERING;
+    };
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -67,6 +67,7 @@ public class TopologyServiceTest {
     topologyManager = mock(BrokerTopologyManager.class);
     when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
     when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(clusterState);
+    when(topologyManager.getClusterConfiguration()).thenReturn(ClusterConfiguration.uninitialized());
     services =
         new TopologyServices(
             PHYSICAL_TENANT_ID,

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -24,14 +24,10 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
@@ -67,8 +63,6 @@ public class TopologyServiceTest {
     topologyManager = mock(BrokerTopologyManager.class);
     when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
     when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(clusterState);
-    when(topologyManager.getClusterConfiguration())
-        .thenReturn(ClusterConfiguration.uninitialized());
     services =
         new TopologyServices(
             PHYSICAL_TENANT_ID,
@@ -252,21 +246,7 @@ public class TopologyServiceTest {
     // given
     final var version = VersionUtil.getVersion();
     when(topologyManager.getTopology(PHYSICAL_TENANT_ID))
-        .thenReturn(new TestBrokerClusterState(null, version, "cluster-id"));
-
-    final var leaderMemberId = BrokerMemberId.from(null, 0).memberId();
-    final var clusterConfiguration =
-        ClusterConfiguration.builder()
-            .members(
-                Map.of(
-                    leaderMemberId,
-                    MemberState.initializeAsActive(
-                        Map.of(
-                            1,
-                            new PartitionState(
-                                dynamicConfigState, 1, DynamicPartitionConfig.init())))))
-            .build();
-    when(topologyManager.getClusterConfiguration()).thenReturn(clusterConfiguration);
+        .thenReturn(new TestBrokerClusterState(null, version, "cluster-id", dynamicConfigState));
 
     // when
     final var topology = services.getTopology().join();
@@ -316,8 +296,17 @@ public class TopologyServiceTest {
    * Topology stub which returns a static topology with 3 brokers, 1 partition, replication factor
    * 3, where 0 is the leader (healthy), 1 is the follower (healthy), and 2 is inactive (unhealthy).
    */
-  private record TestBrokerClusterState(@Nullable String zone, String version, String clusterId)
+  private record TestBrokerClusterState(
+      @Nullable String zone,
+      String version,
+      String clusterId,
+      PartitionState.State leaderPartitionState)
       implements BrokerClusterState {
+
+    TestBrokerClusterState(
+        final @Nullable String zone, final String version, final String clusterId) {
+      this(zone, version, clusterId, PartitionState.State.UNKNOWN);
+    }
 
     @Override
     public boolean isInitialized() {
@@ -391,6 +380,15 @@ public class TopologyServiceTest {
         case 2 -> PartitionHealthStatus.UNHEALTHY;
         default -> PartitionHealthStatus.NULL_VAL;
       };
+    }
+
+    @Override
+    public PartitionState.State getPartitionState(
+        final BrokerMemberId brokerId, final int partition) {
+      if (partition == 1 && brokerId.nodeIdx() == 0) {
+        return leaderPartitionState;
+      }
+      return PartitionState.State.UNKNOWN;
     }
 
     @Override

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.client.api;
 
 import io.atomix.cluster.BrokerMemberId;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +48,13 @@ public interface BrokerClusterState {
   @Nullable String getBrokerVersion(BrokerMemberId brokerId);
 
   @Nullable PartitionHealthStatus getPartitionHealth(BrokerMemberId brokerId, int partition);
+
+  /**
+   * @return the operational state of the given partition on the given broker, as known from the
+   *     cluster configuration. Returns {@link PartitionState.State#UNKNOWN} if the broker or
+   *     partition is not (yet) known in the cluster configuration.
+   */
+  PartitionState.State getPartitionState(BrokerMemberId brokerId, int partition);
 
   long getLastCompletedChangeId();
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -46,7 +46,7 @@ public record BrokerClientTopologyImpl(
 
   public static BrokerClientTopologyImpl uninitialized() {
     return new BrokerClientTopologyImpl(
-        new LiveClusterState(Set.of(), Map.of()),
+        new LiveClusterState(Set.of()),
         new ConfiguredClusterState(
             UNINITIALIZED_CLUSTER_SIZE,
             0,
@@ -54,7 +54,8 @@ public record BrokerClientTopologyImpl(
             List.of(),
             NO_COMPLETED_LAST_CHANGE_ID,
             NO_CLUSTER_ID,
-            UNINITIALIZED_INCARNATION_NUMBER));
+            UNINITIALIZED_INCARNATION_NUMBER,
+            Map.of()));
   }
 
   @Override
@@ -137,7 +138,7 @@ public record BrokerClientTopologyImpl(
   @Override
   public PartitionState.State getPartitionState(
       final BrokerMemberId brokerId, final int partitionId) {
-    final var brokerPartitionStates = liveClusterState.partitionStatesPerBroker.get(brokerId);
+    final var brokerPartitionStates = configuredClusterState.partitionStates().get(brokerId);
 
     if (brokerPartitionStates == null) {
       return PartitionState.State.UNKNOWN;
@@ -157,11 +158,8 @@ public record BrokerClientTopologyImpl(
   }
 
   public static BrokerClientTopologyImpl fromMemberProperties(
-      final Collection<BrokerInfo> values,
-      final ConfiguredClusterState clusterConfiguration,
-      final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {
-    return new BrokerClientTopologyImpl(
-        new LiveClusterState(values, partitionStates), clusterConfiguration);
+      final Collection<BrokerInfo> values, final ConfiguredClusterState clusterConfiguration) {
+    return new BrokerClientTopologyImpl(new LiveClusterState(values), clusterConfiguration);
   }
 
   record ConfiguredClusterState(
@@ -171,7 +169,8 @@ public record BrokerClientTopologyImpl(
       List<Integer> partitionIds,
       long lastChangeId,
       String clusterId,
-      long incarnationNumber) {}
+      long incarnationNumber,
+      Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {}
 
   static class LiveClusterState {
     private static final Long TERM_NONE = -1L;
@@ -181,22 +180,17 @@ public record BrokerClientTopologyImpl(
     private final Int2ObjectHashMap<Set<BrokerMemberId>> partitionInactiveNodes;
     private final HashMap<BrokerMemberId, Int2ObjectHashMap<PartitionHealthStatus>>
         partitionsHealthPerBroker;
-    private final HashMap<BrokerMemberId, Int2ObjectHashMap<PartitionState.State>>
-        partitionStatesPerBroker;
     private final HashMap<BrokerMemberId, String> brokerAddresses;
     private final HashMap<BrokerMemberId, String> brokerVersions;
     private final List<BrokerMemberId> brokers;
     private final Random randomBroker;
 
-    public LiveClusterState(
-        final Collection<BrokerInfo> distributedBrokerInfos,
-        final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {
+    public LiveClusterState(final Collection<BrokerInfo> distributedBrokerInfos) {
       partitionLeaders = new Int2ObjectHashMap<>();
       partitionLeaderTerms = new Int2ObjectHashMap<>();
       partitionFollowers = new Int2ObjectHashMap<>();
       partitionInactiveNodes = new Int2ObjectHashMap<>();
       partitionsHealthPerBroker = new HashMap<>();
-      partitionStatesPerBroker = new HashMap<>();
       brokerAddresses = new HashMap<>();
       brokerVersions = new HashMap<>();
       brokers = new ArrayList<>(5);
@@ -219,11 +213,6 @@ public record BrokerClientTopologyImpl(
             brokerInfo.consumePartitionsHealth(
                 (partition, health) -> setPartitionHealthStatus(memberId, partition, health));
           });
-
-      partitionStates.forEach(
-          (brokerId, statesByPartition) ->
-              statesByPartition.forEach(
-                  (partitionId, state) -> setPartitionState(brokerId, partitionId, state)));
     }
 
     void setPartitionLeader(final int partitionId, final BrokerMemberId leaderId, final long term) {
@@ -248,13 +237,6 @@ public record BrokerClientTopologyImpl(
       partitionsHealth.put(partitionId, status);
     }
 
-    void setPartitionState(
-        final BrokerMemberId brokerId, final int partitionId, final PartitionState.State state) {
-      final var partitionStates =
-          partitionStatesPerBroker.computeIfAbsent(brokerId, integer -> new Int2ObjectHashMap<>());
-      partitionStates.put(partitionId, state);
-    }
-
     void addPartitionFollower(final int partitionId, final BrokerMemberId followerId) {
       partitionFollowers.computeIfAbsent(partitionId, HashSet::new).add(followerId);
       partitionLeaders.remove(partitionId, followerId);
@@ -271,13 +253,6 @@ public record BrokerClientTopologyImpl(
       if (followers != null) {
         followers.remove(brokerId);
       }
-    }
-
-    Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates() {
-      final Map<BrokerMemberId, Map<Integer, PartitionState.State>> result = new HashMap<>();
-      partitionStatesPerBroker.forEach(
-          (brokerId, states) -> result.put(brokerId, new HashMap<>(states)));
-      return result;
     }
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientTopologyImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.client.impl;
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.agrona.collections.Int2ObjectHashMap;
@@ -44,7 +46,7 @@ public record BrokerClientTopologyImpl(
 
   public static BrokerClientTopologyImpl uninitialized() {
     return new BrokerClientTopologyImpl(
-        new LiveClusterState(Set.of()),
+        new LiveClusterState(Set.of(), Map.of()),
         new ConfiguredClusterState(
             UNINITIALIZED_CLUSTER_SIZE,
             0,
@@ -133,6 +135,18 @@ public record BrokerClientTopologyImpl(
   }
 
   @Override
+  public PartitionState.State getPartitionState(
+      final BrokerMemberId brokerId, final int partitionId) {
+    final var brokerPartitionStates = liveClusterState.partitionStatesPerBroker.get(brokerId);
+
+    if (brokerPartitionStates == null) {
+      return PartitionState.State.UNKNOWN;
+    } else {
+      return brokerPartitionStates.getOrDefault(partitionId, PartitionState.State.UNKNOWN);
+    }
+  }
+
+  @Override
   public long getLastCompletedChangeId() {
     return configuredClusterState.lastChangeId;
   }
@@ -143,8 +157,11 @@ public record BrokerClientTopologyImpl(
   }
 
   public static BrokerClientTopologyImpl fromMemberProperties(
-      final Collection<BrokerInfo> values, final ConfiguredClusterState clusterConfiguration) {
-    return new BrokerClientTopologyImpl(new LiveClusterState(values), clusterConfiguration);
+      final Collection<BrokerInfo> values,
+      final ConfiguredClusterState clusterConfiguration,
+      final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {
+    return new BrokerClientTopologyImpl(
+        new LiveClusterState(values, partitionStates), clusterConfiguration);
   }
 
   record ConfiguredClusterState(
@@ -164,17 +181,22 @@ public record BrokerClientTopologyImpl(
     private final Int2ObjectHashMap<Set<BrokerMemberId>> partitionInactiveNodes;
     private final HashMap<BrokerMemberId, Int2ObjectHashMap<PartitionHealthStatus>>
         partitionsHealthPerBroker;
+    private final HashMap<BrokerMemberId, Int2ObjectHashMap<PartitionState.State>>
+        partitionStatesPerBroker;
     private final HashMap<BrokerMemberId, String> brokerAddresses;
     private final HashMap<BrokerMemberId, String> brokerVersions;
     private final List<BrokerMemberId> brokers;
     private final Random randomBroker;
 
-    public LiveClusterState(final Collection<BrokerInfo> distributedBrokerInfos) {
+    public LiveClusterState(
+        final Collection<BrokerInfo> distributedBrokerInfos,
+        final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {
       partitionLeaders = new Int2ObjectHashMap<>();
       partitionLeaderTerms = new Int2ObjectHashMap<>();
       partitionFollowers = new Int2ObjectHashMap<>();
       partitionInactiveNodes = new Int2ObjectHashMap<>();
       partitionsHealthPerBroker = new HashMap<>();
+      partitionStatesPerBroker = new HashMap<>();
       brokerAddresses = new HashMap<>();
       brokerVersions = new HashMap<>();
       brokers = new ArrayList<>(5);
@@ -197,6 +219,11 @@ public record BrokerClientTopologyImpl(
             brokerInfo.consumePartitionsHealth(
                 (partition, health) -> setPartitionHealthStatus(memberId, partition, health));
           });
+
+      partitionStates.forEach(
+          (brokerId, statesByPartition) ->
+              statesByPartition.forEach(
+                  (partitionId, state) -> setPartitionState(brokerId, partitionId, state)));
     }
 
     void setPartitionLeader(final int partitionId, final BrokerMemberId leaderId, final long term) {
@@ -221,6 +248,13 @@ public record BrokerClientTopologyImpl(
       partitionsHealth.put(partitionId, status);
     }
 
+    void setPartitionState(
+        final BrokerMemberId brokerId, final int partitionId, final PartitionState.State state) {
+      final var partitionStates =
+          partitionStatesPerBroker.computeIfAbsent(brokerId, integer -> new Int2ObjectHashMap<>());
+      partitionStates.put(partitionId, state);
+    }
+
     void addPartitionFollower(final int partitionId, final BrokerMemberId followerId) {
       partitionFollowers.computeIfAbsent(partitionId, HashSet::new).add(followerId);
       partitionLeaders.remove(partitionId, followerId);
@@ -237,6 +271,13 @@ public record BrokerClientTopologyImpl(
       if (followers != null) {
         followers.remove(brokerId);
       }
+    }
+
+    Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates() {
+      final Map<BrokerMemberId, Map<Integer, PartitionState.State>> result = new HashMap<>();
+      partitionStatesPerBroker.forEach(
+          (brokerId, states) -> result.put(brokerId, new HashMap<>(states)));
+      return result;
     }
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -159,10 +159,8 @@ public final class BrokerTopologyManagerImpl extends Actor
     final var groupMembers =
         memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
     final var configuredState = currentConfiguredState();
-    final var partitionStates = currentPartitionStates();
     final var newGroupTopology =
-        BrokerClientTopologyImpl.fromMemberProperties(
-            groupMembers, configuredState, partitionStates);
+        BrokerClientTopologyImpl.fromMemberProperties(groupMembers, configuredState);
 
     final Map<String, BrokerClientTopologyImpl> updated = new HashMap<>(topologyPerGroup);
     updated.put(physicalTenantId, newGroupTopology);
@@ -179,13 +177,6 @@ public final class BrokerTopologyManagerImpl extends Actor
         .findFirst()
         .map(BrokerClientTopologyImpl::configuredClusterState)
         .orElse(BrokerClientTopologyImpl.uninitialized().configuredClusterState());
-  }
-
-  private Map<BrokerMemberId, Map<Integer, PartitionState.State>> currentPartitionStates() {
-    return topologyPerGroup.values().stream()
-        .findFirst()
-        .map(topology -> topology.liveClusterState().partitionStates())
-        .orElse(Map.of());
   }
 
   @Override
@@ -253,19 +244,12 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private void applyClusterConfiguration(final ClusterConfiguration clusterTopology) {
-    final var newPartitionStates = buildPartitionStates(clusterTopology);
-
     // Run the full comparison + listener-notification logic against the default group once.
     final var oldDefault =
         topologyPerGroup.getOrDefault(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, BrokerClientTopologyImpl.uninitialized());
-    final var configUpdatedDefault = updateConfiguredClusterState(clusterTopology, oldDefault);
-    final var newConfiguredState = configUpdatedDefault.configuredClusterState();
-    final var updatedDefault =
-        new BrokerClientTopologyImpl(
-            rebuildLiveClusterState(
-                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, newPartitionStates),
-            newConfiguredState);
+    final var updatedDefault = updateConfiguredClusterState(clusterTopology, oldDefault);
+    final var newConfiguredState = updatedDefault.configuredClusterState();
 
     final Map<String, BrokerClientTopologyImpl> allGroups = new HashMap<>(topologyPerGroup);
     allGroups.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, updatedDefault);
@@ -277,23 +261,17 @@ public final class BrokerTopologyManagerImpl extends Actor
             physicalTenantId ->
                 !physicalTenantId.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
         .forEach(
-            physicalTenantId ->
-                allGroups.put(
-                    physicalTenantId,
-                    new BrokerClientTopologyImpl(
-                        rebuildLiveClusterState(physicalTenantId, newPartitionStates),
-                        newConfiguredState)));
+            physicalTenantId -> {
+              final var oldGroup =
+                  topologyPerGroup.getOrDefault(
+                      physicalTenantId, BrokerClientTopologyImpl.uninitialized());
+              allGroups.put(
+                  physicalTenantId,
+                  new BrokerClientTopologyImpl(oldGroup.liveClusterState(), newConfiguredState));
+            });
 
     topologyPerGroup = Map.copyOf(allGroups);
     updateMetrics(updatedDefault);
-  }
-
-  private BrokerClientTopologyImpl.LiveClusterState rebuildLiveClusterState(
-      final String physicalTenantId,
-      final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {
-    final var groupMembers =
-        memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
-    return new BrokerClientTopologyImpl.LiveClusterState(groupMembers, partitionStates);
   }
 
   private BrokerClientTopologyImpl updateConfiguredClusterState(
@@ -321,10 +299,13 @@ public final class BrokerTopologyManagerImpl extends Actor
       topologyListeners.forEach(BrokerTopologyListener::clusterIncarnationChanged);
     }
 
+    final var newPartitionStates = buildPartitionStates(clusterTopology);
+
     if (newClusterSize != oldTopology.getClusterSize()
         || newPartitionsCount != oldTopology.getPartitionsCount()
         || newReplicationFactor != oldTopology.getReplicationFactor()
-        || newLastChange != oldTopology.getLastCompletedChangeId()) {
+        || newLastChange != oldTopology.getLastCompletedChangeId()
+        || !newPartitionStates.equals(oldTopology.configuredClusterState().partitionStates())) {
       LOG.debug(
           "Updating topology with clusterSize {}, partitionsCount {} and replicationFactor {}",
           newClusterSize,
@@ -341,7 +322,8 @@ public final class BrokerTopologyManagerImpl extends Actor
               partitionIds,
               newLastChange,
               clusterId,
-              clusterTopology.incarnationNumber());
+              clusterTopology.incarnationNumber(),
+              newPartitionStates);
 
       return new BrokerClientTopologyImpl(oldTopology.liveClusterState(), newClusterInfo);
     }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerClientTopologyImpl.ConfiguredClusterState;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import java.util.HashMap;
@@ -158,8 +159,10 @@ public final class BrokerTopologyManagerImpl extends Actor
     final var groupMembers =
         memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
     final var configuredState = currentConfiguredState();
+    final var partitionStates = currentPartitionStates();
     final var newGroupTopology =
-        BrokerClientTopologyImpl.fromMemberProperties(groupMembers, configuredState);
+        BrokerClientTopologyImpl.fromMemberProperties(
+            groupMembers, configuredState, partitionStates);
 
     final Map<String, BrokerClientTopologyImpl> updated = new HashMap<>(topologyPerGroup);
     updated.put(physicalTenantId, newGroupTopology);
@@ -176,6 +179,13 @@ public final class BrokerTopologyManagerImpl extends Actor
         .findFirst()
         .map(BrokerClientTopologyImpl::configuredClusterState)
         .orElse(BrokerClientTopologyImpl.uninitialized().configuredClusterState());
+  }
+
+  private Map<BrokerMemberId, Map<Integer, PartitionState.State>> currentPartitionStates() {
+    return topologyPerGroup.values().stream()
+        .findFirst()
+        .map(topology -> topology.liveClusterState().partitionStates())
+        .orElse(Map.of());
   }
 
   @Override
@@ -243,12 +253,19 @@ public final class BrokerTopologyManagerImpl extends Actor
   }
 
   private void applyClusterConfiguration(final ClusterConfiguration clusterTopology) {
+    final var newPartitionStates = buildPartitionStates(clusterTopology);
+
     // Run the full comparison + listener-notification logic against the default group once.
     final var oldDefault =
         topologyPerGroup.getOrDefault(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, BrokerClientTopologyImpl.uninitialized());
-    final var updatedDefault = updateConfiguredClusterState(clusterTopology, oldDefault);
-    final var newConfiguredState = updatedDefault.configuredClusterState();
+    final var configUpdatedDefault = updateConfiguredClusterState(clusterTopology, oldDefault);
+    final var newConfiguredState = configUpdatedDefault.configuredClusterState();
+    final var updatedDefault =
+        new BrokerClientTopologyImpl(
+            rebuildLiveClusterState(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, newPartitionStates),
+            newConfiguredState);
 
     final Map<String, BrokerClientTopologyImpl> allGroups = new HashMap<>(topologyPerGroup);
     allGroups.put(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, updatedDefault);
@@ -260,17 +277,23 @@ public final class BrokerTopologyManagerImpl extends Actor
             physicalTenantId ->
                 !physicalTenantId.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
         .forEach(
-            physicalTenantId -> {
-              final var oldGroup =
-                  topologyPerGroup.getOrDefault(
-                      physicalTenantId, BrokerClientTopologyImpl.uninitialized());
-              allGroups.put(
-                  physicalTenantId,
-                  new BrokerClientTopologyImpl(oldGroup.liveClusterState(), newConfiguredState));
-            });
+            physicalTenantId ->
+                allGroups.put(
+                    physicalTenantId,
+                    new BrokerClientTopologyImpl(
+                        rebuildLiveClusterState(physicalTenantId, newPartitionStates),
+                        newConfiguredState)));
 
     topologyPerGroup = Map.copyOf(allGroups);
     updateMetrics(updatedDefault);
+  }
+
+  private BrokerClientTopologyImpl.LiveClusterState rebuildLiveClusterState(
+      final String physicalTenantId,
+      final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates) {
+    final var groupMembers =
+        memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
+    return new BrokerClientTopologyImpl.LiveClusterState(groupMembers, partitionStates);
   }
 
   private BrokerClientTopologyImpl updateConfiguredClusterState(
@@ -324,5 +347,23 @@ public final class BrokerTopologyManagerImpl extends Actor
     }
 
     return oldTopology;
+  }
+
+  private static Map<BrokerMemberId, Map<Integer, PartitionState.State>> buildPartitionStates(
+      final ClusterConfiguration clusterTopology) {
+    final Map<BrokerMemberId, Map<Integer, PartitionState.State>> partitionStates = new HashMap<>();
+    clusterTopology
+        .members()
+        .forEach(
+            (memberId, memberState) -> {
+              final Map<Integer, PartitionState.State> statesForMember = new HashMap<>();
+              memberState
+                  .partitions()
+                  .forEach(
+                      (partitionId, partitionState) ->
+                          statesForMember.put(partitionId, partitionState.state()));
+              partitionStates.put(BrokerMemberId.from(memberId), Map.copyOf(statesForMember));
+            });
+    return Map.copyOf(partitionStates);
   }
 }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -155,6 +156,12 @@ final class TestTopologyManager implements BrokerTopologyManager {
     public @Nullable PartitionHealthStatus getPartitionHealth(
         final BrokerMemberId brokerId, final int partition) {
       return null;
+    }
+
+    @Override
+    public PartitionState.State getPartitionState(
+        final BrokerMemberId brokerId, final int partition) {
+      return PartitionState.State.UNKNOWN;
     }
 
     @Override

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlServiceTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
 import io.camunda.zeebe.gateway.admin.IncompleteTopologyException;
 import io.camunda.zeebe.protocol.impl.encoding.AdminResponse;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
@@ -255,6 +256,11 @@ public class ExportingControlServiceTest {
       @Override
       public PartitionHealthStatus getPartitionHealth(
           final @NonNull BrokerMemberId brokerId, final int partition) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public State getPartitionState(final BrokerMemberId brokerId, final int partition) {
         throw new UnsupportedOperationException();
       }
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -268,10 +268,8 @@ components:
         state:
           description: >
             Describes the current operational state of the partition within the cluster
-            configuration. May be null if the gateway has not yet received cluster
-            configuration data for this partition.
+            configuration.
           type: string
-          nullable: true
           example: active
           enum:
             - unknown

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -242,6 +242,7 @@ components:
         - partitionId
         - role
         - health
+        - state
       properties:
         partitionId:
           description: The unique ID of this partition.
@@ -264,6 +265,23 @@ components:
             - healthy
             - unhealthy
             - dead
+        state:
+          description: >
+            Describes the current operational state of the partition within the cluster
+            configuration. May be null if the gateway has not yet received cluster
+            configuration data for this partition.
+          type: string
+          nullable: true
+          example: active
+          enum:
+            - unknown
+            - joining
+            - active
+            - leaving
+            - recovering
+      x-properties-added-in-version:
+        - propertyName: state
+          addedInVersion: "8.10"
 
     ClusterModeChangeResponse:
       description: The planned changes resulting from a cluster mode transition request.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -15,6 +15,7 @@ import io.camunda.service.TopologyServices.Broker;
 import io.camunda.service.TopologyServices.Health;
 import io.camunda.service.TopologyServices.Partition;
 import io.camunda.service.TopologyServices.Role;
+import io.camunda.service.TopologyServices.State;
 import io.camunda.service.TopologyServices.Topology;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -65,7 +66,8 @@ public class TopologyControllerTest extends RestControllerTest {
                 {
                   "partitionId": 1,
                   "health": "healthy",
-                  "role": "leader"
+                  "role": "leader",
+                  "state": null
                 }
               ]
             },
@@ -78,7 +80,8 @@ public class TopologyControllerTest extends RestControllerTest {
                 {
                   "partitionId": 1,
                   "health": "healthy",
-                  "role": "follower"
+                  "role": "follower",
+                  "state": null
                 }
               ]
             },
@@ -91,7 +94,8 @@ public class TopologyControllerTest extends RestControllerTest {
                 {
                   "partitionId": 1,
                   "health": "unhealthy",
-                  "role": "inactive"
+                  "role": "inactive",
+                  "state": null
                 }
               ]
             }
@@ -107,24 +111,90 @@ public class TopologyControllerTest extends RestControllerTest {
                     BrokerMemberId.from(0),
                     "localhost",
                     26501,
-                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY)),
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, null)),
                     version),
                 new Broker(
                     BrokerMemberId.from(1),
                     "localhost",
                     26502,
-                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY)),
+                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY, null)),
                     version),
                 new Broker(
                     BrokerMemberId.from(2),
                     "localhost",
                     26503,
-                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY)),
+                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY, null)),
                     version)),
             "cluster-id",
             3,
             1,
             3,
+            version,
+            1L);
+    Mockito.when(topologyServices.getTopology())
+        .thenReturn(CompletableFuture.completedFuture(topology));
+
+    // when / then
+    webClient
+        .get()
+        .uri(baseUrl)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v1/topology", "/v2/topology"})
+  public void shouldGetTopologyWithRecoveringPartitionState(final String baseUrl) {
+    // given
+    final var version = VersionUtil.getVersion();
+    final var expectedResponse =
+        """
+        {
+          "clusterId": "cluster-id",
+          "gatewayVersion": "%s",
+          "clusterSize": 1,
+          "partitionsCount": 1,
+          "replicationFactor": 1,
+          "lastCompletedChangeId": "1",
+          "brokers": [
+            {
+              "nodeId": 0,
+              "host": "localhost",
+              "port": 26501,
+              "version": "%s",
+              "partitions": [
+                {
+                  "partitionId": 1,
+                  "health": "healthy",
+                  "role": "leader",
+                  "state": "recovering"
+                }
+              ]
+            }
+          ]
+        }
+        """
+            .formatted(version, version);
+
+    final var topology =
+        new Topology(
+            List.of(
+                new Broker(
+                    BrokerMemberId.from(0),
+                    "localhost",
+                    26501,
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, State.RECOVERING)),
+                    version)),
+            "cluster-id",
+            1,
+            1,
+            1,
             version,
             1L);
     Mockito.when(topologyServices.getTopology())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -67,7 +67,7 @@ public class TopologyControllerTest extends RestControllerTest {
                   "partitionId": 1,
                   "health": "healthy",
                   "role": "leader",
-                  "state": null
+                  "state": "unknown"
                 }
               ]
             },
@@ -81,7 +81,7 @@ public class TopologyControllerTest extends RestControllerTest {
                   "partitionId": 1,
                   "health": "healthy",
                   "role": "follower",
-                  "state": null
+                  "state": "unknown"
                 }
               ]
             },
@@ -95,7 +95,7 @@ public class TopologyControllerTest extends RestControllerTest {
                   "partitionId": 1,
                   "health": "unhealthy",
                   "role": "inactive",
-                  "state": null
+                  "state": "unknown"
                 }
               ]
             }
@@ -111,19 +111,19 @@ public class TopologyControllerTest extends RestControllerTest {
                     BrokerMemberId.from(0),
                     "localhost",
                     26501,
-                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, null)),
+                    List.of(new Partition(1, Role.LEADER, Health.HEALTHY, State.UNKNOWN)),
                     version),
                 new Broker(
                     BrokerMemberId.from(1),
                     "localhost",
                     26502,
-                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY, null)),
+                    List.of(new Partition(1, Role.FOLLOWER, Health.HEALTHY, State.UNKNOWN)),
                     version),
                 new Broker(
                     BrokerMemberId.from(2),
                     "localhost",
                     26503,
-                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY, null)),
+                    List.of(new Partition(1, Role.INACTIVE, Health.UNHEALTHY, State.UNKNOWN)),
                     version)),
             "cluster-id",
             3,

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/TestBrokerClusterState.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.HashMap;
@@ -31,6 +32,8 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   private final Set<Integer> partitions = new HashSet<>();
   private final Map<Tuple<BrokerMemberId, Integer>, PartitionHealthStatus>
       brokerPartitionHealthStatus = new HashMap<>();
+  private final Map<Tuple<BrokerMemberId, Integer>, PartitionState.State> partitionStates =
+      new HashMap<>();
   private final Map<Integer, Set<BrokerMemberId>> inactivePartitionsToNodeIds = new HashMap<>();
   private final Map<Integer, Set<BrokerMemberId>> followerPartitionToNodeIds = new HashMap<>();
   private String clusterId = "";
@@ -121,6 +124,13 @@ public final class TestBrokerClusterState implements BrokerClusterState {
   }
 
   @Override
+  public PartitionState.State getPartitionState(
+      final BrokerMemberId brokerId, final int partition) {
+    return partitionStates.getOrDefault(
+        Tuple.of(brokerId, partition), PartitionState.State.UNKNOWN);
+  }
+
+  @Override
   public long getLastCompletedChangeId() {
     throw new UnsupportedOperationException();
   }
@@ -152,6 +162,11 @@ public final class TestBrokerClusterState implements BrokerClusterState {
       final int partitionId,
       final PartitionHealthStatus partitionHealthStatus) {
     brokerPartitionHealthStatus.put(Tuple.of(nodeId, partitionId), partitionHealthStatus);
+  }
+
+  public void setPartitionState(
+      final BrokerMemberId nodeId, final int partitionId, final PartitionState.State state) {
+    partitionStates.put(Tuple.of(nodeId, partitionId), state);
   }
 
   public void addPartitionInactive(final int partitionId, final BrokerMemberId nodeId) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We do display this state in the `actuator/cluster` endpoint as well.


Include the `PartitionState` field in the `/v2/topology` endpoint for a clearer picture of the partition's view. The Role and Healthy alone was not enough to distinguish whether a partition has successfully transitioned to `RECOVERING` without having to inspect each broker via the actuator.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
