### PR TITLE
fix: serve swagger UI under physical-tenant prefixed paths

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -14,12 +14,15 @@ import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANTS_PAT
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
+import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.controller.EndpointAccessErrorFilter;
 import io.camunda.zeebe.gateway.rest.controller.PhysicalTenantFilter;
+import io.camunda.zeebe.gateway.rest.controller.PhysicalTenantSwaggerFilter;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.source.ConfigurationPropertyName;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -57,6 +60,8 @@ public class ApiFiltersConfiguration {
   // value anyway and leave the dependency flagged as unused by dependency:analyze. See ADR-0003.
   private static final int PHYSICAL_TENANT_FILTER_ORDER = -101;
 
+  private static final int PHYSICAL_TENANT_SWAGGER_FILTER_ORDER = 1;
+
   private static List<PathPattern> patterns(final String... patterns) {
     return Arrays.stream(patterns).map(PATTERN_PARSER::parse).toList();
   }
@@ -71,6 +76,26 @@ public class ApiFiltersConfiguration {
         new FilterRegistrationBean<>(new PhysicalTenantFilter());
     registration.addUrlPatterns(PHYSICAL_TENANTS_PATH_SEGMENT + "*");
     registration.setOrder(PHYSICAL_TENANT_FILTER_ORDER);
+    return registration;
+  }
+
+  /**
+   * Redirects/forwards Swagger UI requests reached via a tenant-prefixed path to their real,
+   * unprefixed handler. Unlike {@link #physicalTenantFilter()}, this must run after Spring
+   * Security, since the filter does not itself validate the tenant id — see {@link
+   * PhysicalTenantSwaggerFilter}.
+   */
+  @ConditionalOnRestGatewayEnabled
+  @ConditionalOnProperty(
+      name = "camunda.rest.swagger.enabled",
+      havingValue = "true",
+      matchIfMissing = true)
+  @Bean
+  public FilterRegistrationBean<PhysicalTenantSwaggerFilter> physicalTenantSwaggerFilter() {
+    final FilterRegistrationBean<PhysicalTenantSwaggerFilter> registration =
+        new FilterRegistrationBean<>(new PhysicalTenantSwaggerFilter());
+    registration.addUrlPatterns(PHYSICAL_TENANTS_PATH_SEGMENT + "*");
+    registration.setOrder(PHYSICAL_TENANT_SWAGGER_FILTER_ORDER);
     return registration;
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantSwaggerFilter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantSwaggerFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.spring.utils.PhysicalTenantContext;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Servlet {@link jakarta.servlet.Filter} that makes Swagger UI reachable under a tenant-prefixed
+ * path ({@code /physical-tenants/{id}/swagger...}).
+ *
+ * <p>{@code /swagger} and {@code /swagger-ui/**} are not {@code @RequestMapping} controller
+ * methods: {@code /swagger} is a {@code ViewControllerRegistry} redirect (see {@code
+ * OpenApiResourceConfig}) and {@code /swagger-ui/**} is a static resource handler auto-registered
+ * by springdoc, so {@code PhysicalTenantRequestMappingHandlerMapping} can never mint a
+ * tenant-prefixed sibling for them. This filter fills that gap by redirecting the bare paths to
+ * their tenant-prefixed {@code swagger-ui/index.html} and forwarding tenant-prefixed asset requests
+ * to the real, unprefixed handler springdoc registers.
+ *
+ * <p>{@code ApiFiltersConfiguration} registers this to run <em>after</em> Spring Security's {@code
+ * FilterChainProxy}, unlike {@link PhysicalTenantFilter}: this filter does not validate the tenant
+ * id, so it must only run once security has already confirmed the tenant+path is permitted (an
+ * unconfigured tenant is rejected by the catch-all chain with 404 before reaching this filter). See
+ * ADR-0003.
+ */
+public final class PhysicalTenantSwaggerFilter extends HttpFilter {
+
+  private static final String SWAGGER_PATH = "/swagger";
+  private static final String SWAGGER_UI_PATH = "/swagger-ui";
+  private static final String SWAGGER_UI_INDEX = SWAGGER_UI_PATH + "/index.html";
+
+  @Override
+  protected void doFilter(
+      final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
+      throws IOException, ServletException {
+    final String tenantId = PhysicalTenantContext.getPhysicalTenantId(request);
+    if (tenantId == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    final String remainder = swaggerRemainder(request, tenantId);
+    if (remainder == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    if (isBareSwaggerPath(remainder)) {
+      response.sendRedirect(
+          request.getContextPath()
+              + PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT
+              + tenantId
+              + SWAGGER_UI_INDEX);
+    } else {
+      request.getRequestDispatcher(remainder).forward(request, response);
+    }
+  }
+
+  private static boolean isBareSwaggerPath(final String remainder) {
+    return SWAGGER_PATH.equals(remainder)
+        || (SWAGGER_PATH + "/").equals(remainder)
+        || SWAGGER_UI_PATH.equals(remainder)
+        || (SWAGGER_UI_PATH + "/").equals(remainder);
+  }
+
+  /**
+   * Returns the tenant-relative path (e.g. {@code /swagger-ui/index.html}) if the request targets a
+   * swagger path under this tenant's prefix, otherwise {@code null}.
+   */
+  private static String swaggerRemainder(final HttpServletRequest request, final String tenantId) {
+    final String path = contextRelativePath(request);
+    final String prefix = PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + tenantId;
+    if (path == null || !path.startsWith(prefix)) {
+      return null;
+    }
+    final String remainder = path.substring(prefix.length());
+    if (isBareSwaggerPath(remainder) || remainder.startsWith(SWAGGER_UI_PATH + "/")) {
+      return remainder;
+    }
+    return null;
+  }
+
+  private static String contextRelativePath(final HttpServletRequest request) {
+    final String uri = request.getRequestURI();
+    if (uri == null) {
+      return null;
+    }
+    final String contextPath = request.getContextPath();
+    if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+      return uri.substring(contextPath.length());
+    }
+    return uri;
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantSwaggerFilterTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantSwaggerFilterTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.spring.utils.PhysicalTenantContext;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Unit tests for {@link PhysicalTenantSwaggerFilter}. */
+@ExtendWith(MockitoExtension.class)
+class PhysicalTenantSwaggerFilterTest {
+
+  @Mock private FilterChain chain;
+
+  private final PhysicalTenantSwaggerFilter filter = new PhysicalTenantSwaggerFilter();
+
+  @Test
+  void shouldRedirectBareSwaggerPathToTenantPrefixedIndex() throws Exception {
+    assertRedirectsToIndex("/physical-tenants/tenanta/swagger");
+  }
+
+  @Test
+  void shouldRedirectBareSwaggerPathWithTrailingSlash() throws Exception {
+    assertRedirectsToIndex("/physical-tenants/tenanta/swagger/");
+  }
+
+  @Test
+  void shouldRedirectBareSwaggerUiPathToTenantPrefixedIndex() throws Exception {
+    assertRedirectsToIndex("/physical-tenants/tenanta/swagger-ui");
+  }
+
+  @Test
+  void shouldRedirectBareSwaggerUiPathWithTrailingSlash() throws Exception {
+    assertRedirectsToIndex("/physical-tenants/tenanta/swagger-ui/");
+  }
+
+  private void assertRedirectsToIndex(final String uri) throws Exception {
+    final var request = new MockHttpServletRequest("GET", uri);
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getRedirectedUrl())
+        .isEqualTo("/physical-tenants/tenanta/swagger-ui/index.html");
+    verifyNoInteractions(chain);
+  }
+
+  @Test
+  void shouldForwardSwaggerUiIndexAssetToUnprefixedHandler() throws Exception {
+    final var request =
+        new MockHttpServletRequest("GET", "/physical-tenants/tenanta/swagger-ui/index.html");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getForwardedUrl()).isEqualTo("/swagger-ui/index.html");
+    assertThat(response.getRedirectedUrl()).isNull();
+    verifyNoInteractions(chain);
+  }
+
+  @Test
+  void shouldForwardSwaggerUiBundleAssetToUnprefixedHandler() throws Exception {
+    final var request =
+        new MockHttpServletRequest(
+            "GET", "/physical-tenants/tenanta/swagger-ui/swagger-ui-bundle.js");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getForwardedUrl()).isEqualTo("/swagger-ui/swagger-ui-bundle.js");
+    assertThat(response.getRedirectedUrl()).isNull();
+    verifyNoInteractions(chain);
+  }
+
+  @Test
+  void shouldNotMatchPathThatOnlySharesSwaggerUiPrefix() throws Exception {
+    // "/swagger-uiFoo" must not be treated as a swagger-ui asset request
+    final var request =
+        new MockHttpServletRequest("GET", "/physical-tenants/tenanta/swagger-uiFoo");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+    assertThat(response.getForwardedUrl()).isNull();
+    assertThat(response.getRedirectedUrl()).isNull();
+  }
+
+  @Test
+  void shouldPassThroughUnrelatedTenantPrefixedPath() throws Exception {
+    final var request = new MockHttpServletRequest("GET", "/physical-tenants/tenanta/v2/widgets");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldPassThroughWhenNoTenantIdStamped() throws Exception {
+    final var request = new MockHttpServletRequest("GET", "/swagger-ui/index.html");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+    assertThat(response.getForwardedUrl()).isNull();
+    assertThat(response.getRedirectedUrl()).isNull();
+  }
+
+  @Test
+  void shouldRedirectWithServletContextPathPrefixed() throws Exception {
+    final var request =
+        new MockHttpServletRequest("GET", "/zeebe/physical-tenants/tenanta/swagger");
+    request.setContextPath("/zeebe");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getRedirectedUrl())
+        .isEqualTo("/zeebe/physical-tenants/tenanta/swagger-ui/index.html");
+    assertThat(response.getForwardedUrl()).isNull();
+    verifyNoInteractions(chain);
+  }
+}


### PR DESCRIPTION
## Summary

- `/physical-tenants/{id}/swagger` and `/physical-tenants/{id}/swagger-ui/**` 404,
  because those routes are a `ViewController` redirect and a springdoc-managed
  static resource handler — neither is an `@RequestMapping` controller method, so
  `PhysicalTenantRequestMappingHandlerMapping` can never mint a tenant-prefixed
  sibling for them.
- Add `PhysicalTenantSwaggerFilter`, registered in `ApiFiltersConfiguration` to run
  *after* Spring Security (not before, unlike `PhysicalTenantFilter`): it redirects
  the bare `swagger`/`swagger-ui` paths to the tenant-prefixed index, and forwards
  asset requests to springdoc's real, unprefixed handler.
- Running after security is required, not just a style choice: the filter doesn't
  validate the tenant id itself, so an unconfigured tenant must still be rejected
  by the security catch-all (404) before ever reaching it.

Closes camunda/identity#4777

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.
