### PR TITLE
test: derive camunda exporter from unified secondary-storage config in MultiDbConfigurator

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnhandledBpmnErrorActivityIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UnhandledBpmnErrorActivityIdIT.java
@@ -11,19 +11,18 @@ import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AV
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.statistics.response.ProcessElementStatistics;
-import io.camunda.exporter.CamundaExporter;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import java.util.HashMap;
-import java.util.Map;
+import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Reproduces the production bug where the list-view flow-node document for a service task ends up
@@ -117,14 +116,13 @@ public class UnhandledBpmnErrorActivityIdIT {
 
   @BeforeAll
   static void setUp() {
-    final var camundaExporter = CamundaExporter.class.getSimpleName().toLowerCase();
     STANDALONE_CAMUNDA.withUnifiedConfig(
         c -> {
-          final var newArgs =
-              new HashMap<>(c.getData().getExporters().get(camundaExporter).getArgs());
           // See class javadoc for why these specific values reproduce the bug.
-          newArgs.put("bulk", Map.of("size", 5000, "delay", 5, "memoryLimit", 1));
-          c.getData().getExporters().get(camundaExporter).setArgs(newArgs);
+          final var bulk = c.getData().getSecondaryStorage().getDocumentBasedDatabase().getBulk();
+          bulk.setSize(5000);
+          bulk.setDelay(Duration.ofSeconds(5));
+          bulk.setMemoryLimit(DataSize.ofMegabytes(1));
         });
 
     STANDALONE_CAMUNDA.start();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/IncidentNotifierIT.java
@@ -26,14 +26,12 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.SearchResponse;
-import io.camunda.exporter.CamundaExporter;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -77,25 +75,14 @@ public class IncidentNotifierIT {
     // stub webhook endpoint
     wireMockServer.stubFor(post(urlEqualTo(WEBHOOK_PATH)).willReturn(aResponse().withStatus(200)));
 
-    final var camundaExporter = CamundaExporter.class.getSimpleName().toLowerCase();
-
-    // configure exporter to point to WireMock
+    // configure the incident notifier to point to WireMock
     STANDALONE_CAMUNDA.withUnifiedConfig(
         c -> {
-          final var newArgs =
-              new HashMap<>(c.getData().getExporters().get(camundaExporter).getArgs());
-          final var baseUrl = wireMockServer.baseUrl();
-          newArgs.put(
-              "notifier",
-              Map.of(
-                  "webhook",
-                  baseUrl + WEBHOOK_PATH,
-                  "auth0Domain",
-                  "localhost:" + wireMockServer.port(),
-                  "auth0Protocol",
-                  "http"));
-
-          c.getData().getExporters().get(camundaExporter).setArgs(newArgs);
+          final var notifier =
+              c.getData().getSecondaryStorage().getDocumentBasedDatabase().getIncidentNotifier();
+          notifier.setWebhook(wireMockServer.baseUrl() + WEBHOOK_PATH);
+          notifier.setAuth0Domain("localhost:" + wireMockServer.port());
+          notifier.setAuth0Protocol("http");
         });
   }
 

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -116,6 +116,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-exporter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -115,11 +115,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-exporter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-db-rdbms</artifactId>
     </dependency>
     <dependency>

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -12,11 +12,11 @@ import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TEST_INTEGRATIO
 
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
-import io.camunda.exporter.CamundaExporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -83,49 +83,15 @@ public class MultiDbConfigurator {
                   .getElasticsearch()
                   .getHistory()
                   .setPolicyName(indexPrefix + "-ilm");
+              final var history =
+                  cfg.getData().getSecondaryStorage().getElasticsearch().getHistory();
+              // find completed instances almost directly
+              history.setWaitPeriodBeforeArchiving(retentionEnabled ? "1s" : "1h");
+              history.setDelayBetweenRuns(Duration.ofMillis(1000));
+              history.setMaxDelayBetweenRuns(Duration.ofMillis(1000));
+              cfg.getData().getSecondaryStorage().getElasticsearch().getBulk().setSize(1);
               overrideRefreshInterval(cfg.getData().getSecondaryStorage().getElasticsearch());
             });
-    testApplication.withExporter(
-        CamundaExporter.class.getSimpleName().toLowerCase(),
-        cfg -> {
-          cfg.setClassName(CamundaExporter.class.getName());
-          cfg.setArgs(
-              Map.of(
-                  "connect",
-                  Map.of(
-                      "url",
-                      elasticsearchUrl,
-                      "indexPrefix",
-                      indexPrefix,
-                      "type",
-                      io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH),
-                  "index",
-                  Map.of("prefix", indexPrefix),
-                  "history",
-                  Map.of(
-                      "waitPeriodBeforeArchiving",
-                      retentionEnabled ? "1s" : "1h", // find completed instances almost directly
-                      "delayBetweenRuns",
-                      "1000",
-                      "maxDelayBetweenRuns",
-                      "1000",
-                      "retention",
-                      Map.of(
-                          "enabled",
-                          Boolean.toString(retentionEnabled),
-                          "policyName",
-                          indexPrefix + "-ilm",
-                          "minimumAge",
-                          // 0s causes ILM to move data asap - it is normally the default
-                          // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-                          "0s",
-                          "usageMetricsPolicyName",
-                          indexPrefix + "-usage-metrics-ilm",
-                          "usageMetricsMinimumAge",
-                          "0s")),
-                  "bulk",
-                  Map.of("size", 1)));
-        });
   }
 
   public void configureOpenSearchSupportIncludingOldExporter(
@@ -201,52 +167,15 @@ public class MultiDbConfigurator {
               cfg.getData().getSecondaryStorage().getOpensearch().setUsername(userName);
               cfg.getData().getSecondaryStorage().getOpensearch().setPassword(userPassword);
               cfg.getData().getSecondaryStorage().getOpensearch().setAwsEnabled(isAws);
+              // find completed instances almost directly
+              cfg.getData()
+                  .getSecondaryStorage()
+                  .getOpensearch()
+                  .getHistory()
+                  .setWaitPeriodBeforeArchiving(retentionEnabled ? "1s" : "1h");
+              cfg.getData().getSecondaryStorage().getOpensearch().getBulk().setSize(1);
               overrideRefreshInterval(cfg.getData().getSecondaryStorage().getOpensearch());
             });
-
-    testApplication.withExporter(
-        CamundaExporter.class.getSimpleName().toLowerCase(),
-        cfg -> {
-          cfg.setClassName(CamundaExporter.class.getName());
-          cfg.setArgs(
-              Map.of(
-                  "connect",
-                  Map.of(
-                      "url",
-                      opensearchUrl,
-                      "indexPrefix",
-                      indexPrefix,
-                      "type",
-                      io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH,
-                      "username",
-                      userName,
-                      "password",
-                      userPassword,
-                      "awsEnabled",
-                      isAws),
-                  "index",
-                  Map.of("prefix", indexPrefix),
-                  "history",
-                  Map.of(
-                      "waitPeriodBeforeArchiving",
-                      retentionEnabled ? "1s" : "1h", // find completed instances almost directly
-                      "retention",
-                      Map.of(
-                          "enabled",
-                          Boolean.toString(retentionEnabled),
-                          "policyName",
-                          indexPrefix + "-ilm",
-                          "minimumAge",
-                          // 0s causes ILM to move data asap - it is normally the default
-                          // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-                          "0s",
-                          "usageMetricsPolicyName",
-                          indexPrefix + "-usage-metrics-ilm",
-                          "usageMetricsMinimumAge",
-                          "0s")),
-                  "bulk",
-                  Map.of("size", 1)));
-        });
   }
 
   public void configureRDBMSSupport(

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
@@ -10,10 +10,11 @@ package io.camunda.qa.util.multidb;
 import static io.camunda.qa.util.multidb.MultiDbConfigurator.zeebePrefix;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.configuration.beans.BrokerBasedProperties;
-import io.camunda.exporter.CamundaExporter;
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
+import io.camunda.configuration.Exporter;
+import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
-import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import java.util.Map;
@@ -38,83 +39,23 @@ public class MultiDbConfiguratorTest {
     multiDbConfigurator.configureElasticsearchSupport(EXPECTED_URL, EXPECTED_PREFIX);
 
     // then
-
-    /* Tasklist Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.elasticsearch.indexPrefix",
-        EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.elasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.zeebeElasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.elasticsearch.indexPrefix",
-        EXPECTED_PREFIX);
     assertProperty(
         testSimpleCamundaApplication,
         "camunda.tasklist.zeebeElasticsearch.prefix",
         EXPECTED_ZEEBE_PREFIX);
 
-    /* Operate Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.operate.elasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.zeebeElasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.operate.zeebeElasticsearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
+    final SecondaryStorage secondaryStorage =
+        testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
+    assertThat(secondaryStorage.getType()).isEqualTo(SecondaryStorageType.elasticsearch);
+    assertThat(secondaryStorage.getRetention().isEnabled()).isFalse();
+    assertThat(secondaryStorage.getRetention().getMinimumAge()).isEqualTo("0s");
+    assertDocumentBasedDatabase(
+        secondaryStorage.getElasticsearch(), EXPECTED_URL, EXPECTED_PREFIX, "1h");
 
-    /* Camunda Config Assertions */
-
-    assertProperty(testSimpleCamundaApplication, "camunda.database.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.database.url", EXPECTED_URL);
-
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties).isNotNull();
-
-    final ExporterCfg camundaExporter =
-        brokerBasedProperties
-            .getExporters()
-            .get(CamundaExporter.class.getSimpleName().toLowerCase());
-    assertThat(camundaExporter).isNotNull();
-
-    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
-    assertThat(exporterArgs.get("index")).isEqualTo(Map.of("prefix", EXPECTED_PREFIX));
-
-    assertThat(exporterArgs.get("connect"))
-        .isEqualTo(
-            Map.of(
-                "url",
-                EXPECTED_URL,
-                "indexPrefix",
-                EXPECTED_PREFIX,
-                "type",
-                io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH));
-
-    assertThat(exporterArgs.get("history"))
-        .isEqualTo(
-            Map.of(
-                "waitPeriodBeforeArchiving",
-                "1h",
-                "retention",
-                Map.of(
-                    "enabled",
-                    Boolean.toString(false),
-                    "policyName",
-                    EXPECTED_PREFIX + "-ilm",
-                    "minimumAge",
-                    "0s",
-                    "usageMetricsPolicyName",
-                    EXPECTED_PREFIX + "-usage-metrics-ilm",
-                    "usageMetricsMinimumAge",
-                    "0s")));
+    // the camunda exporter is not declared explicitly; it is derived from the unified
+    // secondary-storage configuration at startup so that physical tenants export to their own
+    // storage instead of inheriting a root-pinned connection
+    assertNoExplicitCamundaExporter(testSimpleCamundaApplication);
   }
 
   @Test
@@ -128,78 +69,13 @@ public class MultiDbConfiguratorTest {
     multiDbConfigurator.configureElasticsearchSupport(EXPECTED_URL, EXPECTED_PREFIX, true);
 
     // then
-
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties).isNotNull();
-
-    final ExporterCfg camundaExporter =
-        brokerBasedProperties
-            .getExporters()
-            .get(CamundaExporter.class.getSimpleName().toLowerCase());
-    assertThat(camundaExporter).isNotNull();
-
-    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
-    assertThat(exporterArgs.get("history"))
-        .isEqualTo(
-            Map.of(
-                "waitPeriodBeforeArchiving",
-                "1s",
-                "retention",
-                Map.of(
-                    "enabled",
-                    Boolean.toString(true),
-                    "policyName",
-                    EXPECTED_PREFIX + "-ilm",
-                    "minimumAge",
-                    "0s",
-                    "usageMetricsPolicyName",
-                    EXPECTED_PREFIX + "-usage-metrics-ilm",
-                    "usageMetricsMinimumAge",
-                    "0s")));
-  }
-
-  @Test
-  public void shouldConfigureWithOpenSearchWithRetention() {
-    // given
-    final var testSimpleCamundaApplication = new TestCamundaApplication();
-    final MultiDbConfigurator multiDbConfigurator =
-        new MultiDbConfigurator(testSimpleCamundaApplication);
-
-    // when
-    multiDbConfigurator.configureOpenSearchSupport(
-        EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW, true, false);
-
-    // then
-
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties).isNotNull();
-
-    final ExporterCfg camundaExporter =
-        brokerBasedProperties
-            .getExporters()
-            .get(CamundaExporter.class.getSimpleName().toLowerCase());
-    assertThat(camundaExporter).isNotNull();
-
-    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
-    assertThat(exporterArgs.get("history"))
-        .isEqualTo(
-            Map.of(
-                "waitPeriodBeforeArchiving",
-                "1s",
-                "retention",
-                Map.of(
-                    "enabled",
-                    Boolean.toString(true),
-                    "policyName",
-                    EXPECTED_PREFIX + "-ilm",
-                    "minimumAge",
-                    "0s",
-                    "usageMetricsPolicyName",
-                    EXPECTED_PREFIX + "-usage-metrics-ilm",
-                    "usageMetricsMinimumAge",
-                    "0s")));
+    final SecondaryStorage secondaryStorage =
+        testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
+    assertThat(secondaryStorage.getRetention().isEnabled()).isTrue();
+    assertThat(secondaryStorage.getRetention().getMinimumAge()).isEqualTo("0s");
+    assertDocumentBasedDatabase(
+        secondaryStorage.getElasticsearch(), EXPECTED_URL, EXPECTED_PREFIX, "1s");
+    assertNoExplicitCamundaExporter(testSimpleCamundaApplication);
   }
 
   @Test
@@ -214,83 +90,31 @@ public class MultiDbConfiguratorTest {
         EXPECTED_URL, EXPECTED_PREFIX);
 
     // then
+    final SecondaryStorage secondaryStorage =
+        testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
+    assertThat(secondaryStorage.getType()).isEqualTo(SecondaryStorageType.elasticsearch);
+    assertDocumentBasedDatabase(
+        secondaryStorage.getElasticsearch(), EXPECTED_URL, EXPECTED_PREFIX, "1h");
 
-    /* Tasklist Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.elasticsearch.indexPrefix",
-        EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.elasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.zeebeElasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.elasticsearch.indexPrefix",
-        EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.zeebeElasticsearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-
-    /* Operate Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.operate.elasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.zeebeElasticsearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.operate.zeebeElasticsearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-
-    /* Camunda Config Assertions */
-
-    assertProperty(testSimpleCamundaApplication, "camunda.database.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.database.url", EXPECTED_URL);
-
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties).isNotNull();
-
-    final ExporterCfg esExporter =
-        brokerBasedProperties
+    final Exporter esExporter =
+        testSimpleCamundaApplication
+            .unifiedConfig()
+            .getData()
             .getExporters()
             .get(ElasticsearchExporter.class.getSimpleName().toLowerCase());
     assertThat(esExporter).isNotNull();
     assertThat(esExporter.getClassName()).isEqualTo(ElasticsearchExporter.class.getName());
-
-    final Map<String, Object> esExporterArgs = esExporter.getArgs();
-    assertThat(esExporterArgs)
+    assertThat(esExporter.getArgs())
         .isEqualTo(
             Map.of(
                 "url",
                 EXPECTED_URL,
                 "index",
-                Map.of("prefix", EXPECTED_PREFIX + "-zeebe-records"),
+                Map.of("prefix", EXPECTED_ZEEBE_PREFIX),
                 "bulk",
                 Map.of("size", 1)));
 
-    final ExporterCfg camundaExporter =
-        brokerBasedProperties
-            .getExporters()
-            .get(CamundaExporter.class.getSimpleName().toLowerCase());
-    assertThat(camundaExporter).isNotNull();
-
-    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
-    assertThat(exporterArgs.get("index")).isEqualTo(Map.of("prefix", EXPECTED_PREFIX));
-
-    assertThat(exporterArgs.get("connect"))
-        .isEqualTo(
-            Map.of(
-                "url",
-                EXPECTED_URL,
-                "indexPrefix",
-                EXPECTED_PREFIX,
-                "type",
-                io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH));
+    assertNoExplicitCamundaExporter(testSimpleCamundaApplication);
   }
 
   @Test
@@ -305,92 +129,43 @@ public class MultiDbConfiguratorTest {
         EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW);
 
     // then
-
-    /* Tasklist Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.tasklist.opensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.zeebeOpensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
     assertProperty(
         testSimpleCamundaApplication,
         "camunda.tasklist.zeebeOpensearch.prefix",
         EXPECTED_ZEEBE_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.username", EXPECTED_USER);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.password", EXPECTED_PW);
 
-    /* Operate Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.operate.opensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.zeebeOpensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.operate.zeebeOpensearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.username", EXPECTED_USER);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.password", EXPECTED_PW);
+    final SecondaryStorage secondaryStorage =
+        testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
+    assertThat(secondaryStorage.getType()).isEqualTo(SecondaryStorageType.opensearch);
+    assertThat(secondaryStorage.getRetention().isEnabled()).isFalse();
+    assertDocumentBasedDatabase(
+        secondaryStorage.getOpensearch(), EXPECTED_URL, EXPECTED_PREFIX, "1h");
+    assertThat(secondaryStorage.getOpensearch().getUsername()).isEqualTo(EXPECTED_USER);
+    assertThat(secondaryStorage.getOpensearch().getPassword()).isEqualTo(EXPECTED_PW);
+    assertThat(secondaryStorage.getOpensearch().isAwsEnabled()).isFalse();
 
-    /* Camunda Config Assertions */
+    assertNoExplicitCamundaExporter(testSimpleCamundaApplication);
+  }
 
-    assertProperty(testSimpleCamundaApplication, "camunda.database.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.database.url", EXPECTED_URL);
-    assertProperty(testSimpleCamundaApplication, "camunda.database.username", EXPECTED_USER);
-    assertProperty(testSimpleCamundaApplication, "camunda.database.password", EXPECTED_PW);
+  @Test
+  public void shouldConfigureWithOpenSearchWithRetention() {
+    // given
+    final var testSimpleCamundaApplication = new TestCamundaApplication();
+    final MultiDbConfigurator multiDbConfigurator =
+        new MultiDbConfigurator(testSimpleCamundaApplication);
 
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties).isNotNull();
+    // when
+    multiDbConfigurator.configureOpenSearchSupport(
+        EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW, true, false);
 
-    final ExporterCfg camundaExporter =
-        brokerBasedProperties
-            .getExporters()
-            .get(CamundaExporter.class.getSimpleName().toLowerCase());
-    assertThat(camundaExporter).isNotNull();
-
-    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
-    assertThat(exporterArgs.get("index")).isEqualTo(Map.of("prefix", EXPECTED_PREFIX));
-
-    assertThat(exporterArgs.get("connect"))
-        .isEqualTo(
-            Map.of(
-                "url",
-                EXPECTED_URL,
-                "indexPrefix",
-                EXPECTED_PREFIX,
-                "type",
-                io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH,
-                "username",
-                EXPECTED_USER,
-                "password",
-                EXPECTED_PW));
-
-    assertThat(exporterArgs.get("history"))
-        .isEqualTo(
-            Map.of(
-                "waitPeriodBeforeArchiving",
-                "1h",
-                "retention",
-                Map.of(
-                    "enabled",
-                    Boolean.toString(false),
-                    "policyName",
-                    EXPECTED_PREFIX + "-ilm",
-                    "minimumAge",
-                    "0s",
-                    "usageMetricsPolicyName",
-                    EXPECTED_PREFIX + "-usage-metrics-ilm",
-                    "usageMetricsMinimumAge",
-                    "0s")));
+    // then
+    final SecondaryStorage secondaryStorage =
+        testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
+    assertThat(secondaryStorage.getRetention().isEnabled()).isTrue();
+    assertThat(secondaryStorage.getRetention().getMinimumAge()).isEqualTo("0s");
+    assertDocumentBasedDatabase(
+        secondaryStorage.getOpensearch(), EXPECTED_URL, EXPECTED_PREFIX, "1s");
+    assertNoExplicitCamundaExporter(testSimpleCamundaApplication);
   }
 
   @Test
@@ -405,100 +180,56 @@ public class MultiDbConfiguratorTest {
         EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW);
 
     // then
+    final SecondaryStorage secondaryStorage =
+        testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
+    assertThat(secondaryStorage.getType()).isEqualTo(SecondaryStorageType.opensearch);
+    assertDocumentBasedDatabase(
+        secondaryStorage.getOpensearch(), EXPECTED_URL, EXPECTED_PREFIX, "1h");
 
-    /* Tasklist Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.tasklist.opensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.zeebeOpensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.zeebeOpensearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.username", EXPECTED_USER);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.opensearch.password", EXPECTED_PW);
-
-    /* Operate Config Assertions */
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(testSimpleCamundaApplication, "camunda.operate.opensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.zeebeOpensearch.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.operate.zeebeOpensearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.username", EXPECTED_USER);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.opensearch.password", EXPECTED_PW);
-
-    /* Camunda Config Assertions */
-
-    assertProperty(testSimpleCamundaApplication, "camunda.database.indexPrefix", EXPECTED_PREFIX);
-
-    assertProperty(testSimpleCamundaApplication, "camunda.database.url", EXPECTED_URL);
-    assertProperty(
-        testSimpleCamundaApplication, "camunda.data.secondary-storage.url", EXPECTED_URL);
-
-    assertProperty(testSimpleCamundaApplication, "camunda.database.username", EXPECTED_USER);
-    assertProperty(testSimpleCamundaApplication, "camunda.database.password", EXPECTED_PW);
-
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties).isNotNull();
-
-    final ExporterCfg camundaExporter =
-        brokerBasedProperties
-            .getExporters()
-            .get(CamundaExporter.class.getSimpleName().toLowerCase());
-    assertThat(camundaExporter).isNotNull();
-
-    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
-    assertThat(exporterArgs.get("index")).isEqualTo(Map.of("prefix", EXPECTED_PREFIX));
-
-    assertThat(exporterArgs.get("connect"))
-        .isEqualTo(
-            Map.of(
-                "url",
-                EXPECTED_URL,
-                "indexPrefix",
-                EXPECTED_PREFIX,
-                "type",
-                io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH,
-                "username",
-                EXPECTED_USER,
-                "password",
-                EXPECTED_PW));
-
-    final ExporterCfg osExporter =
-        brokerBasedProperties
+    final Exporter osExporter =
+        testSimpleCamundaApplication
+            .unifiedConfig()
+            .getData()
             .getExporters()
             .get(OpensearchExporter.class.getSimpleName().toLowerCase());
     assertThat(osExporter).isNotNull();
     assertThat(osExporter.getClassName()).isEqualTo(OpensearchExporter.class.getName());
-
-    final Map<String, Object> esExporterArgs = osExporter.getArgs();
-    assertThat(esExporterArgs)
+    assertThat(osExporter.getArgs())
         .isEqualTo(
             Map.of(
                 "url",
                 EXPECTED_URL,
                 "index",
-                Map.of("prefix", EXPECTED_PREFIX + "-zeebe-records"),
+                Map.of("prefix", EXPECTED_ZEEBE_PREFIX),
                 "bulk",
                 Map.of("size", 1),
                 "authentication",
                 Map.of("username", EXPECTED_USER, "password", EXPECTED_PW)));
+
+    assertNoExplicitCamundaExporter(testSimpleCamundaApplication);
   }
 
+  private static void assertDocumentBasedDatabase(
+      final DocumentBasedSecondaryStorageDatabase database,
+      final String expectedUrl,
+      final String expectedPrefix,
+      final String expectedWaitPeriodBeforeArchiving) {
+    assertThat(database.getUrl()).isEqualTo(expectedUrl);
+    assertThat(database.getIndexPrefix()).isEqualTo(expectedPrefix);
+    assertThat(database.getHistory().getPolicyName()).isEqualTo(expectedPrefix + "-ilm");
+    assertThat(database.getHistory().getWaitPeriodBeforeArchiving())
+        .isEqualTo(expectedWaitPeriodBeforeArchiving);
+    assertThat(database.getBulk().getSize()).isEqualTo(1);
+    assertThat(database.getRefreshInterval()).isEqualTo("100ms");
+  }
+
+  private static void assertNoExplicitCamundaExporter(
+      final TestCamundaApplication testApplication) {
+    assertThat(testApplication.unifiedConfig().getData().getExporters())
+        .doesNotContainKey("camundaexporter");
+  }
+
+  @SuppressWarnings("unchecked")
   private <T> void assertProperty(
       final TestCamundaApplication applicationContext,
       final String propertyKey,


### PR DESCRIPTION
## Why

Declaring `camundaexporter` explicitly in the root configuration breaks physical-tenant storage isolation: tenants inherit the root-declared exporter entry verbatim (args pinning the root connection), and `populateFromExporters` overwrites the tenant-derived exporter config with it — so every tenant's partitions export into the root tenant's storage. This is the root cause of the permanent 401s in the physical-tenant ES acceptance tests (#55350 / #57286).

#58203 fixed this in production code by special-casing inheritance of root-declared autoconfigured exporters. This PR takes the harness-only route instead: the test harness was the thing declaring the exporter explicitly, and it doesn't need to — the unified secondary-storage configuration already derives the `camundaexporter` per node (and per tenant) through the normal production code path (`BrokerBasedPropertiesOverride#populateCamundaExporter`).

## What

- `MultiDbConfigurator` no longer declares `camundaexporter` with hardcoded connection args. All settings the explicit args carried (history archiver cadence, bulk size, retention/ILM policy) are now expressed as unified `camunda.data.secondary-storage.*` config, from which the exporter is derived at startup — for the root node and equally for any physical tenant.
- `camunda-exporter` moves to test scope in `qa/util` (no longer referenced from main sources).
- Rewrote `MultiDbConfiguratorTest` to assert the unified-config surface and that no explicit `camundaexporter` is declared. Note: this test was already failing when run (it asserted properties removed from the harness a while ago) and is not picked up by CI surefire includes (`**/*Tests.java`); it now passes when run explicitly.

Supersedes the production-code change in #58203.

## Verification

- `MultiDbConfiguratorTest` — 6/6 pass (were 6/6 failing on `main`).
- `StandaloneCamundaTest` end-to-end against an ES testcontainer — green, exporter derived through the production path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
