### PR TITLE
[Backport stable/8.9] test: wait for latest process definition version before opening Processes tab

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/processes-page.spec.ts
@@ -8,7 +8,7 @@
 
 import {expect} from '@playwright/test';
 import {test} from 'fixtures';
-import {deploy} from 'utils/zeebeClient';
+import {deploy, waitForLatestProcessVersion} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
@@ -22,40 +22,6 @@ test.beforeAll(async () => {
   ]);
   await sleep(2000);
 });
-
-// Polls the process definition search API until the given version is indexed
-// as the latest, so the Processes tab is guaranteed to reflect it.
-const waitForLatestProcessVersion = async (
-  processDefinitionId: string,
-  expectedVersion: number,
-) => {
-  const baseUrl =
-    process.env.ZEEBE_REST_ADDRESS ?? process.env.CORE_APPLICATION_URL;
-  const authorization = `Basic ${Buffer.from(
-    `${process.env.CAMUNDA_BASIC_AUTH_USERNAME}:${process.env.CAMUNDA_BASIC_AUTH_PASSWORD}`,
-  ).toString('base64')}`;
-  for (let attempt = 0; attempt < 30; attempt++) {
-    const response = await fetch(`${baseUrl}/v2/process-definitions/search`, {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json', authorization},
-      body: JSON.stringify({
-        filter: {processDefinitionId, isLatestVersion: true},
-      }),
-    });
-    if (response.ok) {
-      const body = (await response.json()) as {
-        items?: Array<{version: number}>;
-      };
-      if (body.items?.[0]?.version === expectedVersion) {
-        return;
-      }
-    }
-    await sleep(1000);
-  }
-  throw new Error(
-    `Process definition ${processDefinitionId} version ${expectedVersion} was not indexed as latest in time`,
-  );
-};
 
 test.describe('process page', () => {
   test.beforeEach(async ({page, loginPage, taskPanelPage}) => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -147,7 +147,9 @@ const waitForLatestProcessVersion = async (
     if (response.items?.[0]?.version === expectedVersion) {
       return;
     }
-    await sleep(1000);
+    if (attempt < timeoutSeconds - 1) {
+      await sleep(1000);
+    }
   }
   throw new Error(
     `Process definition ${processDefinitionId} version ${expectedVersion} was not indexed as latest within ${timeoutSeconds}s`,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/zeebeClient.ts
@@ -8,6 +8,7 @@
 
 import {Camunda8} from '@camunda8/sdk';
 import {JSONDoc} from '@camunda8/sdk/dist/zeebe/types.js';
+import {sleep} from './sleep';
 
 const c8 = new Camunda8({
   CAMUNDA_AUTH_STRATEGY: process.env.CAMUNDA_AUTH_STRATEGY as
@@ -125,8 +126,37 @@ async function checkUpdateOnVersion(
   return !!item && item.processDefinitionVersion == targetVersion;
 }
 
+/**
+ * Waits until the given process definition version is indexed as the latest,
+ * so UI pages relying on the search API (e.g. Tasklist's Processes tab) are
+ * guaranteed to reflect it.
+ */
+const waitForLatestProcessVersion = async (
+  processDefinitionId: string,
+  expectedVersion: number,
+  timeoutSeconds: number = 30,
+) => {
+  for (let attempt = 0; attempt < timeoutSeconds; attempt++) {
+    const response = await zeebe.searchProcessDefinitions({
+      // isLatestVersion mirrors the query Tasklist's Processes tab issues;
+      // the SDK filter type does not expose the flag yet.
+      filter: {processDefinitionId, isLatestVersion: true} as Parameters<
+        typeof zeebe.searchProcessDefinitions
+      >[0]['filter'] & {isLatestVersion: boolean},
+    });
+    if (response.items?.[0]?.version === expectedVersion) {
+      return;
+    }
+    await sleep(1000);
+  }
+  throw new Error(
+    `Process definition ${processDefinitionId} version ${expectedVersion} was not indexed as latest within ${timeoutSeconds}s`,
+  );
+};
+
 export {
   deploy,
+  waitForLatestProcessVersion,
   createInstances,
   generateManyVariables,
   checkUpdateOnVersion,


### PR DESCRIPTION
⤵️ Backport of #58102 → `stable/8.9`

The automated backport-action could not cherry-pick the 6 commits from #58102 cleanly. Rebuilt manually: moved the indexing-lag helper into `utils/zeebeClient.ts`, using the SDK's `searchProcessDefinitions` with `isLatestVersion` and the shared `sleep` helper.

Verified locally against `camunda/camunda:8.9-SNAPSHOT`: full `processes-page.spec.ts` — 10 passed, 1 skipped (pre-existing), 0 flaky.

relates to #40045, #58050, camunda/team-qa-engineering#554