### PR TITLE
feat: secret resolution background task

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -40,6 +40,9 @@ public class Engine {
   /** Configuration properties for the engine's BPMN/DMN validators. */
   @NestedConfigurationProperty private EngineValidators validators = new EngineValidators();
 
+  /** Configuration properties for the engine's secret resolution scheduler. */
+  @NestedConfigurationProperty private EngineSecrets secrets = new EngineSecrets();
+
   /**
    * Configures the maximum depth of nested call activities allowed before an incident is raised, to
    * guard against unbounded process recursion.
@@ -100,6 +103,14 @@ public class Engine {
 
   public void setValidators(final EngineValidators validators) {
     this.validators = validators;
+  }
+
+  public EngineSecrets getSecrets() {
+    return secrets;
+  }
+
+  public void setSecrets(final EngineSecrets secrets) {
+    this.secrets = secrets;
   }
 
   public int getMaxProcessDepth() {

--- a/configuration/src/main/java/io/camunda/configuration/EngineSecrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineSecrets.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.time.Duration;
+
+/**
+ * Defines configuration for the engine's secret resolution scheduler. The prefix for this class is
+ * camunda.processing.engine.secrets.
+ */
+public class EngineSecrets {
+
+  public static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(5);
+  public static final int DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+  public static final Duration DEFAULT_RETRY_INITIAL_DELAY = Duration.ofSeconds(1);
+  public static final Duration DEFAULT_RETRY_MAX_DELAY = Duration.ofSeconds(30);
+  public static final int DEFAULT_RETRY_BACKOFF_FACTOR = 2;
+
+  private Duration interval = DEFAULT_INTERVAL;
+  private int retryMaxAttempts = DEFAULT_RETRY_MAX_ATTEMPTS;
+  private Duration retryInitialDelay = DEFAULT_RETRY_INITIAL_DELAY;
+  private Duration retryMaxDelay = DEFAULT_RETRY_MAX_DELAY;
+  private int retryBackoffFactor = DEFAULT_RETRY_BACKOFF_FACTOR;
+
+  /**
+   * Cadence at which the secret resolution scheduler polls for pending secret references. This
+   * configuration can be accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.secrets.interval}.
+   *
+   * <p>Defaults to {@code 5s}.
+   */
+  public Duration getInterval() {
+    return interval;
+  }
+
+  public void setInterval(final Duration interval) {
+    this.interval = interval;
+  }
+
+  /**
+   * Maximum number of attempts before a secret store's failure is treated as permanent. This
+   * configuration can be accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.secrets.retry-max-attempts}.
+   *
+   * <p>Defaults to {@code 3}.
+   */
+  public int getRetryMaxAttempts() {
+    return retryMaxAttempts;
+  }
+
+  public void setRetryMaxAttempts(final int retryMaxAttempts) {
+    this.retryMaxAttempts = retryMaxAttempts;
+  }
+
+  /**
+   * Initial delay before the first retry after a secret store failure. This configuration can be
+   * accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.secrets.retry-initial-delay}.
+   *
+   * <p>Defaults to {@code 1s}.
+   */
+  public Duration getRetryInitialDelay() {
+    return retryInitialDelay;
+  }
+
+  public void setRetryInitialDelay(final Duration retryInitialDelay) {
+    this.retryInitialDelay = retryInitialDelay;
+  }
+
+  /**
+   * Maximum delay between retries after repeated secret store failures. This configuration can be
+   * accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.secrets.retry-max-delay}.
+   *
+   * <p>Defaults to {@code 30s}.
+   */
+  public Duration getRetryMaxDelay() {
+    return retryMaxDelay;
+  }
+
+  public void setRetryMaxDelay(final Duration retryMaxDelay) {
+    this.retryMaxDelay = retryMaxDelay;
+  }
+
+  /**
+   * Multiplier applied to the retry delay after each consecutive secret store failure. This
+   * configuration can be accessed via the environment variable: <br>
+   * {@code camunda.processing.engine.secrets.retry-backoff-factor}.
+   *
+   * <p>Defaults to {@code 2}.
+   */
+  public int getRetryBackoffFactor() {
+    return retryBackoffFactor;
+  }
+
+  public void setRetryBackoffFactor(final int retryBackoffFactor) {
+    this.retryBackoffFactor = retryBackoffFactor;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -261,6 +261,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromMessages(override, camunda);
     populateFromUsageMetrics(override, camunda);
     populateFromValidators(override, camunda);
+    populateFromSecretResolution(override, camunda);
 
     override
         .getExperimental()
@@ -1254,5 +1255,16 @@ public class BrokerBasedPropertiesOverride {
     jobsCfg.setIncludeVariablesInJobCompletedEvent(job.isIncludeVariablesInJobCompletedEvent());
     jobsCfg.setTimeoutCheckerBatchLimit(job.getTimeoutCheckerBatchLimit());
     jobsCfg.setTimeoutCheckerPollingInterval(job.getTimeoutCheckerPollingInterval());
+  }
+
+  private static void populateFromSecretResolution(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var engineSecrets = camunda.getProcessing().getEngine().getSecrets();
+    final var secretResolutionCfg = override.getExperimental().getEngine().getSecretResolution();
+    secretResolutionCfg.setInterval(engineSecrets.getInterval());
+    secretResolutionCfg.setRetryMaxAttempts(engineSecrets.getRetryMaxAttempts());
+    secretResolutionCfg.setRetryInitialDelay(engineSecrets.getRetryInitialDelay());
+    secretResolutionCfg.setRetryMaxDelay(engineSecrets.getRetryMaxDelay());
+    secretResolutionCfg.setRetryBackoffFactor(engineSecrets.getRetryBackoffFactor());
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/EngineSecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineSecretsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+@TestPropertySource(
+    properties = {
+      "camunda.processing.engine.secrets.interval=10s",
+      "camunda.processing.engine.secrets.retry-max-attempts=5",
+      "camunda.processing.engine.secrets.retry-initial-delay=2s",
+      "camunda.processing.engine.secrets.retry-max-delay=60s",
+      "camunda.processing.engine.secrets.retry-backoff-factor=3"
+    })
+public class EngineSecretsTest {
+  final BrokerBasedProperties brokerCfg;
+
+  EngineSecretsTest(@Autowired final BrokerBasedProperties brokerCfg) {
+    this.brokerCfg = brokerCfg;
+  }
+
+  @Test
+  void shouldSetSecretResolution() {
+    final var secretResolution = brokerCfg.getExperimental().getEngine().getSecretResolution();
+    assertThat(secretResolution.getInterval()).isEqualTo(Duration.ofSeconds(10));
+    assertThat(secretResolution.getRetryMaxAttempts()).isEqualTo(5);
+    assertThat(secretResolution.getRetryInitialDelay()).isEqualTo(Duration.ofSeconds(2));
+    assertThat(secretResolution.getRetryMaxDelay()).isEqualTo(Duration.ofSeconds(60));
+    assertThat(secretResolution.getRetryBackoffFactor()).isEqualTo(3);
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -288,6 +288,11 @@ processing.engine.job.timeout-checker-polling-interval
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval
+processing.engine.secrets.interval
+processing.engine.secrets.retry-backoff-factor
+processing.engine.secrets.retry-initial-delay
+processing.engine.secrets.retry-max-attempts
+processing.engine.secrets.retry-max-delay
 processing.engine.usage-metrics.export-interval
 processing.engine.validators.results-output-max-size
 processing.flow-control.request.aimd.backoff-ratio

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -18,6 +18,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private JobsCfg jobs = new JobsCfg();
   private ValidatorsCfg validators = new ValidatorsCfg();
   private BatchOperationCfg batchOperations = new BatchOperationCfg();
+  private SecretResolutionCfg secretResolution = new SecretResolutionCfg();
   private UsageMetricsCfg usageMetrics = new UsageMetricsCfg();
   private JobMetricsCfg jobMetrics = new JobMetricsCfg();
   private DistributionCfg distribution = new DistributionCfg();
@@ -34,6 +35,7 @@ public final class EngineCfg implements ConfigurationEntry {
     jobs.init(globalConfig, brokerBase);
     jobMetrics.init(globalConfig, brokerBase);
     batchOperations.init(globalConfig, brokerBase);
+    secretResolution.init(globalConfig, brokerBase);
     validators.init(globalConfig, brokerBase);
     distribution.init(globalConfig, brokerBase);
     usageMetrics.init(globalConfig, brokerBase);
@@ -81,6 +83,14 @@ public final class EngineCfg implements ConfigurationEntry {
 
   public void setBatchOperations(final BatchOperationCfg batchOperations) {
     this.batchOperations = batchOperations;
+  }
+
+  public SecretResolutionCfg getSecretResolution() {
+    return secretResolution;
+  }
+
+  public void setSecretResolution(final SecretResolutionCfg secretResolution) {
+    this.secretResolution = secretResolution;
   }
 
   public UsageMetricsCfg getUsageMetrics() {
@@ -164,6 +174,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + jobMetrics
         + ", batchOperations="
         + batchOperations
+        + ", secretResolution="
+        + secretResolution
         + ", usageMetrics="
         + usageMetrics
         + ", distribution="
@@ -205,6 +217,11 @@ public final class EngineCfg implements ConfigurationEntry {
         .setBatchOperationQueryRetryInitialDelay(batchOperations.getQueryRetryInitialDelay())
         .setBatchOperationQueryRetryMaxDelay(batchOperations.getQueryRetryMaxDelay())
         .setBatchOperationQueryRetryBackoffFactor(batchOperations.getQueryRetryBackoffFactor())
+        .setSecretResolutionInterval(secretResolution.getInterval())
+        .setSecretResolutionRetryMaxAttempts(secretResolution.getRetryMaxAttempts())
+        .setSecretResolutionRetryInitialDelay(secretResolution.getRetryInitialDelay())
+        .setSecretResolutionRetryMaxDelay(secretResolution.getRetryMaxDelay())
+        .setSecretResolutionRetryBackoffFactor(secretResolution.getRetryBackoffFactor())
         .setUsageMetricsExportInterval(usageMetrics.getExportInterval())
         .setJobMetricsExportInterval(jobMetrics.getExportInterval())
         .setJobMetricsExportEnabled(jobMetrics.isEnabled())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfg.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import java.time.Duration;
+
+public class SecretResolutionCfg implements ConfigurationEntry {
+  private Duration interval = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL;
+  private int retryMaxAttempts = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
+  private Duration retryInitialDelay =
+      EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY;
+  private Duration retryMaxDelay = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY;
+  private int retryBackoffFactor =
+      EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR;
+
+  @Override
+  public void init(final BrokerCfg globalConfig, final String brokerBase) {
+    if (interval == null || !interval.isPositive()) {
+      throw new IllegalArgumentException(
+          "Secret resolution interval must be positive but was %s".formatted(interval));
+    }
+    if (retryMaxAttempts < 1) {
+      throw new IllegalArgumentException(
+          "Secret resolution retryMaxAttempts must be at least 1 but was %d"
+              .formatted(retryMaxAttempts));
+    }
+    if (retryInitialDelay == null || !retryInitialDelay.isPositive()) {
+      throw new IllegalArgumentException(
+          "Secret resolution retryInitialDelay must be positive but was %s"
+              .formatted(retryInitialDelay));
+    }
+    if (retryMaxDelay == null
+        || !retryMaxDelay.isPositive()
+        || retryMaxDelay.compareTo(retryInitialDelay) < 0) {
+      throw new IllegalArgumentException(
+          "Secret resolution retryMaxDelay must be positive and not smaller than retryInitialDelay but was %s"
+              .formatted(retryMaxDelay));
+    }
+    if (retryBackoffFactor < 1) {
+      throw new IllegalArgumentException(
+          "Secret resolution retryBackoffFactor must be at least 1 but was %d"
+              .formatted(retryBackoffFactor));
+    }
+  }
+
+  public Duration getInterval() {
+    return interval;
+  }
+
+  public void setInterval(final Duration interval) {
+    this.interval = interval;
+  }
+
+  public int getRetryMaxAttempts() {
+    return retryMaxAttempts;
+  }
+
+  public void setRetryMaxAttempts(final int retryMaxAttempts) {
+    this.retryMaxAttempts = retryMaxAttempts;
+  }
+
+  public Duration getRetryInitialDelay() {
+    return retryInitialDelay;
+  }
+
+  public void setRetryInitialDelay(final Duration retryInitialDelay) {
+    this.retryInitialDelay = retryInitialDelay;
+  }
+
+  public Duration getRetryMaxDelay() {
+    return retryMaxDelay;
+  }
+
+  public void setRetryMaxDelay(final Duration retryMaxDelay) {
+    this.retryMaxDelay = retryMaxDelay;
+  }
+
+  public int getRetryBackoffFactor() {
+    return retryBackoffFactor;
+  }
+
+  public void setRetryBackoffFactor(final int retryBackoffFactor) {
+    this.retryBackoffFactor = retryBackoffFactor;
+  }
+
+  @Override
+  public String toString() {
+    return "SecretResolutionCfg{"
+        + "interval="
+        + interval
+        + ", retryMaxAttempts="
+        + retryMaxAttempts
+        + ", retryInitialDelay="
+        + retryInitialDelay
+        + ", retryMaxDelay="
+        + retryMaxDelay
+        + ", retryBackoffFactor="
+        + retryBackoffFactor
+        + '}';
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -73,6 +73,16 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_GROUP_NAME_CACHE_CAPACITY);
     assertThat(configuration.isCandidateGroupNameResolution())
         .isEqualTo(EngineConfiguration.DEFAULT_CANDIDATE_GROUP_NAME_RESOLUTION);
+    assertThat(configuration.getSecretResolutionInterval())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+    assertThat(configuration.getSecretResolutionRetryMaxAttempts())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS);
+    assertThat(configuration.getSecretResolutionRetryInitialDelay())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY);
+    assertThat(configuration.getSecretResolutionRetryMaxDelay())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY);
+    assertThat(configuration.getSecretResolutionRetryBackoffFactor())
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/engine/SecretResolutionCfgTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+final class SecretResolutionCfgTest {
+
+  @Test
+  void shouldAcceptDefaultValues() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+
+    // when - then
+    assertThatCode(() -> cfg.init(new BrokerCfg(), "")).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectNonPositiveInterval() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setInterval(Duration.ZERO);
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Secret resolution interval must be positive but was PT0S");
+  }
+
+  @Test
+  void shouldRejectRetryMaxAttemptsBelowOne() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setRetryMaxAttempts(0);
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Secret resolution retryMaxAttempts must be at least 1 but was 0");
+  }
+
+  @Test
+  void shouldRejectNonPositiveRetryInitialDelay() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setRetryInitialDelay(Duration.ofSeconds(-1));
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Secret resolution retryInitialDelay must be positive but was PT-1S");
+  }
+
+  @Test
+  void shouldRejectRetryMaxDelaySmallerThanRetryInitialDelay() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setRetryInitialDelay(Duration.ofSeconds(5));
+    cfg.setRetryMaxDelay(Duration.ofSeconds(1));
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Secret resolution retryMaxDelay must be positive and not smaller than"
+                + " retryInitialDelay but was PT1S");
+  }
+
+  @Test
+  void shouldRejectRetryBackoffFactorBelowOne() {
+    // given
+    final var cfg = new SecretResolutionCfg();
+    cfg.setRetryBackoffFactor(0);
+
+    // when - then
+    assertThatThrownBy(() -> cfg.init(new BrokerCfg(), ""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Secret resolution retryBackoffFactor must be at least 1 but was 0");
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -62,6 +62,12 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY =
       Duration.ofSeconds(60);
   public static final int DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR = 2;
+  public static final Duration DEFAULT_SECRET_RESOLUTION_INTERVAL = Duration.ofSeconds(5);
+  public static final int DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS = 3;
+  public static final Duration DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY =
+      Duration.ofSeconds(1);
+  public static final Duration DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY = Duration.ofSeconds(30);
+  public static final int DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR = 2;
   public static final boolean DEFAULT_COMMAND_DISTRIBUTION_PAUSED = false;
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL = Duration.ofSeconds(10);
   public static final Duration DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION =
@@ -137,6 +143,12 @@ public final class EngineConfiguration {
   private Duration batchOperationQueryRetryMaxDelay = DEFAULT_BATCH_OPERATION_QUERY_RETRY_MAX_DELAY;
   private int batchOperationQueryRetryBackoffFactor =
       DEFAULT_BATCH_OPERATION_QUERY_RETRY_BACKOFF_FACTOR;
+  private Duration secretResolutionInterval = DEFAULT_SECRET_RESOLUTION_INTERVAL;
+  private int secretResolutionRetryMaxAttempts = DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
+  private Duration secretResolutionRetryInitialDelay =
+      DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY;
+  private Duration secretResolutionRetryMaxDelay = DEFAULT_SECRET_RESOLUTION_RETRY_MAX_DELAY;
+  private int secretResolutionRetryBackoffFactor = DEFAULT_SECRET_RESOLUTION_RETRY_BACKOFF_FACTOR;
   private Duration usageMetricsExportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
   private boolean commandDistributionPaused = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
   private Duration commandRedistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
@@ -388,6 +400,55 @@ public final class EngineConfiguration {
   public EngineConfiguration setBatchOperationQueryRetryBackoffFactor(
       final int batchOperationQueryRetryBackoffFactor) {
     this.batchOperationQueryRetryBackoffFactor = batchOperationQueryRetryBackoffFactor;
+    return this;
+  }
+
+  public Duration getSecretResolutionInterval() {
+    return secretResolutionInterval;
+  }
+
+  public EngineConfiguration setSecretResolutionInterval(final Duration secretResolutionInterval) {
+    this.secretResolutionInterval = secretResolutionInterval;
+    return this;
+  }
+
+  public int getSecretResolutionRetryMaxAttempts() {
+    return secretResolutionRetryMaxAttempts;
+  }
+
+  public EngineConfiguration setSecretResolutionRetryMaxAttempts(
+      final int secretResolutionRetryMaxAttempts) {
+    this.secretResolutionRetryMaxAttempts = secretResolutionRetryMaxAttempts;
+    return this;
+  }
+
+  public Duration getSecretResolutionRetryInitialDelay() {
+    return secretResolutionRetryInitialDelay;
+  }
+
+  public EngineConfiguration setSecretResolutionRetryInitialDelay(
+      final Duration secretResolutionRetryInitialDelay) {
+    this.secretResolutionRetryInitialDelay = secretResolutionRetryInitialDelay;
+    return this;
+  }
+
+  public Duration getSecretResolutionRetryMaxDelay() {
+    return secretResolutionRetryMaxDelay;
+  }
+
+  public EngineConfiguration setSecretResolutionRetryMaxDelay(
+      final Duration secretResolutionRetryMaxDelay) {
+    this.secretResolutionRetryMaxDelay = secretResolutionRetryMaxDelay;
+    return this;
+  }
+
+  public int getSecretResolutionRetryBackoffFactor() {
+    return secretResolutionRetryBackoffFactor;
+  }
+
+  public EngineConfiguration setSecretResolutionRetryBackoffFactor(
+      final int secretResolutionRetryBackoffFactor) {
+    this.secretResolutionRetryBackoffFactor = secretResolutionRetryBackoffFactor;
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -510,7 +510,13 @@ public final class EngineProcessors {
         keyGenerator, typedRecordProcessors, writers, cslCheck, processingState);
 
     SecretReferenceProcessors.addSecretReferenceProcessors(
-        typedRecordProcessors, writers, keyGenerator, processingState);
+        typedRecordProcessors,
+        writers,
+        keyGenerator,
+        processingState,
+        scheduledTaskStateFactory,
+        secretStoreRegistry,
+        config);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretReferenceProcessors.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.zeebe.engine.processing.secretreference;
 
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.function.Supplier;
 
 public final class SecretReferenceProcessors {
 
@@ -22,7 +26,10 @@ public final class SecretReferenceProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final KeyGenerator keyGenerator,
-      final ProcessingState processingState) {
+      final ProcessingState processingState,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
+      final SecretStoreRegistry secretStoreRegistry,
+      final EngineConfiguration config) {
     typedRecordProcessors.onCommand(
         ValueType.SECRET_REFERENCE,
         SecretReferenceIntent.RESOLUTION_COMPLETE,
@@ -41,5 +48,9 @@ public final class SecretReferenceProcessors {
         ValueType.SECRET_REFERENCE,
         SecretReferenceIntent.BATCH_CREATE_INCIDENTS,
         new SecretReferenceBatchCreateIncidentsProcessor());
+
+    final var scheduler =
+        new SecretResolutionScheduler(scheduledTaskStateFactory, secretStoreRegistry, config);
+    typedRecordProcessors.withListener(scheduler);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionScheduler.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import io.camunda.secretstore.SecretCache;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically reads all pending secret references from state, resolves them in batches (one batch
+ * per store), populates the cache with resolved values, and writes {@link
+ * SecretReferenceIntent#RESOLUTION_COMPLETE} or {@link SecretReferenceIntent#RESOLUTION_FAIL}
+ * commands.
+ *
+ * <p>Two distinct failure modes:
+ *
+ * <ul>
+ *   <li>{@link SecretResolutionResult.Failed} — permanent per-secret error (NOT_FOUND,
+ *       ACCESS_DENIED, INVALID_REF): write {@code RESOLUTION_FAIL} immediately, no retry, no cache
+ *       write.
+ *   <li>{@link SecretStoreUnavailableException} — transient store-level failure: retry the whole
+ *       store with exponential backoff. After {@code retryMaxAttempts} failures, write {@code
+ *       RESOLUTION_FAIL} for all pending refs in that store.
+ * </ul>
+ *
+ * <p>Retry state ({@code attempts} + {@code nextAttemptAt} per storeId) is in-memory only and
+ * intentionally resets on broker restart / partition failover.
+ *
+ * <p>Runs on {@link AsyncTaskGroup#SECRET_RESOLUTION} (IO-bound) so the stream processor is never
+ * blocked by store IO.
+ *
+ * <p>A scheduled task survives a stream processor pause (the platform re-submits it until
+ * processing resumes), so this scheduler keeps exactly one scheduling chain alive across
+ * pause/resume cycles via the {@code shouldReschedule} flag and the {@code taskScheduled} guard.
+ */
+public final class SecretResolutionScheduler implements StreamProcessorLifecycleAware {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SecretResolutionScheduler.class);
+
+  private final SecretReferenceState secretReferenceState;
+  private final Map<String, SecretStore> secretStores;
+  private final Map<String, SecretCache> secretCaches;
+  private final Duration schedulingInterval;
+  private final Duration retryInitialDelay;
+  private final Duration retryMaxDelay;
+  private final int retryMaxAttempts;
+  private final int retryBackoffFactor;
+
+  private final Map<String, StoreRetryState> storeRetryStates = new HashMap<>();
+
+  /**
+   * Whether the scheduler may reschedule itself. Controlled by the stream processor's lifecycle
+   * events, e.g. {@link #onPaused()} and {@link #onResumed()}.
+   */
+  private volatile boolean shouldReschedule;
+
+  /**
+   * Guards against parallel scheduling chains: a scheduled task survives a pause (the platform
+   * re-submits it until processing resumes), so {@link #onResumed()} must not start a second chain
+   * while one is still pending.
+   */
+  private final AtomicBoolean taskScheduled = new AtomicBoolean();
+
+  private ReadonlyStreamProcessorContext processingContext;
+  private InstantSource clock;
+
+  public SecretResolutionScheduler(
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
+      final SecretStoreRegistry secretStoreRegistry,
+      final EngineConfiguration config) {
+    secretReferenceState = scheduledTaskStateFactory.get().getSecretReferenceState();
+    secretStores = secretStoreRegistry.getStores();
+    secretCaches = secretStoreRegistry.getCaches();
+    schedulingInterval = config.getSecretResolutionInterval();
+    retryInitialDelay = config.getSecretResolutionRetryInitialDelay();
+    retryMaxDelay = config.getSecretResolutionRetryMaxDelay();
+    retryMaxAttempts = config.getSecretResolutionRetryMaxAttempts();
+    retryBackoffFactor = config.getSecretResolutionRetryBackoffFactor();
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    processingContext = context;
+    clock = context.getClock();
+    shouldReschedule = true;
+    scheduleNext(schedulingInterval);
+  }
+
+  @Override
+  public void onResumed() {
+    shouldReschedule = true;
+    // Schedule immediately; resolveSecrets computes the real backoff-aware delay on the
+    // SECRET_RESOLUTION actor. Calling computeNextDelay() here would read storeRetryStates from the
+    // stream-processor actor concurrently with the async cycle's mutations (a data race).
+    scheduleNext(Duration.ZERO);
+  }
+
+  @Override
+  public void onPaused() {
+    shouldReschedule = false;
+  }
+
+  @Override
+  public void onClose() {
+    shouldReschedule = false;
+  }
+
+  @Override
+  public void onFailed() {
+    shouldReschedule = false;
+  }
+
+  TaskResult resolveSecrets(final TaskResultBuilder resultBuilder) {
+    taskScheduled.set(false);
+    final long now = clock.millis();
+    try {
+      final Map<String, Set<String>> pendingByStore = collectPendingByStore();
+      // prune retry state for stores that no longer have pending refs
+      storeRetryStates.keySet().retainAll(pendingByStore.keySet());
+      if (!pendingByStore.isEmpty()) {
+        for (final var entry : pendingByStore.entrySet()) {
+          try {
+            resolveStore(entry.getKey(), entry.getValue(), resultBuilder, now);
+          } catch (final RuntimeException e) {
+            LOG.error(
+                "Unexpected error while resolving secrets from store '{}'; "
+                    + "{} secret reference(s) remain pending and will be retried in the next cycle",
+                entry.getKey(),
+                entry.getValue().size(),
+                e);
+          }
+        }
+      }
+    } finally {
+      scheduleNext(computeNextDelay(now));
+    }
+    return resultBuilder.build();
+  }
+
+  /**
+   * Returns the delay until the next execution. If any store is in cooldown with a retry deadline
+   * sooner than {@code schedulingInterval}, returns the shorter duration so backoff is honored.
+   */
+  private Duration computeNextDelay(final long now) {
+    if (storeRetryStates.isEmpty()) {
+      return schedulingInterval;
+    }
+    final long earliestRetryAt =
+        storeRetryStates.values().stream()
+            .mapToLong(StoreRetryState::nextAttemptAt)
+            .min()
+            .getAsLong();
+    final long millisUntilRetry = earliestRetryAt - now;
+    if (millisUntilRetry < schedulingInterval.toMillis()) {
+      return Duration.ofMillis(Math.max(0, millisUntilRetry));
+    }
+    return schedulingInterval;
+  }
+
+  private Map<String, Set<String>> collectPendingByStore() {
+    final Map<String, Set<String>> pendingByStore = new LinkedHashMap<>();
+    secretReferenceState.visitPendingSecretReferences(
+        (storeId, secretRef) ->
+            pendingByStore.computeIfAbsent(storeId, k -> new LinkedHashSet<>()).add(secretRef));
+    return pendingByStore;
+  }
+
+  private void resolveStore(
+      final String storeId,
+      final Set<String> refs,
+      final TaskResultBuilder resultBuilder,
+      final long now) {
+    final StoreRetryState retryState =
+        storeRetryStates.getOrDefault(storeId, StoreRetryState.INITIAL);
+
+    if (now < retryState.nextAttemptAt()) {
+      LOG.trace(
+          "Secret store '{}' in cooldown until {}ms, skipping {} pending refs",
+          storeId,
+          retryState.nextAttemptAt(),
+          refs.size());
+      return;
+    }
+
+    final SecretStore store = secretStores.get(storeId);
+    if (store == null) {
+      LOG.warn(
+          "Secret store '{}' is not configured — failing {} pending secret refs",
+          storeId,
+          refs.size());
+      refs.forEach(
+          ref ->
+              appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE));
+      storeRetryStates.remove(storeId);
+      return;
+    }
+
+    try {
+      final Map<String, SecretResolutionResult> results = store.resolve(refs);
+      final SecretCache cache = secretCaches.get(storeId);
+      results.forEach(
+          (ref, result) -> {
+            switch (result) {
+              case SecretResolutionResult.Resolved(final String value) -> {
+                if (cache == null) {
+                  // The registry guarantees a cache per store, so this is a broken invariant. Do
+                  // NOT write RESOLUTION_COMPLETE: completing without a cached value reactivates
+                  // the job, misses the cache on activation, and re-parks it in a loop. Fail
+                  // loudly, leave pending.
+                  LOG.error(
+                      "Secret store '{}' resolved '{}' but has no associated cache; leaving it"
+                          + " pending",
+                      storeId,
+                      ref);
+                } else {
+                  cache.put(ref, value);
+                  appendResolutionComplete(resultBuilder, storeId, ref);
+                }
+              }
+              case SecretResolutionResult.Failed(
+                      final var code,
+                      final var message,
+                      final var cause) -> {
+                LOG.warn(
+                    "Secret '{}' in secret store '{}' failed permanently: {} — {}",
+                    ref,
+                    storeId,
+                    code,
+                    message,
+                    cause);
+                // All permanent per-secret failures (NOT_FOUND/ACCESS_DENIED/INVALID_REF) map to
+                // NOT_FOUND for now; ResolutionState has no finer per-secret states yet (#57855
+                // will refine).
+                appendResolutionFail(resultBuilder, storeId, ref, ResolutionState.NOT_FOUND);
+              }
+            }
+          });
+      storeRetryStates.remove(storeId);
+    } catch (final SecretStoreUnavailableException e) {
+      final int nextAttempts = retryState.attempts() + 1;
+      if (nextAttempts >= retryMaxAttempts) {
+        LOG.warn(
+            "Secret store '{}' unavailable after {}/{} attempts — failing {} pending refs: {}",
+            storeId,
+            nextAttempts,
+            retryMaxAttempts,
+            refs.size(),
+            e.getMessage());
+        refs.forEach(
+            ref ->
+                appendResolutionFail(
+                    resultBuilder, storeId, ref, ResolutionState.STORE_UNAVAILABLE));
+        storeRetryStates.remove(storeId);
+      } else {
+        final Duration backoff = calculateBackoff(nextAttempts);
+        LOG.warn(
+            "Secret store '{}' unavailable (attempt {}/{}), retrying in {}: {}",
+            storeId,
+            nextAttempts,
+            retryMaxAttempts,
+            backoff,
+            e.getMessage());
+        storeRetryStates.put(storeId, new StoreRetryState(nextAttempts, now + backoff.toMillis()));
+      }
+    }
+  }
+
+  private void appendResolutionComplete(
+      final TaskResultBuilder resultBuilder, final String storeId, final String secretRef) {
+    final var record = new SecretReferenceRecord();
+    record
+        .setStoreId(storeId)
+        .setSecretReference(secretRef)
+        .setResolutionState(ResolutionState.SUCCESS);
+    resultBuilder.appendCommandRecord(SecretReferenceIntent.RESOLUTION_COMPLETE, record);
+  }
+
+  private void appendResolutionFail(
+      final TaskResultBuilder resultBuilder,
+      final String storeId,
+      final String secretRef,
+      final ResolutionState resolutionState) {
+    final var record = new SecretReferenceRecord();
+    record.setStoreId(storeId).setSecretReference(secretRef).setResolutionState(resolutionState);
+    resultBuilder.appendCommandRecord(SecretReferenceIntent.RESOLUTION_FAIL, record);
+  }
+
+  Duration calculateBackoff(final int attempts) {
+    Duration delay = retryInitialDelay;
+    for (int i = 1; i < attempts; i++) {
+      delay = delay.multipliedBy(retryBackoffFactor);
+      if (delay.compareTo(retryMaxDelay) >= 0) {
+        return retryMaxDelay;
+      }
+    }
+    return delay;
+  }
+
+  private void scheduleNext(final Duration delay) {
+    if (!shouldReschedule) {
+      return;
+    }
+    if (!taskScheduled.compareAndSet(false, true)) {
+      // a task is already scheduled or parked; it will continue the chain itself
+      return;
+    }
+    processingContext
+        .getScheduleService()
+        .runDelayedAsync(delay, this::resolveSecrets, AsyncTaskGroup.SECRET_RESOLUTION);
+  }
+
+  /** In-memory retry state for a single store. Resets on broker restart (by design). */
+  record StoreRetryState(int attempts, long nextAttemptAt) {
+    static final StoreRetryState INITIAL = new StoreRetryState(0, 0L);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.PendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.instance.DbJobState;
@@ -35,6 +36,7 @@ import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingMessageStartProcessInstanceAskState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.routing.DbRoutingState;
+import io.camunda.zeebe.engine.state.secretreference.DbSecretReferenceState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import java.time.InstantSource;
 
@@ -53,6 +55,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   private final UserTaskState userTaskState;
   private final BatchOperationState batchOperationState;
   private final DbRoutingState routingState;
+  private final SecretReferenceState secretReferenceState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -80,6 +83,12 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
     userTaskState = new DbUserTaskState(zeebeDb, transactionContext);
     batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
     routingState = new DbRoutingState(zeebeDb, transactionContext);
+    secretReferenceState = new DbSecretReferenceState(zeebeDb, transactionContext);
+  }
+
+  @Override
+  public SecretReferenceState getSecretReferenceState() {
+    return secretReferenceState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.engine.state.routing.DbRoutingState;
 
 public interface ScheduledTaskState {
 
+  SecretReferenceState getSecretReferenceState();
+
   DistributionState getDistributionState();
 
   MessageState getMessageState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SecretReferenceState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.LongPredicate;
 
@@ -27,4 +28,10 @@ public interface SecretReferenceState {
    * false} to stop early.
    */
   void visitSecretReferencesByJob(long jobKey, BiPredicate<String, String> visitor);
+
+  /**
+   * Visits all pending secret references. The visitor receives (storeId, secretReference) for each
+   * entry.
+   */
+  void visitPendingSecretReferences(BiConsumer<String, String> visitor);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceState.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.LongPredicate;
 
@@ -113,6 +114,12 @@ public final class DbSecretReferenceState implements MutableSecretReferenceState
                     key.second().inner().first().toString(),
                     key.second().inner().second().toString());
     waitingJobsByJobKeyColumnFamily.whileEqualPrefix(this.jobKey, kvVisitor);
+  }
+
+  @Override
+  public void visitPendingSecretReferences(final BiConsumer<String, String> visitor) {
+    pendingSecretReferencesColumnFamily.forEach(
+        (key, value) -> visitor.accept(key.first().toString(), key.second().toString()));
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/secretreference/SecretResolutionSchedulerTest.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.secretreference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.secretstore.SecretCache;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.engine.state.immutable.SecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
+import io.camunda.zeebe.protocol.record.value.ResolutionState;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock;
+import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class SecretResolutionSchedulerTest {
+
+  @Mock private SecretStore secretStore;
+  @Mock private SecretCache secretCache;
+  @Mock private ScheduledTaskState scheduledTaskState;
+  @Mock private SecretReferenceState secretReferenceState;
+  @Mock private ReadonlyStreamProcessorContext context;
+  @Mock private ProcessingScheduleService scheduleService;
+  @Mock private TaskResultBuilder resultBuilder;
+  @Mock private StreamClock clock;
+
+  private SecretResolutionScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    when(scheduledTaskState.getSecretReferenceState()).thenReturn(secretReferenceState);
+    when(context.getScheduleService()).thenReturn(scheduleService);
+    when(context.getClock()).thenReturn(clock);
+    lenient().when(clock.millis()).thenReturn(0L);
+
+    final Supplier<ScheduledTaskState> stateFactory = () -> scheduledTaskState;
+    final var registry =
+        new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of("my-store", secretCache));
+    final var config = new EngineConfiguration();
+    scheduler = new SecretResolutionScheduler(stateFactory, registry, config);
+    scheduler.onRecovered(context);
+  }
+
+  @Test
+  void shouldPopulateCacheAndWriteResolutionCompleteOnSuccess() throws Exception {
+    // given
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("s3cr3t")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — cache populated before command written
+    verify(secretCache).put("db-password", "s3cr3t");
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
+    assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.SUCCESS);
+  }
+
+  @Test
+  void shouldNotPopulateCacheAndWriteResolutionFailOnPermanentPerSecretError() throws Exception {
+    // given
+    stubPending("my-store", "missing-key");
+    when(secretStore.resolve(Set.of("missing-key")))
+        .thenReturn(
+            Map.of(
+                "missing-key",
+                new SecretResolutionResult.Failed(
+                    SecretErrorCode.NOT_FOUND, "secret not found", null)));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — cache NOT populated on failure
+    verify(secretCache, never()).put(any(), any());
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_FAIL);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("missing-key");
+    assertThat(recordCaptor.getValue().getResolutionState()).isEqualTo(ResolutionState.NOT_FOUND);
+  }
+
+  @Test
+  void shouldRetryAndNotWriteCommandOnFirstStoreUnavailable() throws Exception {
+    // given
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — first failure: retry, no command written, no cache write
+    verify(resultBuilder, never()).appendCommandRecord(any(), any());
+    verify(secretCache, never()).put(any(), any());
+  }
+
+  @Test
+  void shouldWriteResolutionFailAfterMaxRetries() throws Exception {
+    // given — drive the scheduler past max retries; a monotonic clock (1 day per call) always
+    // exceeds the retry cooldown deadline regardless of how many times it's invoked per cycle
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    final var nowMs = new AtomicLong(0);
+    when(clock.millis()).thenAnswer(inv -> nowMs.getAndAdd(Duration.ofDays(1).toMillis()));
+    final int maxAttempts = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
+    for (int i = 0; i < maxAttempts - 1; i++) {
+      stubPending("my-store", "db-password");
+      scheduler.resolveSecrets(resultBuilder);
+    }
+
+    // when — this call hits maxAttempts
+    stubPending("my-store", "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_FAIL);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
+    assertThat(recordCaptor.getValue().getResolutionState())
+        .isEqualTo(ResolutionState.STORE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldCapBackoffAtRetryMaxDelay() {
+    // given
+    final var config =
+        new EngineConfiguration()
+            .setSecretResolutionRetryInitialDelay(Duration.ofSeconds(1))
+            .setSecretResolutionRetryBackoffFactor(10)
+            .setSecretResolutionRetryMaxDelay(Duration.ofSeconds(2));
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, new SecretStoreRegistry(Map.of()), config);
+
+    // when/then
+    assertThat(localScheduler.calculateBackoff(1)).isEqualTo(Duration.ofSeconds(1));
+    assertThat(localScheduler.calculateBackoff(2)).isEqualTo(Duration.ofSeconds(2));
+    assertThat(localScheduler.calculateBackoff(5)).isEqualTo(Duration.ofSeconds(2));
+  }
+
+  @Test
+  void shouldFailAllRefsWhenRetriesExhausted() throws Exception {
+    // given
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("down"));
+    final var nowMs = new AtomicLong(0);
+    when(clock.millis()).thenAnswer(inv -> nowMs.getAndAdd(Duration.ofDays(1).toMillis()));
+    final int maxAttempts = EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_MAX_ATTEMPTS;
+
+    // when
+    for (int i = 0; i < maxAttempts; i++) {
+      stubPending("my-store", "a", "b");
+      scheduler.resolveSecrets(resultBuilder);
+    }
+
+    // then
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder, times(2))
+        .appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_FAIL), recordCaptor.capture());
+    assertThat(recordCaptor.getAllValues())
+        .extracting(SecretReferenceRecord::getSecretReference)
+        .containsExactlyInAnyOrder("a", "b");
+    assertThat(recordCaptor.getAllValues())
+        .extracting(SecretReferenceRecord::getResolutionState)
+        .containsOnly(ResolutionState.STORE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldNotCompleteWhenResolvedButStoreHasNoCache() throws Exception {
+    // given — store is configured but has no associated cache in the registry
+    final var registry = new SecretStoreRegistry(Map.of("my-store", secretStore), Map.of());
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, registry, new EngineConfiguration());
+    localScheduler.onRecovered(context);
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(Set.of("db-password")))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("v")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then
+    verify(resultBuilder, never()).appendCommandRecord(any(), any());
+  }
+
+  @Test
+  void shouldSkipStoreInCooldownPeriod() throws Exception {
+    // given — first execute causes a retry (cooldown starts at t=0)
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    when(clock.millis()).thenReturn(0L);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when — second execute while still in cooldown (clock still at 0)
+    stubPending("my-store", "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — store called only once; no command or cache write
+    verify(secretStore, times(1)).resolve(any());
+    verify(resultBuilder, never()).appendCommandRecord(any(), any());
+    verify(secretCache, never()).put(any(), any());
+  }
+
+  @Test
+  void shouldResetRetryStateAfterSuccessfulResolution() throws Exception {
+    // given — first execute fails (enters retry state)
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(any()))
+        .thenThrow(new SecretStoreUnavailableException("store down"))
+        .thenReturn(Map.of("db-password", new SecretResolutionResult.Resolved("value")));
+    when(clock.millis()).thenReturn(Long.MAX_VALUE); // skip cooldown
+    scheduler.resolveSecrets(resultBuilder); // first: fails
+
+    // when — second execute succeeds
+    stubPending("my-store", "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — cache written, RESOLUTION_COMPLETE written
+    verify(secretCache).put("db-password", "value");
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("my-store");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
+  }
+
+  @Test
+  void shouldScheduleEarlierThanIntervalWhenRetryDeadlineIsSooner() throws Exception {
+    // given — store fails; retry due in retryInitialDelay (1s) which is < schedulingInterval (5s)
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    when(clock.millis()).thenReturn(0L);
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the schedule after the failure uses retryInitialDelay, not schedulingInterval
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    // two calls total: one from onRecovered in setUp, one from execute
+    verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(1))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_RETRY_INITIAL_DELAY)
+        .isLessThan(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldPruneRetryStateForStoresWithNoPendingRefs() throws Exception {
+    // given — store fails (enters retry state)
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    when(clock.millis()).thenReturn(0L);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when — store no longer has pending refs
+    doNothing().when(secretReferenceState).visitPendingSecretReferences(any());
+    when(clock.millis()).thenReturn(Long.MAX_VALUE);
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — store not retried; full scheduling interval restored
+    verify(secretStore, times(1)).resolve(any());
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    // three calls: onRecovered, first execute (failure → early), second execute (no pending → full)
+    verify(scheduleService, times(3)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(2))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldDoNothingWhenNoPendingReferences() throws Exception {
+    // given — visitPendingSecretReferences does nothing (default mock)
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    verify(resultBuilder, never()).appendCommandRecord(any(), any());
+    verify(secretStore, never()).resolve(any());
+    verify(secretCache, never()).put(any(), any());
+  }
+
+  @Test
+  void shouldFailAllPendingRefsWhenStoreIsNotConfigured() throws Exception {
+    // given — pending refs for a store that has no configured SecretStore
+    stubPending("unknown-store", "db-password");
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    verify(secretStore, never()).resolve(any());
+    verify(secretCache, never()).put(any(), any());
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_FAIL);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("unknown-store");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("db-password");
+    assertThat(recordCaptor.getValue().getResolutionState())
+        .isEqualTo(ResolutionState.STORE_UNAVAILABLE);
+  }
+
+  @Test
+  void shouldContinueWithOtherStoresWhenStoreThrowsUnexpectedException() throws Exception {
+    // given
+    final var storeA = mock(SecretStore.class);
+    final var storeB = mock(SecretStore.class);
+    final var cacheB = mock(SecretCache.class);
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, registry, new EngineConfiguration());
+    localScheduler.onRecovered(context);
+
+    stubPending(Map.of("store-a", "ref-a", "store-b", "ref-b"));
+    when(storeA.resolve(Set.of("ref-a"))).thenThrow(new IllegalStateException("boom"));
+    when(storeB.resolve(Set.of("ref-b")))
+        .thenReturn(Map.of("ref-b", new SecretResolutionResult.Resolved("value-b")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then — store-b was still resolved despite store-a's unexpected exception
+    verify(cacheB).put("ref-b", "value-b");
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("store-b");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("ref-b");
+    // scheduler.onRecovered (setUp) + localScheduler.onRecovered + localScheduler's own reschedule
+    verify(scheduleService, times(3)).runDelayedAsync(any(), any(), any());
+  }
+
+  @Test
+  void shouldLeaveRefsPendingWhenStoreThrowsUnexpectedException() throws Exception {
+    // given
+    stubPending("my-store", "db-password");
+    when(secretStore.resolve(any())).thenThrow(new IllegalStateException("boom"));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — the failure did not enter retry/backoff state
+    verify(resultBuilder, never()).appendCommandRecord(any(), any());
+    verify(secretCache, never()).put(any(), any());
+    final var delayCaptor = ArgumentCaptor.forClass(Duration.class);
+    // two calls total: one from onRecovered in setUp, one from execute
+    verify(scheduleService, times(2)).runDelayedAsync(delayCaptor.capture(), any(), any());
+    assertThat(delayCaptor.getAllValues().get(1))
+        .isEqualTo(EngineConfiguration.DEFAULT_SECRET_RESOLUTION_INTERVAL);
+  }
+
+  @Test
+  void shouldResolveOtherStoreWhenOneStoreIsUnavailable() throws Exception {
+    // given
+    final var storeA = mock(SecretStore.class);
+    final var storeB = mock(SecretStore.class);
+    final var cacheB = mock(SecretCache.class);
+    final var registry =
+        new SecretStoreRegistry(
+            Map.of("store-a", storeA, "store-b", storeB), Map.of("store-b", cacheB));
+    final var localScheduler =
+        new SecretResolutionScheduler(
+            () -> scheduledTaskState, registry, new EngineConfiguration());
+    localScheduler.onRecovered(context);
+
+    stubPending(Map.of("store-a", "ref-a", "store-b", "ref-b"));
+    when(storeA.resolve(Set.of("ref-a"))).thenThrow(new SecretStoreUnavailableException("down"));
+    when(storeB.resolve(Set.of("ref-b")))
+        .thenReturn(Map.of("ref-b", new SecretResolutionResult.Resolved("value-b")));
+
+    // when
+    localScheduler.resolveSecrets(resultBuilder);
+
+    // then
+    verify(cacheB).put("ref-b", "value-b");
+    final var intentCaptor = ArgumentCaptor.forClass(SecretReferenceIntent.class);
+    final var recordCaptor = ArgumentCaptor.forClass(SecretReferenceRecord.class);
+    verify(resultBuilder).appendCommandRecord(intentCaptor.capture(), recordCaptor.capture());
+    assertThat(intentCaptor.getValue()).isEqualTo(SecretReferenceIntent.RESOLUTION_COMPLETE);
+    assertThat(recordCaptor.getValue().getStoreId()).isEqualTo("store-b");
+    assertThat(recordCaptor.getValue().getSecretReference()).isEqualTo("ref-b");
+  }
+
+  @Test
+  void shouldBatchAllRefsOfStoreIntoSingleResolveCall() throws Exception {
+    // given
+    stubPending("my-store", "ref-1", "ref-2");
+    when(secretStore.resolve(Set.of("ref-1", "ref-2")))
+        .thenReturn(
+            Map.of(
+                "ref-1", new SecretResolutionResult.Resolved("value-1"),
+                "ref-2", new SecretResolutionResult.Resolved("value-2")));
+
+    // when
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    verify(secretStore, times(1)).resolve(Set.of("ref-1", "ref-2"));
+    verify(resultBuilder, times(2))
+        .appendCommandRecord(eq(SecretReferenceIntent.RESOLUTION_COMPLETE), any());
+  }
+
+  @Test
+  void shouldNotScheduleSecondChainWhenResumedWhileTaskStillPending() throws Exception {
+    // given — setUp already scheduled once via onRecovered
+
+    // when
+    scheduler.onPaused();
+    scheduler.onResumed();
+
+    // then — the parked task from onRecovered still owns the chain
+    verify(scheduleService, times(1)).runDelayedAsync(any(), any(), any());
+  }
+
+  @Test
+  void shouldNotRescheduleWhilePausedAndScheduleOnceOnResume() throws Exception {
+    // given
+    scheduler.onPaused();
+
+    // when — executing while paused must not reschedule
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then
+    verify(scheduleService, times(1)).runDelayedAsync(any(), any(), any());
+
+    // when — resuming starts exactly one new chain
+    scheduler.onResumed();
+
+    // then
+    verify(scheduleService, times(2)).runDelayedAsync(any(), any(), any());
+  }
+
+  @Test
+  void shouldRetryStoreAfterCooldownElapses() throws Exception {
+    // given
+    when(secretStore.resolve(any())).thenThrow(new SecretStoreUnavailableException("store down"));
+    when(clock.millis()).thenReturn(0L, 10_000L);
+
+    stubPending("my-store", "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // when — cooldown (1s) has elapsed by the time of the second run (clock now at 10s)
+    stubPending("my-store", "db-password");
+    scheduler.resolveSecrets(resultBuilder);
+
+    // then — second attempt happened because the cooldown expired
+    verify(secretStore, times(2)).resolve(any());
+  }
+
+  private void stubPending(final String storeId, final String secretRef) {
+    doAnswer(
+            inv -> {
+              final var visitor = (BiConsumer<String, String>) inv.getArgument(0);
+              visitor.accept(storeId, secretRef);
+              return null;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any());
+  }
+
+  private void stubPending(final String storeId, final String... secretRefs) {
+    doAnswer(
+            inv -> {
+              final var visitor = (BiConsumer<String, String>) inv.getArgument(0);
+              for (final String secretRef : secretRefs) {
+                visitor.accept(storeId, secretRef);
+              }
+              return null;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any());
+  }
+
+  private void stubPending(final Map<String, String> refsByStore) {
+    doAnswer(
+            inv -> {
+              final var visitor = (BiConsumer<String, String>) inv.getArgument(0);
+              refsByStore.forEach(visitor::accept);
+              return null;
+            })
+        .when(secretReferenceState)
+        .visitPendingSecretReferences(any());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
@@ -266,7 +266,7 @@ public final class DbSecretReferenceStateTest {
     state.addPendingSecretReference("store-b", "ref-3");
 
     // when
-    final var collected = new java.util.ArrayList<String>();
+    final var collected = new ArrayList<String>();
     state.visitPendingSecretReferences(
         (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
 
@@ -283,7 +283,7 @@ public final class DbSecretReferenceStateTest {
     state.removePendingSecretReference("store-a", "ref-1");
 
     // when
-    final var collected = new java.util.ArrayList<String>();
+    final var collected = new ArrayList<String>();
     state.visitPendingSecretReferences(
         (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/secretreference/DbSecretReferenceStateTest.java
@@ -259,6 +259,39 @@ public final class DbSecretReferenceStateTest {
   }
 
   @Test
+  void shouldVisitAllPendingSecretReferences() {
+    // given
+    state.addPendingSecretReference("store-a", "ref-1");
+    state.addPendingSecretReference("store-a", "ref-2");
+    state.addPendingSecretReference("store-b", "ref-3");
+
+    // when
+    final var collected = new java.util.ArrayList<String>();
+    state.visitPendingSecretReferences(
+        (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
+
+    // then
+    assertThat(collected)
+        .containsExactlyInAnyOrder("store-a:ref-1", "store-a:ref-2", "store-b:ref-3");
+  }
+
+  @Test
+  void shouldNotVisitRemovedPendingSecretReferences() {
+    // given
+    state.addPendingSecretReference("store-a", "ref-1");
+    state.addPendingSecretReference("store-a", "ref-2");
+    state.removePendingSecretReference("store-a", "ref-1");
+
+    // when
+    final var collected = new java.util.ArrayList<String>();
+    state.visitPendingSecretReferences(
+        (storeId, secretRef) -> collected.add(storeId + ":" + secretRef));
+
+    // then
+    assertThat(collected).containsExactly("store-a:ref-2");
+  }
+
+  @Test
   public void shouldPreserveRemainingEntryWhenOneWaitingJobIsRemoved() {
     // given — two jobs waiting on the same secret; remove one, the other must remain
     final String storeId = "storeA";

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncTaskGroup.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncTaskGroup.java
@@ -25,7 +25,8 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
  */
 public enum AsyncTaskGroup {
   ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.cpuBound()),
-  BATCH_OPERATIONS("BatchOperationActor", SchedulingHints.ioBound());
+  BATCH_OPERATIONS("BatchOperationActor", SchedulingHints.ioBound()),
+  SECRET_RESOLUTION("SecretResolutionActor", SchedulingHints.ioBound());
   private final String name;
   private final SchedulingHints schedulingHints;
 


### PR DESCRIPTION
## Description

This implements the secret resolution background task described in #57848.

When a job is created that references secrets not yet in the cache, the engine parks the job and records a pending secret reference in RocksDB. Previously nothing ever resolved those references. This PR adds a `SecretResolutionScheduler` — a `StreamProcessorLifecycleAware` that wakes up on a dedicated IO-bound actor (`AsyncTaskGroup.SECRET_RESOLUTION`) every 5 seconds, reads all pending refs from state, batches them by store, calls `store.resolve(Set<String>)`, populates the `SecretCache` with resolved values, and writes `RESOLUTION_COMPLETE` or `RESOLUTION_FAIL` commands back into the stream.

Two distinct failure modes are handled:
1. `SecretResolutionResult.Failed` (NOT_FOUND, ACCESS_DENIED, INVALID_REF) — permanent per-secret failure, writes `RESOLUTION_FAIL` immediately, no retry.
2. `SecretStoreUnavailableException` — transient store-level failure, retries with exponential backoff (configurable via `EngineConfiguration`). After `retryMaxAttempts` failures, writes `RESOLUTION_FAIL` for all pending refs in that store. Retry state is in-memory intentionally — it resets on broker restart/failover.

Any other exception thrown by a store is caught and logged per store, so one misbehaving store implementation can't discard the resolution results of the healthy stores in the same cycle. The scheduler also makes sure only a single polling chain exists across stream processor pause/resume, and the interval/retry settings are validated at startup.

The wiring goes through `PhysicalTenantContext` so each physical tenant gets its own `SecretStore` and `SecretCache` instances, sourced from the existing `SecretStoreRegistry` Spring bean.

Note that the `RESOLUTION_COMPLETE`/`RESOLUTION_FAIL` processors are still no-ops and nothing writes `RESOLUTION_REQUESTED` yet, so the scheduler stays dormant until the job-parking follow-up lands. Those processors need to be implemented before (or together with) that follow-up.

## Checklist

- [ ] I have read the [contribution guide](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md)
- [ ] I have documented my changes in the [CHANGELOG](https://github.com/camunda/camunda/blob/main/CHANGELOG.md) as needed
- [ ] I have added tests for my changes as needed

## Related issues

closes #57848
