### PR TITLE
test: stabilize operate decisionNavigation and batchMove nightly flakes

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -69,8 +69,10 @@ class OperateDecisionsPage {
   async gotoDecisionsPage(options?: {
     searchParams?: SearchParams;
   }): Promise<void> {
+    const baseUrl = `${process.env.CORE_APPLICATION_OPERATE_URL}/operate/decisions`;
+
     if (!options?.searchParams) {
-      await this.page.goto('/decisions');
+      await this.page.goto(baseUrl);
       return;
     }
 
@@ -81,7 +83,7 @@ class OperateDecisionsPage {
       }
     });
 
-    await this.page.goto(`/decisions?${searchParams.toString()}`);
+    await this.page.goto(`${baseUrl}?${searchParams.toString()}`);
   }
 
   async selectDecisionName(option: string): Promise<void> {
@@ -95,6 +97,14 @@ class OperateDecisionsPage {
         });
         await expect(optionLocator).toBeVisible();
         await optionLocator.click();
+        // Confirm the selection actually committed. Under nightly load the
+        // option click can visually succeed without updating the combobox,
+        // leaving the list unfiltered — the observed failure signature was an
+        // empty Name combobox after selection, which let callers proceed
+        // against the full, unfiltered list.
+        await expect(this.decisionNameFilter).toHaveValue(option, {
+          timeout: 10000,
+        });
       },
       onFailure: async () => {
         await this.page.reload();

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/batchMoveModification.spec.ts
@@ -66,9 +66,12 @@ test.describe('Process Instance Batch Modification', () => {
         assertion: async () => {
           await expect(
             page.getByText(`${NUM_PROCESS_INSTANCES} results`),
-          ).toBeVisible({timeout: 5000});
+          ).toBeVisible({timeout: 15000});
         },
         onFailure: async () => {
+          // Let the seeded instances finish importing into Operate before
+          // re-navigating; the count won't be exact until the import settles.
+          await sleep(5000);
           await gotoProcessesPage(page, {
             searchParams: {
               active: 'true',
@@ -78,6 +81,7 @@ test.describe('Process Instance Batch Modification', () => {
             },
           });
         },
+        maxRetries: 5,
       });
     });
 
@@ -138,8 +142,15 @@ test.describe('Process Instance Batch Modification', () => {
           ).toBeVisible({timeout: 30000});
         },
         onFailure: async () => {
+          // The batch move is applied asynchronously and then imported into
+          // Operate; a plain reload can outrun that. Give the operation time
+          // to finish and be indexed before re-reading the filtered list. The
+          // shipArticles/canceled filters are URL params, so reload preserves
+          // them.
+          await sleep(5000);
           await page.reload();
         },
+        maxRetries: 5,
       });
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -265,17 +265,21 @@ test.describe('Decision Navigation', () => {
           // A failed attempt can leave us on either page: the decisions list
           // (if the row/click itself failed) or a decision instance detail
           // page (if decisionPanel was just the slow part, or Operate
-          // redirected there before bouncing back). selectDecisionName()
-          // needs the list's Name combobox, which the detail page doesn't
-          // have — clickDecisionsTab() first guarantees we land on the list
-          // regardless of which page we're actually on, via the persistent
-          // nav bar rather than assuming reload's target. Then reload, since
-          // the name filter is client-side React state, not a URL parameter
-          // (confirmed via a failure snapshot showing the empty Name
-          // combobox after a reload that didn't navigate first), so it needs
-          // re-applying every time regardless.
-          await operateHomePage.clickDecisionsTab();
-          await page.reload();
+          // redirected there before bouncing back). Recovering with reload is
+          // unsafe here: when Operate redirects off a not-yet-queryable
+          // decision instance it lands on `/operate/decisions?...&version=1`
+          // with the `name` param dropped, and reloading *that* URL rebuilds a
+          // broken filter state (empty Name combobox, disabled Version), so
+          // the retry keeps racing the same unfiltered list. Do a clean hard
+          // navigation to the unfiltered decisions list instead — this resets
+          // both the URL params and the client-side React filter state
+          // deterministically, regardless of which page we bounced to. Then
+          // give the importer time to make the instance queryable before
+          // re-applying the name filter from scratch.
+          await operateDecisionsPage.gotoDecisionsPage({
+            searchParams: {evaluated: 'true', failed: 'true'},
+          });
+          await sleep(3000);
           await operateDecisionsPage.selectDecisionName(
             'Assign Approver Group Navigation',
           );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -271,9 +271,9 @@ test.describe('Decision Navigation', () => {
           // with the `name` param dropped, and reloading *that* URL rebuilds a
           // broken filter state (empty Name combobox, disabled Version), so
           // the retry keeps racing the same unfiltered list. Do a clean hard
-          // navigation to the unfiltered decisions list instead — this resets
-          // both the URL params and the client-side React filter state
-          // deterministically, regardless of which page we bounced to. Then
+          // navigation back to the decisions list with only evaluated/failed
+          // filters (no name/version) — this resets both the URL params and the
+          // client-side React filter state deterministically. Then
           // give the importer time to make the instance queryable before
           // re-applying the name filter from scratch.
           await operateDecisionsPage.gotoDecisionsPage({


### PR DESCRIPTION
## Description

The **8.7 OC nightly** (run [29710168849](https://github.com/camunda/camunda/actions/runs/29710168849)) went red on two Operate E2E tests. Both are **load/indexing-timing flakes, not product regressions** — the suite was green the prior nights and these fail Gate A for a product-bug verdict.

Key evidence: `decisionNavigation` was **already flaky the night before** ([run 29667740022](https://github.com/camunda/camunda/actions/runs/29667740022) reported `success` overall but `flaky: 2` — it failed attempt 0, recovered on retry) with the **identical error**. Today it exhausted its retries on both attempts. So this hardens the recovery path, not just the timeouts.

### `decisionNavigation.spec.ts › should navigate through DRD to another decision instance`

The failure snapshots (both nights) show the page bounced back to `/operate/decisions?evaluated=true&failed=true&version=1` with the **Name combobox empty** and the **Version combobox disabled** — an inconsistent filter state.

- **Reload was the hazard.** When Operate redirects off a not-yet-queryable decision instance it lands on the list URL **with `name` dropped but `version=1` kept**. The old recovery did `clickDecisionsTab()` + `page.reload()`; reloading that URL *rebuilds* the broken empty-Name / disabled-Version state, so the retry kept racing the same unfiltered list. Recovery now does a **clean hard navigation** to the unfiltered decisions list (resets URL params **and** client-side React state deterministically), waits for the importer, then re-applies the name filter.
- `selectDecisionName` now asserts the combobox **value actually committed** after the option click (the empty-combobox signature) — a click that visually succeeds without committing previously let callers proceed against the full list.
- `gotoDecisionsPage` pointed at a bare `/decisions` (wrong base, effectively unused); repointed at `CORE_APPLICATION_OPERATE_URL/operate/decisions` like `gotoProcessesPage`, so it can drive the clean recovery navigation.

### `batchMoveModification.spec.ts › Move Operation`

Pre-select and post-move `N results` checks now back off (`sleep`) and retry longer. The async batch operation + Operate import can exceed the previous window; an immediate reload outran it. The list filters are URL params, so `reload` preserves them (safe).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `npx prettier --check` and `npx eslint` pass on all three changed files.
- Reasoning is grounded in the nightly `json-report` (retry history) and HTML-report failure snapshots for both the red run and the prior flaky run. Not yet re-run against a live cluster — recommend validating via the 8.7 OC nightly / an ad-hoc run before marking ready.

## Related

- Failing nightly: https://github.com/camunda/camunda/actions/runs/29710168849
- Prior (flaky-but-green) nightly: https://github.com/camunda/camunda/actions/runs/29667740022