### PR TITLE
test: add Tasklist e2e coverage for variable passthrough without output mappings

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/employee_confirmation_form.form
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/employee_confirmation_form.form
@@ -1,0 +1,21 @@
+{
+  "type": "default",
+  "id": "employee_confirmation_form",
+  "components": [
+    {
+      "key": "employeeName",
+      "label": "Employee Name",
+      "type": "textfield"
+    },
+    {
+      "key": "department",
+      "label": "Department",
+      "type": "textfield"
+    },
+    {
+      "key": "confirm",
+      "label": "Confirm",
+      "type": "checkbox"
+    }
+  ]
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/employee_details_form.form
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/employee_details_form.form
@@ -1,0 +1,16 @@
+{
+  "type": "default",
+  "id": "employee_details_form",
+  "components": [
+    {
+      "key": "employeeName",
+      "label": "Employee Name",
+      "type": "textfield"
+    },
+    {
+      "key": "department",
+      "label": "Department",
+      "type": "textfield"
+    }
+  ]
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/employee_registration_no_output_mapping.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/employee_registration_no_output_mapping.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_employee_registration_no_output_mapping" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="employee_registration_no_output_mapping" name="Employee registration without output mappings" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_to_employee_details</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_employee_details" sourceRef="StartEvent_1" targetRef="employee_details" />
+    <bpmn:userTask id="employee_details" name="Employee Details">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="employee_details_form" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_employee_details</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_confirm_employee_details</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_to_confirm_employee_details" sourceRef="employee_details" targetRef="confirm_employee_details" />
+    <bpmn:userTask id="confirm_employee_details" name="Confirm Employee Details">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:formDefinition formId="employee_confirmation_form" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_confirm_employee_details</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_registration_complete">
+      <bpmn:incoming>Flow_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_to_end" sourceRef="confirm_employee_details" targetRef="Event_registration_complete" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="employee_registration_no_output_mapping">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_employee_details_di" bpmnElement="employee_details">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_confirm_employee_details_di" bpmnElement="confirm_employee_details">
+        <dc:Bounds x="400" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_registration_complete_di" bpmnElement="Event_registration_complete">
+        <dc:Bounds x="562" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_employee_details_di" bpmnElement="Flow_to_employee_details">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_confirm_employee_details_di" bpmnElement="Flow_to_confirm_employee_details">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="400" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_end_di" bpmnElement="Flow_to_end">
+        <di:waypoint x="500" y="118" />
+        <di:waypoint x="562" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -380,7 +380,11 @@ test.describe('task details page', () => {
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
 
     await taskPanelPage.filterBy('Unassigned');
-    await taskPanelPage.openTask('Confirm Employee Details');
+    // The next task can take a moment to be indexed/rendered right after
+    // the previous one completes, so allow more time than the default 10s.
+    await taskPanelPage.openTask('Confirm Employee Details', {
+      timeout: 30000,
+    });
     await taskDetailsPage.clickAssignToMeButton();
 
     await taskDetailsPage.assertFieldValue(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -47,6 +47,9 @@ test.beforeAll(async () => {
     './resources/bigVariableProcessWithForm.bpmn',
     './resources/bigVariableForm.form',
     './resources/user_task_with_form_assigned_filter.bpmn',
+    './resources/employee_registration_no_output_mapping.bpmn',
+    './resources/employee_details_form.form',
+    './resources/employee_confirmation_form.form',
   ]);
   await sleep(1000);
 
@@ -83,6 +86,7 @@ test.beforeAll(async () => {
     createInstances('processWithDeployedForm', 1, 1),
     createInstances('zeebe_and_job_worker_process', 1, 1),
     createInstances('bigVariableProcessWithForm', 1, 1),
+    createInstances('employee_registration_no_output_mapping', 1, 1),
   ]);
 
   await sleep(1000);
@@ -360,6 +364,34 @@ test.describe('task details page', () => {
 
     await taskPanelPage.openTask('User Task with form rerender 2');
     await taskDetailsPage.assertFieldValue('Name*', 'Stuart');
+  });
+
+  test('variables are passed along the forms if no output variables are defined', async ({
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('Employee Details');
+    await taskDetailsPage.clickAssignToMeButton();
+
+    await taskDetailsPage.fillTextInput('Employee Name', 'Gaius Julius Caesar');
+    await taskDetailsPage.fillTextInput('Department', 'Rome');
+    await taskDetailsPage.clickCompleteTaskButton();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+
+    await taskPanelPage.filterBy('Unassigned');
+    await taskPanelPage.openTask('Confirm Employee Details');
+    await taskDetailsPage.clickAssignToMeButton();
+
+    await taskDetailsPage.assertFieldValue(
+      'Employee Name',
+      'Gaius Julius Caesar',
+    );
+    await taskDetailsPage.assertFieldValue('Department', 'Rome');
+
+    await taskDetailsPage.checkChecklistBox('Confirm');
+    await taskDetailsPage.clickCompleteTaskButton();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
   });
 
   test('task completion with number form by input', async ({


### PR DESCRIPTION
## Summary
- Automates #58052: two sequential form-linked user tasks with no output variable mappings; verifies the second task's form auto-prefills with values submitted on the first, then completes it with the confirm checkbox.
- New resources: `employee_details_form.form`, `employee_confirmation_form.form` (shared field keys `employeeName`/`department`), `employee_registration_no_output_mapping.bpmn`.

Closes #58052

## Test plan
- [x] `npx playwright test tests/tasklist/task-details.spec.ts -g "variables are passed along the forms" --project=tasklist-e2e` passes locally against a running docker-compose cluster
- [x] on-demand run passed: see comment below