### PR TITLE
Use common method to configure ES and OS in MultiDB tests

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -181,7 +181,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
         createSchema,
         Boolean.class,
         BackwardsCompatibilityMode.SUPPORTED,
-        Set.of("zeebe.broker.exporters.camundaexporter.args.createSchema"));
+        getLegacyCreateSchemaProperties());
   }
 
   public void setCreateSchema(final boolean createSchema) {
@@ -611,5 +611,11 @@ public abstract class DocumentBasedSecondaryStorageDatabase
     return Set.of(
         "camunda.database.index.templatePriority",
         "zeebe.broker.exporters.camundaexporter.args.index.templatePriority");
+  }
+
+  private Set<String> getLegacyCreateSchemaProperties() {
+    return Set.of(
+        "zeebe.broker.exporters.camundaexporter.args.createSchema",
+        "camunda.database.schema-manager.create-schema");
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverride.java
@@ -56,7 +56,6 @@ public class SearchEngineSchemaManagerPropertiesOverride {
     override.setVersionCheckRestrictionEnabled(
         camunda.getSystem().getUpgrade().getEnableVersionCheck());
 
-    /* Clean-up properties */
     camunda
         .getData()
         .getSecondaryStorage()
@@ -64,6 +63,7 @@ public class SearchEngineSchemaManagerPropertiesOverride {
         .ifPresent(
             secondaryStorage -> {
               override.setPerformCleanup(secondaryStorage.isPerformCleanup());
+              override.setCreateSchema(secondaryStorage.isCreateSchema());
             });
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabaseTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabaseTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class DocumentBasedSecondaryStorageDatabaseTest {
+
+  private static final String LEGACY_EXPORTER_ARGS_CREATE_SCHEMA_PROPERTY =
+      "zeebe.broker.exporters.camundaexporter.args.createSchema";
+  private static final String LEGACY_SCHEMA_MANAGER_CREATE_SCHEMA_PROPERTY =
+      "camunda.database.schema-manager.create-schema";
+  private static final String NEW_CREATE_SCHEMA_PROPERTY =
+      "camunda.data.secondary-storage.elasticsearch.create-schema";
+
+  private MockEnvironment mockEnvironment;
+  private Elasticsearch elasticsearch;
+
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    // UnifiedConfigurationHelper keeps its environment in a static field. Clear it so a
+    // previous/subsequent Spring-based test in the same JVM doesn't leak its environment here
+    // (or vice versa).
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @BeforeEach
+  void setup() {
+    mockEnvironment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(mockEnvironment);
+    elasticsearch = new Elasticsearch();
+  }
+
+  @Test
+  void shouldUseNewValueWhenNoLegacyCreateSchemaPropertyIsSet() {
+    // given
+    elasticsearch.setCreateSchema(false);
+
+    // then
+    assertThat(elasticsearch.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldFallBackToLegacyExporterArgsCreateSchemaProperty() {
+    // given
+    mockEnvironment.setProperty(LEGACY_EXPORTER_ARGS_CREATE_SCHEMA_PROPERTY, "false");
+
+    // then
+    assertThat(elasticsearch.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldFallBackToLegacySchemaManagerCreateSchemaProperty() {
+    // given
+    mockEnvironment.setProperty(LEGACY_SCHEMA_MANAGER_CREATE_SCHEMA_PROPERTY, "false");
+
+    // then
+    assertThat(elasticsearch.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldPreferNewValueWhenBothNewAndLegacyPropertiesArePresent() {
+    // given
+    elasticsearch.setCreateSchema(false);
+    mockEnvironment.setProperty(NEW_CREATE_SCHEMA_PROPERTY, "false");
+    mockEnvironment.setProperty(LEGACY_SCHEMA_MANAGER_CREATE_SCHEMA_PROPERTY, "true");
+
+    // then
+    assertThat(elasticsearch.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldThrowWhenLegacyCreateSchemaPropertiesConflict() {
+    // given
+    mockEnvironment.setProperty(LEGACY_EXPORTER_ARGS_CREATE_SCHEMA_PROPERTY, "true");
+    mockEnvironment.setProperty(LEGACY_SCHEMA_MANAGER_CREATE_SCHEMA_PROPERTY, "false");
+
+    // then
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(elasticsearch::isCreateSchema)
+        .withMessageContaining("Ambiguous legacy configuration");
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverrideTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/SearchEngineSchemaManagerPropertiesOverrideTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beans.SearchEngineSchemaManagerProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class SearchEngineSchemaManagerPropertiesOverrideTest {
+
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    // The Camunda config getters delegate to UnifiedConfigurationHelper, which short-circuits
+    // when its static environment is null. Clear it so a previous Spring-based test in the
+    // same JVM doesn't leak its environment into these plain unit tests.
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldApplyVersionCheckRestrictionEnabled() {
+    // given
+    final Camunda camunda = new Camunda();
+    camunda.getSystem().getUpgrade().setEnableVersionCheck(false);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.isVersionCheckRestrictionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldApplyPerformCleanupAndCreateSchemaForElasticsearch() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+    secondaryStorage.getElasticsearch().setPerformCleanup(true);
+    secondaryStorage.getElasticsearch().setCreateSchema(false);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.isPerformCleanup()).isTrue();
+    assertThat(override.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldApplyPerformCleanupAndCreateSchemaForOpensearch() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.opensearch);
+    secondaryStorage.getOpensearch().setPerformCleanup(true);
+    secondaryStorage.getOpensearch().setCreateSchema(false);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.isPerformCleanup()).isTrue();
+    assertThat(override.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldNotTouchPerformCleanupOrCreateSchemaForRdbms() {
+    // given
+    final Camunda camunda = new Camunda();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+    secondaryStorage.setType(SecondaryStorageType.rdbms);
+
+    // and an override pre-populated as if seeded from the legacy properties
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+    override.setPerformCleanup(true);
+    override.setCreateSchema(false);
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then RDBMS is not a document-based database, so these fields are left untouched
+    assertThat(override.isPerformCleanup()).isTrue();
+    assertThat(override.isCreateSchema()).isFalse();
+  }
+
+  @Test
+  void shouldAlwaysApplyVersionCheckRegardlessOfSecondaryStorageType() {
+    // given
+    final Camunda camunda = new Camunda();
+    camunda.getSystem().getUpgrade().setEnableVersionCheck(false);
+    camunda.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+
+    final SearchEngineSchemaManagerProperties override = new SearchEngineSchemaManagerProperties();
+
+    // when
+    SearchEngineSchemaManagerPropertiesOverride.applyTo(camunda, override);
+
+    // then
+    assertThat(override.isVersionCheckRestrictionEnabled()).isFalse();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
@@ -226,7 +226,6 @@ public class MultiExporterIT {
           }
           case CAMUNDA -> {
             final Map<String, Object> elasticsearchProperties = new HashMap<>();
-            elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", INDEX_PREFIX);
             elasticsearchProperties.put(CREATE_SCHEMA_PROPERTY, true);
             testStandaloneApplication.withAdditionalProperties(elasticsearchProperties);
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -133,8 +133,12 @@ public class MultiDbConfigurator {
     documentBasedDatabase.setUrl(url);
     documentBasedDatabase.setIndexPrefix(indexPrefix);
     documentBasedDatabase.getHistory().setPolicyName(indexPrefix + "-ilm");
-    documentBasedDatabase.setUsername(userName);
-    documentBasedDatabase.setPassword(userPassword);
+    if (userName != null && !userName.isBlank()) {
+      documentBasedDatabase.setUsername(userName);
+    }
+    if (userPassword != null && !userPassword.isBlank()) {
+      documentBasedDatabase.setPassword(userPassword);
+    }
     documentBasedDatabase.getHistory().setWaitPeriodBeforeArchiving(retentionEnabled ? "1s" : "1h");
     documentBasedDatabase.getHistory().setDelayBetweenRuns(Duration.ofMillis(1000));
     documentBasedDatabase.getHistory().setMaxDelayBetweenRuns(Duration.ofMillis(1000));

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.qa.util.multidb;
 
-import static io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TEST_INTEGRATION_RDBMS_FAST_INIT;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
@@ -17,7 +17,6 @@ import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
@@ -59,38 +58,12 @@ public class MultiDbConfigurator {
   public void configureElasticsearchSupport(
       final String elasticsearchUrl, final String indexPrefix, final boolean retentionEnabled) {
     this.indexPrefix = indexPrefix;
-    final Map<String, Object> elasticsearchProperties = new HashMap<>();
-
-    /* Tasklist */
-    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", zeebeIndexPrefix());
-
-    /* Camunda */
-    elasticsearchProperties.put(CREATE_SCHEMA_PROPERTY, true);
-
-    testApplication.withAdditionalProperties(elasticsearchProperties);
     testApplication
         .withSecondaryStorageType(SecondaryStorageType.elasticsearch)
         .withUnifiedConfig(
             cfg -> {
-              cfg.getData().getSecondaryStorage().getRetention().setEnabled(retentionEnabled);
-              // 0s causes ILM to move data asap - it is normally the default
-              // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
-              cfg.getData().getSecondaryStorage().getRetention().setMinimumAge("0s");
-              cfg.getData().getSecondaryStorage().getElasticsearch().setUrl(elasticsearchUrl);
-              cfg.getData().getSecondaryStorage().getElasticsearch().setIndexPrefix(indexPrefix);
-              cfg.getData()
-                  .getSecondaryStorage()
-                  .getElasticsearch()
-                  .getHistory()
-                  .setPolicyName(indexPrefix + "-ilm");
-              final var history =
-                  cfg.getData().getSecondaryStorage().getElasticsearch().getHistory();
-              // find completed instances almost directly
-              history.setWaitPeriodBeforeArchiving(retentionEnabled ? "1s" : "1h");
-              history.setDelayBetweenRuns(Duration.ofMillis(1000));
-              history.setMaxDelayBetweenRuns(Duration.ofMillis(1000));
-              cfg.getData().getSecondaryStorage().getElasticsearch().getBulk().setSize(1);
-              overrideRefreshInterval(cfg.getData().getSecondaryStorage().getElasticsearch());
+              configureDocumentBasedStorage(
+                  cfg, elasticsearchUrl, indexPrefix, "", "", retentionEnabled);
             });
   }
 
@@ -134,48 +107,39 @@ public class MultiDbConfigurator {
       final boolean retentionEnabled,
       final boolean isAws) {
     this.indexPrefix = indexPrefix;
-
-    final Map<String, Object> opensearchProperties = new HashMap<>();
-
-    /* Tasklist */
-    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", zeebeIndexPrefix());
-    opensearchProperties.put("camunda.tasklist.opensearch.aws-enabled", isAws);
-
-    /* Operate */
-    opensearchProperties.put("camunda.operate.opensearch.aws-enabled", isAws);
-
-    /* Camunda */
-    opensearchProperties.put(CREATE_SCHEMA_PROPERTY, true);
-    opensearchProperties.put("camunda.database.aws-enabled", isAws);
-
-    testApplication.withAdditionalProperties(opensearchProperties);
-
     /* Unified Config */
     testApplication
         .withSecondaryStorageType(SecondaryStorageType.opensearch)
         .withUnifiedConfig(
             cfg -> {
-              cfg.getData().getSecondaryStorage().getRetention().setEnabled(retentionEnabled);
-              cfg.getData().getSecondaryStorage().getRetention().setMinimumAge("0s");
-              cfg.getData().getSecondaryStorage().getOpensearch().setUrl(opensearchUrl);
-              cfg.getData().getSecondaryStorage().getOpensearch().setIndexPrefix(indexPrefix);
-              cfg.getData()
-                  .getSecondaryStorage()
-                  .getOpensearch()
-                  .getHistory()
-                  .setPolicyName(indexPrefix + "-ilm");
-              cfg.getData().getSecondaryStorage().getOpensearch().setUsername(userName);
-              cfg.getData().getSecondaryStorage().getOpensearch().setPassword(userPassword);
+              configureDocumentBasedStorage(
+                  cfg, opensearchUrl, indexPrefix, userName, userPassword, retentionEnabled);
               cfg.getData().getSecondaryStorage().getOpensearch().setAwsEnabled(isAws);
-              // find completed instances almost directly
-              cfg.getData()
-                  .getSecondaryStorage()
-                  .getOpensearch()
-                  .getHistory()
-                  .setWaitPeriodBeforeArchiving(retentionEnabled ? "1s" : "1h");
-              cfg.getData().getSecondaryStorage().getOpensearch().getBulk().setSize(1);
-              overrideRefreshInterval(cfg.getData().getSecondaryStorage().getOpensearch());
             });
+  }
+
+  private void configureDocumentBasedStorage(
+      final Camunda cfg,
+      final String url,
+      final String indexPrefix,
+      final String userName,
+      final String userPassword,
+      final boolean retentionEnabled) {
+    cfg.getData().getSecondaryStorage().getRetention().setEnabled(retentionEnabled);
+    cfg.getData().getSecondaryStorage().getRetention().setMinimumAge("0s");
+    final var documentBasedDatabase =
+        cfg.getData().getSecondaryStorage().getDocumentBasedDatabase();
+    documentBasedDatabase.setCreateSchema(true);
+    documentBasedDatabase.setUrl(url);
+    documentBasedDatabase.setIndexPrefix(indexPrefix);
+    documentBasedDatabase.getHistory().setPolicyName(indexPrefix + "-ilm");
+    documentBasedDatabase.setUsername(userName);
+    documentBasedDatabase.setPassword(userPassword);
+    documentBasedDatabase.getHistory().setWaitPeriodBeforeArchiving(retentionEnabled ? "1s" : "1h");
+    documentBasedDatabase.getHistory().setDelayBetweenRuns(Duration.ofMillis(1000));
+    documentBasedDatabase.getHistory().setMaxDelayBetweenRuns(Duration.ofMillis(1000));
+    documentBasedDatabase.getBulk().setSize(1);
+    overrideRefreshInterval(documentBasedDatabase);
   }
 
   public void configureRDBMSSupport(

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
@@ -17,6 +17,7 @@ import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.qa.util.cluster.TestCamundaApplication;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -39,11 +40,6 @@ public class MultiDbConfiguratorTest {
     multiDbConfigurator.configureElasticsearchSupport(EXPECTED_URL, EXPECTED_PREFIX);
 
     // then
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.zeebeElasticsearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-
     final SecondaryStorage secondaryStorage =
         testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
     assertThat(secondaryStorage.getType()).isEqualTo(SecondaryStorageType.elasticsearch);
@@ -129,11 +125,6 @@ public class MultiDbConfiguratorTest {
         EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW);
 
     // then
-    assertProperty(
-        testSimpleCamundaApplication,
-        "camunda.tasklist.zeebeOpensearch.prefix",
-        EXPECTED_ZEEBE_PREFIX);
-
     final SecondaryStorage secondaryStorage =
         testSimpleCamundaApplication.unifiedConfig().getData().getSecondaryStorage();
     assertThat(secondaryStorage.getType()).isEqualTo(SecondaryStorageType.opensearch);
@@ -221,6 +212,9 @@ public class MultiDbConfiguratorTest {
         .isEqualTo(expectedWaitPeriodBeforeArchiving);
     assertThat(database.getBulk().getSize()).isEqualTo(1);
     assertThat(database.getRefreshInterval()).isEqualTo("100ms");
+    assertThat(database.getHistory().getDelayBetweenRuns()).isEqualTo(Duration.ofMillis(1000));
+    assertThat(database.getHistory().getMaxDelayBetweenRuns()).isEqualTo(Duration.ofMillis(1000));
+    assertThat(database.isCreateSchema()).isTrue();
   }
 
   private static void assertNoExplicitCamundaExporter(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.qa.util.cluster;
 
-import static io.camunda.configuration.beans.LegacySearchEngineSchemaManagerProperties.CREATE_SCHEMA_PROPERTY;
 import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 
 import io.camunda.application.MainSupport;
@@ -34,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner.Mode;
@@ -297,7 +297,12 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   public T withCreateSchema(final boolean createSchema) {
-    return withProperty(CREATE_SCHEMA_PROPERTY, String.valueOf(createSchema));
+    return withUnifiedConfig(
+        cfg ->
+            Stream.of(
+                    cfg.getData().getSecondaryStorage().getElasticsearch(),
+                    cfg.getData().getSecondaryStorage().getOpensearch())
+                .forEach(storage -> storage.setCreateSchema(createSchema)));
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
To avoid having them diverging

It also adds missing mapping between `camunda.data.secondary-storage.<elasticsearch|opensearch>.create-schema` and legacy `camunda.data.schema-manager.create-schema`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
