### PR TITLE
Expose /cluster/v2/status without authentication

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverter.java
@@ -19,7 +19,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
  *
  * <p>Registered ahead of CSL's DB-backed converter so cluster-admin principals do not pick up DB
  * memberships on name collision. It only claims authentications marked with {@link
- * ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY}.
+ * ClusterAdminBasicSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY}.
  */
 public final class ClusterAdminAuthenticationConverter
     implements CamundaAuthenticationConverter<Authentication> {
@@ -31,7 +31,7 @@ public final class ClusterAdminAuthenticationConverter
         && authentication.getAuthorities().stream()
             .anyMatch(
                 authority ->
-                    ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY.equals(
+                    ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY.equals(
                         authority.getAuthority()));
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicSecurityConfiguration.java
@@ -60,7 +60,7 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  */
 @Configuration
 @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
-public class ClusterAdminSecurityConfiguration {
+public class ClusterAdminBasicSecurityConfiguration {
 
   /**
    * Marker authority assigned to every cluster-admin principal. The chain does not check it
@@ -81,7 +81,7 @@ public class ClusterAdminSecurityConfiguration {
   static final String CLUSTER_ADMIN_API_PATTERN = "/cluster/v2/**";
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(ClusterAdminSecurityConfiguration.class);
+      LoggerFactory.getLogger(ClusterAdminBasicSecurityConfiguration.class);
 
   @Bean
   @Order(ORDER_API)

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminConverterConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminConverterConfiguration.java
@@ -17,8 +17,8 @@ import org.springframework.security.core.Authentication;
 /**
  * Registers {@link ClusterAdminAuthenticationConverter} method-agnostically, so it is present for
  * whichever cluster-admin chain is active — the Basic chain ({@link
- * ClusterAdminSecurityConfiguration}, {@code @ConditionalOnAuthenticationMethod(BASIC)}) or the
- * OIDC chain ({@link ClusterAdminOidcSecurityConfiguration},
+ * ClusterAdminBasicSecurityConfiguration}, {@code @ConditionalOnAuthenticationMethod(BASIC)}) or
+ * the OIDC chain ({@link ClusterAdminOidcSecurityConfiguration},
  * {@code @ConditionalOnAuthenticationMethod(OIDC)}).
  *
  * <p>Registers this converter for OIDC too.
@@ -27,7 +27,7 @@ import org.springframework.security.core.Authentication;
  * membership converter and inherit memberships from a colliding DB principal.
  *
  * <p>This converter only handles principals with {@link
- * ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY}, so it is inactive when the
+ * ClusterAdminBasicSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY}, so it is inactive when the
  * cluster-admin chain is disabled.
  */
 @Configuration

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverter.java
@@ -23,8 +23,9 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 /**
- * Grants {@link ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY} to a validated bearer
- * token when it matches a configured cluster-admin OIDC claim: client id, group, or name/value.
+ * Grants {@link ClusterAdminBasicSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY} to a validated
+ * bearer token when it matches a configured cluster-admin OIDC claim: client id, group, or
+ * name/value.
  *
  * <p>The resulting {@link JwtAuthenticationToken} is named after the resolved client id, or the
  * token subject if unavailable, so {@code ClusterAdminAuthenticationConverter} creates a
@@ -35,7 +36,8 @@ public final class ClusterAdminJwtAuthenticationConverter
 
   private static final Collection<GrantedAuthority> CLUSTER_ADMIN_AUTHORITIES =
       List.of(
-          new SimpleGrantedAuthority(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY));
+          new SimpleGrantedAuthority(
+              ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY));
 
   private final Set<String> clients;
   private final Set<String> groups;

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -34,7 +34,7 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  * is granted access only if it matches a configured cluster-admin client id, group, or claim (see
  * {@link ClusterAdminJwtAuthenticationConverter}).
  *
- * <p>This chain and the Basic chain ({@link ClusterAdminSecurityConfiguration}) are mutually
+ * <p>This chain and the Basic chain ({@link ClusterAdminBasicSecurityConfiguration}) are mutually
  * exclusive by deployment method — only one is instantiated.
  *
  * <p><strong>Statelessness:</strong> the chain binds a request-scoped, session-free {@link
@@ -68,10 +68,11 @@ public class ClusterAdminOidcSecurityConfiguration {
     http.securityMatcher(CLUSTER_ADMIN_API_PATTERN)
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_STATUS_PATH)
+                auth.requestMatchers(
+                        ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_STATUS_PATH)
                     .permitAll()
                     .anyRequest()
-                    .hasAuthority(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))
+                    .hasAuthority(ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))
         .oauth2ResourceServer(
             oauth2 ->
                 oauth2

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -68,7 +68,9 @@ public class ClusterAdminOidcSecurityConfiguration {
     http.securityMatcher(CLUSTER_ADMIN_API_PATTERN)
         .authorizeHttpRequests(
             auth ->
-                auth.anyRequest()
+                auth.requestMatchers(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_STATUS_PATH)
+                    .permitAll()
+                    .anyRequest()
                     .hasAuthority(ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))
         .oauth2ResourceServer(
             oauth2 ->

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -70,6 +70,14 @@ public class ClusterAdminSecurityConfiguration {
    */
   public static final String CLUSTER_ADMIN_AUTHORITY = "ROLE_CLUSTER_ADMIN";
 
+  /**
+   * The cluster-level status endpoint, exposed without authentication as the cluster equivalent of
+   * {@code /v2/status}. Carved out of the otherwise fully protected {@code /cluster/v2/**} chain
+   * with {@code permitAll}; a missing credential is allowed through, but a malformed one is still
+   * rejected by the auth filter, matching {@code /v2/status}.
+   */
+  public static final String CLUSTER_ADMIN_STATUS_PATH = "/cluster/v2/status";
+
   static final String CLUSTER_ADMIN_API_PATTERN = "/cluster/v2/**";
 
   private static final Logger LOG =
@@ -87,7 +95,12 @@ public class ClusterAdminSecurityConfiguration {
     http.authenticationManager(clusterAdminAuthenticationManager(environment, passwordEncoder));
 
     http.securityMatcher(CLUSTER_ADMIN_API_PATTERN)
-        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(CLUSTER_ADMIN_STATUS_PATH)
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated())
         .httpBasic(Customizer.withDefaults())
         .exceptionHandling(
             eh ->

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.authentication.config;
 
+import io.camunda.authentication.clusteradmin.ClusterAdminBasicSecurityConfiguration;
 import io.camunda.authentication.clusteradmin.ClusterAdminConverterConfiguration;
 import io.camunda.authentication.clusteradmin.ClusterAdminOidcSecurityConfiguration;
-import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
 import io.camunda.authentication.config.spi.AdminUserPresenceAdapter;
 import io.camunda.authentication.config.spi.AuthorizationRepositoryAdapter;
 import io.camunda.authentication.config.spi.BasicAuthUserDetailsAdapter;
@@ -70,7 +70,7 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
   BasicAuthBeansConfiguration.class,
   SaasCspModeCompatibility.class,
   PhysicalTenantSecurityConfiguration.class,
-  ClusterAdminSecurityConfiguration.class,
+  ClusterAdminBasicSecurityConfiguration.class,
   ClusterAdminOidcSecurityConfiguration.class,
   ClusterAdminConverterConfiguration.class,
 })

--- a/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverterTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.clusteradmin;
 
-import static io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY;
+import static io.camunda.authentication.clusteradmin.ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.CamundaAuthentication;

--- a/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminJwtAuthenticationConverterTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.clusteradmin;
 
-import static io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY;
+import static io.camunda.authentication.clusteradmin.ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
@@ -95,6 +95,32 @@ public class ClusterAdminBasicAuthWebSecurityConfigTest extends AbstractWebSecur
   }
 
   @Test
+  public void shouldAllowPublicStatusEndpointWithoutCredentials() {
+    // when — the carved-out public status endpoint is hit with no credentials
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT)
+            .exchange();
+
+    // then — permitAll lets it through (dummy returns 200; the real endpoint returns 204)
+    assertThat(result).hasStatus2xxSuccessful();
+  }
+
+  @Test
+  public void shouldRequireCredentialsForSiblingOfPublicStatusEndpoint() {
+    // when — a sibling of the public path (trailing slash) is hit with no credentials
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT + "/")
+            .exchange();
+
+    // then — only the exact path is public; everything else under /cluster/v2/** stays protected
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
   public void shouldReturn404ForUnknownClusterAdminPathWithValidCredentials() {
     // when
     final MvcTestResult result =

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
@@ -108,6 +108,21 @@ public class ClusterAdminBasicAuthWebSecurityConfigTest extends AbstractWebSecur
   }
 
   @Test
+  public void shouldRejectWrongPasswordOnPublicStatusEndpoint() {
+    // when — the public status endpoint is hit with a wrong password
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, "wrong-password"))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT)
+            .exchange();
+
+    // then — permitAll only waives a missing credential; a bad one is still rejected by the Basic
+    // auth filter before the authorization decision is reached
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
   public void shouldRequireCredentialsForSiblingOfPublicStatusEndpoint() {
     // when — a sibling of the public path (trailing slash) is hit with no credentials
     final MvcTestResult result =

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
@@ -8,6 +8,8 @@
 package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
 import io.camunda.authentication.config.controllers.TestApiController;
@@ -15,6 +17,7 @@ import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpSession;
@@ -22,6 +25,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
@@ -47,6 +52,8 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
     })
 public class ClusterAdminOidcChainIsolationTest extends AbstractWebSecurityConfigTest {
+
+  @Autowired private JwtDecoder jwtDecoder;
 
   @Test
   public void shouldRejectWebappSessionOnClusterAdminEndpoint() {
@@ -90,6 +97,26 @@ public class ClusterAdminOidcChainIsolationTest extends AbstractWebSecurityConfi
 
     // then — permitAll lets it through (dummy returns 200; the real endpoint returns 204)
     assertThat(result).hasStatus2xxSuccessful();
+  }
+
+  @Test
+  public void shouldRejectMalformedBearerOnPublicStatusEndpoint() {
+    // given — the decoder rejects this specific token, standing in for a real malformed/invalid
+    // JWT (this context's JwtDecoder is a no-op mock that never validates real tokens)
+    final String malformedToken = "not-a-valid-jwt";
+    when(jwtDecoder.decode(eq(malformedToken))).thenThrow(new BadJwtException("malformed token"));
+
+    // when — the public status endpoint is hit with that malformed bearer token
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .header("Authorization", "Bearer " + malformedToken)
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT)
+            .exchange();
+
+    // then — permitAll only waives a missing token; a bad one is still rejected by the bearer
+    // filter before the authorization decision is reached
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
@@ -78,4 +78,30 @@ public class ClusterAdminOidcChainIsolationTest extends AbstractWebSecurityConfi
         .as("a webapp session cookie must not authenticate the OIDC cluster-admin API")
         .hasStatus(HttpStatus.UNAUTHORIZED);
   }
+
+  @Test
+  public void shouldAllowPublicStatusEndpointWithoutToken() {
+    // when — the carved-out public status endpoint is hit with no bearer token
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT)
+            .exchange();
+
+    // then — permitAll lets it through (dummy returns 200; the real endpoint returns 204)
+    assertThat(result).hasStatus2xxSuccessful();
+  }
+
+  @Test
+  public void shouldRequireTokenForSiblingOfPublicStatusEndpoint() {
+    // when — a sibling of the public path (trailing slash) is hit with no bearer token
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT + "/")
+            .exchange();
+
+    // then — only the exact path is public; everything else under /cluster/v2/** stays protected
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
+import io.camunda.authentication.clusteradmin.ClusterAdminBasicSecurityConfiguration;
 import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
@@ -66,7 +66,7 @@ public class ClusterAdminOidcChainIsolationTest extends AbstractWebSecurityConfi
             null,
             List.of(
                 new SimpleGrantedAuthority(
-                    ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))));
+                    ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY))));
     final MockHttpSession session = new MockHttpSession();
     session.setAttribute(
         HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
@@ -10,7 +10,7 @@ package io.camunda.authentication.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.authentication.clusteradmin.ClusterAdminAuthenticationConverter;
-import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
+import io.camunda.authentication.clusteradmin.ClusterAdminBasicSecurityConfiguration;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
@@ -26,7 +26,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 
 /**
  * Verifies the OIDC leak-prevention path: a cluster-admin bearer token with {@link
- * ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY} is claimed first by {@link
+ * ClusterAdminBasicSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY} is claimed first by {@link
  * ClusterAdminAuthenticationConverter}, which runs at {@code HIGHEST_PRECEDENCE} and returns a
  * client principal with no memberships.
  *
@@ -67,7 +67,7 @@ class ClusterAdminOidcConverterWiringTest extends AbstractWebSecurityConfigTest 
             jwt,
             List.of(
                 new SimpleGrantedAuthority(
-                    ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY)),
+                    ClusterAdminBasicSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY)),
             COLLISION);
 
     // when — the converter chain dispatches to the first converter that claims the principal

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -38,6 +38,14 @@ public class TestApiController {
   public static final String DUMMY_CLUSTER_ADMIN_ENDPOINT = "/cluster/v2/topology";
 
   /**
+   * Public cluster-admin status endpoint at the real {@code /cluster/v2/status} path, carved out of
+   * the cluster-admin chain with {@code permitAll}. Returns a 200 body here (the real {@code
+   * DummyClusterTopologyController} returns 204); slice tests assert reachability, not the status
+   * contract.
+   */
+  public static final String DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT = "/cluster/v2/status";
+
+  /**
    * Isolated, additive endpoint used only by {@code SessionAuthenticationRefreshTest} to force a
    * real, Spring-Session-backed session to exist before the request under test runs. With CSL
    * ADR-0031's per-chain {@code SessionRepositoryFilter}, nothing creates a session for a request
@@ -135,6 +143,11 @@ public class TestApiController {
 
   @GetMapping(DUMMY_CLUSTER_ADMIN_ENDPOINT)
   public @ResponseBody String dummyClusterAdminEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @GetMapping(DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT)
+  public @ResponseBody String dummyClusterAdminStatusEndpoint() {
     return DEFAULT_RESPONSE;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -37,12 +37,6 @@ public class TestApiController {
    */
   public static final String DUMMY_CLUSTER_ADMIN_ENDPOINT = "/cluster/v2/topology";
 
-  /**
-   * Public cluster-admin status endpoint at the real {@code /cluster/v2/status} path, carved out of
-   * the cluster-admin chain with {@code permitAll}. Returns a 200 body here (the real {@code
-   * DummyClusterTopologyController} returns 204); slice tests assert reachability, not the status
-   * contract.
-   */
   public static final String DUMMY_CLUSTER_ADMIN_STATUS_ENDPOINT = "/cluster/v2/status";
 
   /**

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -122,6 +122,17 @@ public class ClusterAdminBasicAuthenticationIT {
   }
 
   @Test
+  void shouldRejectWrongPasswordOnPublicStatusEndpoint() throws Exception {
+    // when — the public status endpoint is hit with a wrong password
+    final HttpResponse<String> response =
+        send(clusterUri(PATH_CLUSTER_STATUS), basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
+
+    // then — permitAll only waives a missing credential; a bad one is still rejected by the Basic
+    // auth filter before the authorization decision is reached, matching /v2/status
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
   void shouldRejectClusterAdminCredentialsOnRegularV2Endpoint() throws Exception {
     // when — cluster-admin credentials presented to the regular /v2 API
     final HttpResponse<String> response =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 public class ClusterAdminBasicAuthenticationIT {
 
   public static final String PATH_CLUSTER_TOPOLOGY = "cluster/v2/topology";
+  public static final String PATH_CLUSTER_STATUS = "cluster/v2/status";
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
 
   private static final String CLUSTER_ADMIN_USER = "cluster-operator";
@@ -107,6 +108,17 @@ public class ClusterAdminBasicAuthenticationIT {
 
     // then — the cluster-admin chain has its own isolated store; a DB user is not known to it
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldAllowPublicStatusEndpointWithoutCredentials() throws Exception {
+    // when — the public cluster status endpoint is hit with no credentials
+    final HttpResponse<String> response = send(clusterUri(PATH_CLUSTER_STATUS), null);
+
+    // then — permitAll: reachable unauthenticated, healthy 204 with no body (the cluster
+    // equivalent of /v2/status), so no topology/membership detail is exposed to anonymous callers
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+    assertThat(response.body()).isEmpty();
   }
 
   @Test

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
@@ -161,6 +161,16 @@ public class ClusterAdminOidcAuthenticationIT {
   }
 
   @Test
+  void shouldRejectMalformedTokenOnPublicStatusEndpoint() throws Exception {
+    // when — the public status endpoint is hit with a malformed bearer token
+    final HttpResponse<String> response = get(statusUri(), "Bearer not-a-valid-jwt");
+
+    // then — permitAll only waives a missing token; a bad one is still rejected by the bearer
+    // filter before the authorization decision is reached, matching /v2/status
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
   void shouldRejectMissingToken() throws Exception {
     // when
     final HttpResponse<String> response = get(clusterUri(), null);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
@@ -43,6 +43,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 public class ClusterAdminOidcAuthenticationIT {
 
   private static final String PATH_CLUSTER_TOPOLOGY = "cluster/v2/topology";
+  private static final String PATH_CLUSTER_STATUS = "cluster/v2/status";
   private static final String REALM = "camunda";
 
   // The provider claims the cluster-admin matcher reads from the token. "azp" is set by Keycloak to
@@ -146,6 +147,17 @@ public class ClusterAdminOidcAuthenticationIT {
     assertThat(response.headers().firstValue("content-type").orElse(""))
         .contains("application/problem+json");
     assertThat(response.body()).contains("\"status\":403");
+  }
+
+  @Test
+  void shouldAllowPublicStatusEndpointWithoutToken() throws Exception {
+    // when — the public cluster status endpoint is hit with no bearer token
+    final HttpResponse<String> response = get(statusUri(), null);
+
+    // then — permitAll: reachable unauthenticated, healthy 204 with no body (the cluster
+    // equivalent of /v2/status), so no topology/membership detail is exposed to anonymous callers
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+    assertThat(response.body()).isEmpty();
   }
 
   @Test
@@ -253,5 +265,9 @@ public class ClusterAdminOidcAuthenticationIT {
   // is that root (no physical-tenant prefix), so no stripping is needed here.
   private static URI clusterUri() {
     return BROKER.restAddress().resolve(PATH_CLUSTER_TOPOLOGY);
+  }
+
+  private static URI statusUri() {
+    return BROKER.restAddress().resolve(PATH_CLUSTER_STATUS);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DummyClusterTopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DummyClusterTopologyController.java
@@ -20,4 +20,12 @@ public class DummyClusterTopologyController {
     // Placeholder response; the aggregated cluster topology is implemented in a follow-up.
     return ResponseEntity.ok().build();
   }
+
+  @CamundaGetMapping(path = "/status")
+  public ResponseEntity<Void> getClusterStatus() {
+    // Public, unauthenticated cluster-level equivalent of /v2/status. Mirrors StatusController's
+    // contract (204 healthy / 503 unhealthy), body-less. Real health wiring is a follow-up; the
+    // response must stay body-less so it never leaks topology/membership to anonymous callers.
+    return ResponseEntity.noContent().build();
+  }
 }


### PR DESCRIPTION
Add a public cluster-level status endpoint as the equivalent of `/v2/status`, while keeping the rest of `/cluster/v2/**` protected.

The endpoint is carved out of both cluster-admin chains (Basic and OIDC) with a permitAll matcher on the exact path. This mirrors how `/v2/status` is exposed: a missing credential is allowed through, but a malformed one is still rejected by the auth filter, so the two endpoints behave identically. 
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/58244
