### PR TITLE
build: publish flattened POM for pom-packaging modules during Central release

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,6 +42,12 @@
     <license.header.file>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header.file>
 
     <plugin.version.flatten>1.7.3</plugin.version.flatten>
+    <!-- Default: do not swap the reactor POM for the flattened one. Overridden to true only under
+         the central-sonatype-publish profile, so pom-packaging modules publish a self-contained
+         (coordinates + metadata + resolved dependency versions) POM to Maven Central without
+         altering normal reactor builds. Defined here (same POM as the profile) so the profile
+         override wins; a definition in a child POM would shadow it. -->
+    <flatten.updatePomFile>false</flatten.updatePomFile>
     <plugin.version.javadoc>3.12.0</plugin.version.javadoc>
     <plugin.version.license>5.0.0</plugin.version.license>
     <plugin.version.spotless>3.2.1</plugin.version.spotless>
@@ -445,6 +451,9 @@
       <id>central-sonatype-publish</id>
       <properties>
         <plugin.version.gpg>1.6</plugin.version.gpg>
+        <!-- Publish the flattened POM for pom-packaging modules so Central can extract coordinates
+             and required metadata. Scoped to this publish profile to avoid altering normal builds. -->
+        <flatten.updatePomFile>true</flatten.updatePomFile>
       </properties>
       <build>
         <pluginManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2985,6 +2985,13 @@
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
           <flattenMode>ossrh</flattenMode>
+          <!--
+            Required for pom-packaging modules: updatePomFile defaults to false for them (unlike
+            jars, and unlike flattenMode=bom which defaults it to true), which would deploy the
+            raw pom.xml with parent inheritance unresolved. Central validates each pom standalone,
+            so inherited metadata and BOM-managed dependency versions must be inlined via flatten.
+            -->
+          <updatePomFile>${flatten.updatePomFile}</updatePomFile>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Problem

The 8.8.32 Maven Central release failed with **14 component validations** + **56 deployment validations** ([run](https://github.com/camunda/camunda/actions/runs/29757656467)), tracked in **INC-6593**. All failing artifacts are `pom`-packaging modules (the `-parent` aggregators + `camunda-8-root`). Their published (raw) POMs fail three distinct Central checks:

1. **Coordinate extraction** ("Failed to get coordinates") — `groupId`/`version` are inherited, not inline.
2. **Metadata** — `description`/`url`/`licenses`/`scm`/`developers` are inherited, not inline.
3. **Dependency versions** — version-less `test`-scope deps in `zeebe-parent`.

Root cause: for `pom`-packaging modules, `flatten-maven-plugin`'s `updatePomFile` defaults to `false`, so `install`/`deploy` publish the **raw** `pom.xml` (inheritance unresolved). Jars and the BOM already publish flattened POMs (hence they pass). Central validates each POM standalone, so the inherited values and managed versions show up as missing. This surfaced now because Central Portal enforcement tightened — 8.8.31 published the same non-compliant raw POMs on 2026-07-07.

## Fix

Enable `updatePomFile=true` **only under the `central-sonatype-publish` profile** (the profile the release deploy already runs with). The flattened `ossrh` POM resolves all three checks (inline coordinates, metadata, dependency versions).

It is **scoped to the publish profile on purpose**: setting it unconditionally changes the reactor build in *every* build, and breaks transitive dependency resolution for reactor-**excluded** modules — e.g. the partitioned "Unit - Back End" job excludes `zeebe-util`, and swapping aggregators to their flattened POMs mid-reactor drops `agrona` from `security-core`'s test classpath (`NoClassDefFoundError`). Gating keeps normal builds byte-for-byte unchanged; only the release deploy (full reactor, tests skipped) publishes flattened POMs.

Implementation: `flatten.updatePomFile` defaults to `false` in `bom/pom.xml` and is overridden to `true` in the `central-sonatype-publish` profile (same POM, so the profile override wins); `parent/pom.xml`'s flatten config references the property.

## Validation (local)

- **Normal build** (default `false`): reproduction of the excluded-reactor UT failure now passes 8/8 — no agrona breakage.
- **Publish path** (`-Pcentral-sonatype-publish`): `zeebe-parent` installs as the flattened POM (3.9 KB) with inline `groupId`/`version`, `packaging=pom`, all six metadata elements, and no version-less deps — Central-compliant.
- Property gating verified via `help:evaluate`: `false` without the profile, `true` with it, for both `zeebe-parent` and `camunda-8-root`.

Final confirmation should be a release **dry-run** so the publish path runs in CI.

## Scope

`main` and `stable/*` share the same config and will hit this on their next patch — needs the equivalent change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
