### PR TITLE
fix: defer synchronous correlate response for cross-partition message start event with businessId

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-business-id-api-tests.spec.ts
@@ -61,8 +61,7 @@ test.describe.parallel('Correlate Message - Business ID API', () => {
     await deploy(['./resources/message_start_business_id_process.bpmn']);
   });
 
-  // Skipped due to bug #58207: https://github.com/camunda/camunda/issues/58207
-  test.skip('Correlate message to a message start event carries the Business ID to the created instance', async ({
+  test('Correlate message to a message start event carries the Business ID to the created instance', async ({
     request,
   }) => {
     const businessId = uniqueBusinessId('correlate-start');
@@ -94,8 +93,7 @@ test.describe.parallel('Correlate Message - Business ID API', () => {
     await cancelProcessInstance(localState['processInstanceKey']);
   });
 
-  // Skipped due to bug #58207: https://github.com/camunda/camunda/issues/58207
-  test.skip('Duplicate Business ID correlation does not start a second instance while the first is active', async ({
+  test('Duplicate Business ID correlation does not start a second instance while the first is active', async ({
     request,
   }) => {
     const businessId = uniqueBusinessId('correlate-duplicate');
@@ -135,8 +133,7 @@ test.describe.parallel('Correlate Message - Business ID API', () => {
     await cancelProcessInstance(localState['processInstanceKey']);
   });
 
-  // Skipped due to bug #58207: https://github.com/camunda/camunda/issues/58207
-  test.skip('Business ID can be reused for correlation after the holding instance is cancelled', async ({
+  test('Business ID can be reused for correlation after the holding instance is cancelled', async ({
     request,
   }) => {
     const businessId = uniqueBusinessId('correlate-reuse');

--- a/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
+++ b/zeebe/docs/adr/0001-810-message-correlation-business-id-cross-partition.md
@@ -86,6 +86,58 @@ local match: a message without a `businessId` correlates regardless; a message w
 only to a subscription whose stored `businessId` matches exactly. Only start events need a uniqueness
 check, and only `P_B` can answer it — hence the asymmetry with D2.
 
+**D6. A synchronous `correlate` defers its response; the `P_K` reply processors resolve it.** D2–D5
+describe the asynchronous `publish`, which has no waiting client — a delegated start simply proceeds
+and a rejected one stays buffered. A synchronous `POST /messages/correlation`, by contrast, has a
+client blocked on the outcome. When the only correlation on `P_K` was a start delegated to `P_B`,
+`P_K` must not answer `NOT_FOUND`: the instance is being created remotely, so the response is
+deferred. The `CORRELATING` event already records the request (`requestId`, `requestStreamId`) keyed
+by `messageKey` — the same deferral used for cross-partition catch-event correlation — and the three
+reply processors resolve it: `STARTED` → `CORRELATED` + accepted response; `REJECT_UNIQUENESS` /
+`REJECT_NO_SUBSCRIPTION` → `NOT_CORRELATED` + a `NOT_FOUND` rejected response carrying the reason.
+Resolution is idempotent (the terminal applier removes the stored request) and a no-op for a
+`publish` (no stored request). The deferral is scoped to a genuine delegation (`P_B != P_K`): a
+start the local partition attempted but could not create — its definition draining or removed, so
+the local trigger reports "nothing started" — is not a delegation and is answered `NOT_FOUND`
+immediately, never deferred.
+
+**A rejected correlate is single-attempt: its message is expired, not buffered for retry.** This is
+the correlate/publish split of D2. A correlate carries no TTL (fire-and-forget), so on a
+`REJECT_UNIQUENESS` / `REJECT_NO_SUBSCRIPTION` the reply processor expires the buffered message — the
+same `EXPIRED` the success path already writes — which both removes the message and clears the
+pending ask, stopping the retry scheduler. Without this, the ask (backed off by the rejection
+applier, cleared only by a success or by the message's TTL) would keep retrying and could start an
+instance _after_ the client already received `NOT_FOUND`. A `publish` keeps the opposite contract:
+its rejected message stays buffered and is retried until it starts or its TTL expires (D2 /
+[ADR 0002](0002-810-message-start-rejection-retry.md)).
+
+**The rejection is reported as `NOT_FOUND` (HTTP 404), matching the single-partition path.** The
+local active-instance block already answers a correlate with `NOT_FOUND`, and the cross-partition
+arm answers with the same rejection type and status, so the client-visible outcome does not depend
+on whether `hash(businessId)` and `hash(correlationKey)` co-locate.
+
+The deferred correlate response, layered on the D2 ask/reply:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant P_K as P_K = hash(correlationKey)
+    participant P_B as P_B = hash(businessId)
+
+    Client->>P_K: correlate(name, correlationKey, businessId)
+    Note over P_K: CORRELATING stores requestId/requestStreamId by messageKey<br/>response deferred (no NOT_FOUND)
+    P_K->>P_B: REQUEST (cross-partition ask, D2)
+    alt instance created
+        P_B-->>P_K: STARTED
+        Note over P_K: CORRELATED + accepted response<br/>message EXPIRED
+        P_K-->>Client: 200 CORRELATED (processInstanceKey)
+    else uniqueness / no-subscription rejection
+        P_B-->>P_K: REJECT_UNIQUENESS / REJECT_NO_SUBSCRIPTION
+        Note over P_K: NOT_CORRELATED + NOT_FOUND response<br/>message EXPIRED (single attempt, no retry)
+        P_K-->>Client: 404 NOT_FOUND (reason)
+    end
+```
+
 ## Alternatives considered
 
 - **Combined-hash routing `hash(correlationKey + businessId)`.** Co-locates the lock and the
@@ -106,6 +158,9 @@ check, and only `P_B` can answer it — hence the asymmetry with D2.
   stays observable from one partition per correlation key.
 - New cross-partition machinery is confined to the message-start path: an ask with three reply
   outcomes, a per-`P_K` record of remotely held locks, and the dedup row on `P_B`.
+- A synchronous `correlate` to a cross-partition start is answered exactly once, when its remote
+  outcome is known, by reusing the existing request-deferral state — so it never reports a spurious
+  `NOT_FOUND` while the instance is being created (D6, closing camunda/camunda#58207).
 - The pull keeps all reaction-to-completion logic on the partition that owns the work and is
   self-healing, at the cost of added latency on the release path (bounded by the poll interval and
   back-off).

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/DeferredMessageStartCorrelationResponse.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+
+/**
+ * Resolves the synchronous response of a {@code POST /messages/correlation} command that was
+ * delegated to {@code P_B = hash(businessId)} for a message start event.
+ *
+ * <p>When a correlate command targets a message-start event whose {@code businessId} hashes to a
+ * different partition than {@code P_K = hash(correlationKey)}, {@link
+ * MessageCorrelationCorrelateProcessor} cannot answer the client synchronously: the instance is
+ * created (or the request rejected) asynchronously on {@code P_B}. The processor therefore leaves
+ * the {@link MessageCorrelationIntent#CORRELATING} event in place, whose applier stored the
+ * originating request's {@code requestId}/{@code requestStreamId} keyed by {@code messageKey} in
+ * {@link MessageCorrelationState} — the same deferral used for cross-partition catch-event
+ * correlation.
+ *
+ * <p>The cross-partition reply processors on {@code P_K} ({@code STARTED}, {@code
+ * UNIQUENESS_REJECTED}, {@code NO_SUBSCRIPTION_REJECTED}) call into this helper to flush that
+ * pending request into the terminal {@link MessageCorrelationIntent#CORRELATED} / {@link
+ * MessageCorrelationIntent#NOT_CORRELATED} event plus the matching gateway response.
+ *
+ * <p>The helper is a no-op when no request data exists for the {@code messageKey}. That is the
+ * expected case for a {@code publish} that was delegated (publishes are asynchronous and never
+ * carry a pending correlate request) and also makes the reply processors idempotent against a
+ * re-delivered reply: writing the terminal event removes the request data, so a retried reply finds
+ * none and does not emit a duplicate response.
+ */
+final class DeferredMessageStartCorrelationResponse {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final MessageCorrelationState messageCorrelationState;
+  private final MessageState messageState;
+  private final MessageCorrelationRecord correlationRecord = new MessageCorrelationRecord();
+  private final MessageRecord expiredMessageRecord = new MessageRecord();
+
+  DeferredMessageStartCorrelationResponse(
+      final StateWriter stateWriter,
+      final TypedResponseWriter responseWriter,
+      final MessageCorrelationState messageCorrelationState,
+      final MessageState messageState) {
+    this.stateWriter = stateWriter;
+    this.responseWriter = responseWriter;
+    this.messageCorrelationState = messageCorrelationState;
+    this.messageState = messageState;
+  }
+
+  /**
+   * Flushes a successful cross-partition start into {@link MessageCorrelationIntent#CORRELATED}
+   * plus an accepted response carrying the created {@code processInstanceKey}. No-op when the reply
+   * did not originate from a synchronous correlate (no pending request data).
+   */
+  void writeCorrelatedResponse(final MessageStartProcessInstanceRequestRecord reply) {
+    final var messageKey = reply.getMessageKey();
+    if (!messageCorrelationState.existsRequestDataForMessageKey(messageKey)) {
+      return;
+    }
+    final var requestData = messageCorrelationState.getRequestData(messageKey);
+
+    correlationRecord.reset();
+    correlationRecord
+        .setName(reply.getMessageName())
+        .setCorrelationKey(reply.getCorrelationKey())
+        .setVariables(reply.getVariablesBuffer())
+        .setTenantId(reply.getTenantId())
+        .setBusinessId(reply.getBusinessId())
+        .setMessageKey(messageKey)
+        .setProcessInstanceKey(reply.getProcessInstanceKey())
+        .setProcessDefinitionKey(reply.getProcessDefinitionKey())
+        .setRequestId(requestData.getRequestId())
+        .setRequestStreamId(requestData.getRequestStreamId());
+
+    stateWriter.appendFollowUpEvent(
+        messageKey, MessageCorrelationIntent.CORRELATED, correlationRecord);
+    responseWriter.writeAcceptedResponse(
+        messageKey,
+        MessageCorrelationIntent.CORRELATED,
+        correlationRecord,
+        ValueType.MESSAGE_CORRELATION,
+        requestData.getRequestId(),
+        requestData.getRequestStreamId());
+  }
+
+  /**
+   * Flushes a cross-partition rejection into {@link MessageCorrelationIntent#NOT_CORRELATED} plus a
+   * rejected response with the given type and reason. No-op when the reply did not originate from a
+   * synchronous correlate (no pending request data).
+   *
+   * <p>A synchronous correlate is fire-and-forget (its message carries {@code TTL = -1}): unlike a
+   * buffered publish it must not linger in state nor be retried. On a rejection this therefore also
+   * expires the buffered message, whose {@code EXPIRED} applier removes it and clears the pending
+   * cross-partition ask — stopping the retry scheduler from starting a late instance after the
+   * client has already received {@code NOT_FOUND}. A publish keeps its buffered message for the
+   * retry mechanism (no request data, so this method is a no-op for it).
+   */
+  void writeNotCorrelatedResponse(
+      final MessageStartProcessInstanceRequestRecord reply,
+      final RejectionType rejectionType,
+      final String reason) {
+    final var messageKey = reply.getMessageKey();
+    if (!messageCorrelationState.existsRequestDataForMessageKey(messageKey)) {
+      return;
+    }
+    final var requestData = messageCorrelationState.getRequestData(messageKey);
+
+    correlationRecord.reset();
+    correlationRecord
+        .setName(reply.getMessageName())
+        .setCorrelationKey(reply.getCorrelationKey())
+        .setVariables(reply.getVariablesBuffer())
+        .setTenantId(reply.getTenantId())
+        .setBusinessId(reply.getBusinessId())
+        .setMessageKey(messageKey)
+        .setRequestId(requestData.getRequestId())
+        .setRequestStreamId(requestData.getRequestStreamId());
+
+    stateWriter.appendFollowUpEvent(
+        messageKey, MessageCorrelationIntent.NOT_CORRELATED, correlationRecord);
+    responseWriter.writeRejectedResponse(
+        messageKey,
+        MessageCorrelationIntent.CORRELATE,
+        correlationRecord,
+        ValueType.MESSAGE_CORRELATION,
+        rejectionType,
+        reason,
+        requestData.getRequestId(),
+        requestData.getRequestStreamId());
+
+    expireBufferedCorrelateMessage(messageKey);
+  }
+
+  /**
+   * Expires the buffered message created by a synchronous correlate so its {@code EXPIRED} applier
+   * removes it and clears the pending cross-partition ask. Guarded by the message's existence: it
+   * may already be gone because its {@code TTL = -1} deadline was swept by the time-to-live
+   * checker, or because an earlier re-delivered reply already expired it.
+   */
+  private void expireBufferedCorrelateMessage(final long messageKey) {
+    final var storedMessage = messageState.getMessage(messageKey);
+    if (storedMessage == null) {
+      return;
+    }
+    expiredMessageRecord.reset();
+    expiredMessageRecord.wrap(storedMessage.getMessage());
+    stateWriter.appendFollowUpEvent(messageKey, MessageIntent.EXPIRED, expiredMessageRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.MutableBoolean;
 
 /**
  * Correlates published messages to message start-event subscriptions and to intermediate message
@@ -121,10 +122,24 @@ public final class MessageCorrelateBehavior {
     correlateToMessageStartEvents(messageData, correlatingSubscriptions, null);
   }
 
-  public void correlateToMessageStartEvents(
+  /**
+   * Correlates the message to every matching message-start-event subscription on this partition.
+   *
+   * @return {@code true} when at least one start event was delegated to {@code P_B} via the
+   *     cross-partition ask ({@code P_B != P_K}). A delegated start produces no local {@code
+   *     correlatingSubscriptions} entry — its terminal outcome is decided asynchronously by {@code
+   *     P_B} and applied by the reply processors on {@code P_K} — so a caller that must distinguish
+   *     "nothing correlated" from "correlation delegated cross-partition" (e.g. the synchronous
+   *     correlate command, to avoid reporting a spurious {@code NOT_FOUND}) relies on this flag. A
+   *     local start that {@link #triggerOrDelegateStartEvent} could not create (definition draining
+   *     or removed) also returns {@code -1} but is <em>not</em> reported as delegated — it must
+   *     fall through to the {@code NOT_FOUND} rejection.
+   */
+  public boolean correlateToMessageStartEvents(
       final MessageData messageData,
       final Subscriptions correlatingSubscriptions,
       final Collection<String> blockedProcessIds) {
+    final var delegatedCrossPartition = new MutableBoolean(false);
     startEventSubscriptionState.visitSubscriptionsByMessageName(
         messageData.tenantId(),
         messageData.messageName(),
@@ -146,11 +161,19 @@ public final class MessageCorrelateBehavior {
               // activation, so it must not be added here.
               subscriptionRecord.setProcessInstanceKey(processInstanceKey);
               correlatingSubscriptions.add(subscriptionRecord);
+            } else if (shouldDelegateToBusinessIdPartition(messageData)) {
+              // triggerOrDelegateStartEvent returned -1: distinguish a genuine cross-partition
+              // delegation (the terminal outcome comes later from P_B via the reply processors)
+              // from a local start that simply could not be created (definition draining or
+              // removed). Only the former defers the synchronous response; the latter must fall
+              // through to the NOT_FOUND rejection so the correlate does not hang.
+              delegatedCrossPartition.set(true);
             }
           } else if (blockedProcessIds != null) {
             blockedProcessIds.add(subscriptionRecord.getBpmnProcessId());
           }
         });
+    return delegatedCrossPartition.get();
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -164,10 +164,22 @@ public final class MessageCorrelationCorrelateProcessor
     // Now actually correlate with state writes
     final var blockedProcessIds = new HashSet<String>();
     correlateBehavior.correlateToMessageEvents(messageData, correlatingSubscriptions);
-    correlateBehavior.correlateToMessageStartEvents(
-        messageData, correlatingSubscriptions, blockedProcessIds);
+    final var delegatedCrossPartition =
+        correlateBehavior.correlateToMessageStartEvents(
+            messageData, correlatingSubscriptions, blockedProcessIds);
 
     if (correlatingSubscriptions.isEmpty()) {
+      if (delegatedCrossPartition) {
+        // A message-start correlation was delegated to P_B = hash(businessId) because the
+        // businessId hashes to a different partition than this one (P_K = hash(correlationKey)).
+        // The instance is being created asynchronously on P_B; the synchronous response is
+        // therefore deferred. The CORRELATING event applied above stored the request's
+        // requestId/requestStreamId keyed by messageKey, and the cross-partition reply processors
+        // on P_K (STARTED / UNIQUENESS_REJECTED / NO_SUBSCRIPTION_REJECTED) resolve that pending
+        // request into the final CORRELATED / NOT_CORRELATED response. Returning NOT_FOUND here
+        // would wrongly report failure while the instance is being created.
+        return;
+      }
       final String errorMessage;
       if (!blockedProcessIds.isEmpty()) {
         errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -190,15 +190,18 @@ public final class MessageEventProcessors {
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.START,
-            new MessageStartProcessInstanceRequestStartProcessor(writers.state(), messageState))
+            new MessageStartProcessInstanceRequestStartProcessor(
+                writers.state(), writers.response(), messageState, messageCorrelationState))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REJECT_UNIQUENESS,
-            new MessageStartProcessInstanceRequestRejectUniquenessProcessor(writers.state()))
+            new MessageStartProcessInstanceRequestRejectUniquenessProcessor(
+                writers.state(), writers.response(), messageCorrelationState, messageState))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REJECT_NO_SUBSCRIPTION,
-            new MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(writers.state()))
+            new MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(
+                writers.state(), writers.response(), messageCorrelationState, messageState))
         .onCommand(
             ValueType.MESSAGE_START_PROCESS_INSTANCE_REQUEST,
             MessageStartProcessInstanceRequestIntent.REJECT_EXPIRED,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor.java
@@ -10,7 +10,11 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -23,23 +27,43 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  * MessageStartProcessInstanceRequestIntent#NO_SUBSCRIPTION_REJECTED} follow-up event whose applier
  * does the bookkeeping cleanup (pending-ask state removal). The message stays buffered on {@code
  * P_K}, preserving the same semantics as when a local start-event subscription is missing.
+ *
+ * <p>When the delegating command was a synchronous {@code correlate} (rather than a {@code
+ * publish}), the client is still awaiting a response; this processor additionally flushes the
+ * deferred {@link io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent#NOT_CORRELATED}
+ * event and a {@code NOT_FOUND} rejected response, and expires the fire-and-forget correlate
+ * message so it is neither retried nor left buffered.
  */
 @ExcludeAuthorizationCheck
 public final class MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
 
+  private static final String SUBSCRIPTION_NOT_FOUND =
+      "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found.";
+
   private final StateWriter stateWriter;
+  private final DeferredMessageStartCorrelationResponse deferredCorrelationResponse;
 
   public MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(
-      final StateWriter stateWriter) {
+      final StateWriter stateWriter,
+      final TypedResponseWriter responseWriter,
+      final MessageCorrelationState messageCorrelationState,
+      final MessageState messageState) {
     this.stateWriter = stateWriter;
+    deferredCorrelationResponse =
+        new DeferredMessageStartCorrelationResponse(
+            stateWriter, responseWriter, messageCorrelationState, messageState);
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
+    final var reply = record.getValue();
     stateWriter.appendFollowUpEvent(
-        record.getKey(),
-        MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED,
-        record.getValue());
+        record.getKey(), MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED, reply);
+
+    deferredCorrelationResponse.writeNotCorrelatedResponse(
+        reply,
+        RejectionType.NOT_FOUND,
+        SUBSCRIPTION_NOT_FOUND.formatted(reply.getMessageName(), reply.getCorrelationKey()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRejectUniquenessProcessor.java
@@ -10,9 +10,14 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Set;
 
 /**
  * Handles the {@link MessageStartProcessInstanceRequestIntent#REJECT_UNIQUENESS} command on {@code
@@ -23,23 +28,46 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
  * follow-up event whose applier does the bookkeeping cleanup (pending-ask state removal). The
  * message stays buffered on {@code P_K}, waiting for the pull-based release mechanism in Increment
  * 4.
+ *
+ * <p>When the delegating command was a synchronous {@code correlate} (rather than a {@code
+ * publish}), the client is still awaiting a response; this processor additionally flushes the
+ * deferred {@link io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent#NOT_CORRELATED}
+ * event and a {@code NOT_FOUND} rejected response reporting the active-instance conflict, and
+ * expires the fire-and-forget correlate message so it is neither retried nor left buffered.
  */
 @ExcludeAuthorizationCheck
 public final class MessageStartProcessInstanceRequestRejectUniquenessProcessor
     implements TypedRecordProcessor<MessageStartProcessInstanceRequestRecord> {
 
+  private static final String BLOCKED_BY_ACTIVE_INSTANCE =
+      "Expected to correlate message with name '%s' to a message start event, but a process instance"
+          + " is already active for business ID '%s' in process IDs %s. Only one active process"
+          + " instance per business ID is allowed for message start events.";
+
   private final StateWriter stateWriter;
+  private final DeferredMessageStartCorrelationResponse deferredCorrelationResponse;
 
   public MessageStartProcessInstanceRequestRejectUniquenessProcessor(
-      final StateWriter stateWriter) {
+      final StateWriter stateWriter,
+      final TypedResponseWriter responseWriter,
+      final MessageCorrelationState messageCorrelationState,
+      final MessageState messageState) {
     this.stateWriter = stateWriter;
+    deferredCorrelationResponse =
+        new DeferredMessageStartCorrelationResponse(
+            stateWriter, responseWriter, messageCorrelationState, messageState);
   }
 
   @Override
   public void processRecord(final TypedRecord<MessageStartProcessInstanceRequestRecord> record) {
+    final var reply = record.getValue();
     stateWriter.appendFollowUpEvent(
-        record.getKey(),
-        MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED,
-        record.getValue());
+        record.getKey(), MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED, reply);
+
+    deferredCorrelationResponse.writeNotCorrelatedResponse(
+        reply,
+        RejectionType.NOT_FOUND,
+        BLOCKED_BY_ACTIVE_INSTANCE.formatted(
+            reply.getMessageName(), reply.getBusinessId(), Set.of(reply.getBpmnProcessId())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestStartProcessor.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
@@ -69,14 +71,21 @@ public final class MessageStartProcessInstanceRequestStartProcessor
 
   private final StateWriter stateWriter;
   private final MessageState messageState;
+  private final DeferredMessageStartCorrelationResponse deferredCorrelationResponse;
   private final MessageStartEventSubscriptionRecord correlatedSubscriptionRecord =
       new MessageStartEventSubscriptionRecord();
   private final MessageRecord expiredMessageRecord = new MessageRecord();
 
   public MessageStartProcessInstanceRequestStartProcessor(
-      final StateWriter stateWriter, final MessageState messageState) {
+      final StateWriter stateWriter,
+      final TypedResponseWriter responseWriter,
+      final MessageState messageState,
+      final MessageCorrelationState messageCorrelationState) {
     this.stateWriter = stateWriter;
     this.messageState = messageState;
+    deferredCorrelationResponse =
+        new DeferredMessageStartCorrelationResponse(
+            stateWriter, responseWriter, messageCorrelationState, messageState);
   }
 
   @Override
@@ -134,5 +143,10 @@ public final class MessageStartProcessInstanceRequestStartProcessor
       stateWriter.appendFollowUpEvent(
           reply.getMessageKey(), MessageIntent.EXPIRED, expiredMessageRecord);
     }
+
+    // (iv) If the cross-partition start was triggered by a synchronous correlate command (rather
+    // than an asynchronous publish), flush the deferred CORRELATED response to the waiting client.
+    // No-op for publishes and idempotent on a re-delivered reply.
+    deferredCorrelationResponse.writeCorrelatedResponse(reply);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCorrelateDrainingRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCorrelateDrainingRejectionTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Pins that a synchronous correlate whose only matching message-start subscription cannot start an
+ * instance locally (the process definition is draining, so {@link
+ * io.camunda.zeebe.engine.processing.common.EventHandle#triggerMessageStartEvent} returns {@code
+ * -1}) is rejected with {@code NOT_FOUND} rather than deferred.
+ *
+ * <p>A single partition guarantees {@code P_B == P_K}, so there is no cross-partition delegation:
+ * the {@code -1} returned here means "nothing started locally", not "delegated". If the correlate
+ * processor mistook it for a delegation it would defer the response forever — the client would hang
+ * and the buffered {@code TTL=-1} correlate message would leak.
+ */
+public final class MessageStartEventCorrelateDrainingRejectionTest {
+
+  private static final String PROCESS_ID = "wf";
+  private static final String MESSAGE_NAME = "start-msg";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("start")
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldRejectNotFoundWhenLocalStartCannotBeCreated() {
+    // given - a deployed message-start process whose definition is then marked DRAINING
+    final var metadata =
+        engine
+            .deployment()
+            .withXmlResource(MESSAGE_START_PROCESS)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0);
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .await();
+    drain(metadata);
+
+    // when - the message is correlated synchronously (no businessId, so no cross-partition arm)
+    final var rejection =
+        engine
+            .messageCorrelation()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey("")
+            .expectRejection()
+            .correlate();
+
+    // then - the correlate is rejected NOT_FOUND instead of being deferred
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
+  }
+
+  /**
+   * Puts the given process definition into the {@code DRAINING} state. Since no processor writes
+   * the {@code DRAINING} event yet, the event is injected onto the log while the engine is stopped
+   * so it is applied to state on the next start (replay). TODO(#56978): drive draining via a real
+   * {@code RESOURCE_DELETION.DELETE} once that change lands, and remove this injection helper.
+   */
+  private void drain(final ProcessMetadataValue metadata) {
+    engine.stop();
+    engine.writeRecords(
+        RecordToWrite.event()
+            .key(metadata.getProcessDefinitionKey())
+            .process(
+                ProcessIntent.DRAINING,
+                new ProcessRecord()
+                    .setKey(metadata.getProcessDefinitionKey())
+                    .setBpmnProcessId(metadata.getBpmnProcessId())
+                    .setVersion(metadata.getVersion())
+                    .setResourceName(metadata.getResourceName())
+                    .setTenantId(metadata.getTenantId())));
+    engine.start();
+
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+        .await();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCrossPartitionCorrelateBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartEventCrossPartitionCorrelateBusinessIdTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Multi-partition behavioral pin for the <em>synchronous correlate</em> arm of the cross-partition
+ * message-start handshake (issue #58207). Unlike a buffered publish, a {@code POST
+ * /messages/correlation} command has a waiting client, so the deferred cross-partition reply
+ * ({@code STARTED} / {@code UNIQUENESS_REJECTED} / {@code NO_SUBSCRIPTION_REJECTED}) must be
+ * reflected back into the correlate response instead of a spurious {@code NOT_FOUND}.
+ *
+ * <p>The constants are chosen so {@code hash(correlationKey)} and {@code hash(businessId)} land on
+ * different partitions, exercising the cross-partition routing flip; a precondition check in {@link
+ * #assertCrossPartitionRouting()} fails loudly if a hash-function change degenerates the scenario
+ * into a single-partition path.
+ */
+public final class MessageStartEventCrossPartitionCorrelateBusinessIdTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  // hash("ck-1") -> P_K = partition 1, hash("biz-1") -> P_B = partition 3 (PARTITION_COUNT = 3),
+  // so the correlate is routed to a different partition than the one that owns the businessId.
+  private static final String CORRELATION_KEY = "ck-1";
+  // A second correlation key on yet another partition (hash("ck-2") -> partition 2). Used by the
+  // uniqueness-rejection test so the second correlate does NOT collide with the local
+  // correlation-key lock written for CORRELATION_KEY on P_K, and is therefore delegated to P_B —
+  // exercising the async UNIQUENESS_REJECTED reply arm rather than the synchronous local-lock path.
+  private static final String SECOND_CORRELATION_KEY = "ck-2";
+  private static final String BUSINESS_ID = "biz-1";
+
+  private static final String PROCESS_ID = "wf-cross-correlate";
+  private static final String MESSAGE_NAME = "start-msg-correlate";
+  private static final String START_EVENT_ID = "msgStart";
+
+  private static final BpmnModelInstance MESSAGE_START_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent(START_EVENT_ID)
+          .message(MESSAGE_NAME)
+          .serviceTask("task", t -> t.zeebeJobType("test"))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.multiplePartition(PARTITION_COUNT)
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Before
+  public void assertCrossPartitionRouting() {
+    assertThat(partitionFor(CORRELATION_KEY))
+        .describedAs(
+            """
+                CORRELATION_KEY (%s) and BUSINESS_ID (%s) must hash to different partitions so the\
+                 cross-partition correlate arm is actually exercised; if this fails after a hash\
+                 change, pick new constants""",
+            CORRELATION_KEY, BUSINESS_ID)
+        .isNotEqualTo(partitionFor(BUSINESS_ID));
+    assertThat(partitionFor(SECOND_CORRELATION_KEY))
+        .describedAs(
+            """
+                SECOND_CORRELATION_KEY (%s) must hash to a partition other than P_B (%s) and other than\
+                 CORRELATION_KEY (%s), so the second correlate is delegated to P_B and does not\
+                 collide with the local correlation-key lock""",
+            SECOND_CORRELATION_KEY, BUSINESS_ID, CORRELATION_KEY)
+        .isNotEqualTo(partitionFor(BUSINESS_ID))
+        .isNotEqualTo(partitionFor(CORRELATION_KEY));
+  }
+
+  @Test
+  public void shouldCorrelateToMessageStartEventAcrossPartitionsAndReturnCorrelated() {
+    // given
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions();
+
+    // when a synchronous correlate lands on P_K but its businessId hashes to P_B
+    final var correlated =
+        engine
+            .messageCorrelation()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
+            .withBusinessId(BUSINESS_ID)
+            .correlate();
+
+    // then
+    assertThat(correlated.getValue().getProcessInstanceKey())
+        .describedAs("the correlate is answered CORRELATED on P_K, carrying the created PI key")
+        .isPositive();
+    assertThat(correlated.getPartitionId())
+        .describedAs("the correlate is answered on P_K = hash(correlationKey)")
+        .isEqualTo(partitionFor(CORRELATION_KEY));
+
+    final var activating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.PROCESS)
+            .withBpmnProcessId(PROCESS_ID)
+            .getFirst();
+    assertThat(Protocol.decodePartitionId(activating.getValue().getProcessInstanceKey()))
+        .describedAs("the new PI lives on P_B = hash(businessId)")
+        .isEqualTo(partitionFor(BUSINESS_ID));
+    assertThat(activating.getValue().getProcessInstanceKey())
+        .describedAs("the correlate response carries the PI key created on P_B")
+        .isEqualTo(correlated.getValue().getProcessInstanceKey());
+    assertThat(activating.getValue().getBusinessId())
+        .describedAs("the new PI carries the businessId")
+        .isEqualTo(BUSINESS_ID);
+  }
+
+  @Test
+  public void shouldRejectDuplicateBusinessIdCorrelateWhileHolderIsActive() {
+    // given a first correlate started a holder PI on P_B
+    deployAndAwaitStartEventSubscriptionsOnAllPartitions();
+    engine
+        .messageCorrelation()
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
+        .withBusinessId(BUSINESS_ID)
+        .correlate();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementType(BpmnElementType.PROCESS)
+        .withBpmnProcessId(PROCESS_ID)
+        .await();
+
+    // when a second correlate reuses the same businessId while the holder is still active. It uses
+    // a different correlationKey so it is not blocked by the local correlation-key lock and is
+    // instead delegated to P_B, which rejects it on businessId uniqueness.
+    final var notCorrelated =
+        engine
+            .messageCorrelation()
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(SECOND_CORRELATION_KEY)
+            .withBusinessId(BUSINESS_ID)
+            .expectNotCorrelated()
+            .correlate();
+
+    // then
+    assertThat(notCorrelated.getIntent())
+        .describedAs(
+            "the second correlate is answered NOT_CORRELATED rather than starting a second instance")
+        .isEqualTo(MessageCorrelationIntent.NOT_CORRELATED);
+    assertThat(notCorrelated.getPartitionId())
+        .describedAs("the NOT_CORRELATED response is returned on its own P_K = hash(secondKey)")
+        .isEqualTo(partitionFor(SECOND_CORRELATION_KEY));
+
+    final var processInstancesActivating =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getIntent() == MessageCorrelationIntent.NOT_CORRELATED
+                        && r.getKey() == notCorrelated.getKey())
+            .processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withBpmnProcessId(PROCESS_ID)
+            .count();
+    assertThat(processInstancesActivating)
+        .describedAs("the active holder blocks the second correlate; no second instance is created")
+        .isEqualTo(1);
+
+    final var expiredMessage =
+        RecordingExporter.messageRecords(MessageIntent.EXPIRED)
+            .withPartitionId(partitionFor(SECOND_CORRELATION_KEY))
+            .withName(MESSAGE_NAME)
+            .getFirst();
+    assertThat(expiredMessage.getKey())
+        .describedAs(
+            "the fire-and-forget correlate message is expired, not retained for retry, so the "
+                + "rejected start is never retried into a late instance (regression guard for #58250)")
+        .isEqualTo(notCorrelated.getKey());
+  }
+
+  private void deployAndAwaitStartEventSubscriptionsOnAllPartitions() {
+    engine.deployment().withXmlResource(MESSAGE_START_PROCESS).deploy();
+    // Wait until every partition has the MessageStartEventSubscription CREATED so the ask processor
+    // on P_B sees its local subscription before the first cross-partition request arrives.
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CREATED)
+        .withMessageName(MESSAGE_NAME)
+        .limit(PARTITION_COUNT)
+        .asList();
+  }
+
+  private static int partitionFor(final String key) {
+    return SubscriptionUtil.getSubscriptionPartitionId(BufferUtil.wrapString(key), PARTITION_COUNT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceReplyProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceReplyProcessorTest.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -16,11 +19,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.state.immutable.MessageCorrelationState;
 import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.message.RequestData;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
@@ -47,11 +57,31 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
 
   private StateWriter mockStateWriter;
   private MessageState mockMessageState;
+  private TypedResponseWriter mockResponseWriter;
+  private MessageCorrelationState mockMessageCorrelationState;
 
   @BeforeEach
   void setUp() {
     mockStateWriter = mock(StateWriter.class);
     mockMessageState = mock(MessageState.class);
+    mockResponseWriter = mock(TypedResponseWriter.class);
+    mockMessageCorrelationState = mock(MessageCorrelationState.class);
+  }
+
+  private MessageStartProcessInstanceRequestStartProcessor startProcessor() {
+    return new MessageStartProcessInstanceRequestStartProcessor(
+        mockStateWriter, mockResponseWriter, mockMessageState, mockMessageCorrelationState);
+  }
+
+  private MessageStartProcessInstanceRequestRejectUniquenessProcessor uniquenessProcessor() {
+    return new MessageStartProcessInstanceRequestRejectUniquenessProcessor(
+        mockStateWriter, mockResponseWriter, mockMessageCorrelationState, mockMessageState);
+  }
+
+  private MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor
+      noSubscriptionProcessor() {
+    return new MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(
+        mockStateWriter, mockResponseWriter, mockMessageCorrelationState, mockMessageState);
   }
 
   @SuppressWarnings("unchecked")
@@ -74,14 +104,31 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     return record;
   }
 
+  private void givenPendingCorrelateRequest() {
+    when(mockMessageCorrelationState.existsRequestDataForMessageKey(MESSAGE_KEY)).thenReturn(true);
+    when(mockMessageCorrelationState.getRequestData(MESSAGE_KEY))
+        .thenReturn(new RequestData().setRequestIdProp(7L).setRequestStreamIdProp(3));
+  }
+
+  private static StoredMessage createStoredMessage() {
+    final var stored = new StoredMessage();
+    stored.setMessageKey(MESSAGE_KEY);
+    stored.setMessage(
+        new MessageRecord()
+            .setName("name")
+            .setCorrelationKey(CORRELATION_KEY)
+            .setTimeToLive(-1L)
+            .setTenantId("<default>"));
+    return stored;
+  }
+
   @Nested
   class StartReplyProcessor {
 
     @Test
     void shouldWriteCorrelatedStartedAndExpiredFollowUpEvents() {
       // given a fresh reply, no prior correlation, and the buffered message still present
-      final var processor =
-          new MessageStartProcessInstanceRequestStartProcessor(mockStateWriter, mockMessageState);
+      final var processor = startProcessor();
       final var record = createMockReplyRecord();
       when(mockMessageState.existMessageCorrelation(eq(MESSAGE_KEY), any())).thenReturn(false);
       when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(createStoredMessage());
@@ -113,8 +160,7 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     @Test
     void shouldSkipCorrelatedWhenAlreadyCorrelated() {
       // given a retried reply: the correlation marker is already present
-      final var processor =
-          new MessageStartProcessInstanceRequestStartProcessor(mockStateWriter, mockMessageState);
+      final var processor = startProcessor();
       final var record = createMockReplyRecord();
       when(mockMessageState.existMessageCorrelation(eq(MESSAGE_KEY), any())).thenReturn(true);
       when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(null);
@@ -138,8 +184,7 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     void shouldSkipExpiredWhenBufferedMessageGone() {
       // given the buffered message no longer exists (TTL already fired, or a previous reply's
       // EXPIRED applier already removed it)
-      final var processor =
-          new MessageStartProcessInstanceRequestStartProcessor(mockStateWriter, mockMessageState);
+      final var processor = startProcessor();
       final var record = createMockReplyRecord();
       when(mockMessageState.existMessageCorrelation(eq(MESSAGE_KEY), any())).thenReturn(false);
       when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(null);
@@ -153,15 +198,58 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     }
 
     private StoredMessage createStoredMessage() {
-      final var stored = new StoredMessage();
-      stored.setMessageKey(MESSAGE_KEY);
-      stored.setMessage(
-          new MessageRecord()
-              .setName("name")
-              .setCorrelationKey(CORRELATION_KEY)
-              .setTimeToLive(60_000L)
-              .setTenantId("<default>"));
-      return stored;
+      return MessageStartProcessInstanceReplyProcessorTest.createStoredMessage();
+    }
+
+    @Test
+    void shouldWriteDeferredCorrelatedResponseWhenOriginatedFromSyncCorrelate() {
+      // given a synchronous correlate is awaiting the cross-partition reply
+      final var processor = startProcessor();
+      final var record = createMockReplyRecord();
+      when(mockMessageState.existMessageCorrelation(eq(MESSAGE_KEY), any())).thenReturn(false);
+      when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(createStoredMessage());
+      givenPendingCorrelateRequest();
+
+      // when
+      processor.processRecord(record);
+
+      // then the deferred CORRELATED event and accepted response are written to the waiting client
+      final var correlationCaptor = ArgumentCaptor.forClass(MessageCorrelationRecord.class);
+      verify(mockStateWriter)
+          .appendFollowUpEvent(
+              eq(MESSAGE_KEY),
+              eq(MessageCorrelationIntent.CORRELATED),
+              correlationCaptor.capture());
+      assertThat(correlationCaptor.getValue().getProcessInstanceKey())
+          .isEqualTo(PROCESS_INSTANCE_KEY);
+      verify(mockResponseWriter)
+          .writeAcceptedResponse(
+              eq(MESSAGE_KEY),
+              eq(MessageCorrelationIntent.CORRELATED),
+              any(),
+              eq(ValueType.MESSAGE_CORRELATION),
+              eq(7L),
+              eq(3));
+    }
+
+    @Test
+    void shouldNotWriteCorrelateResponseForPublish() {
+      // given no pending correlate request (the delegating command was a publish)
+      final var processor = startProcessor();
+      final var record = createMockReplyRecord();
+      when(mockMessageState.existMessageCorrelation(eq(MESSAGE_KEY), any())).thenReturn(false);
+      when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(createStoredMessage());
+      when(mockMessageCorrelationState.existsRequestDataForMessageKey(MESSAGE_KEY))
+          .thenReturn(false);
+
+      // when
+      processor.processRecord(record);
+
+      // then no MessageCorrelation response is produced
+      verify(mockStateWriter, never())
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageCorrelationIntent.CORRELATED), any());
+      verify(mockResponseWriter, never())
+          .writeAcceptedResponse(anyLong(), any(), any(), any(), anyLong(), anyInt());
     }
   }
 
@@ -171,8 +259,7 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     @Test
     void shouldWriteUniquenessRejectedFollowUpEvent() {
       // given
-      final var processor =
-          new MessageStartProcessInstanceRequestRejectUniquenessProcessor(mockStateWriter);
+      final var processor = uniquenessProcessor();
       final var record = createMockReplyRecord();
 
       // when
@@ -185,6 +272,64 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
               eq(MessageStartProcessInstanceRequestIntent.UNIQUENESS_REJECTED),
               any());
     }
+
+    @Test
+    void shouldWriteDeferredNotCorrelatedResponseAndExpireMessageForSyncCorrelate() {
+      // given a synchronous correlate is awaiting the reply and its message is still buffered
+      final var processor = uniquenessProcessor();
+      final var record = createMockReplyRecord();
+      givenPendingCorrelateRequest();
+      when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(createStoredMessage());
+
+      // when
+      processor.processRecord(record);
+
+      // then the deferred NOT_CORRELATED event and a NOT_FOUND rejected response are written, the
+      // reason names the business ID, and the fire-and-forget correlate message is expired so the
+      // pending ask is cleared and no late instance is started
+      verify(mockStateWriter)
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageCorrelationIntent.NOT_CORRELATED), any());
+      verify(mockResponseWriter)
+          .writeRejectedResponse(
+              eq(MESSAGE_KEY),
+              eq(MessageCorrelationIntent.CORRELATE),
+              any(),
+              eq(ValueType.MESSAGE_CORRELATION),
+              eq(RejectionType.NOT_FOUND),
+              contains("business ID 'bid'"),
+              eq(7L),
+              eq(3));
+      verify(mockResponseWriter)
+          .writeRejectedResponse(
+              anyLong(),
+              any(),
+              any(),
+              any(),
+              any(),
+              contains("already active"),
+              anyLong(),
+              anyInt());
+      verify(mockStateWriter)
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageIntent.EXPIRED), any());
+    }
+
+    @Test
+    void shouldNotWriteResponseOrExpireForPublish() {
+      // given no pending correlate request (the delegating command was a publish)
+      final var processor = uniquenessProcessor();
+      final var record = createMockReplyRecord();
+      when(mockMessageCorrelationState.existsRequestDataForMessageKey(MESSAGE_KEY))
+          .thenReturn(false);
+
+      // when
+      processor.processRecord(record);
+
+      // then the buffered publish message is left untouched for the retry mechanism
+      verify(mockStateWriter, never())
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageCorrelationIntent.NOT_CORRELATED), any());
+      verify(mockStateWriter, never())
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageIntent.EXPIRED), any());
+    }
   }
 
   @Nested
@@ -193,8 +338,7 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
     @Test
     void shouldWriteNoSubscriptionRejectedFollowUpEvent() {
       // given
-      final var processor =
-          new MessageStartProcessInstanceRequestRejectNoSubscriptionProcessor(mockStateWriter);
+      final var processor = noSubscriptionProcessor();
       final var record = createMockReplyRecord();
 
       // when
@@ -206,6 +350,53 @@ public final class MessageStartProcessInstanceReplyProcessorTest {
               eq(record.getKey()),
               eq(MessageStartProcessInstanceRequestIntent.NO_SUBSCRIPTION_REJECTED),
               any());
+    }
+
+    @Test
+    void shouldWriteDeferredNotCorrelatedResponseAndExpireMessageForSyncCorrelate() {
+      // given a synchronous correlate is awaiting the reply and its message is still buffered
+      final var processor = noSubscriptionProcessor();
+      final var record = createMockReplyRecord();
+      givenPendingCorrelateRequest();
+      when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(createStoredMessage());
+
+      // when
+      processor.processRecord(record);
+
+      // then the deferred NOT_CORRELATED event, a NOT_FOUND rejected response, and the message
+      // expiry are written
+      verify(mockStateWriter)
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageCorrelationIntent.NOT_CORRELATED), any());
+      verify(mockResponseWriter)
+          .writeRejectedResponse(
+              eq(MESSAGE_KEY),
+              eq(MessageCorrelationIntent.CORRELATE),
+              any(),
+              eq(ValueType.MESSAGE_CORRELATION),
+              eq(RejectionType.NOT_FOUND),
+              contains("none was found"),
+              eq(7L),
+              eq(3));
+      verify(mockStateWriter)
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageIntent.EXPIRED), any());
+    }
+
+    @Test
+    void shouldNotExpireWhenBufferedMessageGone() {
+      // given a sync correlate whose buffered message was already swept by its TTL deadline
+      final var processor = noSubscriptionProcessor();
+      final var record = createMockReplyRecord();
+      givenPendingCorrelateRequest();
+      when(mockMessageState.getMessage(MESSAGE_KEY)).thenReturn(null);
+
+      // when
+      processor.processRecord(record);
+
+      // then the NOT_CORRELATED response is still written, but no EXPIRED event
+      verify(mockStateWriter)
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageCorrelationIntent.NOT_CORRELATED), any());
+      verify(mockStateWriter, never())
+          .appendFollowUpEvent(eq(MESSAGE_KEY), eq(MessageIntent.EXPIRED), any());
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes a bug where `POST /v2/messages/correlation` to a **message start event** with a `businessId` returned `404 NOT_FOUND` on multi-partition clusters, even though the process instance was successfully being created. This happened whenever `hash(businessId)` routed to a different partition (`P_B`) than the one processing the correlate command (`P_K = hash(correlationKey)`).

### Root cause

`MessageCorrelateBehavior.correlateToMessageStartEvents` delegates the start to `P_B` via a cross-partition `MessageStartProcessInstanceRequest`, which returns `-1` (no local instance key). Because `correlatingSubscriptions` remained empty, `MessageCorrelationCorrelateProcessor` immediately wrote `NOT_FOUND` — without waiting for the async reply from `P_B`.

### Fix

Three-part fix:

1. **Detect delegation** — `correlateToMessageStartEvents` now returns a `boolean` indicating whether a genuine cross-partition delegation occurred (`P_B != P_K`). A local start that cannot be created (process definition draining or removed) also returns `-1` but is **not** treated as a delegation; it falls through to `NOT_FOUND` as before, preventing the client from hanging indefinitely.

2. **Defer the response** — When `MessageCorrelationCorrelateProcessor` sees that the only outcome was a cross-partition delegation, it skips the `NOT_FOUND` rejection. The `CORRELATING` event had already stored the request's `requestId`/`requestStreamId` keyed by `messageKey` (the same deferral mechanism used for cross-partition catch-event correlation).

3. **Resolve the deferred response in reply processors** — The new `DeferredMessageStartCorrelationResponse` helper is injected into the three `P_K` reply processors (`STARTED`, `REJECT_UNIQUENESS`, `REJECT_NO_SUBSCRIPTION`). Each processor checks for a pending correlate request by `messageKey` and, if found:
   - `STARTED` → writes `CORRELATED` + accepted response carrying the created `processInstanceKey`.
   - `REJECT_UNIQUENESS` / `REJECT_NO_SUBSCRIPTION` → writes `NOT_CORRELATED` + `NOT_FOUND` rejected response, **and expires the fire-and-forget correlate message** (`TTL=-1`) so its pending cross-partition ask is cleared and no late instance can be started after the client has already received `NOT_FOUND`.

   The helper is a no-op for publishes (no stored request data) and idempotent on re-delivered replies.

### ADR update

ADR `0001-810-message-correlation-business-id-cross-partition.md` is extended with **D6**, documenting the synchronous correlate deferral and the sequencing diagram for the full `P_K → P_B → P_K → Client` response flow.

### Tests added

- `MessageStartEventCrossPartitionCorrelateBusinessIdTest` — multi-partition engine test covering the successful correlate path and the uniqueness-rejection path with a cross-partition `businessId`.
- `MessageStartEventCorrelateDrainingRejectionTest` — pins that a correlate whose local start returns `-1` due to a draining definition is correctly rejected `NOT_FOUND` rather than incorrectly deferred.
- Extended `MessageStartProcessInstanceReplyProcessorTest` with unit tests for the deferred response on all three reply processors (both for the sync correlate case and the no-op publish case).
- Re-enabled 3 previously skipped E2E tests in `correlate-message-business-id-api-tests.spec.ts`.

## Related issues

Closes #58207 