### PR TITLE
58228 token consumers process name

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticTokenUsageKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticTokenUsageKpiTilesIT.java
@@ -17,12 +17,15 @@ import static io.camunda.optimize.service.dashboard.AgenticControlDashboardServi
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.rollingEndDateFilter;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.withDefinitions;
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import io.camunda.optimize.dto.optimize.query.report.CommandEvaluationResult;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
@@ -367,6 +370,43 @@ class AgenticTokenUsageKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
         .hasValueSatisfying(e -> assertThat(e.getValue()).isCloseTo(450.0, within(1.0)));
     assertThat(buckets.stream().filter(e -> lightProc.equals(e.getKey())).findFirst())
         .hasValueSatisfying(e -> assertThat(e.getValue()).isCloseTo(120.0, within(1.0)));
+  }
+
+  @Test
+  void shouldLabelTopTokenConsumersWithLatestVersionProcessName() {
+    // given agentic instances of a process whose (BPMN) key is not human-readable
+    final String processKey = "invoice-agent-process";
+    persistProcessInstances(
+        List.of(
+            agenticInstanceWithTokens(processKey, 200L, 100L).build(),
+            agenticInstanceWithTokens(processKey, 100L, 50L).build()));
+    // and a later version of that definition carrying a human-readable name (the auto-seeded v1
+    // definition defaults its name to the key, so the name must come from the latest version)
+    persistProcessDefinitions(
+        List.of(
+            ProcessDefinitionOptimizeDto.builder()
+                .id(processKey + ":2:2")
+                .key(processKey)
+                .version("2")
+                .name("Invoice Approval Agent")
+                .dataSource(new ZeebeDataSourceDto("test-source", 1))
+                .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+                .bpmn20Xml("<definitions/>")
+                .build()));
+
+    // when evaluating the top-consumers tile
+    final List<MapResultEntryDto> buckets =
+        reports.evaluateMapMeasure(TOKEN_CONSUMERS_REPORT_ID, 0);
+
+    // then the bar is still keyed by the BPMN process id but labelled with the latest-version name
+    assertThat(buckets)
+        .filteredOn(e -> e.getValue() != null)
+        .singleElement()
+        .satisfies(
+            e -> {
+              assertThat(e.getKey()).isEqualTo(processKey);
+              assertThat(e.getLabel()).isEqualTo("Invoice Approval Agent");
+            });
   }
 
   @Test

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterES.java
@@ -18,9 +18,11 @@ import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import co.elastic.clients.util.NamedValue;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.es.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeES;
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.interpreter.util.AgenticProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -51,11 +53,15 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
   private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
       "processDefinitionKeyCountAgg";
 
+  private final DefinitionService definitionService;
+
   public AgenticProcessDefinitionKeyGroupByInterpreterES(
       final ConfigurationService configurationService,
       final ProcessDistributedByInterpreterFacadeES distributedByInterpreter,
-      final ProcessViewInterpreterFacadeES viewInterpreter) {
+      final ProcessViewInterpreterFacadeES viewInterpreter,
+      final DefinitionService definitionService) {
     super(configurationService, distributedByInterpreter, viewInterpreter);
+    this.definitionService = definitionService;
   }
 
   @Override
@@ -104,6 +110,9 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterES
       final ResponseBody<?> response,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     super.addQueryResult(compositeCommandResult, response, context);
+    // Label each bar with the definition's latest-version name instead of the raw BPMN process id.
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(
+        compositeCommandResult, definitionService);
     topNPagination(context)
         .ifPresent(
             pagination -> {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/AgenticProcessDefinitionKeyGroupByInterpreterOS.java
@@ -15,10 +15,12 @@ import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.P
 
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.rest.pagination.PaginationDto;
+import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
 import io.camunda.optimize.service.db.os.report.interpreter.distributedby.process.ProcessDistributedByInterpreterFacadeOS;
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.interpreter.util.AgenticProcessDefinitionNameResolver;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
@@ -54,11 +56,15 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
   private static final String PROCESS_DEFINITION_KEY_COUNT_AGGREGATION =
       "processDefinitionKeyCountAgg";
 
+  private final DefinitionService definitionService;
+
   public AgenticProcessDefinitionKeyGroupByInterpreterOS(
       final ConfigurationService configurationService,
       final ProcessDistributedByInterpreterFacadeOS distributedByInterpreter,
-      final ProcessViewInterpreterFacadeOS viewInterpreter) {
+      final ProcessViewInterpreterFacadeOS viewInterpreter,
+      final DefinitionService definitionService) {
     super(configurationService, distributedByInterpreter, viewInterpreter);
+    this.definitionService = definitionService;
   }
 
   @Override
@@ -102,6 +108,9 @@ public class AgenticProcessDefinitionKeyGroupByInterpreterOS
       final SearchResponse<RawResult> response,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
     super.addQueryResult(compositeCommandResult, response, context);
+    // Label each bar with the definition's latest-version name instead of the raw BPMN process id.
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(
+        compositeCommandResult, definitionService);
     topNPagination(context)
         .ifPresent(
             pagination -> {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/util/AgenticProcessDefinitionNameResolver.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/interpreter/util/AgenticProcessDefinitionNameResolver.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.report.interpreter.util;
+
+import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+
+/**
+ * Shared, database-agnostic helper for the agentic process-definition-key group-by interpreters
+ * (Elasticsearch and OpenSearch). It replaces each group's label with the human-readable name of
+ * the definition's latest version, so the agentic "top token consumers" tile shows process names
+ * instead of the raw BPMN process id (which, under Optimize's C7 naming, is what {@code
+ * processDefinitionKey} holds).
+ *
+ * <p>The group key is left untouched. When no name can be resolved for a key, the label is left
+ * as-is and {@link GroupByResult#getLabel()} keeps falling back to the key.
+ */
+public final class AgenticProcessDefinitionNameResolver {
+
+  private AgenticProcessDefinitionNameResolver() {}
+
+  public static void applyLatestVersionNameLabels(
+      final CompositeCommandResult result, final DefinitionService definitionService) {
+    result.getGroups().forEach(group -> resolveLatestVersionName(group, definitionService));
+  }
+
+  private static void resolveLatestVersionName(
+      final GroupByResult group, final DefinitionService definitionService) {
+    final String processDefinitionKey = group.getKey();
+    if (processDefinitionKey == null || processDefinitionKey.isBlank()) {
+      return;
+    }
+    definitionService
+        .getLatestCachedDefinitionOnAnyTenant(DefinitionType.PROCESS, processDefinitionKey)
+        .map(DefinitionOptimizeResponseDto::getName)
+        .filter(name -> !name.isBlank())
+        .ifPresent(group::setLabel);
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/interpreter/util/AgenticProcessDefinitionNameResolverTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/interpreter/util/AgenticProcessDefinitionNameResolverTest.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.db.report.interpreter.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.DefinitionType;
@@ -93,6 +94,33 @@ class AgenticProcessDefinitionNameResolverTest {
     assertThat(result.getGroups())
         .extracting(GroupByResult::getLabel)
         .containsExactly("Heavy Agent", "light-process");
+  }
+
+  @Test
+  void shouldFallBackToKeyWhenLatestVersionNameIsNull() {
+    // given
+    final CompositeCommandResult result = resultWithGroups("nameless-process");
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "nameless-process"))
+        .thenReturn(Optional.of(definitionWithName(null)));
+
+    // when
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+
+    // then the null name is ignored and the label falls back to the key
+    assertThat(result.getGroups().getFirst().getLabel()).isEqualTo("nameless-process");
+  }
+
+  @Test
+  void shouldNotQueryDefinitionServiceForBlankKeys() {
+    // given a group whose key is blank (nothing to resolve)
+    final CompositeCommandResult result = resultWithGroups("   ");
+
+    // when
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+
+    // then the definition service is never consulted
+    verifyNoInteractions(definitionService);
   }
 
   private static CompositeCommandResult resultWithGroups(final String... processDefinitionKeys) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/interpreter/util/AgenticProcessDefinitionNameResolverTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/interpreter/util/AgenticProcessDefinitionNameResolverTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.report.interpreter.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.service.DefinitionService;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgenticProcessDefinitionNameResolverTest {
+
+  @Mock private DefinitionService definitionService;
+
+  @Test
+  void shouldLabelGroupWithLatestVersionNameWhileKeepingTheKey() {
+    // given
+    final CompositeCommandResult result = resultWithGroups("invoice-process");
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "invoice-process"))
+        .thenReturn(Optional.of(definitionWithName("Invoice Approval")));
+
+    // when
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+
+    // then
+    final GroupByResult group = result.getGroups().getFirst();
+    assertThat(group.getKey()).isEqualTo("invoice-process");
+    assertThat(group.getLabel()).isEqualTo("Invoice Approval");
+  }
+
+  @Test
+  void shouldFallBackToKeyWhenNoDefinitionIsFound() {
+    // given
+    final CompositeCommandResult result = resultWithGroups("orphan-process");
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "orphan-process"))
+        .thenReturn(Optional.empty());
+
+    // when
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+
+    // then the label falls back to the key
+    assertThat(result.getGroups().getFirst().getLabel()).isEqualTo("orphan-process");
+  }
+
+  @Test
+  void shouldFallBackToKeyWhenLatestVersionHasNoName() {
+    // given
+    final CompositeCommandResult result = resultWithGroups("unnamed-process");
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "unnamed-process"))
+        .thenReturn(Optional.of(definitionWithName("   ")));
+
+    // when
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+
+    // then the blank name is ignored and the label falls back to the key
+    assertThat(result.getGroups().getFirst().getLabel()).isEqualTo("unnamed-process");
+  }
+
+  @Test
+  void shouldResolveEachGroupIndependently() {
+    // given
+    final CompositeCommandResult result = resultWithGroups("heavy-process", "light-process");
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "heavy-process"))
+        .thenReturn(Optional.of(definitionWithName("Heavy Agent")));
+    when(definitionService.getLatestCachedDefinitionOnAnyTenant(
+            DefinitionType.PROCESS, "light-process"))
+        .thenReturn(Optional.empty());
+
+    // when
+    AgenticProcessDefinitionNameResolver.applyLatestVersionNameLabels(result, definitionService);
+
+    // then each group is resolved on its own; unresolved keys keep the key as label
+    assertThat(result.getGroups())
+        .extracting(GroupByResult::getLabel)
+        .containsExactly("Heavy Agent", "light-process");
+  }
+
+  private static CompositeCommandResult resultWithGroups(final String... processDefinitionKeys) {
+    final CompositeCommandResult result = new CompositeCommandResult(null, null);
+    result.setGroups(
+        List.of(processDefinitionKeys).stream()
+            .map(key -> GroupByResult.createGroupByResult(key, Collections.emptyList()))
+            .toList());
+    return result;
+  }
+
+  private static ProcessDefinitionOptimizeDto definitionWithName(final String name) {
+    return ProcessDefinitionOptimizeDto.builder().key("ignored").version("1").name(name).build();
+  }
+}


### PR DESCRIPTION
## What?

The Agentic Control Plane **"Top token consumers by process"** tile now labels each bar with the **process definition name** (from its latest version) instead of the raw `processDefinitionKey`.

Under Optimize's C7 naming, `processDefinitionKey` holds the BPMN process id (e.g. `invoice-agent-process`), so the tile previously showed a technical id rather than the human-readable name users see everywhere else.

Change is backend-only and scoped to the agentic tile:
- New shared, DB-agnostic helper `AgenticProcessDefinitionNameResolver` resolves each group's key → latest-version name and sets it as the bar label; the bucket **key is left untouched**, and the label falls back to the key when no name is available.
- Wired into both the Elasticsearch and OpenSearch agentic interpreters (`AgenticProcessDefinitionKeyGroupByInterpreter{ES,OS}`).

Closes #58228

## Why?

The tile exists to show, at a glance, which processes drive token spend. A BPMN id is far less recognisable than the process name shown across the rest of the product, so the technical id undermined the tile's purpose.

**Scope / blast radius:** strictly opt-in. Only the dedicated `PROCESS_GROUP_BY_AGENT_PROCESS_DEFINITION_KEY` interpreter is touched; the generic process-definition-key report and every other dashboard are unchanged. No frontend change — the generic report renderer already displays `label`.

## How to verify?

**Automated**
- Unit: `AgenticProcessDefinitionNameResolverTest` — name applied while key preserved, and fallbacks (missing definition, null/blank name, blank key not queried).
- Integration: `AgenticTokenUsageKpiTilesIT#shouldLabelTopTokenConsumersWithLatestVersionProcessName` — persists v1 instances plus a named v2 definition and asserts the bar's **key stays the BPMN id while the label becomes the latest-version name**.

```bash
# from optimize/
../mvnw verify -pl backend -Dtest=AgenticProcessDefinitionNameResolverTest -DskipTests=false -DskipITs -Dquickly
../mvnw verify -pl backend -Dit.test=AgenticTokenUsageKpiTilesIT -DskipTests=false -DskipUTs -Dquickly
```

**Manual**
1. Run Optimize against a cluster with agentic process data, open the Agentic Control Plane.
2. On the "Top token consumers by process" tile, confirm bars show process **names**.
3. For a definition with no name set, confirm the bar still shows its key (graceful fallback).