### PR TITLE
ci: load-test: fix certificate TTL expired when doing long profiling

### DIFF
--- a/.github/workflows/profile-load-test.yml
+++ b/.github/workflows/profile-load-test.yml
@@ -89,6 +89,9 @@ jobs:
     # automatically -- bump it manually if a caller raises duration-seconds. Largest known
     # caller today: camunda-daily-load-tests.yml's profile-grpc/profile-rest jobs pass
     # duration-seconds: '1800' (30 min), i.e. up to 90 minutes of profiling alone per pod.
+    # If the job timeout is increased, make sure to also increase the Teleport
+    # "certificate-ttl" below to keep it roughly greater or equal to the job
+    # timeout.
     timeout-minutes: 120
     if: ${{ inputs.pod == '' }}
     permissions:
@@ -121,6 +124,12 @@ jobs:
           proxy: camunda.teleport.sh:443
           token: ${{ env.TELEPORT_JOIN_TOKEN }}
           kubernetes-cluster: ${{ env.CLUSTER }}
+          # The Teleport certificate for Kubernetes TTL should be roughly
+          # greater or equal to the configured job "timeout-minutes" value: if
+          # the TTL is lower, the certificate can expire will the job is still
+          # running and the subsequent connections to Kubernetes (via Teleport)
+          # will fail with a "certificate expired" error.
+          certificate-ttl: 2h # defaults to 1h
 
       - name: Set right namespace
         run: |


### PR DESCRIPTION
The tests now can last up to 1h30, whereas [the Teleport default certificate TTL is configured to last only 1h](https://github.com/teleport-actions/auth-k8s/blob/0f46164469ae4fcd4d359d40e06bab17d4be17c9/action.yml#L11-L13).
<img width="590" height="64" alt="image" src="https://github.com/user-attachments/assets/c41a9156-b8ac-4ed9-b9f8-ed2c22f43b18" />

When the 2nd profiling session completes (one session is about 30 minutes) and we try to reach out to Kubernetes again to continue the profiling run, the connection to Kubernetes fails with the following error:

```
Unable to connect to the server: remote error: tls: expired certificate
```

Increasing the default certificate TTL from 1h to 2h (roughly matching the configured job timeout) should prevent the Teleport certificate from expiring before the job completes.

Follow-up to https://github.com/camunda/camunda/pull/57282 where we doubled the duration of GitHub Action jobs running with a single Teleport certificate (job timeout → 2h)

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/actions/runs/29797686840/job/88536176522
* https://camunda.slack.com/archives/C0ANMGS3D4Y/p1784614986394639
* https://camunda.slack.com/archives/C0ANMGS3D4Y/p1784528625202679
* https://github.com/camunda/camunda/pull/57282
