### PR TITLE
test: physical tenant aware job streaming, rolling upgrade

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/JobStreamPhysicalTenantIsolationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/physicaltenant/JobStreamPhysicalTenantIsolationIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.jobstream.JobStreamActuatorAssert;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies per-physical-tenant isolation of gRPC job streaming: a client streaming jobs from one
+ * physical tenant never receives jobs activated on another physical tenant's partitions, even when
+ * both streams share the exact same job type. Also verifies that a client which does not set the
+ * {@code Camunda-Physical-Tenant} header (i.e. the {@code default} physical tenant client built by
+ * {@link PhysicalTenantsITHelper}) only ever receives jobs from the {@code default} physical
+ * tenant.
+ */
+@ZeebeIntegration
+final class JobStreamPhysicalTenantIsolationIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String PROCESS_ID = "job-stream-isolation-proc";
+  private static final String JOB_TYPE = "job-stream-isolation-type";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private static CamundaClient defaultClient;
+  private static CamundaClient tenantAClient;
+
+  @BeforeAll
+  static void start() {
+    BROKER.start();
+    defaultClient =
+        TENANTS
+            .newClientBuilder(BROKER, PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+            .preferRestOverGrpc(false)
+            .build();
+    tenantAClient = TENANTS.newClientBuilder(BROKER, TENANT_A).preferRestOverGrpc(false).build();
+
+    deployServiceTaskProcess(defaultClient);
+    deployServiceTaskProcess(tenantAClient);
+  }
+
+  @AfterAll
+  static void close() {
+    CloseHelper.quietCloseAll(defaultClient, tenantAClient);
+  }
+
+  @Test
+  void shouldIsolateJobStreamsAcrossPhysicalTenants() {
+    // given: a stream opened per physical tenant, both for the exact same job type, so the
+    // isolation boundary being tested is the physical tenant group and not the job type
+    final List<ActivatedJob> defaultJobs = new CopyOnWriteArrayList<>();
+    final List<ActivatedJob> tenantAJobs = new CopyOnWriteArrayList<>();
+
+    final var defaultStream =
+        defaultClient.newStreamJobsCommand().jobType(JOB_TYPE).consumer(defaultJobs::add).send();
+    final var tenantAStream =
+        tenantAClient.newStreamJobsCommand().jobType(JOB_TYPE).consumer(tenantAJobs::add).send();
+
+    try {
+      awaitStreamsRegistered(2);
+
+      // when: a job is activated on the default physical tenant's partitions
+      defaultClient
+          .newCreateInstanceCommand()
+          .bpmnProcessId(PROCESS_ID)
+          .latestVersion()
+          .send()
+          .join();
+
+      // then: only the default tenant's stream receives it, stamped with the default tenant id
+      Awaitility.await("job streamed for the default physical tenant")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                assertThat(defaultJobs).hasSize(1);
+                assertThat(defaultJobs.getFirst().getPhysicalTenantId())
+                    .isEqualTo(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+              });
+      assertThat(tenantAJobs).as("tenant A must not receive the default tenant's job").isEmpty();
+
+      // when: a job is activated on tenant A's partitions
+      tenantAClient
+          .newCreateInstanceCommand()
+          .bpmnProcessId(PROCESS_ID)
+          .latestVersion()
+          .send()
+          .join();
+
+      // then: only tenant A's stream receives it, and the default tenant's stream is unaffected
+      Awaitility.await("job streamed for physical tenant A")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                assertThat(tenantAJobs).hasSize(1);
+                assertThat(tenantAJobs.getFirst().getPhysicalTenantId()).isEqualTo(TENANT_A);
+              });
+      assertThat(defaultJobs).as("the default tenant must not receive tenant A's job").hasSize(1);
+    } finally {
+      defaultStream.cancel(true);
+      tenantAStream.cancel(true);
+    }
+  }
+
+  private static void deployServiceTaskProcess(final CamundaClient client) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    Awaitility.await("process deployed to the tenant's partitions")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var deployment =
+                  client
+                      .newDeployResourceCommand()
+                      .addProcessModel(model, PROCESS_ID + ".bpmn")
+                      .send()
+                      .join();
+              assertThat(deployment.getProcesses()).isNotEmpty();
+            });
+  }
+
+  private static void awaitStreamsRegistered(final int expectedCount) {
+    final var actuator = JobStreamActuator.of(BROKER);
+    Awaitility.await(
+            "until %d streams with type '%s' are registered".formatted(expectedCount, JOB_TYPE))
+        .untilAsserted(
+            () ->
+                JobStreamActuatorAssert.assertThat(actuator)
+                    .remoteStreams()
+                    .haveJobType(expectedCount, JOB_TYPE));
+  }
+}

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -60,6 +60,8 @@ final class ContainerState implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(ContainerState.class);
   private static final DockerImageName PREVIOUS_VERSION =
       DockerImageName.parse("camunda/camunda").withTag(VersionUtil.getPreviousVersion());
+  private static final DockerImageName CURRENT_VERSION =
+      DockerImageName.parse("camunda/camunda").withTag(currentVersionDockerTag());
 
   static {
     CONTAINER_START_RETRY_POLICY
@@ -84,12 +86,21 @@ final class ContainerState implements AutoCloseable {
 
   private DockerImageName brokerImage;
   private DockerImageName gatewayImage;
+  private DockerImageName newGatewayImage;
   private boolean withRemoteDebugging;
 
   private boolean isSpring;
   private TestStandaloneBroker springBroker;
   private Path extractedDataDir;
   private int partitionCount = PARTITION_COUNT;
+
+  private static String currentVersionDockerTag() {
+    final var version = VersionUtil.getSemanticVersion().orElseThrow();
+    if (version.isPreRelease()) {
+      return version.major() + "." + version.minor() + "-SNAPSHOT";
+    }
+    return version.toString();
+  }
 
   CamundaClient client() {
     return client;
@@ -112,6 +123,11 @@ final class ContainerState implements AutoCloseable {
 
   ContainerState withOldGateway() {
     gatewayImage = PREVIOUS_VERSION;
+    return this;
+  }
+
+  ContainerState withNewGateway() {
+    newGatewayImage = CURRENT_VERSION;
     return this;
   }
 
@@ -185,11 +201,13 @@ final class ContainerState implements AutoCloseable {
 
     Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> broker.self().start());
 
-    if (gatewayImage == null) {
+    final var effectiveGatewayImage = gatewayImage != null ? gatewayImage : newGatewayImage;
+
+    if (effectiveGatewayImage == null) {
       grpcAddress = broker.getGrpcAddress();
     } else {
       gateway =
-          new GatewayContainer(gatewayImage)
+          new GatewayContainer(effectiveGatewayImage)
               .withUnifiedConfig(
                   cfg -> {
                     cfg.getCluster()
@@ -203,7 +221,7 @@ final class ContainerState implements AutoCloseable {
               .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, partitionCount))
               .withNetwork(network);
 
-      if (gatewayImage.equals(PREVIOUS_VERSION)) {
+      if (effectiveGatewayImage.equals(PREVIOUS_VERSION)) {
         // Gateway configuration is not part of the Unified config yet in 8.8.x
         gateway
             .withEnv(
@@ -476,5 +494,6 @@ final class ContainerState implements AutoCloseable {
 
     brokerImage = null;
     gatewayImage = null;
+    newGatewayImage = null;
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.JsonSerializable;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.testcontainers.RemoteDebugger;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
@@ -64,7 +65,7 @@ final class ContainerState implements AutoCloseable {
   private static final DockerImageName PREVIOUS_VERSION =
       DockerImageName.parse("camunda/camunda").withTag(VersionUtil.getPreviousVersion());
   private static final DockerImageName CURRENT_VERSION =
-      DockerImageName.parse("camunda/camunda").withTag(currentVersionDockerTag());
+      ZeebeTestContainerDefaults.defaultTestImage();
 
   static {
     CONTAINER_START_RETRY_POLICY
@@ -96,14 +97,6 @@ final class ContainerState implements AutoCloseable {
   private TestStandaloneBroker springBroker;
   private Path extractedDataDir;
   private int partitionCount = PARTITION_COUNT;
-
-  private static String currentVersionDockerTag() {
-    final var version = VersionUtil.getSemanticVersion().orElseThrow();
-    if (version.isPreRelease()) {
-      return version.major() + "." + version.minor() + "-SNAPSHOT";
-    }
-    return version.toString();
-  }
 
   CamundaClient client() {
     return client;
@@ -312,12 +305,6 @@ final class ContainerState implements AutoCloseable {
     final int commandPort = springBroker.mappedPort(TestZeebePort.COMMAND);
     Testcontainers.exposeHostPorts(clusterPort, commandPort);
 
-    // the broker runs as a host process (not on `network`), so it cannot resolve the gateway
-    // container's internal network alias when it pushes job-stream notifications back to the
-    // gateway over the cluster (Atomix) transport; fix the gateway's advertised cluster address
-    // to a host-reachable one so the broker can dial back
-    final int gatewayClusterHostPort = findAvailablePort();
-
     gateway =
         new GatewayContainer(gatewayImage)
             .withUnifiedConfig(
@@ -335,6 +322,11 @@ final class ContainerState implements AutoCloseable {
             .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, partitionCount))
             .withNetwork(network);
 
+    // the host-process broker can't resolve the gateway's container-internal network alias, so
+    // fix-map the gateway's cluster port to a free host port; the broker dials this back to push
+    // job-stream notifications to the gateway. Probed at runtime (not a fixed constant) so a
+    // leftover container from an earlier run never causes a bind collision.
+    final int gatewayClusterHostPort = findAvailablePort();
     gateway.setPortBindings(
         Stream.concat(
                 gateway.getPortBindings().stream(),
@@ -349,7 +341,7 @@ final class ContainerState implements AutoCloseable {
           .withEnv("ZEEBE_GATEWAY_NETWORK_HOST", "0.0.0.0")
           .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", gateway.getInternalHost())
           .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", "0.0.0.0")
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", "localhost")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", gateway.getExternalHost())
           .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDPORT", String.valueOf(gatewayClusterHostPort));
     }
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/ContainerState.java
@@ -17,6 +17,7 @@ import io.camunda.container.CamundaContainer;
 import io.camunda.container.CamundaContainer.BrokerContainer;
 import io.camunda.container.CamundaContainer.GatewayContainer;
 import io.camunda.container.ZeebeTopologyWaitStrategy;
+import io.camunda.container.cluster.CamundaPort;
 import io.camunda.container.volume.CamundaVolume;
 import io.camunda.zeebe.protocol.record.JsonSerializable;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,6 +40,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.agrona.LangUtil;
@@ -309,6 +312,12 @@ final class ContainerState implements AutoCloseable {
     final int commandPort = springBroker.mappedPort(TestZeebePort.COMMAND);
     Testcontainers.exposeHostPorts(clusterPort, commandPort);
 
+    // the broker runs as a host process (not on `network`), so it cannot resolve the gateway
+    // container's internal network alias when it pushes job-stream notifications back to the
+    // gateway over the cluster (Atomix) transport; fix the gateway's advertised cluster address
+    // to a host-reachable one so the broker can dial back
+    final int gatewayClusterHostPort = findAvailablePort();
+
     gateway =
         new GatewayContainer(gatewayImage)
             .withUnifiedConfig(
@@ -326,6 +335,12 @@ final class ContainerState implements AutoCloseable {
             .withTopologyCheck(new ZeebeTopologyWaitStrategy(1, 1, partitionCount))
             .withNetwork(network);
 
+    gateway.setPortBindings(
+        Stream.concat(
+                gateway.getPortBindings().stream(),
+                Stream.of(gatewayClusterHostPort + ":" + CamundaPort.INTERNAL.getPort()))
+            .collect(Collectors.toList()));
+
     if (gatewayImage.equals(PREVIOUS_VERSION)) {
       gateway
           .withEnv(
@@ -333,7 +348,9 @@ final class ContainerState implements AutoCloseable {
               "host.testcontainers.internal:" + clusterPort)
           .withEnv("ZEEBE_GATEWAY_NETWORK_HOST", "0.0.0.0")
           .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", gateway.getInternalHost())
-          .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", gateway.getInternalHost());
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", "0.0.0.0")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDHOST", "localhost")
+          .withEnv("ZEEBE_GATEWAY_CLUSTER_ADVERTISEDPORT", String.valueOf(gatewayClusterHostPort));
     }
 
     Failsafe.with(CONTAINER_START_RETRY_POLICY).run(() -> gateway.self().start());
@@ -344,6 +361,14 @@ final class ContainerState implements AutoCloseable {
             .grpcAddress(gateway.getGrpcAddress())
             .preferRestOverGrpc(false)
             .build();
+  }
+
+  private static int findAvailablePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   public PartitionsActuator getPartitionsActuator() {

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NewGatewayOldBrokerJobStreamingTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/NewGatewayOldBrokerJobStreamingTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.Network;
+
+@ExtendWith(ContainerStateExtension.class)
+final class NewGatewayOldBrokerJobStreamingTest {
+
+  private static final String PROCESS_ID = "new-gateway-old-broker-job-stream-proc";
+  private static final String JOB_TYPE = "new-gateway-old-broker-job-stream-type";
+  private static Network network;
+
+  @BeforeAll
+  static void setUp() {
+    network = Network.newNetwork();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    Optional.ofNullable(network).ifPresent(Network::close);
+  }
+
+  @Timeout(value = 5, unit = TimeUnit.MINUTES)
+  @Test
+  void shouldStreamJobsFromOldBrokerThroughNewGateway(final ContainerState state) {
+    // given
+    state.withNetwork(network).withOldBroker().withNewGateway().start(true);
+
+    final List<ActivatedJob> streamedJobs = new CopyOnWriteArrayList<>();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    state
+        .client()
+        .newDeployResourceCommand()
+        .addProcessModel(process, PROCESS_ID + ".bpmn")
+        .send()
+        .join();
+
+    final var stream =
+        state.client().newStreamJobsCommand().jobType(JOB_TYPE).consumer(streamedJobs::add).send();
+    try {
+      // when: an instance producing a job of the streamed type is created through the new gateway
+      state
+          .client()
+          .newCreateInstanceCommand()
+          .bpmnProcessId(PROCESS_ID)
+          .latestVersion()
+          .send()
+          .join();
+
+      // then: the old broker still pushes the job to the new gateway's stream over the legacy wire
+      Awaitility.await("job streamed from the old broker through the new gateway")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertThat(streamedJobs).hasSize(1));
+    } finally {
+      stream.cancel(true);
+    }
+  }
+}

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/OldGatewayNewBrokerJobStreamingTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/OldGatewayNewBrokerJobStreamingTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.Network;
+
+@ExtendWith(ContainerStateExtension.class)
+final class OldGatewayNewBrokerJobStreamingTest {
+
+  private static final String PROCESS_ID = "old-gateway-job-stream-proc";
+  private static final String JOB_TYPE = "old-gateway-job-stream-type";
+  private static Network network;
+
+  @BeforeAll
+  static void setUp() {
+    network = Network.newNetwork();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    Optional.ofNullable(network).ifPresent(Network::close);
+  }
+
+  @Timeout(value = 5, unit = TimeUnit.MINUTES)
+  @Test
+  void shouldStreamJobsFromNewBrokerThroughOldGateway(final ContainerState state) {
+    // given
+    state.withNetwork(network).withNewBroker().withOldGateway().start(true);
+
+    final List<ActivatedJob> streamedJobs = new CopyOnWriteArrayList<>();
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    state
+        .client()
+        .newDeployResourceCommand()
+        .addProcessModel(process, PROCESS_ID + ".bpmn")
+        .send()
+        .join();
+
+    final var stream =
+        state.client().newStreamJobsCommand().jobType(JOB_TYPE).consumer(streamedJobs::add).send();
+    try {
+      // when: an instance producing a job of the streamed type is created through the new gateway
+      state
+          .client()
+          .newCreateInstanceCommand()
+          .bpmnProcessId(PROCESS_ID)
+          .latestVersion()
+          .send()
+          .join();
+
+      // then: the old broker still pushes the job to the new gateway's stream over the legacy wire
+      Awaitility.await("job streamed from the old broker through the new gateway")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertThat(streamedJobs).hasSize(1));
+    } finally {
+      stream.cancel(true);
+    }
+  }
+}

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/OldGatewayNewBrokerJobStreamingTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/OldGatewayNewBrokerJobStreamingTest.java
@@ -65,7 +65,7 @@ final class OldGatewayNewBrokerJobStreamingTest {
     final var stream =
         state.client().newStreamJobsCommand().jobType(JOB_TYPE).consumer(streamedJobs::add).send();
     try {
-      // when: an instance producing a job of the streamed type is created through the new gateway
+      // when: an instance producing a job of the streamed type is created through the old gateway
       state
           .client()
           .newCreateInstanceCommand()


### PR DESCRIPTION
## Description

### Rolling-upgrade matrix coverage (#56226)
  
  | Gateway | Broker | Expected | Covered by |
  |---|---|---|---|
  | 8.9 | 8.10 | old gateway registers default stream on legacy topic; 8.10 broker serves it from the default group only | `zeebe/qa/update-tests/.../OldGatewayJobStreamingTest.java` |
  | 8.10 | 8.9 | new gateway, default tenant, uses legacy wire; 8.9 broker serves normally; non-default tenants not configurable | `zeebe/qa/update-tests/.../NewGatewayOldBrokerJobStreamingTest.java` |
  | 8.10 | 8.10 (default only) | identical to 8.9 behavior | `StreamJobsTest.shouldStreamJobs` / `.shouldNotInterfereWithPolling` (pre-existing, `zeebe/qa/integration-tests/.../io/camunda/zeebe/it/engine/client/command/StreamJobsTest.java`) |
  | 8.10 | 8.10 (multi-tenant) | full isolation per group | `qa/acceptance-tests/.../JobStreamPhysicalTenantIsolationIT.java` |

## Related issues

closes #56226
