### PR TITLE
fix: align tenant routed AwaitModeChangeApplier

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -119,7 +119,7 @@ public final class PartitionGroupConfigurationChangeAppliersImpl
             case PROCESSING -> new ExitRecoveryApplier(op.memberId(), modeChangeExecutor);
           };
       case final AwaitModeChangeOperation op ->
-          new AwaitModeChangeApplier(op.mode(), modeChangeExecutor);
+          new AwaitModeChangeApplier(op.memberId(), op.mode(), modeChangeExecutor);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplier.java
@@ -7,30 +7,38 @@
  */
 package io.camunda.zeebe.dynamic.config.changes.appliers;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeApplier;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 /**
  * New-model applier for {@code PartitionGroupOperation.AwaitModeChangeOperation}, operating on a
  * single named {@link PartitionGroupConfiguration}. Mirrors the legacy {@code
  * AwaitModeChangeApplier} in {@code changes/}, which this does not replace or modify. Waits for a
- * member's partition manager to finish starting in the target {@link Mode}; changes no
- * configuration state, it only gates the change plan until the local transition has settled.
+ * member's partition manager to finish starting in the target {@link Mode}. Writes {@link
+ * PartitionState.State#RECOVERING} or {@link PartitionState.State#ACTIVE} for the subset of this
+ * member's partitions that {@link ModeChangeExecutor#awaitModeApplied(Mode)} confirms transitioned;
+ * partitions outside that subset (e.g. unhealthy ones) keep their prior state.
  */
 public final class AwaitModeChangeApplier implements PartitionGroupConfigurationChangeApplier {
 
+  private final MemberId memberId;
   private final Mode mode;
   private final ModeChangeExecutor modeChangeExecutor;
 
-  public AwaitModeChangeApplier(final Mode mode, final ModeChangeExecutor modeChangeExecutor) {
+  public AwaitModeChangeApplier(
+      final MemberId memberId, final Mode mode, final ModeChangeExecutor modeChangeExecutor) {
+    this.memberId = Objects.requireNonNull(memberId);
     this.mode = Objects.requireNonNull(mode);
     this.modeChangeExecutor = Objects.requireNonNull(modeChangeExecutor);
   }
@@ -48,13 +56,32 @@ public final class AwaitModeChangeApplier implements PartitionGroupConfiguration
     modeChangeExecutor
         .awaitModeApplied(mode)
         .onComplete(
-            (ignored, error) -> {
+            (confirmedPartitions, error) -> {
               if (error != null) {
                 result.completeExceptionally(error);
               } else {
-                result.complete(UnaryOperator.identity());
+                result.complete(writeConfirmedPartitions(confirmedPartitions));
               }
             });
     return result;
+  }
+
+  private UnaryOperator<PartitionGroupConfiguration> writeConfirmedPartitions(
+      final Set<Integer> confirmedPartitions) {
+    if (confirmedPartitions.isEmpty()) {
+      return UnaryOperator.identity();
+    }
+    final UnaryOperator<PartitionState> partitionStateUpdater =
+        mode == Mode.RECOVERING ? PartitionState::toRecovering : PartitionState::toActive;
+    return clusterConfiguration ->
+        clusterConfiguration.updateMember(
+            memberId,
+            memberState -> {
+              var updatedState = memberState;
+              for (final var partitionId : confirmedPartitions) {
+                updatedState = updatedState.updatePartition(partitionId, partitionStateUpdater);
+              }
+              return updatedState;
+            });
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/AwaitModeChangeApplierTest.java
@@ -13,13 +13,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +40,7 @@ final class AwaitModeChangeApplierTest {
   void shouldAlwaysAcceptOnInit() {
     // when
     final var result =
-        new AwaitModeChangeApplier(Mode.RECOVERING, modeChangeExecutor)
+        new AwaitModeChangeApplier(MemberId.from(0), Mode.RECOVERING, modeChangeExecutor)
             .init(globalConfiguration, group);
 
     // then
@@ -45,9 +50,10 @@ final class AwaitModeChangeApplierTest {
   @Test
   void shouldExecuteAwaitModeAppliedAsNoop() {
     // given
-    final var applier = new AwaitModeChangeApplier(Mode.PROCESSING, modeChangeExecutor);
+    final var applier =
+        new AwaitModeChangeApplier(MemberId.from(0), Mode.PROCESSING, modeChangeExecutor);
     when(modeChangeExecutor.awaitModeApplied(Mode.PROCESSING))
-        .thenReturn(CompletableActorFuture.completed(null));
+        .thenReturn(CompletableActorFuture.completed(Set.of()));
 
     // when
     final var resultingGroup = applier.apply().join().apply(group);
@@ -55,5 +61,70 @@ final class AwaitModeChangeApplierTest {
     // then
     verify(modeChangeExecutor, times(1)).awaitModeApplied(Mode.PROCESSING);
     Assertions.assertThat(resultingGroup).isEqualTo(group);
+  }
+
+  @Test
+  void shouldWriteRecoveringForConfirmedPartitionsOnly() {
+    // given
+    final var memberId = MemberId.from(0);
+    final var partitionConfig = DynamicPartitionConfig.init();
+    final var groupWithMember =
+        group.addMember(
+            memberId,
+            BrokerPartitionState.initialize(
+                Map.of(
+                    1, PartitionState.active(1, partitionConfig),
+                    2, PartitionState.active(1, partitionConfig))));
+    final var applier = new AwaitModeChangeApplier(memberId, Mode.RECOVERING, modeChangeExecutor);
+    when(modeChangeExecutor.awaitModeApplied(Mode.RECOVERING))
+        .thenReturn(CompletableActorFuture.completed(Set.of(1)));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(groupWithMember);
+
+    // then - only the confirmed partition (1) is marked RECOVERING; partition 2 (e.g. dead) is
+    // left untouched
+    Assertions.assertThat(resultingGroup.getMember(memberId).getPartition(1).state())
+        .isEqualTo(PartitionState.State.RECOVERING);
+    Assertions.assertThat(resultingGroup.getMember(memberId).getPartition(2).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+  }
+
+  @Test
+  void shouldWriteActiveForConfirmedPartitionsWhenExitingRecovery() {
+    // given
+    final var memberId = MemberId.from(0);
+    final var partitionConfig = DynamicPartitionConfig.init();
+    final var groupWithMember =
+        group.addMember(
+            memberId,
+            BrokerPartitionState.initialize(
+                Map.of(1, PartitionState.active(1, partitionConfig).toRecovering())));
+    final var applier = new AwaitModeChangeApplier(memberId, Mode.PROCESSING, modeChangeExecutor);
+    when(modeChangeExecutor.awaitModeApplied(Mode.PROCESSING))
+        .thenReturn(CompletableActorFuture.completed(Set.of(1)));
+
+    // when
+    final var resultingGroup = applier.apply().join().apply(groupWithMember);
+
+    // then
+    Assertions.assertThat(resultingGroup.getMember(memberId).getPartition(1).state())
+        .isEqualTo(PartitionState.State.ACTIVE);
+  }
+
+  @Test
+  void shouldFailWhenAwaitFails() {
+    // given
+    final var applier =
+        new AwaitModeChangeApplier(MemberId.from(0), Mode.PROCESSING, modeChangeExecutor);
+    when(modeChangeExecutor.awaitModeApplied(Mode.PROCESSING))
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(new RuntimeException("not started")));
+
+    // when
+    final var result = applier.apply();
+
+    // then - a failed await is propagated so the cluster change is retried
+    Assertions.assertThat(result.isCompletedExceptionally()).isTrue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Align the Group specific ModeChange operation applier with the recent changes of updating the PartitionState for the confirmed transitioned partitions.

_This is just a sync commit with no further PT implementation so as not to miss this drift of the appliers_

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
