### PR TITLE
feat: add suspension state and column families

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -96,6 +96,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
@@ -106,6 +107,7 @@ import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.engine.state.routing.DbRoutingState;
 import io.camunda.zeebe.engine.state.secretreference.DbSecretReferenceState;
 import io.camunda.zeebe.engine.state.signal.DbSignalSubscriptionState;
+import io.camunda.zeebe.engine.state.suspension.DbSuspensionState;
 import io.camunda.zeebe.engine.state.tenant.DbTenantState;
 import io.camunda.zeebe.engine.state.user.DbUserState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
@@ -139,6 +141,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final DbMessageCorrelationState messageCorrelationState;
   private final MutableIncidentState incidentState;
   private final MutableBannedInstanceState bannedInstanceState;
+  private final MutableSuspensionState suspensionState;
   private final MutableMigrationState mutableMigrationState;
   private final MutableDecisionState decisionState;
   private final MutableFormState formState;
@@ -215,6 +218,7 @@ public class ProcessingDbState implements MutableProcessingState {
     messageCorrelationState = new DbMessageCorrelationState(zeebeDb, transactionContext);
     incidentState = new DbIncidentState(zeebeDb, transactionContext);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext);
+    suspensionState = new DbSuspensionState(zeebeDb, transactionContext);
     decisionState = new DbDecisionState(zeebeDb, transactionContext, config);
     formState = new DbFormState(zeebeDb, transactionContext, config);
     resourceState = new DbResourceState(zeebeDb, transactionContext, config);
@@ -315,6 +319,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableBannedInstanceState getBannedInstanceState() {
     return bannedInstanceState;
+  }
+
+  @Override
+  public MutableSuspensionState getSuspensionState() {
+    return suspensionState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -38,6 +38,8 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   BannedInstanceState getBannedInstanceState();
 
+  SuspensionState getSuspensionState();
+
   VariableState getVariableState();
 
   ClusterVariableState getClusterVariableState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+
+public interface SuspensionState {
+
+  enum State {
+    SUSPENDED,
+    RESUMING
+  }
+
+  /**
+   * @return the current suspension marker for the process instance, or {@code null} if it has no
+   *     suspension marker
+   */
+  State getSuspensionState(long processInstanceKey);
+
+  /**
+   * @return {@code true} if the process instance has any suspension marker (either {@link
+   *     State#SUSPENDED} or {@link State#RESUMING}); {@code false} if it has none. The marker is
+   *     only removed once resuming has fully drained the buffer.
+   *     <p>This reflects marker <em>presence</em>, not a specific state, and does not imply {@link
+   *     State#SUSPENDED} and {@link State#RESUMING} should be gated identically — e.g. the primary
+   *     buffering gate must buffer forward-progress commands while {@code SUSPENDED} but pass them
+   *     through while {@code RESUMING}. Callers that need to distinguish the two should branch on
+   *     {@link #getSuspensionState} instead.
+   */
+  boolean isSuspended(long processInstanceKey);
+
+  /**
+   * Visits every buffered command for the given process instance in ascending {@code
+   * bufferedCommandKey} order. This is FIFO (insertion) order because {@code bufferedCommandKey} is
+   * expected to be KeyGenerator-issued and therefore monotonically increasing.
+   */
+  void visitBufferedCommands(long processInstanceKey, BufferedCommandVisitor visitor);
+
+  @FunctionalInterface
+  interface BufferedCommandVisitor {
+    void visit(long bufferedCommandKey, ProcessInstanceBufferedCommandRecordValue command);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -8,7 +8,10 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
+@NullMarked
 public interface SuspensionState {
 
   enum State {
@@ -20,7 +23,7 @@ public interface SuspensionState {
    * @return the current suspension marker for the process instance, or {@code null} if it has no
    *     suspension marker
    */
-  State getSuspensionState(long processInstanceKey);
+  @Nullable State getSuspensionState(long processInstanceKey);
 
   /**
    * @return {@code true} if the process instance has any suspension marker (either {@link

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -50,6 +50,9 @@ public interface MutableProcessingState extends ProcessingState {
   MutableBannedInstanceState getBannedInstanceState();
 
   @Override
+  MutableSuspensionState getSuspensionState();
+
+  @Override
   MutableVariableState getVariableState();
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSuspensionState.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public interface MutableSuspensionState extends SuspensionState {
 
   /** Sets (inserts or overwrites) the suspension marker for the process instance. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSuspensionState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+
+public interface MutableSuspensionState extends SuspensionState {
+
+  /** Sets (inserts or overwrites) the suspension marker for the process instance. */
+  void setSuspensionState(long processInstanceKey, State state);
+
+  /** Removes the suspension marker for the process instance. No-op if not present. */
+  void removeSuspensionState(long processInstanceKey);
+
+  /**
+   * Appends a buffered command under the given (KeyGenerator-issued) bufferedCommandKey. The
+   * process instance it belongs to is read from {@code command.getProcessInstanceKey()} — not a
+   * separate parameter — so a mismatched caller-supplied key can never desync the secondary FIFO
+   * index from the record it was built from. Callers are responsible for key generation and
+   * uniqueness.
+   */
+  void bufferCommand(long bufferedCommandKey, ProcessInstanceBufferedCommandRecord command);
+
+  /**
+   * Removes a single buffered command entry. No-op if it does not exist. The process instance it
+   * belongs to is read from the stored record itself, mirroring {@link #bufferCommand} — there is
+   * no separate parameter to desync from it.
+   */
+  void removeBufferedCommand(long bufferedCommandKey);
+
+  /** Removes all remaining buffered commands for the process instance. */
+  void clearBufferedCommands(long processInstanceKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbProcessInstanceBufferedCommand.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbProcessInstanceBufferedCommand.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.suspension;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+
+public final class DbProcessInstanceBufferedCommand extends UnpackedObject implements DbValue {
+
+  private final ObjectProperty<ProcessInstanceBufferedCommandRecord> recordProp =
+      new ObjectProperty<>(
+          "processInstanceBufferedCommand", new ProcessInstanceBufferedCommandRecord());
+
+  public DbProcessInstanceBufferedCommand() {
+    super(1);
+    declareProperty(recordProp);
+  }
+
+  public ProcessInstanceBufferedCommandRecord getRecord() {
+    return recordProp.getValue();
+  }
+
+  public void setRecord(final ProcessInstanceBufferedCommandRecord record) {
+    recordProp.getValue().copyFrom(record);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.suspension;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DbSuspensionState implements MutableSuspensionState {
+
+  private final DbLong processInstanceKey = new DbLong();
+  private final SuspensionMarkerValue suspensionMarkerValue = new SuspensionMarkerValue();
+  private final ColumnFamily<DbLong, SuspensionMarkerValue> suspensionColumnFamily;
+
+  private final DbLong bufferedCommandKey = new DbLong();
+  private final DbProcessInstanceBufferedCommand dbBufferedCommand =
+      new DbProcessInstanceBufferedCommand();
+  private final ColumnFamily<DbLong, DbProcessInstanceBufferedCommand> bufferedCommandColumnFamily;
+
+  private final DbCompositeKey<DbLong, DbLong> processInstanceKeyAndBufferedCommandKey =
+      new DbCompositeKey<>(processInstanceKey, bufferedCommandKey);
+  private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, DbNil>
+      bufferedCommandByProcessInstanceKeyColumnFamily;
+
+  public DbSuspensionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    suspensionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.SUSPENDED_PROCESS_INSTANCES,
+            transactionContext,
+            processInstanceKey,
+            suspensionMarkerValue);
+    bufferedCommandColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.BUFFERED_PROCESS_INSTANCE_COMMANDS,
+            transactionContext,
+            bufferedCommandKey,
+            dbBufferedCommand);
+    bufferedCommandByProcessInstanceKeyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.BUFFERED_PROCESS_INSTANCE_COMMANDS_BY_PROCESS_INSTANCE_KEY,
+            transactionContext,
+            processInstanceKeyAndBufferedCommandKey,
+            DbNil.INSTANCE);
+  }
+
+  @Override
+  public SuspensionState.State getSuspensionState(final long key) {
+    processInstanceKey.wrapLong(key);
+    final var stored = suspensionColumnFamily.get(processInstanceKey);
+    return stored == null ? null : stored.getState();
+  }
+
+  @Override
+  public boolean isSuspended(final long key) {
+    processInstanceKey.wrapLong(key);
+    return suspensionColumnFamily.exists(processInstanceKey);
+  }
+
+  @Override
+  public void setSuspensionState(final long key, final SuspensionState.State state) {
+    processInstanceKey.wrapLong(key);
+    suspensionMarkerValue.setState(state);
+    suspensionColumnFamily.upsert(processInstanceKey, suspensionMarkerValue);
+  }
+
+  @Override
+  public void removeSuspensionState(final long key) {
+    processInstanceKey.wrapLong(key);
+    suspensionColumnFamily.deleteIfExists(processInstanceKey);
+  }
+
+  @Override
+  public void visitBufferedCommands(final long key, final BufferedCommandVisitor visitor) {
+    processInstanceKey.wrapLong(key);
+    bufferedCommandByProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        (compositeKey, nil) -> {
+          final long bufferedKey = compositeKey.second().getValue();
+          bufferedCommandKey.wrapLong(bufferedKey);
+          final var stored =
+              bufferedCommandColumnFamily.get(
+                  bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
+          if (stored != null) {
+            visitor.visit(bufferedKey, stored.getRecord());
+          }
+        });
+  }
+
+  @Override
+  public void bufferCommand(
+      final long bufferedCommandKeyValue, final ProcessInstanceBufferedCommandRecord command) {
+    processInstanceKey.wrapLong(command.getProcessInstanceKey());
+    bufferedCommandKey.wrapLong(bufferedCommandKeyValue);
+    dbBufferedCommand.setRecord(command);
+    bufferedCommandColumnFamily.insert(bufferedCommandKey, dbBufferedCommand);
+    bufferedCommandByProcessInstanceKeyColumnFamily.insert(
+        processInstanceKeyAndBufferedCommandKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void removeBufferedCommand(final long bufferedCommandKeyValue) {
+    bufferedCommandKey.wrapLong(bufferedCommandKeyValue);
+    final var stored = bufferedCommandColumnFamily.get(bufferedCommandKey);
+    if (stored == null) {
+      // no-op: nothing buffered under this key (already removed, or never existed) — the normal
+      // case per the interface contract. Primary and secondary index are always written together
+      // in the same transaction (see #bufferCommand), so this also means there is no secondary
+      // entry to clean up.
+      return;
+    }
+    // derive the secondary-index key from the stored record itself, mirroring #bufferCommand,
+    // rather than taking it as a separate parameter that could desync from it
+    processInstanceKey.wrapLong(stored.getRecord().getProcessInstanceKey());
+    bufferedCommandColumnFamily.deleteIfExists(bufferedCommandKey);
+    bufferedCommandByProcessInstanceKeyColumnFamily.deleteIfExists(
+        processInstanceKeyAndBufferedCommandKey);
+  }
+
+  @Override
+  public void clearBufferedCommands(final long processInstanceKeyValue) {
+    processInstanceKey.wrapLong(processInstanceKeyValue);
+    final List<Long> keysToRemove = new ArrayList<>();
+    bufferedCommandByProcessInstanceKeyColumnFamily.whileEqualPrefix(
+        processInstanceKey,
+        (compositeKey, nil) -> {
+          keysToRemove.add(compositeKey.second().getValue());
+        });
+    // delete directly instead of delegating to #removeBufferedCommand: the prefix just iterated
+    // is already the authoritative processInstanceKey for every one of these entries, so there is
+    // no need to re-fetch each record just to re-derive it
+    keysToRemove.forEach(
+        k -> {
+          bufferedCommandKey.wrapLong(k);
+          bufferedCommandColumnFamily.deleteIfExists(bufferedCommandKey);
+          bufferedCommandByProcessInstanceKeyColumnFamily.deleteIfExists(
+              processInstanceKeyAndBufferedCommandKey);
+        });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -95,9 +95,18 @@ public final class DbSuspensionState implements MutableSuspensionState {
           final var stored =
               bufferedCommandColumnFamily.get(
                   bufferedCommandKey, DbProcessInstanceBufferedCommand::new);
-          if (stored != null) {
-            visitor.visit(bufferedKey, stored.getRecord());
+          if (stored == null) {
+            // the secondary index and the primary CF are written and deleted together in a single
+            // transaction (see #bufferCommand / #removeBufferedCommand), so a secondary-index entry
+            // with no matching primary record is a broken invariant. Fail loud rather than silently
+            // dropping a buffered command, which would lose forward progress on resume.
+            throw new IllegalStateException(
+                String.format(
+                    "Expected to find buffered command with key '%d' for process instance '%d', "
+                        + "but none was stored; the buffered-command index is inconsistent",
+                    bufferedKey, key));
           }
+          visitor.visit(bufferedKey, stored.getRecord());
         });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/SuspensionMarkerValue.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/SuspensionMarkerValue.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.suspension;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+
+public final class SuspensionMarkerValue extends UnpackedObject implements DbValue {
+
+  private final EnumProperty<SuspensionState.State> stateProp =
+      new EnumProperty<>("suspensionState", SuspensionState.State.class);
+
+  public SuspensionMarkerValue() {
+    super(1);
+    declareProperty(stateProp);
+  }
+
+  public SuspensionState.State getState() {
+    return stateProp.getValue();
+  }
+
+  public void setState(final SuspensionState.State state) {
+    stateProp.setValue(state);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 @ExtendWith(ProcessingStateExtension.class)
 public final class SuspensionStateTest {
@@ -48,16 +50,18 @@ public final class SuspensionStateTest {
     assertThat(state).isNull();
   }
 
-  @Test
-  public void shouldSetAndGetSuspensionState() {
+  @ParameterizedTest
+  @EnumSource(State.class)
+  public void shouldSetAndGetSuspensionState(final State state) {
     // given
     final long processInstanceKey = 1L;
 
     // when
-    suspensionState.setSuspensionState(processInstanceKey, State.SUSPENDED);
+    suspensionState.setSuspensionState(processInstanceKey, state);
 
     // then
-    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.SUSPENDED);
+    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(state);
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
   }
 
   @Test
@@ -71,19 +75,6 @@ public final class SuspensionStateTest {
 
     // then
     assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.RESUMING);
-  }
-
-  @Test
-  public void shouldSetAndGetResumingSuspensionState() {
-    // given
-    final long processInstanceKey = 1L;
-
-    // when
-    suspensionState.setSuspensionState(processInstanceKey, State.RESUMING);
-
-    // then
-    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.RESUMING);
-    assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/suspension/SuspensionStateTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.suspension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.engine.state.immutable.SuspensionState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBufferedCommandRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBufferedCommandRecordValue;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public final class SuspensionStateTest {
+
+  private MutableProcessingState processingState;
+  private MutableSuspensionState suspensionState;
+
+  @BeforeEach
+  public void setup() {
+    suspensionState = processingState.getSuspensionState();
+  }
+
+  @Test
+  public void shouldReturnNullSuspensionStateWhenAbsent() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when
+    final var state = suspensionState.getSuspensionState(processInstanceKey);
+
+    // then
+    assertThat(state).isNull();
+  }
+
+  @Test
+  public void shouldSetAndGetSuspensionState() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when
+    suspensionState.setSuspensionState(processInstanceKey, State.SUSPENDED);
+
+    // then
+    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.SUSPENDED);
+  }
+
+  @Test
+  public void shouldOverwriteSuspensionStateWhenSetTwice() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.setSuspensionState(processInstanceKey, State.SUSPENDED);
+
+    // when
+    suspensionState.setSuspensionState(processInstanceKey, State.RESUMING);
+
+    // then
+    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.RESUMING);
+  }
+
+  @Test
+  public void shouldSetAndGetResumingSuspensionState() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when
+    suspensionState.setSuspensionState(processInstanceKey, State.RESUMING);
+
+    // then
+    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.RESUMING);
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
+  }
+
+  @Test
+  public void shouldReportIsSuspendedBeforeAndAfterSettingMarker() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when - then
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isFalse();
+
+    // when
+    suspensionState.setSuspensionState(processInstanceKey, State.SUSPENDED);
+
+    // then
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isTrue();
+  }
+
+  @Test
+  public void shouldRemoveSuspensionState() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.setSuspensionState(processInstanceKey, State.SUSPENDED);
+
+    // when
+    suspensionState.removeSuspensionState(processInstanceKey);
+
+    // then
+    assertThat(suspensionState.isSuspended(processInstanceKey)).isFalse();
+    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isNull();
+  }
+
+  @Test
+  public void shouldNotFailWhenRemovingAbsentSuspensionState() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when - then (no exception)
+    assertThatCode(() -> suspensionState.removeSuspensionState(processInstanceKey))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldKeepSuspensionMarkerAndBufferedCommandsIndependent() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.setSuspensionState(processInstanceKey, State.SUSPENDED);
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+
+    // when - clearing the buffered commands
+    suspensionState.clearBufferedCommands(processInstanceKey);
+
+    // then - the suspension marker is untouched
+    assertThat(suspensionState.getSuspensionState(processInstanceKey)).isEqualTo(State.SUSPENDED);
+
+    // given - a fresh buffered command
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when - removing the suspension marker
+    suspensionState.removeSuspensionState(processInstanceKey);
+
+    // then - the buffered command is untouched
+    final List<Long> visitedKeys = new ArrayList<>();
+    suspensionState.visitBufferedCommands(processInstanceKey, (key, value) -> visitedKeys.add(key));
+    assertThat(visitedKeys).containsExactly(20L);
+  }
+
+  @Test
+  public void shouldBufferAndVisitSingleCommand() {
+    // given
+    final long processInstanceKey = 1L;
+    final long elementInstanceKey = 2L;
+    final long bufferedCommandKey = 10L;
+    final var command = bufferedCommandRecord(processInstanceKey, elementInstanceKey);
+
+    // when
+    suspensionState.bufferCommand(bufferedCommandKey, command);
+
+    // then
+    final List<Long> visitedKeys = new ArrayList<>();
+    final List<ProcessInstanceBufferedCommandRecordValue> visitedValues = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKey,
+        (key, value) -> {
+          visitedKeys.add(key);
+          visitedValues.add(value);
+        });
+
+    assertThat(visitedKeys).containsExactly(bufferedCommandKey);
+    assertThat(visitedValues).hasSize(1);
+    final var visited = visitedValues.get(0);
+    assertThat(visited.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(visited.getElementInstanceKey()).isEqualTo(elementInstanceKey);
+    assertThat(visited.getValueType()).isEqualTo(ValueType.PROCESS_INSTANCE);
+    assertThat(visited.getIntent()).isEqualTo(ProcessInstanceIntent.ACTIVATE_ELEMENT);
+    assertThat(visited.getCommandValue()).isInstanceOf(ProcessInstanceRecord.class);
+    final var payload = (ProcessInstanceRecord) visited.getCommandValue();
+    assertThat(payload.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(payload.getBpmnProcessId()).isEqualTo("process");
+  }
+
+  @Test
+  public void shouldVisitBufferedCommandsInAscendingKeyOrderRegardlessOfInsertionOrder() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.bufferCommand(30L, bufferedCommandRecord(processInstanceKey, 3L));
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when
+    final List<Long> visitedKeys = new ArrayList<>();
+    suspensionState.visitBufferedCommands(processInstanceKey, (key, value) -> visitedKeys.add(key));
+
+    // then
+    assertThat(visitedKeys).containsExactly(10L, 20L, 30L);
+  }
+
+  @Test
+  public void shouldOnlyVisitBufferedCommandsOfRequestedProcessInstance() {
+    // given
+    final long processInstanceKeyA = 1L;
+    final long processInstanceKeyB = 2L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKeyA, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKeyB, 2L));
+
+    // when
+    final List<Long> visitedKeysForA = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKeyA, (key, value) -> visitedKeysForA.add(key));
+
+    final List<Long> visitedKeysForB = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKeyB, (key, value) -> visitedKeysForB.add(key));
+
+    // then
+    assertThat(visitedKeysForA).containsExactly(10L);
+    assertThat(visitedKeysForB).containsExactly(20L);
+  }
+
+  @Test
+  public void shouldRemoveExactlyOneBufferedCommand() {
+    // given
+    final long processInstanceKey = 1L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKey, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKey, 2L));
+
+    // when
+    suspensionState.removeBufferedCommand(10L);
+
+    // then
+    final List<Long> visitedKeys = new ArrayList<>();
+    suspensionState.visitBufferedCommands(processInstanceKey, (key, value) -> visitedKeys.add(key));
+    assertThat(visitedKeys).containsExactly(20L);
+  }
+
+  @Test
+  public void shouldClearAllBufferedCommandsForProcessInstanceOnly() {
+    // given
+    final long processInstanceKeyA = 1L;
+    final long processInstanceKeyB = 2L;
+    suspensionState.bufferCommand(10L, bufferedCommandRecord(processInstanceKeyA, 1L));
+    suspensionState.bufferCommand(20L, bufferedCommandRecord(processInstanceKeyA, 1L));
+    suspensionState.bufferCommand(30L, bufferedCommandRecord(processInstanceKeyB, 2L));
+
+    // when
+    suspensionState.clearBufferedCommands(processInstanceKeyA);
+
+    // then
+    final List<Long> visitedKeysForA = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKeyA, (key, value) -> visitedKeysForA.add(key));
+    assertThat(visitedKeysForA).isEmpty();
+
+    final List<Long> visitedKeysForB = new ArrayList<>();
+    suspensionState.visitBufferedCommands(
+        processInstanceKeyB, (key, value) -> visitedKeysForB.add(key));
+    assertThat(visitedKeysForB).containsExactly(30L);
+  }
+
+  @Test
+  public void shouldNotFailWhenRemovingOrClearingBufferedCommandsWithNothingBuffered() {
+    // given
+    final long processInstanceKey = 1L;
+
+    // when - then (no exception)
+    assertThatCode(() -> suspensionState.removeBufferedCommand(10L)).doesNotThrowAnyException();
+    assertThatCode(() -> suspensionState.clearBufferedCommands(processInstanceKey))
+        .doesNotThrowAnyException();
+
+    final List<Long> visitedKeys = new ArrayList<>();
+    suspensionState.visitBufferedCommands(processInstanceKey, (key, value) -> visitedKeys.add(key));
+    assertThat(visitedKeys).isEmpty();
+  }
+
+  private ProcessInstanceBufferedCommandRecord bufferedCommandRecord(
+      final long processInstanceKey, final long elementInstanceKey) {
+    return new ProcessInstanceBufferedCommandRecord()
+        .setProcessInstanceKey(processInstanceKey)
+        .setProcessDefinitionKey(1)
+        .setTenantId("tenant")
+        .setElementInstanceKey(elementInstanceKey)
+        .setValueType(ValueType.PROCESS_INSTANCE)
+        .setIntent(ProcessInstanceIntent.ACTIVATE_ELEMENT)
+        .setCommandValue(
+            new ProcessInstanceRecord()
+                .setProcessInstanceKey(processInstanceKey)
+                .setBpmnProcessId("process"));
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -338,7 +338,18 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   SECRET_REFERENCES_BY_JOB(154, PARTITION_LOCAL),
   // secondary index: (storeId, secretReference, jobKey) → ∅; supports prefix iteration by (storeId,
   // secretReference)
-  JOBS_BY_SECRET_REFERENCE(155, PARTITION_LOCAL);
+  JOBS_BY_SECRET_REFERENCE(155, PARTITION_LOCAL),
+  // suspension marker: processInstanceKey -> State (SUSPENDED/RESUMING); presence of an entry
+  // means the process instance has a suspension marker (either SUSPENDED or still draining as
+  // RESUMING) — the marker is only removed once resuming has fully completed
+  SUSPENDED_PROCESS_INSTANCES(156, PARTITION_LOCAL),
+  // commands diverted while their target process instance is suspended, keyed by a
+  // KeyGenerator-issued bufferedCommandKey -> ProcessInstanceBufferedCommandRecord
+  BUFFERED_PROCESS_INSTANCE_COMMANDS(157, PARTITION_LOCAL),
+  // secondary index: (processInstanceKey, bufferedCommandKey) → ∅; supports FIFO prefix iteration
+  // of buffered commands for a process instance (bufferedCommandKey is KeyGenerator-issued and
+  // therefore monotonically increasing, so key order == FIFO insertion order)
+  BUFFERED_PROCESS_INSTANCE_COMMANDS_BY_PROCESS_INSTANCE_KEY(158, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;


### PR DESCRIPTION
## Description

Adds the suspension state and column families for the process-instance suspend/resume epic ([#56080](https://github.com/camunda/camunda/issues/56080)):

- `SUSPENDED_PROCESS_INSTANCES` CF: `processInstanceKey` -> suspension marker (`SUSPENDED`/`RESUMING`).
- `BUFFERED_PROCESS_INSTANCE_COMMANDS` CF: `bufferedCommandKey` (KeyGenerator-issued) -> `ProcessInstanceBufferedCommandRecord`, plus a `(processInstanceKey, bufferedCommandKey)` secondary index for per-instance FIFO iteration.
- `SuspensionState` / `MutableSuspensionState` interfaces + `DbSuspensionState` implementation, registered in `ProcessingState` / `MutableProcessingState` / `ProcessingDbState`.

This is the state-layer foundation only — no processor, applier, or buffering-gate wiring yet (those land in follow-up tickets: #57519, #57520, #57521). Built via a contract-first approach: implementation and unit tests were written independently against a shared interface contract, then cross-checked by an independent review pass.

Reviewer note: the rejection conditions in the processors mentioned in the comments of the issue will be implemented with  https://github.com/camunda/camunda/issues/57518 since IT otherwise fail. Added it as an acceptance criteria there.

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57517
