### PR TITLE
test: add IT test for failover procedure on coordinator zone

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/management/cluster/BrokerId.java
+++ b/dist/src/main/java/io/camunda/zeebe/management/cluster/BrokerId.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.management.cluster;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.atomix.cluster.BrokerMemberId;
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.management.cluster.BrokerId.Integer;
 import io.camunda.zeebe.management.cluster.BrokerId.String;
 import java.util.Objects;
@@ -55,6 +56,7 @@ public abstract sealed class BrokerId permits Integer, String {
     return switch (obj) {
       case final java.lang.Integer integer -> new Integer(integer);
       case final java.lang.String string -> new String(string);
+      case final MemberId memberId -> of(memberId.toString());
       case final BrokerId brokerId -> brokerId;
       default -> throw new IllegalStateException("Unexpected value: " + obj);
     };

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -66,7 +66,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
                   "Cannot reassign partitions if no brokers are provided")));
     }
 
-    return generatePartitionDistributionOperations(clusterConfiguration, members);
+    return generatePartitionDistributionOperations(clusterConfiguration, members).mapLeft(x -> x);
   }
 
   private int getReplicationFactor(final ClusterConfiguration clusterConfiguration) {
@@ -77,7 +77,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     return newPartitionCount.orElse(clusterConfiguration.partitionCount());
   }
 
-  private Either<Exception, List<ClusterConfigurationChangeOperation>>
+  private Either<InvalidRequest, List<ClusterConfigurationChangeOperation>>
       generatePartitionDistributionOperations(
           final ClusterConfiguration currentConfiguration, final Set<MemberId> brokers) {
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
@@ -137,7 +137,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
           distributor.distributePartitions(brokers, allPartitions, replicationFactor).stream()
               .collect(Collectors.toMap(PartitionMetadata::id, p -> p));
     } catch (final Exception e) {
-      return Either.left(e);
+      return Either.left(new InvalidRequest(e));
     }
 
     for (final PartitionId partition : oldPartitions) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -129,9 +130,15 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
         Stream.of(oldPartitions, newPartitions).flatMap(List::stream).toList();
 
     final var distributor = currentConfiguration.partitionDistributor();
-    final var newDistribution =
-        distributor.distributePartitions(brokers, allPartitions, replicationFactor).stream()
-            .collect(Collectors.toMap(PartitionMetadata::id, p -> p));
+    final Map<PartitionId, PartitionMetadata> newDistribution;
+    try {
+      newDistribution =
+          // in rare cases the distributor might throw an exception
+          distributor.distributePartitions(brokers, allPartitions, replicationFactor).stream()
+              .collect(Collectors.toMap(PartitionMetadata::id, p -> p));
+    } catch (final Exception e) {
+      return Either.left(e);
+    }
 
     for (final PartitionId partition : oldPartitions) {
       final var newMetadata = newDistribution.get(partition);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributor.java
@@ -94,7 +94,7 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
    */
   public ZoneAwarePartitionDistributor(final List<ZoneSpec> zoneSpecs) {
     this.zoneSpecs = List.copyOf(zoneSpecs);
-    this.zoneSpecsByPriority =
+    zoneSpecsByPriority =
         zoneSpecs.stream().sorted(Comparator.comparingInt(ZoneSpec::priority).reversed()).toList();
     if (this.zoneSpecs.size() == 1) {
       LOG.warn(
@@ -197,7 +197,6 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
   }
 
   private void validateReplicaSum(final int replicationFactor) {
-
     final var totalReplicas = zoneSpecs.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();
     if (totalReplicas != replicationFactor) {
       throw new IllegalStateException(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
@@ -49,8 +49,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 final class AddZoneToClusterIT {
 
   private static final int PARTITIONS_COUNT = 2;
-  @AutoClose
-  final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
+  @AutoClose final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("addZoneScenarios")
@@ -63,14 +62,15 @@ final class AddZoneToClusterIT {
 
       // when - start a broker in the new zone, add it to the topology, then add the zone to the
       // partition distribution
-      closeables.manage(addBrokerInZone(
-          cluster,
-          actuator,
-          scenario.clusterName(),
-          scenario.newZone(),
-          0,
-          3,
-          scenario.targetZones()));
+      closeables.manage(
+          addBrokerInZone(
+              cluster,
+              actuator,
+              scenario.clusterName(),
+              scenario.newZone(),
+              0,
+              3,
+              scenario.targetZones()));
 
       final var config =
           new PartitionDistributionConfig()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
@@ -7,18 +7,22 @@
  */
 package io.camunda.zeebe.it.cluster.clustering.zoneaware;
 
+import static io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.Zone;
+import io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers.AddZoneScenario;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.DynamicAutoCloseable;
 import java.util.List;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -42,9 +46,11 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @ZeebeIntegration
 @Timeout(2 * 60)
-final class AddZoneToClusterIT extends ZoneHelpers {
+final class AddZoneToClusterIT {
 
   private static final int PARTITIONS_COUNT = 2;
+  @AutoClose
+  final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("addZoneScenarios")
@@ -57,14 +63,14 @@ final class AddZoneToClusterIT extends ZoneHelpers {
 
       // when - start a broker in the new zone, add it to the topology, then add the zone to the
       // partition distribution
-      addBrokerInZone(
+      closeables.manage(addBrokerInZone(
           cluster,
           actuator,
           scenario.clusterName(),
           scenario.newZone(),
           0,
           3,
-          scenario.targetZones());
+          scenario.targetZones()));
 
       final var config =
           new PartitionDistributionConfig()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
-import java.time.Duration;
 import java.util.List;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
@@ -49,7 +48,7 @@ public class ZoneHelpers {
    * {@link TestStandaloneBroker#start()} runs on a virtual thread because it only returns once the
    * broker has joined the topology (i.e. after {@code addBroker}).
    */
-  public static AutoCloseable addBrokerInZone(
+  public static TestStandaloneBroker addBrokerInZone(
       final TestCluster cluster,
       final ClusterActuator actuator,
       final String clusterName,
@@ -79,24 +78,14 @@ public class ZoneHelpers {
         Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
 
     final var added = actuator.addBroker(MemberId.from(zone, nodeId).toString());
-    final AutoCloseable closeable =
-        () -> {
-          // Close the broker first to unblock the (potentially still blocked) start() call, then
-          // join the
-          // virtual thread so it does not leak beyond the test.
-          broker.close();
-          startThread.interrupt();
-          startThread.join(Duration.ofSeconds(30));
-        };
     try {
       Awaitility.await()
           .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(added));
     } catch (final Exception e) {
-      CloseHelper.close(closeable);
+      CloseHelper.close(broker);
     }
-    cluster.brokers().put(broker.nodeId(), broker);
 
-    return closeable;
+    return broker;
   }
 
   public static void assertZoneHostsPartitions(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import java.time.Duration;
 import java.util.List;
+import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 
 public class ZoneHelpers {
@@ -76,17 +77,25 @@ public class ZoneHelpers {
 
     final var startThread =
         Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
-    // Close the broker first to unblock the (potentially still blocked) start() call, then join the
-    // virtual thread so it does not leak beyond the test.
 
     final var added = actuator.addBroker(MemberId.from(zone, nodeId).toString());
-    Awaitility.await()
-        .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(added));
-    return () -> {
-      broker.close();
-      startThread.interrupt();
-      startThread.join(Duration.ofSeconds(30));
-    };
+    final AutoCloseable closeable =
+        () -> {
+          // Close the broker first to unblock the (potentially still blocked) start() call, then
+          // join the
+          // virtual thread so it does not leak beyond the test.
+          broker.close();
+          startThread.interrupt();
+          startThread.join(Duration.ofSeconds(30));
+        };
+    try {
+      Awaitility.await()
+          .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(added));
+    } catch (final Exception e) {
+      CloseHelper.close(closeable);
+    }
+
+    return closeable;
   }
 
   public static void assertZoneHostsPartitions(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -94,6 +94,7 @@ public class ZoneHelpers {
     } catch (final Exception e) {
       CloseHelper.close(closeable);
     }
+    cluster.brokers().put(broker.nodeId(), broker);
 
     return closeable;
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -20,18 +20,13 @@ import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
-import io.camunda.zeebe.test.DynamicAutoCloseable;
 import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
 
 public class ZoneHelpers {
 
-  @AutoClose protected final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
-
-  @SuppressWarnings("resource")
-  protected TestCluster createCluster(
+  public static TestCluster createCluster(
       final String name,
       final List<Zone> zones,
       final int partitionCount,
@@ -53,7 +48,7 @@ public class ZoneHelpers {
    * {@link TestStandaloneBroker#start()} runs on a virtual thread because it only returns once the
    * broker has joined the topology (i.e. after {@code addBroker}).
    */
-  protected void addBrokerInZone(
+  public static AutoCloseable addBrokerInZone(
       final TestCluster cluster,
       final ClusterActuator actuator,
       final String clusterName,
@@ -83,19 +78,18 @@ public class ZoneHelpers {
         Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
     // Close the broker first to unblock the (potentially still blocked) start() call, then join the
     // virtual thread so it does not leak beyond the test.
-    closeables.manage(
-        () -> {
-          broker.close();
-          startThread.interrupt();
-          startThread.join(Duration.ofSeconds(30));
-        });
 
     final var added = actuator.addBroker(MemberId.from(zone, nodeId).toString());
     Awaitility.await()
         .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(added));
+    return () -> {
+      broker.close();
+      startThread.interrupt();
+      startThread.join(Duration.ofSeconds(30));
+    };
   }
 
-  protected static void assertZoneHostsPartitions(
+  public static void assertZoneHostsPartitions(
       final ClusterActuator actuator, final String zone, final int nodeId) {
     final var brokerId = new BrokerId.String(MemberId.from(zone, nodeId).toString());
     Awaitility.await()
@@ -117,7 +111,7 @@ public class ZoneHelpers {
    * start a cluster over {@code initialZones}, add a broker in {@code newZone}, then update the
    * partition distribution to {@code targetZones}.
    */
-  protected record AddZoneScenario(
+  public record AddZoneScenario(
       String clusterName, List<Zone> initialZones, List<Zone> targetZones, String newZone) {
     @Override
     public String toString() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.DynamicAutoCloseable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -31,12 +32,15 @@ import java.util.List;
 import java.util.stream.IntStream;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 @Timeout(2 * 60) // 2 minutes
 abstract class ClusterEndpointIT {
+
+  @AutoClose protected final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
 
   protected abstract int brokerCount();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
@@ -27,6 +28,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -376,6 +378,14 @@ abstract class ClusterEndpointIT {
         .describedAs("Partitions are evenly distributed")
         .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size());
     assertThat(response.getPlannedChanges()).isNotEmpty();
+  }
+
+  protected void assertChangeDone(
+      final ClusterActuator actuator, final PlannedOperationsResponse response) {
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
   }
 
   @Nested

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -16,6 +16,7 @@ import feign.FeignException;
 import io.atomix.cluster.MemberId;
 import io.camunda.configuration.Zone;
 import io.camunda.zeebe.management.cluster.BrokerId;
+import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.Operation;
@@ -26,8 +27,8 @@ import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
-import java.time.Duration;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -280,26 +281,43 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
       // when
       // 1. stop both zoneA brokers (incl. coordinator zoneA_0)
-      cluster.brokers().get(MemberId.from("zoneA", 0)).close();
-      cluster.brokers().get(MemberId.from("zoneA", 1)).close();
+      final var brokersToRemove = List.of(MemberId.from("zoneA", 0), MemberId.from("zoneA", 1));
+      brokersToRemove.forEach(b -> cluster.brokers().get(b).close());
 
       // 2. force-remove both zoneA brokers; remaining member set = zoneB only
-      final var remaining =
-          List.<BrokerId>of(
-              new BrokerId.String(MemberId.from("zoneB", 0).toString()),
-              new BrokerId.String(MemberId.from("zoneB", 1).toString()));
-      final var removed = actuator.scaleByBrokerIds(remaining, false, true);
-      Awaitility.await()
-          .atMost(Duration.ofSeconds(60))
-          .untilAsserted(
-              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(removed));
+      final var removed =
+          actuator.patchCluster(
+              new ClusterConfigPatchRequest()
+                  .brokers(
+                      new ClusterConfigPatchRequestBrokers()
+                          .remove(brokersToRemove.stream().map(BrokerId::of).toList())),
+              false,
+              true);
+
+      assertChangeDone(actuator, removed);
+
+      final var zoneBOnlyResponse =
+          actuator.patchPartitionDistribution(
+              new PartitionDistributionConfig()
+                  .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
+                  .zones(List.of(new ZoneSpec().name("zoneB").numberOfReplicas(2).priority(10))),
+              false);
+      assertChangeDone(actuator, zoneBOnlyResponse);
 
       // 3. add 2 new brokers to zoneB (zoneB_2, zoneB_3)
       final var targetZones = List.of(new Zone("zoneB", 4, 4, 10));
-      closeables.manage(
-          addBrokerInZone(cluster, actuator, DEFAULT_CLUSTER_NAME, "zoneB", 2, 3, targetZones));
-      closeables.manage(
-          addBrokerInZone(cluster, actuator, DEFAULT_CLUSTER_NAME, "zoneB", 3, 4, targetZones));
+      final var brokersToAdd = List.of(MemberId.from("zoneB", 2), MemberId.from("zoneB", 3));
+      brokersToAdd.forEach(
+          id ->
+              closeables.manage(
+                  addBrokerInZone(
+                      cluster,
+                      actuator,
+                      DEFAULT_CLUSTER_NAME,
+                      id.zone(),
+                      id.nodeIdx(),
+                      4,
+                      targetZones)));
 
       // 4. reconfigure partition distribution: RF=4 all in zoneB, no zoneA
       final var config =
@@ -309,11 +327,31 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       final var response = actuator.patchPartitionDistribution(config, false);
 
       // then -- recovery applied; RF=4 all in zoneB
-      Awaitility.await()
-          .atMost(Duration.ofSeconds(60))
-          .untilAsserted(
-              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
-      assertThat(actuator.getTopology().getPartitionDistribution()).isEqualTo(config);
+      assertChangeDone(actuator, response);
+
+      cluster.awaitHealthyTopology();
+      final var finalTopology = actuator.getTopology();
+      assertThat(finalTopology.getPartitionDistribution()).isEqualTo(config);
+
+      final var expectedMemberIds =
+          IntStream.range(0, 4).mapToObj(i -> MemberId.from("zoneB", i)).toList();
+
+      // all zoneB brokers present in the final topology, each hosting both partitions (RF=4)
+      assertThat(finalTopology.getBrokers())
+          .describedAs("all zoneB brokers present in final topology")
+          .extracting(BrokerState::getId)
+          .containsExactlyInAnyOrder(
+              expectedMemberIds.stream().map(BrokerId::of).toList().toArray(new BrokerId[0]));
+      assertThat(finalTopology.getBrokers())
+          .allSatisfy(
+              broker ->
+                  assertThat(broker.getPartitions())
+                      .describedAs("broker %s has all partitions", broker.getId())
+                      .hasSize(2));
+      for (final var id : expectedMemberIds) {
+        Awaitility.await()
+            .untilAsserted(() -> TestCluster.assertHealthyTopology(cluster.brokers().get(id)));
+      }
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
+import static io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers.addBrokerInZone;
+import static io.camunda.zeebe.qa.util.cluster.TestClusterBuilder.DEFAULT_CLUSTER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -24,9 +26,11 @@ import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
@@ -260,6 +264,56 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
           new PartitionDistributionConfig().type(PartitionDistributionConfig.TypeEnum.ROUND_ROBIN);
       assertThatCode(() -> actuator.patchPartitionDistribution(config, false))
           .isInstanceOf(FeignException.BadRequest.class);
+    }
+  }
+
+  @Test
+  @Timeout(3 * 60) // 6 broker JVMs total over the run; override the class-level 2-min timeout
+  @SuppressWarnings("resource")
+  void shouldRecoverZoneAwareClusterAfterZoneFailover() {
+    // given -- zoneA x2, zoneB x2, RF=4 (2 replicas/zone), 2 partitions
+    try (final var cluster = createCluster(4, 2, 4)) {
+      cluster.awaitCompleteTopology();
+      // Pin the actuator to a surviving zoneB broker -- availableGateway() may resolve to a
+      // zoneA broker, which is closed below and would take the actuator connection down with it.
+      final var actuator = ClusterActuator.of(cluster.brokers().get(MemberId.from("zoneB", 0)));
+
+      // when
+      // 1. stop both zoneA brokers (incl. coordinator zoneA_0)
+      cluster.brokers().get(MemberId.from("zoneA", 0)).close();
+      cluster.brokers().get(MemberId.from("zoneA", 1)).close();
+
+      // 2. force-remove both zoneA brokers; remaining member set = zoneB only
+      final var remaining =
+          List.<BrokerId>of(
+              new BrokerId.String(MemberId.from("zoneB", 0).toString()),
+              new BrokerId.String(MemberId.from("zoneB", 1).toString()));
+      final var removed = actuator.scaleByBrokerIds(remaining, false, true);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(60))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(removed));
+
+      // 3. add 2 new brokers to zoneB (zoneB_2, zoneB_3)
+      final var targetZones = List.of(new Zone("zoneB", 4, 4, 10));
+      closeables.manage(
+          addBrokerInZone(cluster, actuator, DEFAULT_CLUSTER_NAME, "zoneB", 2, 3, targetZones));
+      closeables.manage(
+          addBrokerInZone(cluster, actuator, DEFAULT_CLUSTER_NAME, "zoneB", 3, 4, targetZones));
+
+      // 4. reconfigure partition distribution: RF=4 all in zoneB, no zoneA
+      final var config =
+          new PartitionDistributionConfig()
+              .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
+              .zones(List.of(new ZoneSpec().name("zoneB").numberOfReplicas(4).priority(10)));
+      final var response = actuator.patchPartitionDistribution(config, false);
+
+      // then -- recovery applied; RF=4 all in zoneB
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(60))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
+      assertThat(actuator.getTopology().getPartitionDistribution()).isEqualTo(config);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -28,9 +28,9 @@ import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -279,7 +279,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       cluster.awaitCompleteTopology();
       // Pin the actuator to a surviving zoneB broker -- availableGateway() may resolve to a
       // zoneA broker, which is closed below and would take the actuator connection down with it.
-      final var actuator = ClusterActuator.of(cluster.brokers().get(MemberId.from("zoneB", 0)));
+      final var actuator = ClusterActuator.of(cluster.brokers().get(MemberId.from(ZONES[1], 0)));
 
       // when
       // 1. stop both zoneA brokers (incl. coordinator zoneA_0)
@@ -302,16 +302,16 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
           actuator.patchPartitionDistribution(
               new PartitionDistributionConfig()
                   .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
-                  .zones(List.of(new ZoneSpec().name("zoneB").numberOfReplicas(2).priority(10))),
+                  .zones(List.of(new ZoneSpec().name(ZONES[1]).numberOfReplicas(2).priority(10))),
               false);
       assertChangeDone(actuator, zoneBOnlyResponse);
 
       // 3. add 2 new brokers to zoneB (zoneB_2, zoneB_3)
-      final var targetZones = List.of(new Zone("zoneB", 4, 4, 10));
-      final var brokersToAdd = List.of(MemberId.from("zoneB", 2), MemberId.from("zoneB", 3));
+      final var targetZones = List.of(new Zone(ZONES[1], 4, 4, 10));
+      final var brokersToAdd = brokersInZone(ZONES[1], 2, 3);
       final var zoneBBrokers = new HashMap<MemberId, TestStandaloneBroker>();
       cluster.brokers().entrySet().stream()
-          .filter(e -> e.getKey().isInZone("zoneB"))
+          .filter(e -> e.getKey().isInZone(ZONES[1]))
           .forEach(e -> zoneBBrokers.put(e.getKey(), e.getValue()));
       brokersToAdd.forEach(
           id -> {
@@ -332,7 +332,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       final var config =
           new PartitionDistributionConfig()
               .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
-              .zones(List.of(new ZoneSpec().name("zoneB").numberOfReplicas(4).priority(10)));
+              .zones(List.of(new ZoneSpec().name(ZONES[1]).numberOfReplicas(4).priority(10)));
       final var response = actuator.patchPartitionDistribution(config, false);
 
       // then -- recovery applied; RF=4 all in zoneB
@@ -341,8 +341,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       final var finalTopology = actuator.getTopology();
       assertThat(finalTopology.getPartitionDistribution()).isEqualTo(config);
 
-      final var expectedMemberIds =
-          IntStream.range(0, 4).mapToObj(i -> MemberId.from("zoneB", i)).toList();
+      final var expectedMemberIds = brokersInZone(ZONES[1], 0, 1, 2, 3);
 
       // all zoneB brokers present in the final topology, each hosting both partitions (RF=4)
       assertThat(finalTopology.getBrokers())
@@ -380,5 +379,9 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("Members without a zone cannot be added to a zone-aware cluster");
     }
+  }
+
+  private static List<MemberId> brokersInZone(final String zone, final int... ids) {
+    return Arrays.stream(ids).mapToObj(id -> MemberId.from(zone, id)).toList();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -26,7 +26,9 @@ import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
@@ -269,7 +271,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
   }
 
   @Test
-  @Timeout(3 * 60) // 6 broker JVMs total over the run; override the class-level 2-min timeout
+  @Timeout(2 * 60)
   @SuppressWarnings("resource")
   void shouldRecoverZoneAwareClusterAfterZoneFailover() {
     // given -- zoneA x2, zoneB x2, RF=4 (2 replicas/zone), 2 partitions
@@ -307,17 +309,24 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // 3. add 2 new brokers to zoneB (zoneB_2, zoneB_3)
       final var targetZones = List.of(new Zone("zoneB", 4, 4, 10));
       final var brokersToAdd = List.of(MemberId.from("zoneB", 2), MemberId.from("zoneB", 3));
+      final var zoneBBrokers = new HashMap<MemberId, TestStandaloneBroker>();
+      cluster.brokers().entrySet().stream()
+          .filter(e -> e.getKey().isInZone("zoneB"))
+          .forEach(e -> zoneBBrokers.put(e.getKey(), e.getValue()));
       brokersToAdd.forEach(
-          id ->
-              closeables.manage(
-                  addBrokerInZone(
-                      cluster,
-                      actuator,
-                      DEFAULT_CLUSTER_NAME,
-                      id.zone(),
-                      id.nodeIdx(),
-                      4,
-                      targetZones)));
+          id -> {
+            final var broker =
+                closeables.manage(
+                    addBrokerInZone(
+                        cluster,
+                        actuator,
+                        DEFAULT_CLUSTER_NAME,
+                        id.zone(),
+                        id.nodeIdx(),
+                        4,
+                        targetZones));
+            zoneBBrokers.put(id, broker);
+          });
 
       // 4. reconfigure partition distribution: RF=4 all in zoneB, no zoneA
       final var config =
@@ -329,7 +338,6 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // then -- recovery applied; RF=4 all in zoneB
       assertChangeDone(actuator, response);
 
-      cluster.awaitHealthyTopology();
       final var finalTopology = actuator.getTopology();
       assertThat(finalTopology.getPartitionDistribution()).isEqualTo(config);
 
@@ -350,7 +358,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
                       .hasSize(2));
       for (final var id : expectedMemberIds) {
         Awaitility.await()
-            .untilAsserted(() -> TestCluster.assertHealthyTopology(cluster.brokers().get(id)));
+            .untilAsserted(() -> TestCluster.assertHealthyTopology(zoneBBrokers.get(id)));
       }
     }
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -338,7 +338,8 @@ public final class TestCluster implements CloseableSilently {
   public TestCluster awaitHealthyTopology(final Duration timeout) {
     Awaitility.await("until cluster topology is complete")
         .atMost(timeout)
-        .untilAsserted(() -> assertThat(allGateways()).allSatisfy(this::assertHealthyTopology));
+        .untilAsserted(
+            () -> assertThat(allGateways()).allSatisfy(TestCluster::assertHealthyTopology));
     return this;
   }
 
@@ -427,7 +428,7 @@ public final class TestCluster implements CloseableSilently {
     }
   }
 
-  private void assertHealthyTopology(final TestGateway<?> node) {
+  public static void assertHealthyTopology(final TestGateway<?> node) {
     assertThatCode(() -> node.probe(TestHealthProbe.READY))
         .as("gateway '%s' is ready", node.nodeId())
         .doesNotThrowAnyException();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -24,7 +24,7 @@ import java.util.stream.IntStream;
 @SuppressWarnings({"unused", "resource"})
 public final class TestClusterBuilder {
 
-  private static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+  public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
 
   private String name = DEFAULT_CLUSTER_NAME;
 


### PR DESCRIPTION
## Description
A new IT test has been added to test the failover procedure when one zone is lost (with the coordinator) and new brokers are spawned in the surviving zone. 
The replication factor is then updated in that zone to match the previous one. 

Exceptions thrown by the validations are now catched and returned as `Either.left(new InvalidRequest(e))`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
