### PR TITLE
Reduce default acceptable backlog size to improve data availability

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Throttle.java
+++ b/configuration/src/main/java/io/camunda/configuration/Throttle.java
@@ -16,7 +16,7 @@ public class Throttle {
   private static final String PREFIX = "camunda.processing.flow-control.write.throttle";
 
   private static final boolean DEFAULT_THROTTLING_ENABLED = false;
-  private static final int DEFAULT_ACCEPTABLE_BACKLOG = 100_000;
+  private static final int DEFAULT_ACCEPTABLE_BACKLOG = 50_000;
   private static final int DEFAULT_MINIMUM_LIMIT = 100;
   private static final Duration DEFAULT_RESOLUTION = Duration.ofSeconds(15);
 

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1377,7 +1377,7 @@ camunda: # Type: io.camunda.configuration.Camunda
         ramp-up: 0 # Type: Duration, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_RAMPUP
         throttle: # Type: io.camunda.configuration.Throttle  
           # When exporting is a bottleneck, the write rate is throttled to keep the backlog at this value.
-          acceptable-backlog: 100000 # Type: Integer, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_THROTTLE_ACCEPTABLEBACKLOG
+          acceptable-backlog: 50000 # Type: Integer, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_THROTTLE_ACCEPTABLEBACKLOG
           # Enable throttling. If enabled, throttle the write rate based on exporting backlog
           enabled: false # Type: Boolean, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_THROTTLE_ENABLED
           # Even when exporting is fully blocked, always allow this many writes per second

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1403,7 +1403,7 @@ camunda: # Type: io.camunda.configuration.Camunda
         ramp-up: 0 # Type: Duration, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_RAMPUP
         throttle: # Type: io.camunda.configuration.Throttle
           # When exporting is a bottleneck, the write rate is throttled to keep the backlog at this value.
-          acceptable-backlog: 100000 # Type: Integer, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_THROTTLE_ACCEPTABLEBACKLOG
+          acceptable-backlog: 50000 # Type: Integer, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_THROTTLE_ACCEPTABLEBACKLOG
           # Enable throttling. If enabled, throttle the write rate based on exporting backlog
           enabled: false # Type: Boolean, Env: CAMUNDA_PROCESSING_FLOWCONTROL_WRITE_THROTTLE_ENABLED
           # Even when exporting is fully blocked, always allow this many writes per second

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backpressure/ThrottleCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/backpressure/ThrottleCfg.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 public class ThrottleCfg {
   private boolean enabled = false;
-  private int acceptableBacklog = 100_000;
+  private int acceptableBacklog = 50_000;
   private int minimumLimit = 100;
   private Duration resolution = Duration.ofSeconds(15);
 


### PR DESCRIPTION
## Description

When running "max" load tests (300 PI/s) we regularly see the data availability metric climb to a minute or more.

It seems that a large part of that is by design.

During load tests we enable throttling based on how many records have been written, but not yet exported.  As that number increases we gradually introduce more back-pressure (rejecting new PIs etc).  This is the "acceptable backlog".

The default "acceptable backlog" is 100K.

If secondary storage is not able to process records faster than the Zeebe engine, this backlog grows until it hits the maximum.  This is intended so that secondary storage does to slow down the engine where there are brief surges etc.  However when there is sustained load that backlog never has a chance to reduce.

If we observe a 60 second data availability metric and the "acceptable backlog" is 100K:

* Dividing 100K into batches of 5K (Camunda Exporter batch size) we have 20 batches
* This is optimistic as some records create multiple documents to insert into ES
* If we processes those 20 batches in. 60 seconds then we can expect each batch to take 3 seconds to write
* This is quite a normal amount of time when under load
* Even with "typical" benchmarks a batch is typically about 1.5 seconds to write   

If we reduce that "acceptable backlog" to 50K we essentially halve the availability metric.  Doing so does not seem to adversely affect throughput when under load.

## Related issues

refs #43121
