### PR TITLE
ci: share distball in standalone rdbms + search integration workflows

### DIFF
--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -23,10 +23,8 @@ env:
 jobs:
   build-distball:
     name: "Build / Distribution Tarball"
-    # Transport differs by runner: docker-checks (GitHub-hosted, ci.yml only) uses the GHA
-    # artifact API; self-hosted gcp-perf consumers (integration-tests, and the reusable
-    # database/webapp-UT workflows) use GCS, since the artifact API is throughput-capped on
-    # self-hosted runners.
+    # GHA artifact API for ci.yml's docker-checks (GitHub-hosted); GCS for self-hosted
+    # gcp-perf consumers, since the artifact API is throughput-capped there.
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci-build-distball-reusable.yml
+++ b/.github/workflows/ci-build-distball-reusable.yml
@@ -1,0 +1,136 @@
+# description: This is a reusable workflow used to build the distball once and share it with
+#   callers, replacing a per-consumer reactor build. See #52693 and #56931.
+# type: CI
+# owner: @camunda/engineering-operations
+
+name: Build distball reusable
+
+on:
+  workflow_call:
+    inputs:
+      skip-artifact-upload:
+        required: false
+        type: boolean
+        default: false
+        description: >-
+          When true, skip uploading the distball/m2 tarball to the GitHub artifact API.
+          Only ci.yml's docker-checks job consumes that artifact; standalone callers with no
+          such consumer should set this to true to skip the unused upload.
+
+env:
+  GCS_BUILD_CACHE_BUCKET: camunda-monorepo-ci-artifacts
+
+jobs:
+  build-distball:
+    name: "Build / Distribution Tarball"
+    # Transport differs by runner: docker-checks (GitHub-hosted, ci.yml only) uses the GHA
+    # artifact API; self-hosted gcp-perf consumers (integration-tests, and the reusable
+    # database/webapp-UT workflows) use GCS, since the artifact API is throughput-capped on
+    # self-hosted runners.
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@6f1db2426ec34a020db86cb6a6fecb5bda9f8138 # main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        timeout-minutes: 1
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: build-shared
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Log distball size
+        run: ls -lh "${{ steps.build-zeebe.outputs.distball }}"
+      # build-zeebe installs this run's io.camunda SNAPSHOTs into ~/.m2; consumers
+      # resolve them via `mvn verify`, but the GHA Maven cache never propagates
+      # locally-installed SNAPSHOTs between jobs, so archive them for the consumers.
+      - name: Archive local Maven SNAPSHOT artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `installed/` is the split-local-repository partition holding only artifacts this
+          # reactor installed (see maven resolver split local repository), so archive the whole
+          # tree rather than filtering to io/camunda -- robust if the group id ever changes.
+          # Drop the distro assemblies (shipped as the distball), sources/javadoc and
+          # bookkeeping to ~halve the payload.
+          tar \
+            --exclude='*.tar.gz' \
+            --exclude='*-sources.jar' \
+            --exclude='*-javadoc.jar' \
+            --exclude='*.lastUpdated' \
+            --exclude='_remote.repositories' \
+            --exclude='*.repositories' \
+            -cf m2-installed.tar -C "${HOME}/.m2/repository/installed" .
+          ls -lh m2-installed.tar
+      # docker-checks (GitHub-hosted, ci.yml only) consumes these via the artifact API.
+      - name: Upload distball (artifact)
+        if: ${{ !inputs.skip-artifact-upload }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: distball-${{ github.run_id }}
+          path: ${{ steps.build-zeebe.outputs.distball }}
+          retention-days: 1
+          compression-level: 0  # tarball is already gzipped
+          if-no-files-found: error
+      - name: Upload local Maven SNAPSHOT artifacts (artifact)
+        if: ${{ !inputs.skip-artifact-upload }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: m2-installed-${{ github.run_id }}
+          path: m2-installed.tar
+          retention-days: 1
+          compression-level: 6
+          if-no-files-found: error
+      # integration-tests' gcp-perf shards consume these from GCS (ingress is free).
+      # Authenticate here (not via setup-build) so the WIF/OIDC token is fresh: the
+      # build-zeebe step above can run ~15 min, close to the OIDC token lifetime.
+      - uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Upload distball to GCS
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
+        env:
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 2
+          shell: bash
+          command: |
+            set -euo pipefail
+            gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
+              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
+      - name: Upload SNAPSHOTs to GCS
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        env:
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
+        with:
+          max_attempts: 5
+          retry_wait_seconds: 10
+          timeout_minutes: 1
+          shell: bash
+          command: |
+            set -euo pipefail
+            gcloud storage cp m2-installed.tar \
+              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -66,9 +66,8 @@ on:
           When true, restore the io.camunda SNAPSHOTs from the run-scoped GCS
           artifact produced by a build-distball job (ci-build-distball-reusable.yml)
           elsewhere in the same run, instead of running a local build-zeebe reactor.
-          Only safe when the calling run also runs that build-distball job. Callers
-          without one must leave this false so the build-zeebe fallback runs.
-          See #52693 and #56931.
+          Leave false if the calling run has no build-distball job, so the
+          build-zeebe fallback runs. See #52693 and #56931.
     outputs:
       flakyTests:
         description: "Flaky tests detected during database integration tests"

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -64,10 +64,11 @@ on:
         default: false
         description: >-
           When true, restore the io.camunda SNAPSHOTs from the run-scoped GCS
-          artifact produced by ci.yml's build-distball job instead of running a
-          local build-zeebe reactor. Only safe when called from a run that has a
-          build-distball job (i.e. ci.yml). Standalone callers must leave this
-          false so the build-zeebe fallback runs. See #52693.
+          artifact produced by a build-distball job (ci-build-distball-reusable.yml)
+          elsewhere in the same run, instead of running a local build-zeebe reactor.
+          Only safe when the calling run also runs that build-distball job. Callers
+          without one must leave this false so the build-zeebe fallback runs.
+          See #52693 and #56931.
     outputs:
       flakyTests:
         description: "Flaky tests detected during database integration tests"
@@ -122,12 +123,12 @@ jobs:
             docker compose -f db/docker-compose.yml logs
             exit 1
           }
-      # When called from ci.yml (use-shared-distball=true) restore the io.camunda SNAPSHOTs
-      # that build-distball installed + archived to GCS, instead of re-running the ~2 min
-      # reactor in each of the ~15 database/history/identity matrix entries. gcp-perf runners
+      # When use-shared-distball is true, restore the io.camunda SNAPSHOTs that a
+      # build-distball job elsewhere in the same run installed + archived to GCS,
+      # instead of re-running the ~2 min reactor in each matrix entry. gcp-perf runners
       # pull from GCS (same-region, non-billable); the GHA artifact API is throughput-capped
       # on self-hosted runners. github.run_id is stable across nested workflow_call, so it
-      # addresses the same run-scoped prefix build-distball wrote. See #52693.
+      # addresses the same run-scoped prefix build-distball wrote. See #52693 and #56931.
       # (gcloud is authenticated by setup-build's gcs-build-cache-auth above.)
       - if: ${{ inputs.use-shared-distball }}
         uses: ./.github/actions/restore-shared-m2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,6 @@ jobs:
 
   build-distball:
     name: "Build / Distribution Tarball"
-    # Build the distball once and share it, replacing a reactor build in each consumer.
     # Extracted into a reusable workflow so the standalone rdbms/search integration-test
     # workflows can share it too. See #52693 and #56931.
     # Gated on the union of all consumers' conditions so the artifact exists whenever one runs;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,119 +466,18 @@ jobs:
   build-distball:
     name: "Build / Distribution Tarball"
     # Build the distball once and share it, replacing a reactor build in each consumer.
-    # Transport differs by runner: docker-checks (GitHub-hosted) uses the GHA artifact API;
-    # self-hosted gcp-perf consumers (integration-tests, and the reusable database/webapp-UT
-    # workflows) use GCS, since the artifact API is throughput-capped on self-hosted runners.
+    # Extracted into a reusable workflow so the standalone rdbms/search integration-test
+    # workflows can share it too. See #52693 and #56931.
     # Gated on the union of all consumers' conditions so the artifact exists whenever one runs;
     # frontend-changes is included because the webapp back-end UTs run on it; rdbms-integration-tests
     # is included because its filter is a superset of java-code-changes (adds rdbms-change). See #52693.
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
-    runs-on: gcp-perf-core-8-default
-    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
-    steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@f063d613a0c7eb6d1b5a155722f09f336e39ccb5 # main
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        timeout-minutes: 1
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: build-shared
-          dockerhub-readonly: true
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          minimus: true
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
-      - name: Log distball size
-        run: ls -lh "${{ steps.build-zeebe.outputs.distball }}"
-      # build-zeebe installs this run's io.camunda SNAPSHOTs into ~/.m2; consumers
-      # resolve them via `mvn verify`, but the GHA Maven cache never propagates
-      # locally-installed SNAPSHOTs between jobs, so archive them for the consumers.
-      - name: Archive local Maven SNAPSHOT artifacts
-        shell: bash
-        run: |
-          set -euo pipefail
-          # `installed/` is the split-local-repository partition holding only artifacts this
-          # reactor installed (see maven resolver split local repository), so archive the whole
-          # tree rather than filtering to io/camunda -- robust if the group id ever changes.
-          # Drop the distro assemblies (shipped as the distball), sources/javadoc and
-          # bookkeeping to ~halve the payload.
-          tar \
-            --exclude='*.tar.gz' \
-            --exclude='*-sources.jar' \
-            --exclude='*-javadoc.jar' \
-            --exclude='*.lastUpdated' \
-            --exclude='_remote.repositories' \
-            --exclude='*.repositories' \
-            -cf m2-installed.tar -C "${HOME}/.m2/repository/installed" .
-          ls -lh m2-installed.tar
-      # docker-checks (GitHub-hosted) consumes these via the artifact API.
-      - name: Upload distball (artifact)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: distball-${{ github.run_id }}
-          path: ${{ steps.build-zeebe.outputs.distball }}
-          retention-days: 1
-          compression-level: 0  # tarball is already gzipped
-          if-no-files-found: error
-      - name: Upload local Maven SNAPSHOT artifacts (artifact)
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: m2-installed-${{ github.run_id }}
-          path: m2-installed.tar
-          retention-days: 1
-          compression-level: 6
-          if-no-files-found: error
-      # integration-tests' gcp-perf shards consume these from GCS (ingress is free).
-      # Authenticate here (not via setup-build) so the WIF/OIDC token is fresh: the
-      # build-zeebe step above can run ~15 min, close to the OIDC token lifetime.
-      - uses: ./.github/actions/gcs-build-cache-auth
-        with:
-          vault-addr: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - name: Upload distball to GCS
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
-        env:
-          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
-        with:
-          max_attempts: 5
-          retry_wait_seconds: 10
-          timeout_minutes: 2
-          shell: bash
-          command: |
-            set -euo pipefail
-            gcloud storage cp "${{ steps.build-zeebe.outputs.distball }}" \
-              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
-      - name: Upload SNAPSHOTs to GCS
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
-        env:
-          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
-        with:
-          max_attempts: 5
-          retry_wait_seconds: 10
-          timeout_minutes: 1
-          shell: bash
-          command: |
-            set -euo pipefail
-            gcloud storage cp m2-installed.tar \
-              "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+    uses: ./.github/workflows/ci-build-distball-reusable.yml
+    secrets: inherit
 
   build-platform-frontend:
     # Runs when the frontend changed, OR on any non-PR event targeting main/stable

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -73,6 +73,8 @@ jobs:
 
   # Builds the distball once and shares it with every matrix shard below via GCS,
   # replacing a per-shard reactor build (~33 shards). See #56931.
+  # This job block is duplicated verbatim in zeebe-search-integration-tests.yml --
+  # GHA has no way to share a job stanza across workflow files. Keep both in sync.
   build-distball:
     permissions:
       contents: read
@@ -81,6 +83,56 @@ jobs:
     secrets: inherit
     with:
       skip-artifact-upload: true  # no docker-checks-style GH-artifact consumer in this workflow
+
+  # If build-distball fails/is cancelled, every matrix job below is skipped by its
+  # needs: dependency (not failed), so their own send-slack-notification never runs.
+  # Without this job that failure would be silent on scheduled runs.
+  notify-build-distball-failure:
+    name: "Send slack notification on build-distball fail"
+    needs: build-distball
+    if: always() && (needs.build-distball.result == 'failure' || needs.build-distball.result == 'cancelled') && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify-slack-on-failure))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Import secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions DATA_ENGINE_CI_ALERT_WEBHOOK_URL;
+      - name: Send notification
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ steps.secrets.outputs.DATA_ENGINE_CI_ALERT_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            text: "Scheduled RDBMS Integration Tests shared build (build-distball) on ${{ github.ref_name }} failed or was cancelled — all matrix shards were skipped"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "Scheduled *RDBMS Integration Tests* shared build (`build-distball`) on *${{ github.ref_name }}* FAILED or WAS CANCELLED — every matrix shard was skipped as a result\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Send metrics about CI health
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "notify-build-distball-failure"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   rdbms-integration-tests:
     name: "RDBMS ${{ matrix.database-name }}"

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -71,13 +71,24 @@ jobs:
         id: read-versions
         uses: ./.github/actions/read-db-versions
 
+  # Builds the distball once and shares it with every matrix shard below via GCS,
+  # replacing a per-shard reactor build (~33 shards). See #56931.
+  build-distball:
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    uses: ./.github/workflows/ci-build-distball-reusable.yml
+    secrets: inherit
+    with:
+      skip-artifact-upload: true  # no docker-checks-style GH-artifact consumer in this workflow
+
   rdbms-integration-tests:
     name: "RDBMS ${{ matrix.database-name }}"
-    needs: [ generate-matrix ]
+    needs: [ generate-matrix, build-distball ]
     permissions:
       actions: write
       contents: read
-      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required to restore the shared distball from GCS
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -89,14 +100,15 @@ jobs:
       database-name: ${{ matrix.database-name }}
       it-database-type: ${{ matrix.it-database-type }}
       notify-slack-on-failure: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify-slack-on-failure) }}
+      use-shared-distball: true
 
   rdbms-history-tests:
     name: "RDBMS History Tests / ${{ matrix.database-name }}"
-    needs: [ generate-matrix ]
+    needs: [ generate-matrix, build-distball ]
     permissions:
       actions: write
       contents: read
-      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required to restore the shared distball from GCS
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -112,14 +124,15 @@ jobs:
       test-type-label: "History"
       runs-on: "gcp-perf-core-8-default"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify-slack-on-failure) }}
+      use-shared-distball: true
 
   rdbms-identity-tests:
     name: "RDBMS Identity Tests / ${{ matrix.database-name }}"
-    needs: [ generate-matrix ]
+    needs: [ generate-matrix, build-distball ]
     permissions:
       actions: write
       contents: read
-      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required to restore the shared distball from GCS
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -134,3 +147,4 @@ jobs:
       test-type: "identity-tests"
       test-type-label: "Identity"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.notify-slack-on-failure) }}
+      use-shared-distball: true

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -42,6 +42,8 @@ jobs:
 
   # Builds the distball once and shares it with every matrix shard below via GCS,
   # replacing a per-shard reactor build (~18 shards). See #56931.
+  # This job block is duplicated verbatim in zeebe-rdbms-integration-tests.yml --
+  # GHA has no way to share a job stanza across workflow files. Keep both in sync.
   build-distball:
     permissions:
       contents: read
@@ -50,6 +52,56 @@ jobs:
     secrets: inherit
     with:
       skip-artifact-upload: true  # no docker-checks-style GH-artifact consumer in this workflow
+
+  # If build-distball fails/is cancelled, every matrix job below is skipped by its
+  # needs: dependency (not failed), so their own send-slack-notification never runs.
+  # Without this job that failure would be silent on scheduled runs.
+  notify-build-distball-failure:
+    name: "Send slack notification on build-distball fail"
+    needs: build-distball
+    if: always() && (needs.build-distball.result == 'failure' || needs.build-distball.result == 'cancelled') && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Import secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/camunda/ci/github-actions DATA_ENGINE_CI_ALERT_WEBHOOK_URL;
+      - name: Send notification
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ steps.secrets.outputs.DATA_ENGINE_CI_ALERT_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            text: "Scheduled Search Integration Tests shared build (build-distball) on ${{ github.ref_name }} failed or was cancelled — all matrix shards were skipped"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "Scheduled *Search Integration Tests* shared build (`build-distball`) on *${{ github.ref_name }}* FAILED or WAS CANCELLED — every matrix shard was skipped as a result\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      # Send metrics about CI health
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "notify-build-distball-failure"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   search-integration-tests:
     name: "Search ${{ matrix.database-name }}"

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -40,13 +40,24 @@ jobs:
         id: read-versions
         uses: ./.github/actions/read-db-versions
 
+  # Builds the distball once and shares it with every matrix shard below via GCS,
+  # replacing a per-shard reactor build (~18 shards). See #56931.
+  build-distball:
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    uses: ./.github/workflows/ci-build-distball-reusable.yml
+    secrets: inherit
+    with:
+      skip-artifact-upload: true  # no docker-checks-style GH-artifact consumer in this workflow
+
   search-integration-tests:
     name: "Search ${{ matrix.database-name }}"
-    needs: [ generate-matrix ]
+    needs: [ generate-matrix, build-distball ]
     permissions:
       actions: write
       contents: read
-      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required to restore the shared distball from GCS
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -59,14 +70,15 @@ jobs:
       database-name: ${{ matrix.database-name }}
       it-database-type: ${{ matrix.it-database-type }}
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+      use-shared-distball: true
 
   search-history-tests:
     name: "Search History Tests / ${{ matrix.database-name }}"
-    needs: [ generate-matrix ]
+    needs: [ generate-matrix, build-distball ]
     permissions:
       actions: write
       contents: read
-      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required to restore the shared distball from GCS
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -83,14 +95,15 @@ jobs:
       test-type-label: "History"
       runs-on: "gcp-perf-core-8-default"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+      use-shared-distball: true
 
   search-identity-tests:
     name: "Search Identity Tests / ${{ matrix.database-name }}"
-    needs: [ generate-matrix ]
+    needs: [ generate-matrix, build-distball ]
     permissions:
       actions: write
       contents: read
-      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required to restore the shared distball from GCS
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -106,3 +119,4 @@ jobs:
       test-type: "identity-tests"
       test-type-label: "Identity"
       notify-slack-on-failure: ${{ github.event_name == 'schedule' }}
+      use-shared-distball: true


### PR DESCRIPTION
## Summary
- Extract ci.yml's `build-distball` job into a reusable workflow (`ci-build-distball-reusable.yml`), no behavior change for ci.yml.
- Wire `zeebe-search-integration-tests.yml` and `zeebe-rdbms-integration-tests.yml` to build the distball once and share it across their matrix shards (`use-shared-distball: true`), instead of every shard rebuilding the full zeebe reactor.
- Add a `notify-build-distball-failure` job to both standalone workflows so a shared-build failure on a scheduled run still pages Slack (previously each shard building its own distball meant a build failure surfaced as that shard's own failure and correctly notified; sharing one build meant a build-distball failure now skips every matrix job instead, silently, so the notification needed its own path).

## Measured impact
Verified live on this PR's own scheduled-workflow runs vs. main's same-day runs (2026-07-21):

|                                          | Search (15 shards) | RDBMS (48 shards) | Combined |
|------------------------------------------|--------------------|--------------------|----------|
| Reactor builds/run before → after        | 15 → 1             | 48 → 1             | 63 → 2   |
| Redundant build time before (Σ `build-zeebe` step) | 85.5 min    | 270.6 min          | 356.1 min |
| Build time after (shared build + restores) | 5.4 min           | 8.1 min            | 13.5 min |
| Build compute eliminated / run           | 80.1 min           | 262.5 min          | 342.6 min (5.71 hrs) |

Both run 5x/week (Mon-Fri schedule) → **~124 gcp-perf runner-hours/month** eliminated (~$21/mo at spot rates, ~$78/mo at on-demand, using the rate from the original #52693 extraction).

## Design notes
- The extracted job keeps the id `build-distball` in ci.yml, so its ~15 existing `needs: [..., build-distball]` dependents needed zero edits.
- Added a `skip-artifact-upload` input to skip the GH-artifact upload (only ci.yml's `docker-checks` consumes it) for the two standalone callers.
- No new GCS cleanup job for the standalone workflows — relies on the existing Infra-owned bucket TTL, same as ci.yml already does for failed runs.
- `runs-on` stays hardcoded (no new input) — all 3 callers use the same runner today.
- The `build-distball` job block (and now the `notify-build-distball-failure` job) is duplicated verbatim across the two standalone workflow files — GitHub Actions has no way to share a job stanza across files, so this is noted in a comment rather than eliminated.

Closes #56931

## Test plan
- [x] `actionlint` clean on all touched/new workflow files (no new warning categories vs `origin/main` baseline)
- [x] `conftest` policy check: 0 failures (only pre-existing warning classes, e.g. missing `print-metadata` on jobs that already lacked it)
- [x] `./mvnw spotless:apply` — no reformatting needed
- [x] Manual read-through: ci.yml's `needs: [..., build-distball]` job lists unchanged
- [x] Manual read-through: all 6 matrix jobs across the 2 standalone workflows gained `needs: [generate-matrix, build-distball]` + `use-shared-distball: true`
- [x] First run of both standalone workflows on this PR branch — confirmed shards restore from GCS instead of rebuilding (see Measured impact above)
- [x] Multi-angle diff review (self + Copilot) — addressed the one confirmed regression (silent Slack notification on build-distball failure); Copilot's other two comments (missing `id-token: write`, lost fork-PR fallback) were checked and are not accurate — the permission is present, and the pre-existing per-shard fallback needed the same Vault secrets forks don't get, so nothing that worked for forks was removed.