### PR TITLE
feat: per-physical-tenant AWS Aurora IAM credentials

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -19,6 +19,12 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   /** If true, the database schema is automatically created and updated on application startup. */
   private boolean autoDdl = DEFAULT_AUTO_DDL;
 
+  /**
+   * If true, connections authenticate via AWS IAM database authentication (Aurora/RDS) using the
+   * identity from {@code camunda.aws} instead of {@code password}.
+   */
+  private boolean awsEnabled = false;
+
   /** The prefix to use for all database artifacts like tables, indexes etc. */
   private String prefix;
 
@@ -100,6 +106,14 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setAutoDdl(final boolean autoDdl) {
     this.autoDdl = autoDdl;
+  }
+
+  public boolean isAwsEnabled() {
+    return awsEnabled;
+  }
+
+  public void setAwsEnabled(final boolean awsEnabled) {
+    this.awsEnabled = awsEnabled;
   }
 
   public String getPrefix() {

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/SearchEngineConnectPropertiesOverride.java
@@ -122,7 +122,7 @@ public class SearchEngineConnectPropertiesOverride {
       override.setPassword(database.getPassword());
     }
 
-    static void populateAws(final Aws aws, final AwsConfiguration target) {
+    public static void populateAws(final Aws aws, final AwsConfiguration target) {
       target.setAccessKey(aws.getAccessKey());
       target.setSecretKey(aws.getSecretKey());
       target.setSessionToken(aws.getSessionToken());

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -194,6 +194,7 @@ data.secondary-storage.rdbms.async-replication.min-sync-replicas
 data.secondary-storage.rdbms.async-replication.pause-on-max-lag-exceeded
 data.secondary-storage.rdbms.async-replication.polling-interval
 data.secondary-storage.rdbms.auto-ddl
+data.secondary-storage.rdbms.aws-enabled
 data.secondary-storage.rdbms.batch-operation-cache
 data.secondary-storage.rdbms.batch-operation-item-insert-block-size
 data.secondary-storage.rdbms.connection-pool.connection-timeout

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -74,6 +74,11 @@
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
     </dependency>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -402,7 +402,6 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>rds</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -70,9 +70,7 @@ public class MyBatisConfiguration {
   @Bean
   public RdbmsDataSources rdbmsDataSources(final PhysicalTenantResolver physicalTenantResolver)
       throws IOException {
-    return RdbmsDataSources.of(
-        physicalTenantResolver.mapValues(
-            camunda -> camunda.getData().getSecondaryStorage().getRdbms()));
+    return RdbmsDataSources.of(physicalTenantResolver.getAll());
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDataSources.java
@@ -8,6 +8,8 @@
 package io.camunda.application.commons.rdbms;
 
 import com.zaxxer.hikari.HikariDataSource;
+import io.camunda.configuration.Aws;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Rdbms;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.config.VendorDatabasePropertiesLoader;
@@ -51,16 +53,17 @@ public final class RdbmsDataSources implements AutoCloseable {
     this.databaseIdProviders = databaseIdProviders;
   }
 
-  public static RdbmsDataSources of(final Map<String, Rdbms> physicalTenantConfigs)
+  public static RdbmsDataSources of(final Map<String, Camunda> physicalTenantConfigs)
       throws IOException {
     final var dataSources = new LinkedHashMap<String, HikariDataSource>();
     final var vendorProperties = new LinkedHashMap<String, VendorDatabaseProperties>();
     final var databaseIdProviders = new LinkedHashMap<String, DatabaseIdProvider>();
     for (final var entry : physicalTenantConfigs.entrySet()) {
       final var currentPhysicalTenantId = entry.getKey();
-      final var rdbms = entry.getValue();
+      final var camunda = entry.getValue();
+      final var rdbms = camunda.getData().getSecondaryStorage().getRdbms();
       try {
-        final var ds = buildDataSource(currentPhysicalTenantId, rdbms);
+        final var ds = buildDataSource(currentPhysicalTenantId, rdbms, camunda.getAws());
         dataSources.put(currentPhysicalTenantId, ds);
         final var databaseIdProvider = new RdbmsDatabaseIdProvider(rdbms.getDatabaseVendorId());
         databaseIdProviders.put(currentPhysicalTenantId, databaseIdProvider);
@@ -124,15 +127,19 @@ public final class RdbmsDataSources implements AutoCloseable {
   }
 
   private static HikariDataSource buildDataSource(
-      final String physicalTenantId, final Rdbms rdbms) {
+      final String physicalTenantId, final Rdbms rdbms, final Aws aws) {
     final var ds = new HikariDataSource();
     ds.setPoolName("camunda-rdbms-" + physicalTenantId);
-    ds.setJdbcUrl(rdbms.getUrl());
-    ds.setUsername(rdbms.getUsername());
-    ds.setPassword(rdbms.getPassword());
-    final var driverClassName = DatabaseDriver.fromJdbcUrl(rdbms.getUrl()).getDriverClassName();
-    if (driverClassName != null) {
-      ds.setDriverClassName(driverClassName);
+    if (rdbms.isAwsEnabled()) {
+      ds.setDataSource(RdsIamAuthDataSource.of(rdbms, aws));
+    } else {
+      ds.setJdbcUrl(rdbms.getUrl());
+      ds.setUsername(rdbms.getUsername());
+      ds.setPassword(rdbms.getPassword());
+      final var driverClassName = DatabaseDriver.fromJdbcUrl(rdbms.getUrl()).getDriverClassName();
+      if (driverClassName != null) {
+        ds.setDriverClassName(driverClassName);
+      }
     }
     final var pool = rdbms.getConnectionPool();
     ds.setMaximumPoolSize(pool.getMaximumPoolSize());

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdsIamAuthDataSource.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdsIamAuthDataSource.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rdbms;
+
+import io.camunda.configuration.Aws;
+import io.camunda.configuration.Rdbms;
+import io.camunda.configuration.beanoverrides.SearchEngineConnectPropertiesOverride.Converter;
+import io.camunda.search.connect.aws.AwsCredentialsProviders;
+import io.camunda.search.connect.configuration.AwsConfiguration;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import javax.sql.DataSource;
+import software.amazon.awssdk.services.rds.RdsUtilities;
+
+/**
+ * {@link DataSource} authenticating via AWS IAM database authentication (Aurora/RDS): each new
+ * connection uses a freshly generated, short-lived authentication token as the password. Existing
+ * connections stay authenticated, so token expiry only affects connection creation.
+ */
+public final class RdsIamAuthDataSource implements DataSource {
+
+  private static final Pattern JDBC_URL =
+      Pattern.compile("^jdbc:(?<vendor>[a-z0-9]+)://(?<host>[^/:?]+)(?::(?<port>\\d+))?.*");
+  private static final Map<String, Integer> DEFAULT_PORTS =
+      Map.of("postgresql", 5432, "mysql", 3306, "mariadb", 3306);
+
+  private final String jdbcUrl;
+  private final String username;
+  private final String hostname;
+  private final int port;
+  private final RdsUtilities rdsUtilities;
+
+  private RdsIamAuthDataSource(
+      final String jdbcUrl,
+      final String username,
+      final String hostname,
+      final int port,
+      final RdsUtilities rdsUtilities) {
+    this.jdbcUrl = jdbcUrl;
+    this.username = username;
+    this.hostname = hostname;
+    this.port = port;
+    this.rdsUtilities = rdsUtilities;
+  }
+
+  public static RdsIamAuthDataSource of(final Rdbms rdbms, final Aws aws) {
+    final var awsConfiguration = new AwsConfiguration();
+    Converter.populateAws(aws, awsConfiguration);
+    final var rdsUtilities =
+        RdsUtilities.builder()
+            .credentialsProvider(AwsCredentialsProviders.from(awsConfiguration))
+            .region(AwsCredentialsProviders.region(awsConfiguration))
+            .build();
+    final var url = rdbms.getUrl();
+    final var matcher = JDBC_URL.matcher(url);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          "Cannot derive hostname and port for AWS IAM authentication from JDBC URL '%s'"
+              .formatted(url));
+    }
+    final var portGroup = matcher.group("port");
+    final var defaultPort = DEFAULT_PORTS.get(matcher.group("vendor"));
+    if (portGroup == null && defaultPort == null) {
+      throw new IllegalArgumentException(
+          "JDBC URL '%s' must declare an explicit port for AWS IAM authentication".formatted(url));
+    }
+    final var port = portGroup != null ? Integer.parseInt(portGroup) : defaultPort;
+    return new RdsIamAuthDataSource(
+        url, rdbms.getUsername(), matcher.group("host"), port, rdsUtilities);
+  }
+
+  @VisibleForTesting
+  String generateToken() {
+    return rdsUtilities.generateAuthenticationToken(
+        builder -> builder.hostname(hostname).port(port).username(username));
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    final var properties = new Properties();
+    properties.setProperty("user", username);
+    properties.setProperty("password", generateToken());
+    return DriverManager.getConnection(jdbcUrl, properties);
+  }
+
+  @Override
+  public Connection getConnection(final String username, final String password)
+      throws SQLException {
+    throw new SQLFeatureNotSupportedException(
+        "AWS IAM authentication does not support explicit credentials");
+  }
+
+  @Override
+  public PrintWriter getLogWriter() {
+    return null;
+  }
+
+  @Override
+  public void setLogWriter(final PrintWriter out) {}
+
+  @Override
+  public int getLoginTimeout() {
+    return 0;
+  }
+
+  @Override
+  public void setLoginTimeout(final int seconds) {}
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    throw new SQLFeatureNotSupportedException();
+  }
+
+  @Override
+  public <T> T unwrap(final Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return iface.cast(this);
+    }
+    throw new SQLException("Cannot unwrap to " + iface.getName());
+  }
+
+  @Override
+  public boolean isWrapperFor(final Class<?> iface) {
+    return iface.isInstance(this);
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/MyBatisConfigurationPerTenantIT.java
@@ -83,8 +83,7 @@ class MyBatisConfigurationPerTenantIT {
     final var env = new MockEnvironment();
     env.getPropertySources().addFirst(new MapPropertySource("test", props));
     final var resolver = PhysicalTenantResolver.of(env, new Camunda());
-    final var dataSources =
-        RdbmsDataSources.of(resolver.mapValues(c -> c.getData().getSecondaryStorage().getRdbms()));
+    final var dataSources = RdbmsDataSources.of(resolver.getAll());
     final var factories = MY_BATIS.sqlSessionFactories(dataSources, resolver);
     final var bundles = MY_BATIS.rdbmsMapperBundles(factories, dataSources);
     return new TenantFixture(dataSources, factories, bundles);

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDataSourcesTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 
 import com.zaxxer.hikari.HikariDataSource;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Rdbms;
 import io.camunda.configuration.RdbmsConnectionPool;
 import java.time.Duration;
@@ -36,11 +37,18 @@ class RdbmsDataSourcesTest {
     return rdbms;
   }
 
+  private static Camunda camundaWith(final Rdbms rdbms) {
+    final var camunda = new Camunda();
+    camunda.getData().getSecondaryStorage().setRdbms(rdbms);
+    return camunda;
+  }
+
   @Test
   void shouldBuildDataSourceForSinglePhysicalTenant() throws Exception {
     final var rdbms = h2Rdbms();
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWith(rdbms)))) {
 
       // then
       final var ds =
@@ -65,7 +73,8 @@ class RdbmsDataSourcesTest {
     rdbms.setConnectionPool(pool);
 
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rdbms))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWith(rdbms)))) {
 
       final var ds =
           (HikariDataSource) registry.dataSourceFor(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
@@ -80,9 +89,9 @@ class RdbmsDataSourcesTest {
 
   @Test
   void shouldDetectVendorPropertiesPerPhysicalTenant() throws Exception {
-    final var configs = new LinkedHashMap<String, Rdbms>();
-    configs.put("tenant-a", h2Rdbms());
-    configs.put("tenant-b", h2Rdbms());
+    final var configs = new LinkedHashMap<String, Camunda>();
+    configs.put("tenant-a", camundaWith(h2Rdbms()));
+    configs.put("tenant-b", camundaWith(h2Rdbms()));
 
     try (final var registry = RdbmsDataSources.of(configs)) {
       assertThat(registry.dataSourceFor("tenant-a")).isNotNull();
@@ -95,7 +104,8 @@ class RdbmsDataSourcesTest {
   @Test
   void shouldThrowWhenLookingUpUnknownPhysicalTenantDataSource() throws Exception {
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWith(h2Rdbms())))) {
       assertThatThrownBy(() -> registry.dataSourceFor("missing"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missing");
@@ -105,7 +115,8 @@ class RdbmsDataSourcesTest {
   @Test
   void shouldThrowWhenLookingUpUnknownPhysicalTenantVendorProperties() throws Exception {
     try (final var registry =
-        RdbmsDataSources.of(Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, h2Rdbms()))) {
+        RdbmsDataSources.of(
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWith(h2Rdbms())))) {
       assertThatThrownBy(() -> registry.vendorPropertiesFor("missing"))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("missing");
@@ -114,9 +125,9 @@ class RdbmsDataSourcesTest {
 
   @Test
   void shouldCloseAllDataSourcesOnClose() throws Exception {
-    final var configs = new LinkedHashMap<String, Rdbms>();
-    configs.put("tenant-a", h2Rdbms());
-    configs.put("tenant-b", h2Rdbms());
+    final var configs = new LinkedHashMap<String, Camunda>();
+    configs.put("tenant-a", camundaWith(h2Rdbms()));
+    configs.put("tenant-b", camundaWith(h2Rdbms()));
 
     final HikariDataSource dsA;
     final HikariDataSource dsB;
@@ -140,9 +151,9 @@ class RdbmsDataSourcesTest {
       final var tenantBRdbms = h2Rdbms();
       tenantBRdbms.setDatabaseVendorId("unsupported");
 
-      final var configs = new LinkedHashMap<String, Rdbms>();
-      configs.put("tenant-a", h2Rdbms());
-      configs.put("tenant-b", tenantBRdbms);
+      final var configs = new LinkedHashMap<String, Camunda>();
+      configs.put("tenant-a", camundaWith(h2Rdbms()));
+      configs.put("tenant-b", camundaWith(tenantBRdbms));
 
       // when / then
       assertThatThrownBy(() -> RdbmsDataSources.of(configs))

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdsIamAuthDataSourceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdsIamAuthDataSourceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Aws;
+import io.camunda.configuration.Rdbms;
+import org.junit.jupiter.api.Test;
+
+class RdsIamAuthDataSourceTest {
+
+  private static Rdbms rdbmsWithUrl(final String url) {
+    final var rdbms = new Rdbms();
+    rdbms.setUrl(url);
+    rdbms.setUsername("app-user");
+    rdbms.setAwsEnabled(true);
+    return rdbms;
+  }
+
+  private static Aws staticAws() {
+    final var aws = new Aws();
+    aws.setAccessKey("key");
+    aws.setSecretKey("secret");
+    aws.setRegion("eu-west-1");
+    return aws;
+  }
+
+  @Test
+  void shouldGenerateSignedTokenForConfiguredIdentity() {
+    // given
+    final var dataSource =
+        RdsIamAuthDataSource.of(
+            rdbmsWithUrl("jdbc:postgresql://db.example.com:5432/camunda"), staticAws());
+
+    // when
+    final var token = dataSource.generateToken();
+
+    // then the token is a presigned request for the configured endpoint, user, and identity
+    assertThat(token).startsWith("db.example.com:5432/");
+    assertThat(token).contains("DBUser=app-user");
+    assertThat(token).contains("X-Amz-Credential=key");
+    assertThat(token).contains("X-Amz-Signature=");
+  }
+
+  @Test
+  void shouldDefaultPortByVendorWhenUrlOmitsIt() {
+    // given
+    final var dataSource =
+        RdsIamAuthDataSource.of(
+            rdbmsWithUrl("jdbc:postgresql://db.example.com/camunda"), staticAws());
+
+    // when / then
+    assertThat(dataSource.generateToken()).startsWith("db.example.com:5432/");
+  }
+
+  @Test
+  void shouldRejectUrlWithoutHostname() {
+    assertThatThrownBy(() -> RdsIamAuthDataSource.of(rdbmsWithUrl("jdbc:h2:mem:test"), staticAws()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("jdbc:h2:mem:test");
+  }
+
+  @Test
+  void shouldRejectUrlWithoutPortForVendorWithoutDefault() {
+    assertThatThrownBy(
+            () ->
+                RdsIamAuthDataSource.of(
+                    rdbmsWithUrl("jdbc:sqlserver://db.example.com/camunda"), staticAws()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("explicit port");
+  }
+}


### PR DESCRIPTION
## Description

Implements the tenant-level AWS credentials ADR (#57218) for the RDBMS (Aurora) secondary storage. Stacked on #58209 (per-PT AWS OpenSearch credentials): based on that branch so the `camunda.aws` section, per-tenant merge, boot validation, and `AwsCredentialsProviders` are shared, not duplicated — only the last commit is new.

- New `camunda.data.secondary-storage.rdbms.aws-enabled` switch (default `false`), overridable per physical tenant via `camunda.physical-tenants.<id>.data.secondary-storage.rdbms.aws-enabled` like the rest of the rdbms block. When enabled, connections authenticate via AWS IAM database authentication using the tenant's resolved `camunda.aws` identity instead of `rdbms.password`. Tenant-specific `url`/`username` already ride the existing per-tenant override surface, so each tenant's pool can point at its own Aurora endpoint, database user, and IAM identity; a fully empty `camunda.aws` section falls back to the AWS SDK default provider chain, so env-var/IRSA/instance-profile deployments work with just the switch.
- `RdsIamAuthDataSource` is the single translation to the SDK: it derives hostname/port from the JDBC URL (explicit port, or the vendor default for postgresql/mysql/mariadb — anything else fails fast at boot), builds `RdsUtilities` from the same `AwsCredentialsProviders.from(...)`/`region(...)` used by the OpenSearch connector, and generates a fresh short-lived auth token as the password for each new connection. Existing connections stay authenticated, so token expiry (15 min) only affects pool growth/replacement, and IRSA token rotation needs no restarts.
- `RdbmsDataSources` now receives the full per-tenant `Camunda` (not just the `Rdbms` block) and, when `aws-enabled`, hands Hikari the IAM-authenticating datasource instead of jdbc-url/username/password; pool tuning, vendor detection, and the per-tenant registry are unchanged. The half-configured-identity boot validation from #58209 applies as-is — it validates the `aws` block per tenant regardless of which consumer uses it.

Dependency note: `software.amazon.awssdk:rds` moves from `runtime` to compile scope in `dist` (it was already staged and shipped; token generation now references it from code). The staged `aws-advanced-jdbc-wrapper` remains unused.

Follow-ups (per ADR): document store, S3 backup store, legacy Operate/Tasklist connectors, ES exporter. Additionally: user-facing docs for IAM prerequisites (Aurora IAM auth requires SSL on the JDBC URL and a `rds-db:connect` grant for the database user).

Closes #53494

## Checklist

- [x] Unit tests: config binding + golden per-tenant override surface, token generation/URL parsing/fail-fast validation, datasource registry wiring
- [x] Golden overridable-properties file regenerated