### PR TITLE
feat: reject physical tenants sharing an ES/OS lifecycle policy when retention enabled

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -70,6 +70,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
   private static final List<CrossTenantValidation> CROSS_TENANT_VALIDATIONS =
       List.of(
           new SecondaryStorageIsolationValidation(),
+          new RetentionPolicyIsolationValidation(),
           new SecondaryStorageTypeHomogeneityValidation(),
           new DocumentStoreIsolationValidation());
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/RetentionPolicyIdentity.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/RetentionPolicyIdentity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The identity of the ILM/ISM lifecycle policy a retention-enabled document-based (Elasticsearch /
+ * OpenSearch) physical tenant would create: {@code (type, connection, policyName)}.
+ *
+ * <p>Unlike {@link StorageIdentity}, the index prefix is deliberately <em>absent</em>: a lifecycle
+ * policy is a cluster-global named object (Elasticsearch {@code _ilm/policy/<name>}, OpenSearch
+ * {@code _plugins/_ism/policies/<name>}), not scoped to any index prefix. Two tenants that share a
+ * cluster but use distinct index prefixes — the explicitly-allowed "shared cluster, distinct
+ * prefix" setup under {@link SecondaryStorageIsolationValidation} — would nevertheless overwrite
+ * each other's lifecycle policy if they resolve to the same {@code (type, connection, policyName)}.
+ *
+ * <p>The {@code connection} is normalized by {@link StorageIdentity#connectionOf} so this rule and
+ * the index-isolation rule agree on what "the same cluster" means. The {@code policyName} is only
+ * trimmed — <em>not</em> lowercased — because lifecycle-policy names are case-sensitive identifiers
+ * on both engines. {@code type} discriminates Elasticsearch from OpenSearch, mirroring {@link
+ * StorageIdentity}: the two engines store policies in different subsystems.
+ *
+ * @param type the document-based secondary-storage type (elasticsearch or opensearch)
+ * @param connection the normalized, sorted connection url(s)
+ * @param policyName the trimmed lifecycle-policy name
+ */
+@NullMarked
+record RetentionPolicyIdentity(
+    SecondaryStorageType type, List<String> connection, String policyName) {
+
+  static RetentionPolicyIdentity of(
+      final SecondaryStorageType type, final DocumentBasedSecondaryStorageDatabase database) {
+    return new RetentionPolicyIdentity(
+        type, StorageIdentity.connectionOf(database), database.getHistory().getPolicyName().trim());
+  }
+
+  /** A human-readable rendering of this identity for error messages. */
+  String describe() {
+    final String connectionText =
+        connection.size() == 1 ? connection.get(0) : connection.toString();
+    return String.format(
+        "type=%s, connection=%s, policyName='%s'", type, connectionText, policyName);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/RetentionPolicyIsolationValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/RetentionPolicyIsolationValidation.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Cross-tenant rule: no two physical tenants with retention enabled may resolve to the same {@link
+ * RetentionPolicyIdentity} — the same ILM/ISM lifecycle policy on the same cluster.
+ *
+ * <p>When retention is enabled, each document-based (Elasticsearch/OpenSearch) tenant's schema
+ * manager creates a lifecycle policy named {@code
+ * data.secondary-storage.<database>.history.policy-name} on its target cluster. Because that policy
+ * is a cluster-global named object — <em>not</em> scoped to the tenant's index prefix — two tenants
+ * that share a cluster (an allowed setup when their index prefixes differ) would silently overwrite
+ * each other's policy unless they use distinct policy names. This rule complements {@link
+ * SecondaryStorageIsolationValidation}, which guards the indices themselves.
+ *
+ * <p>Only tenants with retention enabled participate: a tenant with retention disabled never
+ * creates a lifecycle policy and therefore cannot collide. RDBMS and {@code none} tenants have no
+ * ILM/ISM policy and are skipped.
+ *
+ * <p>The synthesized {@code default} tenant participates like any other. Single-tenant deployments
+ * resolve to a one-entry map and are a no-op. Colliding tenants are reported as a single grouped
+ * error, not O(n²) pairwise messages.
+ *
+ * <p><b>Out of scope:</b> the separate <em>usage-metrics</em> lifecycle policy. It is created with
+ * a fixed default name today and is not yet configurable through unified configuration; extending
+ * this rule to cover it is tracked by <a
+ * href="https://github.com/camunda/camunda/issues/58237">#58237</a>.
+ */
+@NullMarked
+class RetentionPolicyIsolationValidation implements CrossTenantValidation {
+
+  @Override
+  public void validate(final Map<String, Camunda> resolvedByTenant) {
+    if (resolvedByTenant.size() <= 1) {
+      // a single tenant cannot collide with anything
+      return;
+    }
+
+    final Map<RetentionPolicyIdentity, List<String>> tenantsByPolicy = new LinkedHashMap<>();
+    resolvedByTenant.forEach(
+        (tenantId, camunda) -> {
+          final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
+          if (!secondaryStorage.getRetention().isEnabled()) {
+            // retention disabled → no lifecycle policy is created → cannot collide
+            return;
+          }
+          // rdbms/none have no ILM/ISM policy; elasticsearchOrOpensearch() is empty for them
+          secondaryStorage
+              .elasticsearchOrOpensearch()
+              .ifPresent(
+                  database ->
+                      tenantsByPolicy
+                          .computeIfAbsent(
+                              RetentionPolicyIdentity.of(secondaryStorage.getType(), database),
+                              k -> new ArrayList<>())
+                          .add(tenantId));
+        });
+
+    final List<String> collisions = new ArrayList<>();
+    tenantsByPolicy.forEach(
+        (identity, tenantIds) -> {
+          if (tenantIds.size() > 1) {
+            collisions.add(
+                String.format(
+                    "tenants %s share the same lifecycle policy [%s]",
+                    tenantIds, identity.describe()));
+          }
+        });
+
+    if (!collisions.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Physical tenants with retention enabled must not share a secondary-storage lifecycle "
+              + "(ILM/ISM) policy, or they would overwrite each other's retention policy on the same "
+              + "cluster. Use a distinct data.secondary-storage.<database>.history.policy-name per "
+              + "tenant that shares a cluster. Conflicts: "
+              + String.join("; ", collisions));
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/StorageIdentity.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/StorageIdentity.java
@@ -128,7 +128,7 @@ record StorageIdentity(
    * The connection is the {@code urls} list when configured, otherwise the single {@code url}. Both
    * live on {@link SecondaryStorageDatabase} and are mutually exclusive (enforced at getter time).
    */
-  private static List<String> connectionOf(final SecondaryStorageDatabase<?> database) {
+  static List<String> connectionOf(final SecondaryStorageDatabase<?> database) {
     final List<String> urls = database.getUrls();
     final List<String> raw = (urls != null && !urls.isEmpty()) ? urls : List.of(database.getUrl());
     return raw.stream().map(StorageIdentity::normalizeUrl).sorted().toList();

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolverTest.java
@@ -355,6 +355,53 @@ class PhysicalTenantResolverTest {
   }
 
   @Test
+  void shouldRejectRetentionEnabledTenantsSharingLifecyclePolicyOnSharedCluster() {
+    // given two tenants on the same Elasticsearch cluster with distinct index prefixes (so the
+    // isolation rule passes) but both with retention enabled and the default policy name — the
+    // cluster-global ILM policy would be overwritten
+    setProperties(
+        Map.of(
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.retention.enabled", "true",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.retention.enabled", "true"),
+        "tenanta",
+        "tenantb");
+
+    // when / then resolution fails fast at boot on the shared lifecycle policy
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(this::newResolver)
+        .withMessageContaining("lifecycle");
+  }
+
+  @Test
+  void shouldResolveWhenSharedClusterButDistinctLifecyclePolicyNames() {
+    // given two retention-enabled tenants on the same cluster (distinct index prefixes) that give
+    // their history lifecycle policies distinct names
+    setProperties(
+        Map.of(
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.retention.enabled", "true",
+            "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.history.policy-name",
+                "tenanta-policy",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.retention.enabled", "true",
+            "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.history.policy-name",
+                "tenantb-policy"),
+        "tenanta",
+        "tenantb");
+
+    // when / then distinct policy names isolate the tenants — resolution succeeds
+    final PhysicalTenantResolver resolver = newResolver();
+    assertThat(resolver.getAll())
+        .containsOnlyKeys("tenanta", "tenantb", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Test
   void shouldRejectInvalidTenantIds() {
     // tenant ids must be lowercase alphanumeric — no underscores, no uppercase, no dashes
     // (dashes would make yaml and env-var forms address two different tenants).

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/RetentionPolicyIsolationValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/RetentionPolicyIsolationValidationTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit tests for the {@link RetentionPolicyIsolationValidation} cross-tenant rule: no two physical
+ * tenants with retention enabled may resolve to the same {@link RetentionPolicyIdentity} (they
+ * would overwrite each other's cluster-global ILM/ISM lifecycle policy).
+ */
+class RetentionPolicyIsolationValidationTest {
+
+  private static final String DEFAULT_POLICY = "camunda-retention-policy";
+
+  private final RetentionPolicyIsolationValidation validation =
+      new RetentionPolicyIsolationValidation();
+
+  @BeforeEach
+  void setUp() {
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldRejectTenantsSharingClusterAndDefaultPolicyName() {
+    // given two retention-enabled tenants on the same cluster, both left at the default policy name
+    // (the headline footgun: distinct index prefixes pass the isolation rule, yet the ILM policy is
+    // cluster-global and would be overwritten)
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", true, null),
+            "tenantb", es("http://es:9200", true, null));
+
+    // when / then the shared lifecycle policy is rejected, naming both tenants and the policy
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("http://es:9200")
+        .withMessageContaining(DEFAULT_POLICY);
+  }
+
+  @Test
+  void shouldRejectTenantsSharingClusterAndExplicitPolicyName() {
+    // given two retention-enabled tenants on the same cluster with the same explicit policy name
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", true, "shared-policy"),
+            "tenantb", es("http://es:9200", true, "shared-policy"));
+
+    // when / then the collision is rejected
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("shared-policy");
+  }
+
+  @Test
+  void shouldPassWhenSharedClusterButDistinctPolicyNames() {
+    // given two retention-enabled tenants on the same cluster with distinct policy names
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", true, "tenant-a-policy"),
+            "tenantb", es("http://es:9200", true, "tenant-b-policy"));
+
+    // when / then distinct policy names isolate the tenants — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenSamePolicyNameButDistinctClusters() {
+    // given two retention-enabled tenants using the same policy name but on distinct clusters
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es-a:9200", true, DEFAULT_POLICY),
+            "tenantb", es("http://es-b:9200", true, DEFAULT_POLICY));
+
+    // when / then distinct clusters mean the policies never overwrite each other — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldIgnoreTenantsWithRetentionDisabled() {
+    // given two tenants that would collide, but both have retention disabled
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", false, DEFAULT_POLICY),
+            "tenantb", es("http://es:9200", false, DEFAULT_POLICY));
+
+    // when / then retention disabled → no lifecycle policy is created → no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldOnlyConsiderRetentionEnabledTenants() {
+    // given two tenants sharing cluster + policy name, but only one has retention enabled
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", true, DEFAULT_POLICY),
+            "tenantb", es("http://es:9200", false, DEFAULT_POLICY));
+
+    // when / then only the retention-enabled tenant participates → single participant → no
+    // collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassForSingleTenantMap() {
+    // given a single-tenant deployment with retention enabled
+    final Map<String, Camunda> resolved =
+        tenants("default", es("http://es:9200", true, DEFAULT_POLICY));
+
+    // when / then uniqueness over one entry is a no-op
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectWhenDefaultTenantSharesPolicyWithExplicitTenant() {
+    // given the synthesized 'default' tenant and an explicit tenant resolve to the same policy
+    final Map<String, Camunda> resolved =
+        tenants(
+            "default", es("http://es:9200", true, DEFAULT_POLICY),
+            "tenanta", es("http://es:9200", true, DEFAULT_POLICY));
+
+    // when / then 'default' participates like any other tenant
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("default")
+        .withMessageContaining("tenanta");
+  }
+
+  @Test
+  void shouldReportOneGroupedErrorWhenThreeTenantsShareOnePolicy() {
+    // given three retention-enabled tenants all sharing the same cluster + policy name
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", true, DEFAULT_POLICY),
+            "tenantb", es("http://es:9200", true, DEFAULT_POLICY),
+            "tenantc", es("http://es:9200", true, DEFAULT_POLICY));
+
+    // when / then one grouped error lists all three (not three pairwise errors)
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("tenantc")
+        // a single grouped message mentions the shared policy exactly once
+        .satisfies(e -> assertThat(countOccurrences(e.getMessage(), DEFAULT_POLICY)).isEqualTo(1));
+  }
+
+  @Test
+  void shouldRejectOpensearchTenantsSharingClusterAndPolicyName() {
+    // given two retention-enabled OpenSearch tenants on the same cluster with the same policy name
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", os("http://os:9200", true, DEFAULT_POLICY),
+            "tenantb", os("http://os:9200", true, DEFAULT_POLICY));
+
+    // when / then the OpenSearch (ISM) collision is rejected
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb")
+        .withMessageContaining("opensearch");
+  }
+
+  @Test
+  void shouldTreatElasticsearchAndOpensearchAsDistinctLocations() {
+    // given one ES and one OS tenant whose urls and policy names happen to match
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://same:9200", true, DEFAULT_POLICY),
+            "tenantb", os("http://same:9200", true, DEFAULT_POLICY));
+
+    // when / then the engine type discriminates (ILM vs ISM subsystems) — no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldIgnoreRdbmsAndNoneTenants() {
+    // given rdbms/none tenants with retention enabled — they have no ILM/ISM lifecycle policy
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", rdbmsRetentionEnabled(),
+            "tenantb", rdbmsRetentionEnabled(),
+            "tenantc", noneRetentionEnabled());
+
+    // when / then non-document stores never create a lifecycle policy → no collision
+    assertThatCode(() -> validation.validate(resolved)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldTrimPolicyNameWhitespace() {
+    // given two tenants whose policy names differ only by surrounding whitespace — a config typo
+    final Map<String, Camunda> resolved =
+        tenants(
+            "tenanta", es("http://es:9200", true, "policy"),
+            "tenantb", es("http://es:9200", true, "  policy  "));
+
+    // when / then trimming folds them together → the likely-unintended collision is surfaced
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validation.validate(resolved))
+        .withMessageContaining("tenanta")
+        .withMessageContaining("tenantb");
+  }
+
+  // --- helpers -----------------------------------------------------------------------------------
+
+  private static Camunda es(
+      final String url, final boolean retentionEnabled, final String policyName) {
+    return documentBased(SecondaryStorageType.elasticsearch, url, retentionEnabled, policyName);
+  }
+
+  private static Camunda os(
+      final String url, final boolean retentionEnabled, final String policyName) {
+    return documentBased(SecondaryStorageType.opensearch, url, retentionEnabled, policyName);
+  }
+
+  private static Camunda documentBased(
+      final SecondaryStorageType type,
+      final String url,
+      final boolean retentionEnabled,
+      final String policyName) {
+    final Camunda camunda = new Camunda();
+    final var ss = camunda.getData().getSecondaryStorage();
+    ss.setType(type);
+    ss.getRetention().setEnabled(retentionEnabled);
+    final var database =
+        type == SecondaryStorageType.elasticsearch ? ss.getElasticsearch() : ss.getOpensearch();
+    database.setUrl(url);
+    if (policyName != null) {
+      database.getHistory().setPolicyName(policyName);
+    }
+    return camunda;
+  }
+
+  private static Camunda rdbmsRetentionEnabled() {
+    final Camunda camunda = new Camunda();
+    final var ss = camunda.getData().getSecondaryStorage();
+    ss.setType(SecondaryStorageType.rdbms);
+    ss.getRdbms().setUrl("jdbc:postgresql://db:5432/camunda");
+    ss.getRetention().setEnabled(true);
+    return camunda;
+  }
+
+  private static Camunda noneRetentionEnabled() {
+    final Camunda camunda = new Camunda();
+    final var ss = camunda.getData().getSecondaryStorage();
+    ss.setType(SecondaryStorageType.none);
+    ss.getRetention().setEnabled(true);
+    return camunda;
+  }
+
+  private static Map<String, Camunda> tenants(final Object... idThenCamunda) {
+    final Map<String, Camunda> map = new LinkedHashMap<>();
+    for (int i = 0; i < idThenCamunda.length; i += 2) {
+      map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
+    }
+    return map;
+  }
+
+  private static int countOccurrences(final String haystack, final String needle) {
+    int count = 0;
+    int from = 0;
+    while ((from = haystack.indexOf(needle, from)) >= 0) {
+      count++;
+      from += needle.length();
+    }
+    return count;
+  }
+}


### PR DESCRIPTION
## Description

An ILM/ISM retention lifecycle policy is a **cluster-global named object** (`_ilm/policy/<name>` on Elasticsearch, `_plugins/_ism/policies/<name>` on OpenSearch), created by `SchemaManager#createLifecyclePolicies` with the name resolved from `DocumentBasedHistory#getPolicyName` (default `camunda-retention-policy`). It is **not** scoped to a tenant's index prefix. So two retention-enabled physical tenants sharing a cluster with distinct index prefixes — a setup explicitly allowed by `SecondaryStorageIsolationValidation` (which guards indices, keyed on `(type, connection, index-prefix)`) — would silently overwrite each other's lifecycle policy: whichever tenant's schema manager runs last wins, and every sharing tenant inherits that tenant's `minimumAge`/policy definition. That is a hard-to-diagnose data-lifecycle footgun (data deleted too early, or never).

This PR adds `RetentionPolicyIsolationValidation`, a new `CrossTenantValidation` that rejects the collision fail-fast at boot, complementing the index-level isolation rule.

## What changed

- **`RetentionPolicyIdentity`** — identity record `(type, connection, policyName)`. Index prefix deliberately excluded (policies are cluster-global). Connection normalization is reused from `StorageIdentity#connectionOf` (bumped to package-private) so both rules agree on what "the same cluster" means; the policy name is trimmed but not lowercased (lifecycle-policy names are case-sensitive on both engines).
- **`RetentionPolicyIsolationValidation`** — groups tenants by identity and rejects any group larger than one with a single grouped `UnifiedConfigurationException`. Only tenants with retention enabled participate (a disabled tenant never creates a policy); only Elasticsearch/OpenSearch tenants are considered (RDBMS and `none` have no ILM/ISM policy), with ES and OS treated as distinct.
- Wired into `PhysicalTenantResolver.CROSS_TENANT_VALIDATIONS`.
- Tests: `RetentionPolicyIsolationValidationTest` (13 unit tests) plus two wiring tests in `PhysicalTenantResolverTest`.

## Why not other approaches

Including the index prefix in the key (as `StorageIdentity` does) would miss the collision entirely, since the policy is not prefix-scoped. Gating on retention being enabled avoids false positives for the common case where a shared cluster is intentional and no lifecycle policy is created.

## Out of scope

The separate **usage-metrics** lifecycle policy (`RetentionConfiguration#getUsageMetricsPolicyName`, fixed default `camunda-usage-metrics-retention-policy`) is not yet configurable through unified configuration; extending this check to cover it is tracked by #58237.

## Testing

`configuration` module: 1052 unit tests green. (Two pre-existing failing classes on `main` — `DocumentBasedSecondaryStorageDatabaseTest`, `SearchEngineSchemaManagerPropertiesOverrideTest`, both about legacy `createSchema` resolution — are unrelated to this change and were excluded.)

Closes #58296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
