### PR TITLE
test: add coverage for job activation priority order

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts
@@ -406,3 +406,74 @@ test.describe.parallel('Job Priority API Tests', () => {
     }).toPass(defaultAssertionOptions);
   });
 });
+
+test.describe.parallel('Activate Jobs API Tests - priority order', () => {
+  const runSuffix = randomUUID().slice(0, 8);
+  const processId = `processWithJobPriority-${runSuffix}`;
+  const priorityJobType = `priorityJobType-${runSuffix}`;
+  const processInstanceKeysToCancel: string[] = [];
+
+  test.beforeAll(async () => {
+    await deployWithSubstitutions('./resources/processWithJobPriority.bpmn', {
+      processWithJobPriority: processId,
+      priorityJobType: priorityJobType,
+    });
+  });
+
+  test.afterAll(async () => {
+    for (const processInstanceKey of processInstanceKeysToCancel) {
+      await cancelProcessInstance(processInstanceKey);
+    }
+  });
+
+  test('Activate Jobs - jobs of the same type are activated in descending priority order', async ({
+    request,
+  }) => {
+    const [processInstance] = await createInstances(processId, 1, 1);
+    processInstanceKeysToCancel.push(
+      String(processInstance.processInstanceKey),
+    );
+
+    await expect(async () => {
+      const res = await request.post(buildUrl('/jobs/search'), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: {$eq: processInstance.processInstanceKey},
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(json.items).toHaveLength(3);
+    }).toPass(defaultAssertionOptions);
+
+    const activatedPriorities: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await request.post(buildUrl('/jobs/activation'), {
+        headers: jsonHeaders(),
+        data: {
+          type: priorityJobType,
+          timeout: 10000,
+          maxJobsToActivate: 1,
+        },
+      });
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/jobs/activation',
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const json = await res.json();
+      expect(json.jobs).toHaveLength(1);
+      expect(json.jobs[0].priority).not.toBeUndefined();
+      activatedPriorities.push(json.jobs[0].priority);
+    }
+
+    expect(activatedPriorities).toEqual([90, 50, 10]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new `Activate Jobs API Tests - priority order` describe block to `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-api-tests.spec.ts`, reusing the `resources/processWithJobPriority.bpmn` fixture (3 service tasks of the same job type with static priorities 90/50/10) introduced in #57940.
- Verifies that repeated `POST /jobs/activation` calls (`maxJobsToActivate: 1`) return jobs of the same type in strictly descending priority order (90, then 50, then 10), and that the `priority` field is present on every returned `ActivatedJob`.
- Deploys its own process instance (isolated from the sibling `Job Priority API Tests` block) so activating/locking jobs here can't interfere with the search-focused assertions in that block.

Closes camunda/camunda#57922 (sub-issue of camunda/camunda#50567, linked to QA epic https://github.com/camunda/product-hub/issues/3615).

## Verification
- `npx tsc --noEmit`, `eslint`, `prettier --check` all pass clean on the changed file.
- Ran locally against a live `main` broker + Elasticsearch: activation ordering and `priority` field presence both verified passing.
- **On-demand E2E workflow run**: https://github.com/camunda/camunda/actions/runs/29827949196 — the new `Activate Jobs - jobs of the same type are activated in descending priority order` test **passed in all 4 API job variants** (`Mode all-in-one`, `Mode profiles`, `H2/RDBMS Mode all-in-one`, `H2/RDBMS Mode profiles`) and both E2E (UI) variants reported success overall. The 4 API job variants were each marked "failure", but every failing test is in `tests/api/v2/authorization/*.spec.ts` and `tests/api/v2/cluster-variables/*.spec.ts` — completely unrelated feature areas this PR does not touch (same pre-existing failure pattern documented in #57975's verification). The broker startup step for these jobs also logged transient Docker Hub registry timeout retries, consistent with infra flakiness rather than a regression from this change.

## Test plan
- [x] On-demand workflow run reviewed; new test passes in all variants, failures confirmed pre-existing and unrelated
- [ ] TestRail test case suite linked (https://camunda.testrail.com/index.php?/suites/view/17050)
