### PR TITLE
feat: add POST /v2/secrets/list endpoint

### DIFF
--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -68,6 +68,7 @@ import io.camunda.gateway.protocol.model.ResourceResult;
 import io.camunda.gateway.protocol.model.RoleCreateResult;
 import io.camunda.gateway.protocol.model.RoleUpdateResult;
 import io.camunda.gateway.protocol.model.SecretErrorCode;
+import io.camunda.gateway.protocol.model.SecretListResult;
 import io.camunda.gateway.protocol.model.SecretResolutionError;
 import io.camunda.gateway.protocol.model.SecretResolveResult;
 import io.camunda.gateway.protocol.model.SignalBroadcastResult;
@@ -702,6 +703,10 @@ public final class ResponseMapper {
       case ACCESS_DENIED -> SecretErrorCode.ACCESS_DENIED;
       case INVALID_REFERENCE -> SecretErrorCode.INVALID_REFERENCE;
     };
+  }
+
+  public static SecretListResult toSecretListResult(final List<String> references) {
+    return SecretListResult.Builder.create().references(references).build();
   }
 
   public static UserCreateResult toUserCreateResponse(final UserRecord userRecord) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/SecretRequestValidator.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/validator/SecretRequestValidator.java
@@ -10,6 +10,7 @@ package io.camunda.gateway.mapping.http.validator;
 import static io.camunda.gateway.mapping.http.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.gateway.mapping.http.validator.RequestValidator.validate;
 
+import io.camunda.gateway.protocol.model.SecretListRequest;
 import io.camunda.gateway.protocol.model.SecretResolveRequest;
 import java.util.Objects;
 import java.util.Optional;
@@ -49,5 +50,12 @@ public final class SecretRequestValidator {
             violations.add("The references list must not contain null entries.");
           }
         });
+  }
+
+  public static Optional<ProblemDetail> validateSecretListRequest(final SecretListRequest request) {
+    // The list request body is optional: a missing or null body (and the empty object) means "no
+    // filters", so there is nothing to reject here yet. Kept as the extension point for validating
+    // the filtering options this request is reserved to carry in the future.
+    return validate(violations -> {});
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/SecretAuthorizationIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.auth;
 
+import static io.camunda.client.api.search.enums.PermissionType.READ;
 import static io.camunda.client.api.search.enums.PermissionType.REVEAL;
 import static io.camunda.client.api.search.enums.ResourceType.SECRET;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,13 +39,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 /**
- * End-to-end authorization coverage for {@code POST /v2/secrets/resolve} against a real
- * authorization-enabled broker. Unlike {@code SecretControllerTest} and {@code SecretServicesTest}
- * (which mock the authorization stack), this exercises the real per-reference {@code SECRET:REVEAL}
- * check so the security guarantee is proven, not assumed.
+ * End-to-end authorization coverage for {@code POST /v2/secrets/resolve} and {@code POST
+ * /v2/secrets/list} against a real authorization-enabled broker. Unlike {@code
+ * SecretControllerTest} and {@code SecretServicesTest} (which mock the authorization stack), this
+ * exercises the real per-reference {@code SECRET:REVEAL} / {@code SECRET:READ} checks so the
+ * security guarantee is proven, not assumed.
  *
- * <p>The secret backend is mocked in Phase 1 (#56567): references in the service's mock allow-list
- * ({@code camunda.secrets.token} etc.) resolve to a placeholder value; authorization is real.
+ * <p>The secret backend is mocked in Phase 1 (#56567, #56568): references in the service's mock
+ * allow-list ({@code camunda.secrets.token} etc.) resolve to a placeholder value or are listed;
+ * authorization is real.
  */
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
@@ -63,9 +66,22 @@ class SecretAuthorizationIT {
   // Not in SecretServices#MOCK_RESOLVABLE_REFERENCES, so a wildcard-authorized lookup misses.
   private static final String UNKNOWN_REFERENCE = "camunda.secrets.doesnotexist";
 
+  // Under a physical tenant, secret authorization is resolved against root storage, so grants
+  // created for these test users are not visible in the tenant context and every authorized call
+  // is denied (same class of limitation as https://github.com/camunda/camunda/issues/58393). Tests
+  // that assert a granted or wildcard caller is authorized cannot pass there yet and are disabled
+  // in that mode; the unauthenticated and no-grant tests remain tenant-agnostic and still run.
+  private static final String PHYSICAL_TENANT_PROPERTY = "test.integration.camunda.physical-tenant";
+  private static final String PHYSICAL_TENANT_DISABLED_REASON =
+      "Secret authorization is resolved against root storage under a physical tenant, so grants for "
+          + "the test users are not visible in the tenant context; see "
+          + "https://github.com/camunda/camunda/issues/58393";
+
   private static final String REVEAL_USER = "revealUser";
   private static final String WILDCARD_USER = "wildcardUser";
   private static final String NO_PERMISSION_USER = "noPermissionUser";
+  private static final String READ_USER = "readUser";
+  private static final String WILDCARD_READ_USER = "wildcardReadUser";
 
   @UserDefinition
   private static final TestUser REVEAL_USER_DEF =
@@ -87,7 +103,27 @@ class SecretAuthorizationIT {
   private static final TestUser NO_PERMISSION_USER_DEF =
       new TestUser(NO_PERMISSION_USER, "password", List.of());
 
+  @UserDefinition
+  private static final TestUser READ_USER_DEF =
+      new TestUser(
+          READ_USER,
+          "password",
+          // Granted READ on GRANTED_REFERENCE only — not on OTHER_REFERENCE, and no REVEAL.
+          List.of(new Permissions(SECRET, READ, List.of(GRANTED_REFERENCE))));
+
+  @UserDefinition
+  private static final TestUser WILDCARD_READ_USER_DEF =
+      new TestUser(
+          WILDCARD_READ_USER,
+          "password",
+          // Granted READ on all references via the "*" wildcard.
+          List.of(new Permissions(SECRET, READ, List.of("*"))));
+
   @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
   void shouldResolveReferenceWhenAuthorizedOnThatReference(
       @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
     // when a user with SECRET:REVEAL on the reference resolves it
@@ -116,6 +152,10 @@ class SecretAuthorizationIT {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
   void shouldEnforceAuthorizationPerReferenceResourceId(
       @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
     // when a user granted only on GRANTED_REFERENCE resolves a batch of both references
@@ -131,6 +171,10 @@ class SecretAuthorizationIT {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
   void shouldResolveAnyReferenceWithWildcardGrant(
       @Authenticated(WILDCARD_USER) final CamundaClient client) throws Exception {
     // when a user granted SECRET:REVEAL:* resolves a reference it was not explicitly granted
@@ -144,6 +188,10 @@ class SecretAuthorizationIT {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
   void shouldReportNotFoundForAuthorizedUnknownReference(
       @Authenticated(WILDCARD_USER) final CamundaClient client) throws Exception {
     // when a wildcard-authorized user resolves a reference the mock backend does not know
@@ -193,6 +241,98 @@ class SecretAuthorizationIT {
         .hasValueSatisfying(value -> assertThat(value).contains("no-store"));
   }
 
+  @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
+  void shouldListAllReferencesWithWildcardReadGrant(
+      @Authenticated(WILDCARD_READ_USER) final CamundaClient client) throws Exception {
+    // when a user granted SECRET:READ:* lists references
+    final var response = list(client, WILDCARD_READ_USER);
+
+    // then every reference the mock backend knows is returned, names only
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(referenceNames(body.get("references")))
+        .containsExactlyInAnyOrder(GRANTED_REFERENCE, OTHER_REFERENCE, "camunda.secrets.b");
+  }
+
+  @Test
+  @DisabledIfSystemProperty(
+      named = PHYSICAL_TENANT_PROPERTY,
+      matches = ".+",
+      disabledReason = PHYSICAL_TENANT_DISABLED_REASON)
+  void shouldListOnlyAuthorizedReferenceWithScopedReadGrant(
+      @Authenticated(READ_USER) final CamundaClient client) throws Exception {
+    // when a user granted SECRET:READ on GRANTED_REFERENCE only lists references
+    final var response = list(client, READ_USER);
+
+    // then only the granted reference is returned, even though the backend knows more
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(referenceNames(body.get("references"))).containsExactly(GRANTED_REFERENCE);
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoReadGrant(
+      @Authenticated(NO_PERMISSION_USER) final CamundaClient client) throws Exception {
+    // when an authenticated user without any SECRET grant lists references
+    final var response = list(client, NO_PERMISSION_USER);
+
+    // then nothing is listed, even though the backend knows references
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(body.get("references")).isEmpty();
+  }
+
+  @Test
+  void shouldNotAuthorizeListingWithRevealOnlyGrant(
+      @Authenticated(REVEAL_USER) final CamundaClient client) throws Exception {
+    // when a user granted SECRET:REVEAL only (no SECRET:READ) lists references
+    final var response = list(client, REVEAL_USER);
+
+    // then the listing is empty: REVEAL does not imply READ
+    assertThat(response.statusCode()).isEqualTo(200);
+    final var body = read(response.body());
+    assertThat(body.get("references")).isEmpty();
+  }
+
+  @Test
+  void shouldRejectUnauthenticatedListRequest(
+      @Authenticated(WILDCARD_READ_USER) final CamundaClient client) throws Exception {
+    // when the list endpoint is called without credentials — the injected client is used only to
+    // discover the broker's REST base address; the request below carries no Authorization header
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/secrets/list"))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString("{}"))
+            .build();
+    final var response = HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+
+    // then it is rejected as unauthorized
+    assertThat(response.statusCode()).isEqualTo(401);
+  }
+
+  @Test
+  void shouldNotAllowDownstreamCachingOfListedReferences(
+      @Authenticated(WILDCARD_READ_USER) final CamundaClient client) throws Exception {
+    // Reference names are metadata, not values, but the response must still not be cached by an
+    // intermediary proxy or browser, consistent with every other authenticated endpoint. We do not
+    // set cache headers on the controller: they are expected from the shared Spring Security filter
+    // chain (Cache-Control: no-cache, no-store, max-age=0, must-revalidate).
+
+    // when a listing response is returned
+    final var response = list(client, WILDCARD_READ_USER);
+
+    // then it forbids downstream storage
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.headers().firstValue("Cache-Control"))
+        .as("list responses must not be cached downstream")
+        .hasValueSatisfying(value -> assertThat(value).contains("no-store"));
+  }
+
   /**
    * Issues a raw HTTP call to {@code POST /v2/secrets/resolve} authenticated as the given user. The
    * endpoint has no fluent Java client method yet.
@@ -211,6 +351,22 @@ class SecretAuthorizationIT {
     return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
   }
 
+  /**
+   * Issues a raw HTTP call to {@code POST /v2/secrets/list} authenticated as the given user. The
+   * endpoint has no fluent Java client method yet.
+   */
+  private static HttpResponse<String> list(final CamundaClient client, final String username)
+      throws Exception {
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/secrets/list"))
+            .header("Content-Type", "application/json")
+            .header("Authorization", basicAuthentication(username))
+            .POST(BodyPublishers.ofString("{}"))
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
   private static JsonNode read(final String body) throws Exception {
     return JSON.readTree(body);
   }
@@ -219,6 +375,10 @@ class SecretAuthorizationIT {
     return StreamSupport.stream(array.spliterator(), false)
         .map(item -> item.get("reference").asText())
         .toList();
+  }
+
+  private static List<String> referenceNames(final JsonNode array) {
+    return StreamSupport.stream(array.spliterator(), false).map(JsonNode::asText).toList();
   }
 
   private static String basicAuthentication(final String username) {

--- a/service/src/main/java/io/camunda/service/SecretServices.java
+++ b/service/src/main/java/io/camunda/service/SecretServices.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.SECRET_READ_AUTHORIZATION;
 import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
 
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -14,6 +15,7 @@ import io.camunda.security.api.model.authz.AuthorizationResourceMatcher;
 import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.config.AuthorizationsConfiguration;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.security.SecurityContextProvider;
@@ -32,15 +34,18 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Resolves a deduplicated batch of {@code camunda.secrets.<name>} references, checking {@code
- * SECRET:REVEAL} per reference. Each reference succeeds or fails independently; a denied or
+ * SECRET:REVEAL} per reference, and lists the references the caller is authorized to see, checking
+ * {@code SECRET:READ}. Each resolved reference succeeds or fails independently; a denied or
  * unresolvable reference is reported in {@link SecretResolution#errors()} rather than failing the
  * batch.
  *
- * <p><b>Phase 1 scope (#56567):</b> the per-reference authorization, deduplication, reference
- * validation and per-reference outcome routing are real. The secret value lookup itself is
- * <b>mocked</b> ({@link #mockResolve}); this endpoint does not yet use the {@code SecretStore}
- * wiring — that lands with #56561 / #57199. The sibling {@code SECRET:READ} list endpoint (#56568)
- * reuses this authorization/validation shape.
+ * <p><b>Phase 1 scope (#56567, #56568):</b> the per-reference authorization, deduplication,
+ * reference validation and per-reference outcome routing are real. The secret backend itself is
+ * <b>mocked</b> ({@link #mockResolve}, {@link #mockListReferences}); neither endpoint yet uses the
+ * {@code SecretStore} wiring. That wiring needs the physical-tenant {@code SecretStoreRegistry} to
+ * be reachable from this module, but the registry currently lives in {@code dist}, which this
+ * module cannot depend on without a cycle — resolving that dependency direction is tracked
+ * alongside #56561 / #57199.
  */
 @NullMarked
 public class SecretServices extends PhysicalTenantScopedApiServices<SecretServices> {
@@ -68,8 +73,10 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   // subsystems agree on what counts as a valid reference name for the same syntax.
   private static final Pattern REFERENCE_NAME_PATTERN = Pattern.compile("[\\p{Alnum}_]+");
 
-  // Phase 1 only: the references the mocked backend pretends to know. Any other authorized, valid
-  // reference resolves to NOT_FOUND. Removed once a real SecretStore is wired (#56561/#57199).
+  // Phase 1 only: the references the mocked backend pretends to know, shared by mockResolve and
+  // mockListReferences so a caller who lists then resolves sees consistent references. Any other
+  // authorized, valid reference resolves to NOT_FOUND and is absent from the listing. Removed once
+  // a real SecretStore is wired (#56561/#57199).
   private static final Set<String> MOCK_RESOLVABLE_REFERENCES =
       Set.of("camunda.secrets.token", "camunda.secrets.a", "camunda.secrets.b");
 
@@ -130,10 +137,11 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
       // Authorize before any lookup so an unauthorized caller never receives a value or learns
       // whether the secret exists. A single query covers the whole batch instead of one
       // authorization round-trip per reference.
-      final var authorizedReferences = resolveAuthorizedReferences(validReferences, authentication);
+      final var authorizedScopes =
+          retrieveAuthorizedScopes(authentication, SECRET_REVEAL_AUTHORIZATION);
 
       for (final var reference : validReferences) {
-        if (!authorizedReferences.contains(reference)) {
+        if (!authorizedScopes.authorizes(reference)) {
           LOG.debug(
               "Denied secret reveal of '{}' for {}",
               reference,
@@ -166,35 +174,62 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
   }
 
   /**
-   * Returns the subset of {@code validReferences} the caller holds {@code SECRET:REVEAL} on. Issues
-   * at most one authorization query for the whole batch, mirroring the bulk-fetch-then-
-   * locally-match pattern {@code DefaultResourceAccessProvider} uses for search pre-filtering,
-   * rather than one query per reference.
+   * Lists the references the caller holds {@code SECRET:READ} on, filtering the backend's full
+   * enumeration down to what the caller is authorized to see rather than accepting a
+   * caller-supplied batch (contrast {@link #resolve}).
+   *
+   * <p>Authorizes before enumerating, mirroring {@link #resolve}: a caller with no wildcard and no
+   * ID-scoped grant is denied everything, so the (mocked, but eventually store-backed) enumeration
+   * is never invoked for them. Once a real {@code SecretStore} is wired, that enumeration is a
+   * tenant-wide backend call with real cost (money, rate limits on AWS/GCP); skipping it for a
+   * zero-grant caller avoids paying that cost for a result that is discarded anyway.
+   *
+   * <p>Synchronous today for the same reason {@link #resolve} is (see its Javadoc).
    */
-  private Set<String> resolveAuthorizedReferences(
-      final List<String> validReferences, final CamundaAuthentication authentication) {
+  public CompletableFuture<List<String>> list(final CamundaAuthentication authentication) {
+    try {
+      final var authorizedScopes =
+          retrieveAuthorizedScopes(authentication, SECRET_READ_AUTHORIZATION);
+      if (!authorizedScopes.authorizesEverything() && authorizedScopes.isEmpty()) {
+        return CompletableFuture.completedFuture(List.of());
+      }
+      final var references = mockListReferences();
+      final var result = references.stream().filter(authorizedScopes::authorizes).toList();
+      return CompletableFuture.completedFuture(result);
+    } catch (final Exception ex) {
+      return CompletableFuture.failedFuture(ErrorMapper.mapError(ex));
+    }
+  }
+
+  /**
+   * Retrieves the caller's authorization scopes for {@code requiredAuthorization} in a single
+   * query, mirroring the bulk-fetch-then-locally-match pattern {@code
+   * DefaultResourceAccessProvider} uses for search pre-filtering, rather than one query per
+   * reference.
+   */
+  private AuthorizedScopes retrieveAuthorizedScopes(
+      final CamundaAuthentication authentication,
+      final RequiredAuthorization<?> requiredAuthorization) {
     // Matches DocumentServices#hasDocumentPermission: when authorization is disabled
     // cluster-wide, every reference is treated as authorized rather than denied. A deny-all here
     // would make the endpoint unusable in authorization-disabled setups (e.g. C8Run's default),
     // which the epic this endpoint serves explicitly targets.
     if (!authorizationsConfig.isEnabled()) {
-      return new LinkedHashSet<>(validReferences);
+      return AuthorizedScopes.everything();
     }
     final var authorizedScopes =
         authorizationChecker.retrieveAuthorizedAuthorizationScopes(
-            authentication, SECRET_REVEAL_AUTHORIZATION);
+            authentication, requiredAuthorization);
     if (authorizedScopes.contains(AuthorizationScope.WILDCARD)) {
-      // A SECRET:REVEAL:* grant authorizes every reference in the batch.
-      return new LinkedHashSet<>(validReferences);
+      // A wildcard grant authorizes every reference.
+      return AuthorizedScopes.everything();
     }
     final var authorizedResourceIds =
         authorizedScopes.stream()
             .filter(scope -> scope.getMatcher() == AuthorizationResourceMatcher.ID)
             .map(AuthorizationScope::getResourceId)
             .collect(Collectors.toSet());
-    return validReferences.stream()
-        .filter(authorizedResourceIds::contains)
-        .collect(Collectors.toCollection(LinkedHashSet::new));
+    return AuthorizedScopes.only(authorizedResourceIds);
   }
 
   private static boolean isValidReference(final String reference) {
@@ -222,6 +257,46 @@ public class SecretServices extends PhysicalTenantScopedApiServices<SecretServic
     }
     final var name = reference.substring(REFERENCE_PREFIX.length());
     return Optional.of("mock-value-for-" + name + "-in-tenant-" + getPhysicalTenantId());
+  }
+
+  /**
+   * Mocked reference enumeration for Phase 1, sharing {@link #MOCK_RESOLVABLE_REFERENCES} with
+   * {@link #mockResolve} so a caller who lists then resolves sees consistent references. Sorted for
+   * a deterministic response, since the backing {@link Set} has no defined iteration order.
+   * TODO(#56561/#57199): replace with {@code SecretStore.list(...)} once store wiring is reachable
+   * from this module (see the class Javadoc for why it is not yet).
+   */
+  private List<String> mockListReferences() {
+    return MOCK_RESOLVABLE_REFERENCES.stream().sorted().toList();
+  }
+
+  /**
+   * The caller's authorization scopes for one {@code RequiredAuthorization}, either "authorizes
+   * everything" (disabled cluster-wide authorization, or a wildcard grant) or a concrete set of
+   * authorized secret references.
+   *
+   * <p>Grants are keyed by the full {@code camunda.secrets.<name>} reference — the canonical FEEL
+   * reference that appears in the BPMN/FEEL expression — not the bare {@code <name>} segment. A
+   * permission grant on that string maps 1:1 to what a process author actually writes, and the same
+   * reference is the API-facing identifier in {@link #resolve} / {@link #list}, so the
+   * authorization resource id, the API name and the FEEL expression all agree on one identifier.
+   */
+  private record AuthorizedScopes(boolean authorizesEverything, Set<String> authorizedReferences) {
+    static AuthorizedScopes everything() {
+      return new AuthorizedScopes(true, Set.of());
+    }
+
+    static AuthorizedScopes only(final Set<String> authorizedReferences) {
+      return new AuthorizedScopes(false, authorizedReferences);
+    }
+
+    boolean isEmpty() {
+      return authorizedReferences.isEmpty();
+    }
+
+    boolean authorizes(final String reference) {
+      return authorizesEverything || authorizedReferences.contains(reference);
+    }
   }
 
   /** The per-reference outcome of a resolve request. */

--- a/service/src/main/java/io/camunda/service/authorization/Authorizations.java
+++ b/service/src/main/java/io/camunda/service/authorization/Authorizations.java
@@ -10,6 +10,7 @@ package io.camunda.service.authorization;
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.COMPONENT;
 import static io.camunda.security.api.model.authz.AuthorizationResourceType.SECRET;
 import static io.camunda.security.api.model.authz.PermissionType.ACCESS;
+import static io.camunda.security.api.model.authz.PermissionType.READ;
 import static io.camunda.security.api.model.authz.PermissionType.READ_TASK_LISTENER;
 import static io.camunda.security.api.model.authz.PermissionType.REVEAL;
 
@@ -113,6 +114,9 @@ public abstract class Authorizations {
 
   public static final RequiredAuthorization<Object> SECRET_REVEAL_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.resourceType(SECRET).permissionType(REVEAL));
+
+  public static final RequiredAuthorization<Object> SECRET_READ_AUTHORIZATION =
+      RequiredAuthorization.of(a -> a.resourceType(SECRET).permissionType(READ));
 
   public static final RequiredAuthorization<TenantEntity> TENANT_READER_AUTHORIZATION =
       RequiredAuthorization.of(a -> a.tenant().read());

--- a/service/src/test/java/io/camunda/service/SecretServicesTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesTest.java
@@ -7,8 +7,11 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.authorization.Authorizations.SECRET_READ_AUTHORIZATION;
+import static io.camunda.service.authorization.Authorizations.SECRET_REVEAL_AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -56,17 +59,38 @@ public class SecretServicesTest {
   }
 
   private void grantReveal(final String... references) {
-    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(any(), any()))
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_REVEAL_AUTHORIZATION)))
         .thenReturn(Arrays.stream(references).map(AuthorizationScope::id).toList());
   }
 
   private void grantRevealWildcard() {
-    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(any(), any()))
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_REVEAL_AUTHORIZATION)))
         .thenReturn(List.of(AuthorizationScope.WILDCARD));
   }
 
   private void denyAllReveals() {
-    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(any(), any()))
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_REVEAL_AUTHORIZATION)))
+        .thenReturn(List.of());
+  }
+
+  private void grantRead(final String... references) {
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_READ_AUTHORIZATION)))
+        .thenReturn(Arrays.stream(references).map(AuthorizationScope::id).toList());
+  }
+
+  private void grantReadWildcard() {
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_READ_AUTHORIZATION)))
+        .thenReturn(List.of(AuthorizationScope.WILDCARD));
+  }
+
+  private void denyAllReads() {
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_READ_AUTHORIZATION)))
         .thenReturn(List.of());
   }
 
@@ -277,6 +301,38 @@ public class SecretServicesTest {
   }
 
   @Test
+  void shouldNotListByBareSecretNameAlone() {
+    // given the checker grants only the bare name "a", not the canonical camunda.secrets.a
+    // reference
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_READ_AUTHORIZATION)))
+        .thenReturn(List.of(AuthorizationScope.id("a")));
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then nothing is listed: the authorization resource id is the full camunda.secrets.<name>
+    // reference, so a grant on the bare name alone does not match
+    assertThat(references).isEmpty();
+  }
+
+  @Test
+  void shouldNotEnumerateBackendWhenCallerHasNoReadGrant() {
+    // given the caller holds no SECRET:READ grant at all (no wildcard, no ID scope)
+    authorizationsConfig.setEnabled(true);
+    denyAllReads();
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then nothing is listed — the empty-grant short-circuit skips the (mocked, but eventually
+    // tenant-wide and costly) backend enumeration entirely rather than enumerating then filtering
+    // everything out
+    assertThat(references).isEmpty();
+  }
+
+  @Test
   void shouldAuthorizeExactlyTheGrantedResourceId() {
     // given the caller is granted REVEAL only on a different reference
     authorizationsConfig.setEnabled(true);
@@ -288,6 +344,25 @@ public class SecretServicesTest {
 
     // then the ungranted reference is denied — matching is by exact resource id, not a blanket
     // allow once any grant exists
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldNotAuthorizeByBareSecretNameAlone() {
+    // given the checker grants only the bare name "token", not the canonical camunda.secrets.token
+    // reference
+    authorizationsConfig.setEnabled(true);
+    when(authorizationChecker.retrieveAuthorizedAuthorizationScopes(
+            any(), eq(SECRET_REVEAL_AUTHORIZATION)))
+        .thenReturn(List.of(AuthorizationScope.id("token")));
+
+    // when the full reference for that name is resolved
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then it is denied: the authorization resource id is the full camunda.secrets.<name>
+    // reference, so a grant on the bare name alone does not match
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
   }
@@ -345,5 +420,95 @@ public class SecretServicesTest {
     // then values only ever live in resolved entries; error entries carry metadata only
     assertThat(resolution.resolved()).isEmpty();
     assertThat(resolution.errors().get(0).message()).doesNotContain("mock-value-for-");
+  }
+
+  @Test
+  void shouldListOnlyAuthorizedReferences() {
+    // given the caller is granted READ on one of the three known references
+    authorizationsConfig.setEnabled(true);
+    grantRead("camunda.secrets.a");
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then only the authorized reference is listed, via a single bulk authorization query
+    assertThat(references).containsExactly("camunda.secrets.a");
+    verify(authorizationChecker, times(1))
+        .retrieveAuthorizedAuthorizationScopes(any(), eq(SECRET_READ_AUTHORIZATION));
+  }
+
+  @Test
+  void shouldListAllKnownReferencesWithReadWildcardGrant() {
+    // given a SECRET:READ:* wildcard grant
+    authorizationsConfig.setEnabled(true);
+    grantReadWildcard();
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then every known reference is listed, in a stable sorted order
+    assertThat(references)
+        .containsExactly("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoReadGrant() {
+    // given the caller holds no SECRET:READ grant
+    authorizationsConfig.setEnabled(true);
+    denyAllReads();
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then nothing is listed, even though the backend knows references
+    assertThat(references).isEmpty();
+  }
+
+  @Test
+  void shouldListAllReferencesWhenAuthorizationIsDisabled() {
+    // given authorization is disabled cluster-wide. Matches DocumentServices#hasDocumentPermission:
+    // a deny-all here would make the endpoint unusable in authorization-disabled setups (e.g.
+    // C8Run's default), which the epic this endpoint serves explicitly targets.
+    authorizationsConfig.setEnabled(false);
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then every known reference is listed and the checker (which cannot be trusted while
+    // disabled) is never consulted
+    assertThat(references)
+        .containsExactly("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
+    verify(authorizationChecker, never())
+        .retrieveAuthorizedAuthorizationScopes(any(), eq(SECRET_READ_AUTHORIZATION));
+  }
+
+  @Test
+  void shouldNotAuthorizeListingWithRevealOnlyGrant() {
+    // given the caller holds SECRET:REVEAL on every known reference but no SECRET:READ
+    authorizationsConfig.setEnabled(true);
+    grantReveal("camunda.secrets.a", "camunda.secrets.b", "camunda.secrets.token");
+    denyAllReads();
+
+    // when
+    final var references = services.list(authentication).join();
+
+    // then nothing is listed: a REVEAL grant does not imply READ
+    assertThat(references).isEmpty();
+  }
+
+  @Test
+  void shouldNotAuthorizeRevealWithReadOnlyGrant() {
+    // given the caller holds SECRET:READ on a reference but no SECRET:REVEAL
+    authorizationsConfig.setEnabled(true);
+    grantRead("camunda.secrets.token");
+    denyAllReveals();
+
+    // when
+    final var resolution =
+        services.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then the reveal is denied: a READ grant does not imply REVEAL
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -477,9 +477,6 @@ components:
           enum:
             - ACTIVE
             - DELETED
-      x-properties-added-in-version:
-        - propertyName: state
-          addedInVersion: "8.10"
 
     ProcessDefinitionSearchQueryResult:
       type: object
@@ -543,9 +540,6 @@ components:
           enum:
             - ACTIVE
             - DELETED
-      x-properties-added-in-version:
-        - propertyName: state
-          addedInVersion: "8.10"
 
     ProcessDefinitionElementStatisticsQuery:
       description: Process definition element statistics request.

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -431,6 +431,8 @@ paths:
   # Secret endpoints
   /secrets/resolve:
     $ref: 'secrets.yaml#/paths/~1secrets~1resolve'
+  /secrets/list:
+    $ref: 'secrets.yaml#/paths/~1secrets~1list'
 
   # Setup endpoints
   /setup/user:

--- a/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/secrets.yaml
@@ -54,6 +54,49 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
       x-added-in-version: "8.10"
 
+  /secrets/list:
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Secret
+      operationId: listSecrets
+      x-permission-enforcement: filter
+      x-required-permissions:
+        - { resourceType: SECRET, permissionType: READ }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: List secrets (alpha)
+      description: |
+        List the `camunda.secrets.*` references known for the caller's physical tenant.
+
+        Only references the caller holds `SECRET:READ` on are returned. This endpoint never
+        returns secret values, only the reference names.
+
+        This endpoint is an alpha feature and may be subject to change in future releases.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecretListRequest'
+      responses:
+        "200":
+          description: The references the caller is authorized to see.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecretListResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+        "503":
+          $ref: 'common-responses.yaml#/components/responses/ServiceUnavailable'
+      x-added-in-version: "8.10"
+
 components:
   schemas:
     SecretResolveRequest:
@@ -130,3 +173,27 @@ components:
         - NOT_FOUND
         - ACCESS_DENIED
         - INVALID_REFERENCE
+    SecretListRequest:
+      type: object
+      additionalProperties: false
+      description: |
+        Reserved for future filtering options. Currently takes no properties. The request body is
+        optional: omitting it (or sending an empty object) applies no filters.
+    SecretListResult:
+      type: object
+      required:
+        - references
+      description: |
+        The secret references the caller is authorized to see.
+
+        Unbounded for now: Phase 1's backend is mocked with at most 3 references. Pagination is
+        expected to land here before GA, once a real secret store can return a tenant's full
+        enumeration in one response. This is an alpha endpoint, so that is not yet a
+        breaking-contract concern.
+      properties:
+        references:
+          type: array
+          description: The secret references, each of the form `camunda.secrets.<name>`.
+          items:
+            type: string
+            description: A secret reference of the form `camunda.secrets.<name>`.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SecretController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SecretController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.validator.SecretRequestValidator;
+import io.camunda.gateway.protocol.model.SecretListRequest;
 import io.camunda.gateway.protocol.model.SecretResolveRequest;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
@@ -54,6 +55,25 @@ public class SecretController {
     return RequestExecutor.executeServiceMethod(
         () -> secretServices.resolve(references, authentication),
         ResponseMapper::toSecretResolveResult,
+        HttpStatus.OK);
+  }
+
+  @CamundaPostMapping(path = "/list")
+  public CompletableFuture<ResponseEntity<Object>> listSecrets(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestBody(required = false) final SecretListRequest request) {
+    return SecretRequestValidator.validateSecretListRequest(request)
+        .<CompletableFuture<ResponseEntity<Object>>>map(
+            RestErrorMapper::mapProblemToCompletedResponse)
+        .orElseGet(() -> list(physicalTenantId));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> list(final String physicalTenantId) {
+    final var secretServices = serviceRegistry.secretServices(physicalTenantId);
+    final var authentication = authenticationProvider.getCamundaAuthentication();
+    return RequestExecutor.executeServiceMethod(
+        () -> secretServices.list(authentication),
+        ResponseMapper::toSecretListResult,
         HttpStatus.OK);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretControllerTest.java
@@ -45,6 +45,7 @@ import org.springframework.test.json.JsonCompareMode;
 public class SecretControllerTest extends RestControllerTest {
 
   static final String RESOLVE_URL = "/v2/secrets/resolve";
+  static final String LIST_URL = "/v2/secrets/list";
 
   @Captor ArgumentCaptor<List<String>> referencesCaptor;
   @MockitoBean SecretServices secretServices;
@@ -266,6 +267,107 @@ public class SecretControllerTest extends RestControllerTest {
         .expectStatus()
         .isBadRequest();
     verifyNoInteractions(secretServices);
+  }
+
+  @Test
+  void shouldReturnAuthorizedReferences() {
+    // given
+    when(secretServices.list(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("camunda.secrets.a")));
+
+    // when / then only reference names are returned; the schema has no value field to leak
+    webClient
+        .post()
+        .uri(LIST_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "references": ["camunda.secrets.a"] }""",
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldReturnEmptyReferencesWhenNoneAuthorized() {
+    // given
+    when(secretServices.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when / then
+    webClient
+        .post()
+        .uri(LIST_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            { "references": [] }""",
+            JsonCompareMode.STRICT);
+  }
+
+  @Test
+  void shouldTreatNullListRequestBodyAsNoFilters() {
+    // given a literal JSON null body (deserialized as a null request)
+    when(secretServices.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when / then the body is optional, so a null body applies no filters and still reaches the
+    // service rather than being rejected
+    webClient
+        .post()
+        .uri(LIST_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("null")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+    verify(secretServices).list(any());
+  }
+
+  @Test
+  void shouldTreatMissingListRequestBodyAsNoFilters() {
+    // given no request body at all
+    when(secretServices.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when / then the body is optional, so omitting it applies no filters and still reaches the
+    // service — clients need not send an empty object
+    webClient
+        .post()
+        .uri(LIST_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+    verify(secretServices).list(any());
+  }
+
+  @Test
+  void shouldForwardAuthenticationToServiceOnList() {
+    // given
+    when(secretServices.list(any())).thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    // when
+    webClient
+        .post()
+        .uri(LIST_URL)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    // then
+    verify(secretServices).list(eq(AUTHENTICATION_WITH_DEFAULT_TENANT));
   }
 
   private static String referencesJson(final int count) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretRequestValidatorSpecSyncTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/SecretRequestValidatorSpecSyncTest.java
@@ -29,10 +29,16 @@ import org.junit.jupiter.api.Test;
  * {@code zeebe-gateway-protocol} dependency) rather than through an OpenAPI parser: the file is a
  * fragment referenced piecemeal by {@code rest-api.yaml} ($ref per path item, not per schema), so a
  * full-spec parse does not reliably resolve its schemas back onto a single root document.
+ *
+ * <p>Extraction is scoped to the {@code SecretResolveRequest} schema block (up to the next
+ * top-level schema key), not the whole file: other schemas in {@code secrets.yaml} may later
+ * declare their own {@code maxItems}/{@code maxLength} constraints (e.g. pagination on {@code
+ * SecretListResult}), and this test must not break when they do.
  */
 class SecretRequestValidatorSpecSyncTest {
 
   private static final String SECRETS_YAML_CLASSPATH_RESOURCE = "v2/secrets.yaml";
+  private static final String SCHEMA_UNDER_TEST = "SecretResolveRequest";
 
   @Test
   void shouldMatchMaxBatchSizeDeclaredInSpec() {
@@ -54,20 +60,41 @@ class SecretRequestValidatorSpecSyncTest {
 
   private static int extractIntValue(final String yamlKey) {
     final var pattern = Pattern.compile(yamlKey + ":\\s*(\\d+)");
-    final Matcher matcher = pattern.matcher(secretsYaml());
+    final Matcher matcher = pattern.matcher(schemaUnderTest());
     if (!matcher.find()) {
       throw new AssertionError(
-          "Expected '%s' to declare a '%s' constraint, but none was found."
-              .formatted(SECRETS_YAML_CLASSPATH_RESOURCE, yamlKey));
+          "Expected the '%s' schema in '%s' to declare a '%s' constraint, but none was found."
+              .formatted(SCHEMA_UNDER_TEST, SECRETS_YAML_CLASSPATH_RESOURCE, yamlKey));
     }
     final var value = Integer.parseInt(matcher.group(1));
     if (matcher.find()) {
       throw new AssertionError(
-          "Expected '%s' to declare exactly one '%s' constraint, but found more than one. "
-                  .formatted(SECRETS_YAML_CLASSPATH_RESOURCE, yamlKey)
+          "Expected the '%s' schema in '%s' to declare exactly one '%s' constraint, but found "
+              + "more than one. "
+                  .formatted(SCHEMA_UNDER_TEST, SECRETS_YAML_CLASSPATH_RESOURCE, yamlKey)
               + "Narrow this test's extraction so it targets the right occurrence.");
     }
     return value;
+  }
+
+  /**
+   * Slices {@code secrets.yaml} down to the {@code SecretResolveRequest} schema block: from its
+   * declaration to the next top-level ({@code schemaName:}, 4-space indented) schema key.
+   */
+  private static String schemaUnderTest() {
+    final var yaml = secretsYaml();
+    final var start = yaml.indexOf(SCHEMA_UNDER_TEST + ":");
+    if (start < 0) {
+      throw new AssertionError(
+          "Expected '%s' to declare a '%s' schema, but none was found."
+              .formatted(SECRETS_YAML_CLASSPATH_RESOURCE, SCHEMA_UNDER_TEST));
+    }
+    final var nextSchema =
+        Pattern.compile("\\n {4}\\w+:")
+            .matcher(yaml)
+            .region(start + SCHEMA_UNDER_TEST.length(), yaml.length());
+    final var end = nextSchema.find() ? nextSchema.start() : yaml.length();
+    return yaml.substring(start, end);
   }
 
   private static String secretsYaml() {


### PR DESCRIPTION
depends on https://github.com/camunda/camunda/pull/57909
Rebase once https://github.com/camunda/camunda/pull/57909 is merged

## Description

Lists camunda.secrets.* references caller authorised for (SECRET:READ), names only, no values.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56568 
