### PR TITLE
fix: recover the latest appended Raft configuration at startup

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -46,9 +46,13 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Manages the persistent state of the Raft cluster from the perspective of a single server. */
 public final class RaftClusterContext implements RaftCluster, AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RaftClusterContext.class);
+
   private final RaftContext raft;
   private final DefaultRaftMember localMember;
   private final Map<MemberId, RaftMemberContext> remoteMemberContexts = new HashMap<>();
@@ -75,13 +79,17 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     raft.getThreadContext()
         .execute(
             () -> {
-              // If a configuration is stored, use the stored configuration, otherwise configure the
-              // server
-              // with the user provided configuration.
+              // Start from the stored configuration, which reflects the newest committed
+              // configuration, and apply any newer configuration entry from the log on top:
+              // configurations take effect as soon as they are appended, so an appended but not
+              // yet committed configuration must survive a restart. Only if neither source has a
+              // configuration, configure the server with the user provided configuration.
               final var storedConfiguration = raft.getMetaStore().loadConfiguration();
               if (storedConfiguration != null) {
                 updateConfiguration(storedConfiguration);
-              } else {
+              }
+              reloadConfigurationFromLog();
+              if (configuration == null) {
                 createInitialConfig(cluster);
               }
               raft.transition(localMember.getType());
@@ -302,10 +310,28 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
    */
   public void reloadConfigurationFromLog() {
     raft.checkThread();
+    final var currentConfiguration = configuration;
+    if (currentConfiguration != null && currentConfiguration.force()) {
+      // A forced configuration is authoritative until a new leader appends the configuration that
+      // leaves the forced state. The log may still contain a stale, higher-index configuration
+      // entry from a reconfiguration that was in flight before the force - recovering it would
+      // resurrect exactly the configuration that the force configure was meant to replace. The
+      // force-leaving configuration is not needed from the log either, a leader will disseminate
+      // it via configure requests.
+      return;
+    }
     IndexedRaftLogEntry lastConfigurationEntry = null;
     // The reader needs to be uncommitted because the configuration entry might not be committed yet
     // on this node, but committed on the leader already.
     try (final var reader = raft.getLog().openUncommittedReader()) {
+      if (currentConfiguration != null) {
+        // Entries covered by the current configuration or the commit index can be skipped: the
+        // configuration guard ignores older indexes anyway, and a committed configuration entry is
+        // always persisted before the commit index that covers it, so it is already reflected in
+        // the current configuration. Without a current configuration (the join path and members
+        // without a meta store), the whole log has to be searched.
+        reader.seek(Math.max(currentConfiguration.index(), raft.getCommitIndex()) + 1);
+      }
       while (reader.hasNext()) {
         final var entry = reader.next();
         if (entry.entry() instanceof ConfigurationEntry) {
@@ -314,6 +340,10 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
       }
       if (lastConfigurationEntry != null) {
         final var configurationEntry = (ConfigurationEntry) lastConfigurationEntry.entry();
+        LOGGER.info(
+            "Reloading configuration {} from log entry at index {}",
+            configurationEntry,
+            lastConfigurationEntry.index());
         configure(
             new Configuration(
                 lastConfigurationEntry.index(),

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -26,6 +26,8 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.impl.ReconfigurationHelper;
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
+import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.utils.JointConsensusVoteQuorum;
 import io.atomix.raft.utils.SimpleVoteQuorum;
@@ -291,6 +293,37 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
       configure(storedConfiguration);
     }
     return this;
+  }
+
+  /**
+   * Applies the newest configuration entry from the log if it is newer than the current
+   * configuration. Configurations take effect as soon as they are appended, so the newest
+   * configuration entry in the log is authoritative, whether it is committed or not.
+   */
+  public void reloadConfigurationFromLog() {
+    raft.checkThread();
+    IndexedRaftLogEntry lastConfigurationEntry = null;
+    // The reader needs to be uncommitted because the configuration entry might not be committed yet
+    // on this node, but committed on the leader already.
+    try (final var reader = raft.getLog().openUncommittedReader()) {
+      while (reader.hasNext()) {
+        final var entry = reader.next();
+        if (entry.entry() instanceof ConfigurationEntry) {
+          lastConfigurationEntry = entry;
+        }
+      }
+      if (lastConfigurationEntry != null) {
+        final var configurationEntry = (ConfigurationEntry) lastConfigurationEntry.entry();
+        configure(
+            new Configuration(
+                lastConfigurationEntry.index(),
+                lastConfigurationEntry.term(),
+                configurationEntry.timestamp(),
+                configurationEntry.newMembers(),
+                configurationEntry.oldMembers(),
+                false));
+      }
+    }
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -291,26 +291,6 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
   }
 
   /**
-   * Resets the cluster state to the persisted state.
-   *
-   * <p>This cannot revert an appended-but-uncommitted configuration: the stored configuration is
-   * applied through {@link #configure(Configuration)}, which ignores configurations with an index
-   * at or below the current one, and the stored index never exceeds the in-memory index because
-   * configurations are persisted on commit only. That guard is what makes calling this on term
-   * changes safe - a member must keep operating under the newest configuration in its log,
-   * committed or not.
-   *
-   * @return The cluster state.
-   */
-  public RaftClusterContext reset() {
-    final var storedConfiguration = raft.getMetaStore().loadConfiguration();
-    if (storedConfiguration != null) {
-      configure(storedConfiguration);
-    }
-    return this;
-  }
-
-  /**
    * Applies the newest configuration entry from the log if it is newer than the current
    * configuration. Configurations take effect as soon as they are appended, so the newest
    * configuration entry in the log is authoritative, whether it is committed or not.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -293,6 +293,13 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
   /**
    * Resets the cluster state to the persisted state.
    *
+   * <p>This cannot revert an appended-but-uncommitted configuration: the stored configuration is
+   * applied through {@link #configure(Configuration)}, which ignores configurations with an index
+   * at or below the current one, and the stored index never exceeds the in-memory index because
+   * configurations are persisted on commit only. That guard is what makes calling this on term
+   * changes safe - a member must keep operating under the newest configuration in its log,
+   * committed or not.
+   *
    * @return The cluster state.
    */
   public RaftClusterContext reset() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -581,7 +581,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       }
       raftLog.setCommitIndex(commitIndex);
       this.commitIndex = commitIndex;
-      meta.storeCommitIndex(commitIndex);
       final var clusterConfig = cluster.getConfiguration();
       if (clusterConfig != null) {
         final long configurationIndex = clusterConfig.index();
@@ -589,6 +588,13 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
           cluster.commitCurrentConfiguration();
         }
       }
+      // Persist the commit index only after the configuration it covers is persisted. This keeps
+      // the invariant that a committed configuration entry at or below the stored commit index is
+      // always recoverable from the meta store, so startup only needs to search the uncommitted
+      // part of the log for configuration entries. The reverse order would allow a crash to leave
+      // a stored commit index covering a configuration that is in neither the meta store nor,
+      // after restart, in memory.
+      meta.storeCommitIndex(commitIndex);
       replicationMetrics.setCommitIndex(commitIndex);
       notifyCommitListeners(commitIndex);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -219,7 +219,19 @@ public final class ReconfigurationHelper {
                     raftContext.getCluster().getVotingMembers().stream()
                         .map(RaftMember::memberId)
                         .findAny())
-            .orElseThrow();
+            .orElse(null);
+    if (receiver == null) {
+      // The local member is the last voting member left but has not elected itself leader yet, as
+      // when the second-to-last member just left. Fail with the same error a member without a
+      // known leader would respond with so that the caller retries after the election. Throwing
+      // here instead would crash the raft thread and permanently transition to inactive.
+      future.completeExceptionally(
+          new RaftError(
+                  RaftError.Type.NO_LEADER,
+                  "Cannot leave, no leader is known and there is no other voting member to receive the leave request. Retry after a leader is elected.")
+              .createException());
+      return;
+    }
     raftContext
         .getProtocol()
         .leave(receiver, LeaveRequest.builder().withLeavingMember(leaving).build())

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -22,8 +22,6 @@ import io.atomix.raft.protocol.JoinRequest;
 import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.TransferRequest;
-import io.atomix.raft.storage.log.IndexedRaftLogEntry;
-import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.utils.ForceConfigureQuorum;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -58,8 +56,15 @@ public final class ReconfigurationHelper {
     final var result = new CompletableFuture<Void>();
     threadContext.execute(
         () -> {
+          // If the previous join was partially or fully completed, i.e. committed the first
+          // configuration with joint consensus or committed the final configuration, then in the
+          // next retry, this member can already start with that configuration. This is mainly
+          // required if the member is joining a single member cluster, making the quorum 2 out of
+          // 2. If this member did not re-start in the ACTIVE state when the other node has already
+          // included it in the quorum, then the other member cannot become leader and continue the
+          // reconfiguration step.
           try {
-            tryReloadConfigurationFromLog();
+            raftContext.getCluster().reloadConfigurationFromLog();
           } catch (final Exception e) {
             LOGGER.warn("Failed to join cluster, could not reload configuration from log", e);
             result.completeExceptionally(e);
@@ -67,7 +72,7 @@ public final class ReconfigurationHelper {
           }
 
           // Always transition to PASSIVE or the last member type as found by
-          // `tryReloadConfigurationFromLog`.
+          // `reloadConfigurationFromLog`.
           // This ensures that the member trying to join is not stuck in `INACTIVE` which would
           // prevent the joining from completing, particularly when joining a single-member cluster
           // where this new node is already required for quorum.
@@ -109,42 +114,6 @@ public final class ReconfigurationHelper {
           threadContext.execute(() -> joinWithRetry(joining, assistingMembers, result, deadline));
         });
     return result;
-  }
-
-  /**
-   * If the previous join was partially or fully completed, i.e. committed the first configuration
-   * with joint consensus or committed the final configuration, then in the next retry, this member
-   * can already start with that configuration. This is mainly required if the member is joining to
-   * a single member cluster, making the quorum to 2 out of 2. If this member did not re-start in
-   * the ACTIVE state when the other node has already included it in the quorum, then the other
-   * member cannot become leader and continue the reconfiguration step.
-   */
-  private void tryReloadConfigurationFromLog() {
-    IndexedRaftLogEntry lastConfigurationEntry = null;
-    // The reader needs to be uncommitted because the configuration entry might not be committed yet
-    // on this node, but committed on the leader already.
-    try (final var reader = raftContext.getLog().openUncommittedReader()) {
-      while (reader.hasNext()) {
-        final var entry = reader.next();
-        if (entry.entry() instanceof ConfigurationEntry) {
-          lastConfigurationEntry = entry;
-        }
-      }
-      if (lastConfigurationEntry != null) {
-        final ConfigurationEntry configurationEntry =
-            (ConfigurationEntry) lastConfigurationEntry.entry();
-        raftContext
-            .getCluster()
-            .configure(
-                new Configuration(
-                    lastConfigurationEntry.index(),
-                    lastConfigurationEntry.term(),
-                    configurationEntry.timestamp(),
-                    configurationEntry.newMembers(),
-                    configurationEntry.oldMembers(),
-                    false));
-      }
-    }
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -164,24 +164,28 @@ public final class ReconfigurationHelper {
               } else if (response.status() == Status.OK) {
                 LOGGER.debug("Join request accepted");
                 result.complete(null);
-              } else if (response.error().type() == RaftError.Type.NO_LEADER) {
+              } else if (response.error().type() == RaftError.Type.NO_LEADER
+                  || response.error().type() == RaftError.Type.CONFIGURATION_ERROR) {
                 if (Instant.now().isBefore(deadline)) {
                   LOGGER.debug(
                       "Join request failed, retrying after {}",
                       raftContext.getElectionTimeout(),
                       response.error().createException());
-                  // The member is reachable but doesn't know a leader yet. Re-offer it so that,
-                  // after falling over to the remaining members, it is retried once a new leader
-                  // could be elected. The election may depend on this join attempt: while the
-                  // join is in flight, this server is a passive member that answers polls and
-                  // votes.
+                  // The member is reachable but doesn't know a leader yet, or the leader cannot
+                  // make configuration changes yet. Re-offer it so that, after falling over to the
+                  // remaining members, it is retried once the cluster made progress. That progress
+                  // may depend on this join attempt: while the join is in flight, this server is a
+                  // passive member that answers polls and votes and accepts appends. For example,
+                  // a leader that recovered an uncommitted joint configuration cannot commit its
+                  // initialization entry - and thus rejects configuration changes - until the
+                  // joining member acknowledged it.
                   assistingMembers.offer(receiver);
                   threadContext.schedule(
                       raftContext.getElectionTimeout(),
                       () -> joinWithRetry(joining, assistingMembers, result, deadline));
                 } else {
                   LOGGER.error(
-                      "Join request failed, not retrying because no leader was elected within {}",
+                      "Join request failed, not retrying because the join did not complete within {}",
                       raftContext.getConfigurationChangeTimeout(),
                       response.error().createException());
                   result.completeExceptionally(response.error().createException());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
@@ -125,10 +125,6 @@ public abstract class AbstractRole implements RaftRole {
         || (term == raft.getTerm() && raft.getLeader() == null && leader != null)) {
       raft.setTerm(term);
       raft.setLeader(leader);
-
-      // Reset the current cluster configuration to the last committed configuration when a leader
-      // change occurs.
-      raft.getCluster().reset();
       return true;
     }
     return false;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -310,6 +310,27 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             });
   }
 
+  @Override
+  public CompletableFuture<PollResponse> onPoll(final PollRequest request) {
+    logRequest(request);
+
+    // If a member sends a PollRequest to the leader, that indicates that it likely healed from
+    // a network partition and may have had its status set to UNAVAILABLE by the leader. In order
+    // to ensure heartbeats are immediately stored to the member, update its status if necessary.
+    final RaftMemberContext member = raft.getCluster().getMemberContext(request.candidate());
+    if (member != null) {
+      member.resetFailureCount();
+    }
+
+    return CompletableFuture.completedFuture(
+        logResponse(
+            PollResponse.builder()
+                .withStatus(RaftResponse.Status.OK)
+                .withTerm(raft.getTerm())
+                .withAccepted(false)
+                .build()));
+  }
+
   private void leaveJointConsensus(
       final Collection<RaftMember> updatedMembers, final Configuration configuration) {
     configure(updatedMembers, List.of())
@@ -391,7 +412,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   /** Sets the current node as the cluster leader. */
   private void takeLeadership() {
     raft.setLeader(raft.getCluster().getLocalMember().memberId());
-    raft.getCluster().reset();
     raft.getCluster()
         .getReplicationTargets()
         .forEach(member -> member.openReplicationContext(raft.getLog()));
@@ -606,27 +626,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       raft.transition(RaftServer.Role.FOLLOWER);
       return super.onAppend(request);
     }
-  }
-
-  @Override
-  public CompletableFuture<PollResponse> onPoll(final PollRequest request) {
-    logRequest(request);
-
-    // If a member sends a PollRequest to the leader, that indicates that it likely healed from
-    // a network partition and may have had its status set to UNAVAILABLE by the leader. In order
-    // to ensure heartbeats are immediately stored to the member, update its status if necessary.
-    final RaftMemberContext member = raft.getCluster().getMemberContext(request.candidate());
-    if (member != null) {
-      member.resetFailureCount();
-    }
-
-    return CompletableFuture.completedFuture(
-        logResponse(
-            PollResponse.builder()
-                .withStatus(RaftResponse.Status.OK)
-                .withTerm(raft.getTerm())
-                .withAccepted(false)
-                .build()));
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -106,6 +106,12 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       raft.getThreadContext()
           .execute(
               () -> {
+                if (!isRunning()) {
+                  // The role was stopped between scheduling and running this task, e.g. because
+                  // the server stepped down or shut down. Do not append as an ex-leader; the next
+                  // elected leader resumes the exit from joint consensus.
+                  return;
+                }
                 final var currentMembers = raft.getCluster().getConfiguration().newMembers();
                 ongoingReconfigurationRequestFuture = new CompletableFuture<>();
                 leaveJointConsensus(currentMembers, raft.getCluster().getConfiguration());

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -611,6 +611,34 @@ final class ReconfigurationTest {
     }
 
     /**
+     * The live scenario of <a href="https://github.com/camunda/camunda/issues/55856">#55856</a>:
+     * scale down from two members to zero. After the leader left, the remaining follower holds the
+     * single-member configuration, typically only as an uncommitted log entry. It must elect itself
+     * based on that configuration, commit it, and then be able to leave as well.
+     */
+    @Test
+    void lastMemberCanLeave(@TempDir final Path tmp) {
+      // given - a cluster with 2 members
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      CompletableFuture.allOf(m1.bootstrap(id1, id2), m2.bootstrap(id1, id2)).join();
+      awaitLeader(m1, m2);
+      final var leader = getLeaderServer(List.of(m1, m2)).orElseThrow();
+      final var follower = getFollower(m1, m2).orElseThrow();
+
+      // when - the leader leaves first
+      leader.leave().join();
+
+      // then - the remaining follower elects itself and can leave as well
+      awaitLeader(follower);
+      assertThat(follower.leave()).succeedsWithin(Duration.ofSeconds(10));
+      assertThat(follower.cluster().getMembers()).isEmpty();
+    }
+
+    /**
      * Reproduces <a href="https://github.com/camunda/camunda/issues/55856">#55856</a>: when the
      * second-to-last member leaves, the remaining follower acks the new single-member configuration
      * entry but typically never learns that it committed, because the leaving leader steps down as

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -632,9 +632,11 @@ final class ReconfigurationTest {
       // when - the leader leaves first
       leader.leave().join();
 
-      // then - the remaining follower elects itself and can leave as well
-      awaitLeader(follower);
-      assertThat(follower.leave()).succeedsWithin(Duration.ofSeconds(10));
+      // then - the remaining follower can leave as well. The first attempts may fail with
+      // NO_LEADER until the follower elected itself, but must not break the member - the caller
+      // retries, like the cluster configuration coordinator does.
+      Awaitility.await("the last member can leave")
+          .untilAsserted(() -> assertThat(follower.leave()).succeedsWithin(Duration.ofSeconds(2)));
       assertThat(follower.cluster().getMembers()).isEmpty();
     }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -23,6 +23,7 @@ import io.atomix.raft.protocol.TestRaftProtocolFactory;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.system.Configuration;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -227,6 +228,62 @@ final class ReconfigurationTest {
           .as("m2 can join when retrying after a failed first attempt")
           .succeedsWithin(Duration.ofSeconds(30));
       awaitLeader(m1, retriedM2);
+    }
+
+    /**
+     * Reproduces the restart aspect of <a
+     * href="https://github.com/camunda/camunda/issues/57389">#57389</a>: configurations take effect
+     * as soon as they are appended, so a leader that appended a joint configuration must still
+     * operate under it after a restart, even though the configuration is not yet committed and thus
+     * not persisted in the meta store. Forgetting it would allow electing a leader without the
+     * joining member's vote and losing a configuration that the joining member may already have
+     * received.
+     */
+    @Test
+    void jointConfigurationSurvivesLeaderRestart(@TempDir final Path tmp) {
+      // given - a single-member cluster that appended a joint configuration it cannot commit
+      // because replication to the joining member fails
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      m1.bootstrap(id1).join();
+      awaitLeader(m1);
+
+      protocolFactory.blockMessagesTo(id2);
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(m2.join(id1, id2)).failsWithin(Duration.ofSeconds(30));
+      m2.shutdown().join();
+      assertThat(m1.getContext().getCluster().getConfiguration().requiresJointConsensus())
+          .as("m1 operates under the appended joint configuration")
+          .isTrue();
+
+      // when - m1 restarts before the joint configuration is committed. The bootstrap future can
+      // only complete once the server is ready, which requires a leader, so don't wait on it yet.
+      m1.shutdown().join();
+      final var restartedM1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      final var m1Started = restartedM1.bootstrap(id1);
+
+      // then - the joint configuration is recovered from the log and quorum still requires m2,
+      // so m1 cannot elect itself alone
+      Awaitility.await("the joint configuration is recovered from the log after restart")
+          .untilAsserted(
+              () ->
+                  assertThat(restartedM1.getContext().getCluster().getConfiguration())
+                      .isNotNull()
+                      .returns(true, Configuration::requiresJointConsensus));
+      Awaitility.await("m1 cannot become leader alone under the joint configuration")
+          .during(Duration.ofSeconds(2))
+          .until(() -> getLeader(restartedM1).isEmpty());
+
+      // and the join succeeds when retried once connectivity is restored
+      protocolFactory.heal(id2);
+      final var retriedM2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      assertThat(retriedM2.join(id1, id2))
+          .as("m2 can join when retrying after m1 restarted")
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitLeader(restartedM1, retriedM2);
+      assertThat(m1Started).succeedsWithin(Duration.ofSeconds(10));
     }
 
     @Test
@@ -551,6 +608,55 @@ final class ReconfigurationTest {
 
       // then - the committed configuration is empty
       assertThat(m1.cluster().getMembers()).isEmpty();
+    }
+
+    /**
+     * Reproduces <a href="https://github.com/camunda/camunda/issues/55856">#55856</a>: when the
+     * second-to-last member leaves, the remaining follower acks the new single-member configuration
+     * entry but typically never learns that it committed, because the leaving leader steps down as
+     * soon as the commit completes the leave. The follower then holds the configuration only as an
+     * uncommitted log entry. If it restarts before electing itself, it must recover that
+     * configuration from the log instead of reverting to the stored two-member configuration and
+     * waiting forever on a quorum that no longer exists.
+     */
+    @Test
+    void lastMemberCanLeaveAfterRestart(@TempDir final Path tmp) {
+      // given - a cluster with 2 members
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, StaticClusterMembershipService.of(id1, id2));
+      final var m2 = createServer(tmp, StaticClusterMembershipService.of(id2, id1));
+      CompletableFuture.allOf(m1.bootstrap(id1, id2), m2.bootstrap(id1, id2)).join();
+      awaitLeader(m1, m2);
+      final var leader = getLeaderServer(List.of(m1, m2)).orElseThrow();
+      final var follower = getFollower(m1, m2).orElseThrow();
+      final var followerId = MemberId.from(follower.name());
+
+      // when - the leader leaves and the follower restarts before it can elect itself and commit
+      // the new configuration. Block any straggler messages so the follower cannot learn that the
+      // new configuration is already committed.
+      leader.leave().join();
+      protocolFactory.blockMessagesTo(followerId);
+      follower.shutdown().join();
+      final var restarted = createServer(tmp, StaticClusterMembershipService.of(followerId));
+      final var started = restarted.bootstrap(id1, id2);
+
+      // then - the restarted follower recovers the single-member configuration from its log
+      // instead of the stored two-member configuration
+      Awaitility.await("the restarted follower recovers the configuration from the log")
+          .untilAsserted(
+              () ->
+                  assertThat(restarted.cluster().getMembers())
+                      .containsExactly(
+                          new DefaultRaftMember(followerId, Type.ACTIVE, Instant.now())));
+
+      // and it elects itself, becomes ready and can leave, scaling the partition down to zero
+      protocolFactory.heal(followerId);
+      awaitLeader(restarted);
+      assertThat(started).succeedsWithin(Duration.ofSeconds(10));
+      assertThat(restarted.leave()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(restarted.cluster().getMembers()).isEmpty();
     }
 
     @Test

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -731,28 +731,6 @@ final class RaftClusterContextTest {
   }
 
   @Test
-  void shouldNotRevertToStoredConfigurationOnReset() {
-    // given -- a member with a stored configuration and a newer appended configuration
-    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
-    final var otherMember = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
-    final var storedConfiguration =
-        new Configuration(1, 1, Instant.now().toEpochMilli(), List.of(localMember, otherMember));
-    final var raft = raftWithStoredConfiguration(storedConfiguration);
-    final var context = new RaftClusterContext(localMember.memberId(), raft);
-    context.bootstrap(List.of()).join();
-
-    final var appendedConfiguration =
-        new Configuration(2, 1, Instant.now().toEpochMilli(), List.of(localMember));
-    context.configure(appendedConfiguration);
-
-    // when -- resetting to the stored configuration, as happens on term changes
-    context.reset();
-
-    // then -- the newer configuration is retained
-    assertThat(context.getConfiguration()).isEqualTo(appendedConfiguration);
-  }
-
-  @Test
   void shouldRecoverAppendedConfigurationFromLogOnBootstrap() {
     // given -- a stored configuration and a newer configuration entry in the log
     final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -18,6 +18,8 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.log.RaftLogUncommittedReader;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.utils.concurrent.Scheduled;
@@ -748,9 +750,13 @@ final class RaftClusterContextTest {
         };
     final var raft = mock(RaftContext.class, withSettings().stubOnly());
     final var metaStore = mock(MetaStore.class, withSettings().stubOnly());
+    final var log = mock(RaftLog.class, withSettings().stubOnly());
+    final var reader = mock(RaftLogUncommittedReader.class, withSettings().stubOnly());
     when(raft.getThreadContext()).thenReturn(threadContext);
     when(metaStore.loadConfiguration()).thenReturn(configuration);
     when(raft.getMetaStore()).thenReturn(metaStore);
+    when(raft.getLog()).thenReturn(log);
+    when(log.openUncommittedReader()).thenReturn(reader);
     return raft;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -18,8 +18,10 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.impl.RaftContext;
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogUncommittedReader;
+import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.system.Configuration;
 import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.utils.concurrent.Scheduled;
@@ -728,7 +730,68 @@ final class RaftClusterContextTest {
             new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
   }
 
-  private RaftContext raftWithStoredConfiguration(final Configuration configuration) {
+  @Test
+  void shouldNotRevertToStoredConfigurationOnReset() {
+    // given -- a member with a stored configuration and a newer appended configuration
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var otherMember = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var storedConfiguration =
+        new Configuration(1, 1, Instant.now().toEpochMilli(), List.of(localMember, otherMember));
+    final var raft = raftWithStoredConfiguration(storedConfiguration);
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    final var appendedConfiguration =
+        new Configuration(2, 1, Instant.now().toEpochMilli(), List.of(localMember));
+    context.configure(appendedConfiguration);
+
+    // when -- resetting to the stored configuration, as happens on term changes
+    context.reset();
+
+    // then -- the newer configuration is retained
+    assertThat(context.getConfiguration()).isEqualTo(appendedConfiguration);
+  }
+
+  @Test
+  void shouldRecoverAppendedConfigurationFromLogOnBootstrap() {
+    // given -- a stored configuration and a newer configuration entry in the log
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var otherMember = new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now());
+    final var storedConfiguration =
+        new Configuration(1, 1, Instant.now().toEpochMilli(), List.of(localMember, otherMember));
+    final var configurationEntry =
+        new ConfigurationEntry(
+            Instant.now().toEpochMilli(), List.of(localMember), List.of(localMember, otherMember));
+    final var raft =
+        raftWithStoredConfiguration(storedConfiguration, logEntry(2, 1, configurationEntry));
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+
+    // when
+    context.bootstrap(List.of()).join();
+
+    // then -- the configuration from the log entry is applied on top of the stored one
+    assertThat(context.getConfiguration())
+        .isEqualTo(
+            new Configuration(
+                2,
+                1,
+                configurationEntry.timestamp(),
+                configurationEntry.newMembers(),
+                configurationEntry.oldMembers(),
+                false));
+  }
+
+  private static IndexedRaftLogEntry logEntry(
+      final long index, final long term, final ConfigurationEntry entry) {
+    final var logEntry = mock(IndexedRaftLogEntry.class, withSettings().stubOnly());
+    when(logEntry.index()).thenReturn(index);
+    when(logEntry.term()).thenReturn(term);
+    when(logEntry.entry()).thenReturn(entry);
+    return logEntry;
+  }
+
+  private RaftContext raftWithStoredConfiguration(
+      final Configuration configuration, final IndexedRaftLogEntry... logEntries) {
     final var threadContext =
         new ThreadContext() {
           @Override
@@ -752,11 +815,14 @@ final class RaftClusterContextTest {
     final var metaStore = mock(MetaStore.class, withSettings().stubOnly());
     final var log = mock(RaftLog.class, withSettings().stubOnly());
     final var reader = mock(RaftLogUncommittedReader.class, withSettings().stubOnly());
+    final var entries = List.of(logEntries).iterator();
     when(raft.getThreadContext()).thenReturn(threadContext);
     when(metaStore.loadConfiguration()).thenReturn(configuration);
     when(raft.getMetaStore()).thenReturn(metaStore);
     when(raft.getLog()).thenReturn(log);
     when(log.openUncommittedReader()).thenReturn(reader);
+    when(reader.hasNext()).thenAnswer(invocation -> entries.hasNext());
+    when(reader.next()).thenAnswer(invocation -> entries.next());
     return raft;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterPurgeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterPurgeTest.java
@@ -89,6 +89,40 @@ public class ClusterPurgeTest {
     }
   }
 
+  @RegressionTest("https://github.com/camunda/camunda/issues/55856")
+  void shouldPurgeClusterWithReplicationFactor3() {
+    // given
+    try (final var cluster =
+        TestCluster.builder()
+            .withEmbeddedGateway(true)
+            .withBrokersCount(3)
+            .withPartitionsCount(1)
+            .withReplicationFactor(3)
+            .build()
+            .start()) {
+
+      cluster.awaitCompleteTopology();
+
+      // when - purging the cluster, which scales the partition down to zero members and back up
+      final var purge = ClusterActuator.of(cluster.availableGateway()).purge(false);
+
+      // then - the purge completes. Scaling down requires the last remaining member to leave,
+      // which only works if it retains the configuration it acked but never learned to be
+      // committed before the second-to-last member went away.
+      Awaitility.await("until the purge is applied")
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(purge));
+
+      try (final CamundaClient client = cluster.newClientBuilder().build()) {
+        Awaitility.await("until cluster is healthy")
+            .untilAsserted(
+                () ->
+                    TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                        .isHealthy());
+      }
+    }
+  }
+
   private static void getSet(final boolean newValue) {
     PurgingExporter.BLOCK_PURGE.set(newValue);
   }


### PR DESCRIPTION
A Raft member must operate under the newest configuration in its log, committed or not — but the meta store only persists configurations on commit, so a restart reverted a member to the last committed configuration and forgot an appended-but-uncommitted one. `RaftClusterContext.bootstrap()` now applies the newest `ConfigurationEntry` from the log on top of the stored configuration (https://github.com/camunda/camunda/blob/ce8baf72297c7c7f9817720087832849233190bc/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java#L82-L94), reusing the recovery that the join path already had. This is the root cause of #55856: after an RF 2→1 scale-down the remaining follower usually holds the single-member configuration only as an uncommitted log entry, and a restart put it back on the two-member configuration, waiting forever on a quorum that no longer exists — permanently wedging Cluster Purge with replication factor > 1. It was also the accidental escape hatch for the #56808 join deadlock, which is only safe to remove now that #57388 made polls and votes membership-blind (part of #57386).

Only the uncommitted part of the log is searched at startup: a committed configuration entry is always reflected in the meta store because the leader gates replication behind configuration dissemination, and a separate commit closes the remaining crash window by persisting the configuration before the commit index that covers it. Recovery is skipped while the stored configuration is a forced one, since the log may still contain a stale, higher-index entry from a reconfiguration that was in flight before the force. `reset()` needed no behavior change — `configure()`'s index guard already prevents reverting to an older stored configuration — so it is only documented and pinned by a test. Known pre-existing gap, tracked separately in #57393: a recovered uncommitted configuration entry that is later truncated by a new leader is not rolled back in memory.

Retaining configurations across restarts made two adjacent defects reachable, fixed here as well. First, a leader that recovered an uncommitted joint configuration cannot commit its initialization entry without the joining member's ack, but the joiner treated the "Not ready to make configuration changes" rejection as fatal and tore itself down before acknowledging anything — a livelock found by `RandomizedRaftJoinTest`; the joiner now retries such rejections like NO_LEADER within the configuration change timeout. Second, when the last remaining member tried to leave before electing itself, `leaveInternal` threw on the raft thread and permanently transitioned the partition to inactive; it now fails cleanly with NO_LEADER so the coordinator's retry succeeds once the member elected itself.

New regression tests: a leader restart retains an appended joint configuration, the #55856 scale-down reproducers (live and with restart), and purge with replication factor 3. Note for the release: this must ship in the same release as #57388 on every branch — backports will be handled later and must mirror #58099's.

closes #57389
closes #55856