### PR TITLE
Name ad-hoc subprocess inner instance after its entry element

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AdHocSubProcessInnerInstanceNameIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.search.enums.ElementInstanceState;
+import io.camunda.client.api.search.response.ElementInstance;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Pins the behaviour that the synthetic <em>inner instance</em> of an ad-hoc subprocess surfaces in
+ * the instance history named after the element that was activated inside it (its entry element),
+ * rather than the generic synthetic id {@code <ahspId>#innerInstance}.
+ *
+ * <p>Activating "listUsers" (name "List users") makes the inner instance's {@code elementName} read
+ * "List users". The name must also survive completion of the inner instance / process instance
+ * (guarding the null-clobber regression where a later write could overwrite the resolved name).
+ *
+ * <p>Disabled on RDBMS: the naming lives only in the camunda-exporter (Elasticsearch/OpenSearch).
+ * The RDBMS exporter has no equivalent handler, so the inner instance name stays null there and
+ * this test's await would time out. RDBMS parity is out of scope for 8.10.
+ */
+@MultiDbTest
+@CompatibilityTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason =
+        "Inner-instance naming is implemented only in the camunda-exporter (ES/OS); "
+            + "the RDBMS exporter has no equivalent, so the name stays null on RDBMS.")
+public class AdHocSubProcessInnerInstanceNameIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldNameInnerInstanceAfterActivatedEntryElementAndRetainItAfterCompletion() {
+    // given
+    final var processModel =
+        Bpmn.createExecutableProcess("adHocInnerInstanceNameProcess")
+            .startEvent()
+            .adHocSubProcess(
+                "adHocSubProcess",
+                ahsp ->
+                    ahsp.serviceTask("listUsers", t -> t.zeebeJobType("listUsersJob"))
+                        .name("List users"))
+            .endEvent("end")
+            .done();
+
+    final var process =
+        deployProcessAndWaitForIt(camundaClient, processModel, "adhoc-inner-instance-name.bpmn");
+
+    // when
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, process.getBpmnProcessId()).getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId("adHocSubProcess").processInstanceKey(processInstanceKey),
+        1);
+
+    final long adHocSubProcessInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId("adHocSubProcess").processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    camundaClient
+        .newActivateAdHocSubProcessActivitiesCommand(String.valueOf(adHocSubProcessInstanceKey))
+        .activateElements("listUsers")
+        .send()
+        .join();
+
+    waitForElementInstances(
+        camundaClient,
+        f -> f.elementId("adHocSubProcess#innerInstance").processInstanceKey(processInstanceKey),
+        1);
+
+    final long jobKey = awaitEntryElementJobKey("listUsersJob");
+
+    // the name is written by the entry child's ELEMENT_ACTIVATING record, which may be exported
+    // after the inner-instance doc itself, so await the name before asserting on it.
+    final var activeInnerInstance =
+        Awaitility.await("inner instance is named")
+            .atMost(Duration.ofSeconds(60))
+            .ignoreExceptions()
+            .until(
+                () -> queryInnerInstance(processInstanceKey, "adHocSubProcess#innerInstance"),
+                instance -> instance.getElementName() != null);
+
+    // then
+    assertThat(activeInnerInstance.getElementName())
+        .describedAs("inner instance should be named after the activated entry element")
+        .isEqualTo("List users");
+    assertThat(activeInnerInstance.getElementName())
+        .describedAs("inner instance name should not fall back to the synthetic id")
+        .isNotEqualTo("adHocSubProcess#innerInstance");
+
+    // when
+    camundaClient.newCompleteCommand(jobKey).send().join();
+
+    Awaitility.await("inner instance completed")
+        .atMost(Duration.ofSeconds(60))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        queryInnerInstance(processInstanceKey, "adHocSubProcess#innerInstance")
+                            .getState())
+                    .isEqualTo(ElementInstanceState.COMPLETED));
+
+    // then
+    final var completedInnerInstance =
+        queryInnerInstance(processInstanceKey, "adHocSubProcess#innerInstance");
+    assertThat(completedInnerInstance.getElementName())
+        .describedAs("inner instance name should survive completion")
+        .isEqualTo("List users");
+    assertThat(completedInnerInstance.getElementName())
+        .describedAs("completed inner instance name should not fall back to the synthetic id")
+        .isNotEqualTo("adHocSubProcess#innerInstance");
+  }
+
+  private static long awaitEntryElementJobKey(final String jobType) {
+    return Awaitility.await("job for entry element is created")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () ->
+                camundaClient
+                    .newActivateJobsCommand()
+                    .jobType(jobType)
+                    .maxJobsToActivate(1)
+                    .timeout(Duration.ofMinutes(5))
+                    .send()
+                    .join()
+                    .getJobs()
+                    .stream()
+                    .findFirst()
+                    .map(ActivatedJob::getKey)
+                    .orElse(null),
+            key -> key != null);
+  }
+
+  private static ElementInstance queryInnerInstance(
+      final long processInstanceKey, final String innerInstanceElementId) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.elementId(innerInstanceElementId).processInstanceKey(processInstanceKey))
+        .execute()
+        .items()
+        .getFirst();
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/cache/process/CachedProcessEntity.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.common.cache.process;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public record CachedProcessEntity(
     String name,
@@ -17,4 +18,29 @@ public record CachedProcessEntity(
     List<String> callElementIds,
     Map<String, String> flowNodesMap,
     boolean hasUserTasks,
-    Map<String, Map<String, String>> elementExtensionProperties) {}
+    Map<String, Map<String, String>> elementExtensionProperties,
+    Set<String> adHocActivityIds) {
+
+  /**
+   * Backwards-compatible constructor that defaults {@code adHocActivityIds} to an empty set, so
+   * existing call sites that do not compute the ad-hoc activity set keep compiling.
+   */
+  public CachedProcessEntity(
+      final String name,
+      final int version,
+      final String versionTag,
+      final List<String> callElementIds,
+      final Map<String, String> flowNodesMap,
+      final boolean hasUserTasks,
+      final Map<String, Map<String, String>> elementExtensionProperties) {
+    this(
+        name,
+        version,
+        versionTag,
+        callElementIds,
+        flowNodesMap,
+        hasUserTasks,
+        elementExtensionProperties,
+        Set.of());
+  }
+}

--- a/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
+++ b/zeebe/exporter-common/src/main/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtil.java
@@ -115,6 +115,7 @@ public final class ProcessCacheUtil {
       final var extensionProperties =
           ProcessModelReader.extractExtensionProperties(
               flowNodes, extensionPropertiesConfiguration.extensionPropertyFilter());
+      final var adHocActivityIds = reader.extractAdHocActivityIds();
       return new CachedProcessEntity(
           name,
           version,
@@ -122,7 +123,8 @@ public final class ProcessCacheUtil {
           callActivityIds,
           flowNodesMap,
           hasUserTasks,
-          extensionProperties);
+          extensionProperties,
+          adHocActivityIds);
     }
     return new CachedProcessEntity(name, version, versionTag, List.of(), Map.of(), true, Map.of());
   }

--- a/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
+++ b/zeebe/exporter-common/src/test/java/io/camunda/zeebe/exporter/common/utils/ProcessCacheUtilTest.java
@@ -66,6 +66,45 @@ public class ProcessCacheUtilTest {
   }
 
   @Test
+  void shouldExtractOnlyDirectlyActivatableAdHocActivityIds() {
+    // given — an ad-hoc subprocess with an internal flow: listUsers -> sortTask.
+    // Only listUsers is directly activatable; sortTask has an incoming sequence flow and is
+    // reached by flow, not by the ActivateAdHocSubProcessActivities command (see the engine's
+    // AdHocSubProcessTransformer, which filters activatable activities to getIncoming().isEmpty()).
+    final String processId = "adHocProcess";
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(
+                "adHocSubProcess",
+                ahsp ->
+                    ahsp.serviceTask("listUsers", t -> t.zeebeJobType("listUsersJob"))
+                        .serviceTask("sortTask", t -> t.zeebeJobType("sortJob")))
+            .endEvent()
+            .done();
+
+    // when
+    final var adHocActivityIds =
+        ProcessCacheUtil.createCachedProcessEntity(
+                null,
+                0,
+                null,
+                Bpmn.convertToString(model),
+                processId,
+                new ExtensionPropertyConfiguration())
+            .adHocActivityIds();
+
+    // then
+    assertThat(adHocActivityIds)
+        .describedAs("only the directly-activatable (no-incoming-edge) ad-hoc activity is included")
+        .containsExactly("listUsers");
+    assertThat(adHocActivityIds)
+        .describedAs(
+            "a downstream sequence-flow target is not directly activatable and is excluded")
+        .doesNotContain("sortTask");
+  }
+
+  @Test
   void shouldOnlyRetainKnownToolPropertiesInProcessCache() {
     // given — a service task with both tool-related and unrelated zeebe:properties
     final String processId = "mixedPropsProcess";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -32,6 +32,7 @@ import io.camunda.exporter.handlers.EmbeddedFormHandler;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromIncidentHandler;
 import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceNameFromAdHocActivityHandler;
 import io.camunda.exporter.handlers.FormHandler;
 import io.camunda.exporter.handlers.GlobalListenerCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.GlobalListenerDeletedHandler;
@@ -279,6 +280,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new FlowNodeInstanceFromIncidentHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new FlowNodeInstanceFromProcessInstanceHandler(
+                indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
+                processCache),
+            new FlowNodeInstanceNameFromAdHocActivityHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
                 processCache),
             new IncidentHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -162,7 +162,19 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       updateFields.put(FlowNodeInstanceTemplate.LEVEL, entity.getLevel());
     }
     updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, entity.getFlowNodeId());
-    updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName());
+    // The ad-hoc subprocess inner instance has no name of its own: its synthetic id is absent from
+    // the BPMN, so the name resolves to null here. Its name is instead written by
+    // FlowNodeInstanceNameFromAdHocActivityHandler, derived from the activated entry element.
+    //
+    // We therefore skip writing a null name for the inner instance, so this handler's later
+    // lifecycle records (e.g. COMPLETED, TERMINATED) don't clobber that resolved name.
+    //
+    // Normal elements always write their name, including a null that must clear a name
+    // (e.g. migration to an unnamed target).
+    if (entity.getType() != FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE
+        || entity.getFlowNodeName() != null) {
+      updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName());
+    }
     updateFields.put(
         FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     updateFields.put(FlowNodeInstanceTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -8,13 +8,17 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.exporter.common.utils.ProcessCacheUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Names the inner instance of an ad-hoc subprocess after the element that was initially activated
@@ -30,16 +34,13 @@ import java.util.List;
  * <p>This handler reacts to the <em>entry child's</em> {@code ELEMENT_ACTIVATING} record and writes
  * the child's resolved name onto the parent inner-instance document, so the inner instance reads as
  * the element that was activated (e.g. {@code listUsers} → "List users").
- *
- * <p>NOTE: no-op stub; the naming behaviour is implemented in the green phase.
  */
 public class FlowNodeInstanceNameFromAdHocActivityHandler
     implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
 
   /**
-   * Painless script that sets {@code flowNodeName} only when it is not already set, so that the
-   * first-activated child (the entry element) wins and later activations in the same inner instance
-   * cannot clobber the name.
+   * Painless script that sets {@code flowNodeName} only when it is not already set (first-writer
+   * wins), so re-processing the entry child's record can't overwrite the resolved name.
    */
   public static final String SET_IF_NULL_NAME_SCRIPT =
       """
@@ -69,14 +70,21 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
 
   @Override
   public boolean handlesRecord(final Record<ProcessInstanceRecordValue> record) {
-    // stub
-    return false;
+    if (!ProcessInstanceIntent.ELEMENT_ACTIVATING.equals(record.getIntent())) {
+      return false;
+    }
+    final var recordValue = record.getValue();
+    return processCache
+        .get(recordValue.getProcessDefinitionKey())
+        .map(CachedProcessEntity::adHocActivityIds)
+        .map(ids -> ids.contains(recordValue.getElementId()))
+        .orElse(false);
   }
 
   @Override
   public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
-    // stub
-    return List.of();
+    // the child's flow scope is the parent inner-instance, whose document we want to name
+    return List.of(String.valueOf(record.getValue().getFlowScopeKey()));
   }
 
   @Override
@@ -87,12 +95,28 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
   @Override
   public void updateEntity(
       final Record<ProcessInstanceRecordValue> record, final FlowNodeInstanceEntity entity) {
-    // stub
+    // resolve the name from the entry child's element id; keep the parent inner-instance id that
+    // generateIds established on the entity, so flush writes onto the inner-instance document
+    final var recordValue = record.getValue();
+    final var elementId = recordValue.getElementId();
+    entity.setFlowNodeName(
+        ProcessCacheUtil.getFlowNodeName(
+                processCache, recordValue.getProcessDefinitionKey(), elementId)
+            .orElse(elementId));
   }
 
   @Override
   public void flush(final FlowNodeInstanceEntity entity, final BatchRequest batchRequest) {
-    // stub
+    // Only sets the name. The inner-instance document (with its identifying fields) is normally
+    // inserted first by FlowNodeInstanceFromProcessInstanceHandler, since the engine writes the
+    // inner instance's own ELEMENT_ACTIVATING before the entry child's. The upsert here is a
+    // defensive fallback: it lets ES/OS create the document rather than fail if it is missing.
+    batchRequest.upsertWithScript(
+        indexName,
+        entity.getId(),
+        entity,
+        SET_IF_NULL_NAME_SCRIPT,
+        Map.of(FlowNodeInstanceTemplate.FLOW_NODE_NAME, entity.getFlowNodeName()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
+
+/**
+ * Names the inner instance of an ad-hoc subprocess after the element that was initially activated
+ * inside it (its entry element).
+ *
+ * <p>Activating an element inside an ad-hoc subprocess creates a synthetic <em>inner instance</em>:
+ * a scope that owns the activated element together with everything reachable from it (e.g. the
+ * elements targeted by its outgoing sequence flows), so variables and state persist across those
+ * elements for the lifetime of the activation. That inner instance has no name of its own — its
+ * element id is the synthetic {@code <ahspId>#innerInstance}, which is not present in the deployed
+ * BPMN — so in the instance history it surfaces with a generic label.
+ *
+ * <p>This handler reacts to the <em>entry child's</em> {@code ELEMENT_ACTIVATING} record and writes
+ * the child's resolved name onto the parent inner-instance document, so the inner instance reads as
+ * the element that was activated (e.g. {@code listUsers} → "List users").
+ *
+ * <p>NOTE: no-op stub; the naming behaviour is implemented in the green phase.
+ */
+public class FlowNodeInstanceNameFromAdHocActivityHandler
+    implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
+
+  /**
+   * Painless script that sets {@code flowNodeName} only when it is not already set, so that the
+   * first-activated child (the entry element) wins and later activations in the same inner instance
+   * cannot clobber the name.
+   */
+  public static final String SET_IF_NULL_NAME_SCRIPT =
+      """
+      if (ctx._source.flowNodeName == null) {
+          ctx._source.flowNodeName = params.flowNodeName;
+      }
+      """;
+
+  private final String indexName;
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+
+  public FlowNodeInstanceNameFromAdHocActivityHandler(
+      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+    this.indexName = indexName;
+    this.processCache = processCache;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE;
+  }
+
+  @Override
+  public Class<FlowNodeInstanceEntity> getEntityType() {
+    return FlowNodeInstanceEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ProcessInstanceRecordValue> record) {
+    // stub
+    return false;
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ProcessInstanceRecordValue> record) {
+    // stub
+    return List.of();
+  }
+
+  @Override
+  public FlowNodeInstanceEntity createNewEntity(final String id) {
+    return new FlowNodeInstanceEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ProcessInstanceRecordValue> record, final FlowNodeInstanceEntity entity) {
+    // stub
+  }
+
+  @Override
+  public void flush(final FlowNodeInstanceEntity entity, final BatchRequest batchRequest) {
+    // stub
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -216,7 +216,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setType(FlowNodeType.SERVICE_TASK)
             .setState(FlowNodeState.ACTIVE)
             .setFlowNodeId("flowNode1")
-            .setFlowNodeId("flowNodeName")
+            .setFlowNodeName(null)
             .setProcessDefinitionKey(222L)
             .setBpmnProcessId("bpmnId");
     final BatchRequest mockRequest = mock(BatchRequest.class);
@@ -237,6 +237,39 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     // when
     underTest.flush(inputEntity, mockRequest);
     // then
+    verify(mockRequest, times(1))
+        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+  }
+
+  @Test
+  public void shouldOmitFlowNodeNameForInnerInstanceWhenNull() {
+    final FlowNodeInstanceEntity inputEntity =
+        new FlowNodeInstanceEntity()
+            .setId("111")
+            .setKey(111)
+            .setProcessInstanceKey(444L)
+            .setPartitionId(1)
+            .setType(FlowNodeType.AD_HOC_SUB_PROCESS_INNER_INSTANCE)
+            .setState(FlowNodeState.COMPLETED)
+            .setFlowNodeId("adHocSubProcess#innerInstance")
+            .setFlowNodeName(null)
+            .setProcessDefinitionKey(222L)
+            .setBpmnProcessId("bpmnId");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final Map<String, Object> expectedUpdateFields = new HashMap<>();
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.ID, inputEntity.getId());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, inputEntity.getPartitionId());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.TYPE, inputEntity.getType());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.STATE, inputEntity.getState());
+    expectedUpdateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, inputEntity.getFlowNodeId());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, inputEntity.getProcessDefinitionKey());
+    expectedUpdateFields.put(
+        FlowNodeInstanceTemplate.BPMN_PROCESS_ID, inputEntity.getBpmnProcessId());
+
+    underTest.flush(inputEntity, mockRequest);
+
     verify(mockRequest, times(1))
         .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
+import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class FlowNodeInstanceNameFromAdHocActivityHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-flow-node-instance";
+  private final TestProcessCache processCache = new TestProcessCache();
+  private final FlowNodeInstanceNameFromAdHocActivityHandler underTest =
+      new FlowNodeInstanceNameFromAdHocActivityHandler(indexName, processCache);
+
+  @Test
+  public void shouldHandleActivatingAdHocActivity() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 0L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  public void shouldNotHandleNonAdHocActivity() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "someTask", 222L, 0L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  public void shouldNotHandleNonActivatingIntent() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_COMPLETED, "listUsers", 222L, 0L);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  public void shouldNotHandleWhenProcessNotInCache() {
+    // given - no entry in the process cache for this process definition key
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 0L);
+
+    // when - then
+    // a cache miss must not be treated as a match (and must not NPE resolving adHocActivityIds)
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  public void shouldGenerateInnerInstanceIdFromFlowScopeKey() {
+    // given
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly("999");
+  }
+
+  @Test
+  public void shouldResolveEntryElementName() {
+    // given
+    processCache.put(
+        222L, cachedProcessEntity(Map.of("listUsers", "List users"), Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
+
+    // when
+    // the entity is created by the exporter framework with the id from generateIds (the parent
+    // inner-instance key); updateEntity must only enrich it, never re-key it to the child.
+    final FlowNodeInstanceEntity entity = new FlowNodeInstanceEntity().setId("999");
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getFlowNodeName()).isEqualTo("List users");
+    assertThat(entity.getId())
+        .describedAs(
+            "updateEntity must keep the parent inner-instance id from generateIds; re-keying it to "
+                + "the child would make flush write the name onto the child doc instead")
+        .isEqualTo("999");
+  }
+
+  @Test
+  public void shouldFallbackToElementIdWhenEntryUnnamed() {
+    // given
+    final Map<String, String> flowNodesMap = new HashMap<>();
+    flowNodesMap.put("listUsers", null);
+    processCache.put(222L, cachedProcessEntity(flowNodesMap, Set.of("listUsers")));
+    final Record<ProcessInstanceRecordValue> record =
+        createRecord(ProcessInstanceIntent.ELEMENT_ACTIVATING, "listUsers", 222L, 999L);
+
+    // when
+    final FlowNodeInstanceEntity entity = new FlowNodeInstanceEntity();
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getFlowNodeName()).isEqualTo("listUsers");
+  }
+
+  @Test
+  public void shouldUpsertNameWithSetIfNullScriptOnFlush() {
+    // given
+    final FlowNodeInstanceEntity entity =
+        new FlowNodeInstanceEntity().setId("111").setFlowNodeName("List users");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsertWithScript(
+            eq(indexName),
+            eq("111"),
+            eq(entity),
+            eq(FlowNodeInstanceNameFromAdHocActivityHandler.SET_IF_NULL_NAME_SCRIPT),
+            eq(Map.of(FlowNodeInstanceTemplate.FLOW_NODE_NAME, "List users")));
+  }
+
+  private CachedProcessEntity cachedProcessEntity(
+      final Map<String, String> flowNodesMap, final Set<String> adHocActivityIds) {
+    return new CachedProcessEntity(
+        "process", 1, null, List.of(), flowNodesMap, false, Map.of(), adHocActivityIds);
+  }
+
+  private Record<ProcessInstanceRecordValue> createRecord(
+      final ProcessInstanceIntent intent,
+      final String elementId,
+      final long processDefinitionKey,
+      final long flowScopeKey) {
+    final ProcessInstanceRecordValue value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withElementId(elementId)
+            .withProcessDefinitionKey(processDefinitionKey)
+            .withFlowScopeKey(flowScopeKey)
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE, r -> r.withIntent(intent).withValue(value));
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/modelreader/ProcessModelReader.java
@@ -9,8 +9,11 @@ package io.camunda.zeebe.util.modelreader;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.Query;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.BoundaryEvent;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Process;
@@ -27,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -90,6 +94,40 @@ public final class ProcessModelReader {
         .getChildElementsByType(FlowNode.class)
         .forEach(fn -> extractCallActivities(callActivities, fn));
     return callActivities;
+  }
+
+  /**
+   * Returns the ids of all directly-activatable ad-hoc activities across every ad-hoc subprocess in
+   * the process: the direct child flow nodes that can be activated via the {@code
+   * ActivateAdHocSubProcessActivities} command.
+   *
+   * <p>This mirrors the engine's {@code AdHocSubProcessTransformer}, which selects an activity as
+   * directly-activatable when it has no incoming sequence flow (i.e. it is an entry point, not
+   * reached by flow) and its type is activatable — excluding start, boundary and end events as well
+   * as event subprocesses.
+   */
+  public Set<String> extractAdHocActivityIds() {
+    return extractFlowNodes().stream()
+        .filter(AdHocSubProcess.class::isInstance)
+        .map(AdHocSubProcess.class::cast)
+        .flatMap(ahsp -> ahsp.getChildElementsByType(FlowNode.class).stream())
+        .filter(ProcessModelReader::isDirectlyActivatableAdHocActivity)
+        .map(FlowNode::getId)
+        .collect(Collectors.toSet());
+  }
+
+  private static boolean isDirectlyActivatableAdHocActivity(final FlowNode flowNode) {
+    return flowNode.getIncoming().isEmpty() && isActivatableActivity(flowNode);
+  }
+
+  private static boolean isActivatableActivity(final FlowNode flowNode) {
+    if (flowNode instanceof StartEvent
+        || flowNode instanceof BoundaryEvent
+        || flowNode instanceof EndEvent) {
+      return false;
+    }
+    // event subprocesses are not re-parented into the inner instance and are not activatable
+    return !(flowNode instanceof final SubProcess subProcess && subProcess.triggeredByEvent());
   }
 
   public static boolean hasUserTasks(final Collection<FlowNode> flowNodes) {


### PR DESCRIPTION
## Description

The synthetic *inner instance* of an ad-hoc subprocess surfaced in the instance history under the generic id `<ahspId>#innerInstance`, because it has no name of its own. This names it after the element that was activated inside it (its entry element), so the history reads e.g. "List users".

The name is never on the `ProcessInstanceRecord`; it is resolved downstream from a per-definition BPMN map in which the synthetic id is absent. Rather than add hot-path metadata to every element instance or change the stable `elementId`, the camunda-exporter reacts to the entry child's `ELEMENT_ACTIVATING` and writes its resolved name onto the parent inner-instance document with a set-if-null (first-writer-wins) upsert. The shared handler is scoped so its later lifecycle writes cannot clobber that name.

Implemented in the camunda-exporter only (Elasticsearch/OpenSearch); RDBMS parity is out of scope (tracked in #58431). New instances only — already-exported inner instances are not backfilled, and raw-record consumers still see the synthetic id.

Commits are structured for commit-by-commit review: four `test: red …` commits (handler, id extraction, null-omit guard, e2e IT) followed by the `feat:` green implementation.

## Related issues

closes #58430

Parent: #56094

