### PR TITLE
feat: track per-follower log replication lag in bytes

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -491,8 +491,8 @@ public final class RaftMemberContext {
   }
 
   /** Tracks replication lag for each locally-appended entry. */
-  public void recordAppendedBytes(final long bytes) {
-    logReplicationLag += bytes;
+  public void recordAppendedBytes(final long appendedBytes) {
+    logReplicationLag += appendedBytes;
   }
 
   /**
@@ -515,8 +515,9 @@ public final class RaftMemberContext {
     if (appendWatermark <= acknowledgedAppendWatermark) {
       return;
     }
+    final long acknowledgedBytes = appendWatermark - acknowledgedAppendWatermark;
     // non-atomic write is okay because we only write from one thread
-    logReplicationLag -= appendWatermark - acknowledgedAppendWatermark;
+    logReplicationLag = Math.max(0, logReplicationLag - acknowledgedBytes);
     acknowledgedAppendWatermark = appendWatermark;
   }
 
@@ -532,7 +533,7 @@ public final class RaftMemberContext {
    * @return the replication lag in bytes, never negative
    */
   public long getReplicationLagBytes() {
-    return logReplicationLag + snapshotReplicationLag;
+    return Math.max(0, logReplicationLag + snapshotReplicationLag);
   }
 
   public boolean hasNextEntry() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -52,9 +52,9 @@ public final class RaftMemberContext {
   private volatile RaftLogReader reader;
   private SnapshotChunkReader snapshotChunkReader;
   private IndexedRaftLogEntry currentEntry;
-  private volatile long snapshotReplicationLag;
+  private long snapshotReplicationLag;
   private long snapshotChunkBytesInFlight;
-  private volatile long logReplicationLag;
+  private long logReplicationLag;
   private long sentAppendWatermark;
   private long acknowledgedAppendWatermark;
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -119,21 +119,22 @@ public final class RaftMemberContext {
   }
 
   private void openReader(final RaftLog log) {
-    switch (member.getType()) {
-      case PASSIVE:
-        reader = log.openCommittedReader();
-        resetReaderAtEndOfLog(reader);
-        break;
-      case PROMOTABLE:
-      case ACTIVE:
-        reader = log.openUncommittedReader();
-        resetReaderAtEndOfLog(reader);
-        break;
-      default:
+    reader = newReader(log);
+    if (reader != null) {
+      resetReaderAtEndOfLog(reader);
+    }
+  }
+
+  private RaftLogReader newReader(final RaftLog log) {
+    return switch (member.getType()) {
+      case PASSIVE -> log.openCommittedReader();
+      case PROMOTABLE, ACTIVE -> log.openUncommittedReader();
+      default -> {
         LoggerFactory.getLogger(RaftMemberContext.class)
             .error("ResetState: No case for Member type {}", member.getType());
-        break;
-    }
+        yield null;
+      }
+    };
   }
 
   private void resetReaderAtEndOfLog(final RaftLogReader reader) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -51,7 +51,7 @@ public final class RaftMemberContext {
   private volatile RaftLogReader reader;
   private SnapshotChunkReader snapshotChunkReader;
   private IndexedRaftLogEntry currentEntry;
-  private long snapshotReplicationLag;
+  private volatile long snapshotReplicationLag;
   private long snapshotChunkBytesInFlight;
 
   RaftMemberContext(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -54,9 +54,25 @@ public final class RaftMemberContext {
   private volatile RaftLogReader reader;
   private SnapshotChunkReader snapshotChunkReader;
   private IndexedRaftLogEntry currentEntry;
+
+  // Number of bytes remaining to replicate for this member for any pending/in-flight snapshot
+  // install
   private long snapshotReplicationLag;
+  // Size in bytes of any in-flight snapshot chunk being sent to this member
   private long snapshotChunkBytesInFlight;
+
+  // Number of bytes remaining to replicate to this member for log appends
   private long logReplicationLag;
+  // Cumulative number of bytes assigned to append requests across the lifetime of this instance.
+  // The watermark is only incremented, never decreased or reset. For each append request, we track
+  // the value of the watermark after incrementing it for that request. When the append request is
+  // successfully acknowledged, we check that no later append request has yet been acknowledged by
+  // comparing the tracked watermark to acknowledgedAppendWatermark. If the acknowledged watermark
+  // is less than the watermark for the request, we can calculate the number of bytes replicated
+  // since the last acknowledgement by subtracting the request watermark from the acknowledged one.
+  // If it's greater than or equal to the acknowledged watermark, we know that a later append
+  // request has already been acknowledged (and that the earlier log entries have already been
+  // replicated).
   private long sentAppendWatermark;
   private long acknowledgedAppendWatermark;
 
@@ -463,6 +479,12 @@ public final class RaftMemberContext {
     snapshotReplicationLag = Math.max(0, snapshotReplicationLag - bytes);
   }
 
+  /**
+   * Returns the number of bytes remaining to replicate for this member for any pending/in-flight
+   * snapshot installs
+   *
+   * @return The snapshot replication lag, in bytes.
+   */
   public long getSnapshotReplicationLag() {
     return snapshotReplicationLag;
   }
@@ -478,6 +500,11 @@ public final class RaftMemberContext {
     this.snapshotReplicationLag = snapshotReplicationLag;
   }
 
+  /**
+   * Returns the size in bytes of any in-flight snapshot chunk being sent to this member.
+   *
+   * @return The size of any in-flight snapshot chunk, in bytes.
+   */
   public long getSnapshotChunkBytesInFlight() {
     return snapshotChunkBytesInFlight;
   }
@@ -534,6 +561,11 @@ public final class RaftMemberContext {
     acknowledgedAppendWatermark = appendWatermark;
   }
 
+  /**
+   * Returns the number of bytes remaining to replicate to this member for log appends.
+   *
+   * @return The log replication lag, in bytes.
+   */
   public long getLogReplicationLag() {
     return logReplicationLag;
   }
@@ -574,8 +606,7 @@ public final class RaftMemberContext {
       currentEntry = null;
     }
 
-    acknowledgedAppendWatermark = sentAppendWatermark;
-    logReplicationLag = reader.bytesUntilEnd();
+    resetLogReplicationLag(reader);
   }
 
   public void beginSnapshotInstall(final RaftLog log, final PersistedSnapshot persistedSnapshot) {
@@ -590,8 +621,15 @@ public final class RaftMemberContext {
         return;
       }
       lagReader.seek(persistedSnapshot.getIndex() + 1);
-      acknowledgedAppendWatermark = sentAppendWatermark;
-      logReplicationLag = lagReader.bytesUntilEnd();
+      resetLogReplicationLag(lagReader);
     }
+  }
+
+  private void resetLogReplicationLag(final RaftLogReader lagReader) {
+    // Advance the acknowledged watermark to the sent watermark to invalidate callbacks for every
+    // request issued before the reset, and recalculate the lag from the follower's new replication
+    // position.
+    acknowledgedAppendWatermark = sentAppendWatermark;
+    logReplicationLag = lagReader.bytesUntilEnd();
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import java.nio.ByteBuffer;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,9 @@ public final class RaftMemberContext {
   private IndexedRaftLogEntry currentEntry;
   private volatile long snapshotReplicationLag;
   private long snapshotChunkBytesInFlight;
+  private volatile long logReplicationLag;
+  private long sentAppendWatermark;
+  private long acknowledgedAppendWatermark;
 
   RaftMemberContext(
       final DefaultRaftMember member,
@@ -78,6 +82,8 @@ public final class RaftMemberContext {
     failureTime = 0;
     snapshotReplicationLag = 0;
     snapshotChunkBytesInFlight = 0;
+    logReplicationLag = 0;
+    acknowledgedAppendWatermark = sentAppendWatermark;
 
     if (reader != null) {
       closeReader();
@@ -266,6 +272,7 @@ public final class RaftMemberContext {
         .add("installing", installing)
         .add("failures", failures)
         .add("snapshotReplicationLag", snapshotReplicationLag)
+        .add("logReplicationLag", logReplicationLag)
         .toString();
   }
 
@@ -483,16 +490,49 @@ public final class RaftMemberContext {
     this.snapshotChunkBytesInFlight = snapshotChunkBytesInFlight;
   }
 
+  /** Tracks replication lag for each locally-appended entry. */
+  public void recordAppendedBytes(final long bytes) {
+    logReplicationLag += bytes;
+  }
+
+  /**
+   * Update the watermark tracking appended bytes for lag replication, and return the new watermark.
+   *
+   * @param bytes the size of this append batch, in bytes
+   * @return the updated watermark
+   */
+  public long recordInFlightAppend(final long bytes) {
+    sentAppendWatermark += bytes;
+    return sentAppendWatermark;
+  }
+
+  /**
+   * Acknowledges every byte up to {@code appendWatermark}. A later successful request therefore
+   * accounts for an earlier request whose local future timed out, while callbacks at or below the
+   * current watermark are no-ops.
+   */
+  public void acknowledgeInFlightAppends(final long appendWatermark) {
+    if (appendWatermark <= acknowledgedAppendWatermark) {
+      return;
+    }
+    // non-atomic write is okay because we only write from one thread
+    logReplicationLag -= appendWatermark - acknowledgedAppendWatermark;
+    acknowledgedAppendWatermark = appendWatermark;
+  }
+
+  public long getLogReplicationLag() {
+    return logReplicationLag;
+  }
+
   /**
    * The total per-follower replication lag in bytes.
    *
-   * <p>Currently this is the remaining snapshot-install bytes; log replication lag will be added to
-   * this total in future.
+   * <p>This is the outstanding log replication bytes plus the remaining snapshot-install bytes.
    *
    * @return the replication lag in bytes, never negative
    */
   public long getReplicationLagBytes() {
-    return snapshotReplicationLag;
+    return logReplicationLag + snapshotReplicationLag;
   }
 
   public boolean hasNextEntry() {
@@ -518,6 +558,26 @@ public final class RaftMemberContext {
       currentEntry = reader.next();
     } else {
       currentEntry = null;
+    }
+
+    acknowledgedAppendWatermark = sentAppendWatermark;
+    logReplicationLag = reader.bytesUntilEnd();
+  }
+
+  public void beginSnapshotInstall(final RaftLog log, final PersistedSnapshot persistedSnapshot) {
+    setNextSnapshotIndex(persistedSnapshot.getIndex());
+    setNextSnapshotChunkId(null);
+    setSnapshotReplicationLag(persistedSnapshot.getTotalSizeInBytes());
+
+    // Get the remaining log bytes after the snapshot with a temporary reader to avoid disrupting
+    // the current reader
+    try (final var lagReader = newReader(log)) {
+      if (lagReader == null) {
+        return;
+      }
+      lagReader.seek(persistedSnapshot.getIndex() + 1);
+      acknowledgedAppendWatermark = sentAppendWatermark;
+      logReplicationLag = lagReader.bytesUntilEnd();
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -26,12 +26,14 @@ import io.atomix.raft.storage.log.RaftLogReader;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import java.nio.ByteBuffer;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Cluster member state. */
 public final class RaftMemberContext {
 
-  private static final int APPEND_WINDOW_SIZE = 8;
+  private static final Logger LOG = LoggerFactory.getLogger(RaftMemberContext.class);
+
   private final DefaultRaftMember member;
   private final int maxAppendsPerMember;
   private boolean open = true;
@@ -516,8 +518,19 @@ public final class RaftMemberContext {
       return;
     }
     final long acknowledgedBytes = appendWatermark - acknowledgedAppendWatermark;
-    // non-atomic write is okay because we only write from one thread
-    logReplicationLag = Math.max(0, logReplicationLag - acknowledgedBytes);
+    if (acknowledgedBytes > logReplicationLag) {
+      LOG.warn(
+          "Log replication lag underflow for member {}: lag={}, acknowledged bytes={}, "
+              + "append watermark={}, previous watermark={}",
+          member.memberId(),
+          logReplicationLag,
+          acknowledgedBytes,
+          appendWatermark,
+          acknowledgedAppendWatermark);
+      logReplicationLag = 0;
+    } else {
+      logReplicationLag -= acknowledgedBytes;
+    }
     acknowledgedAppendWatermark = appendWatermark;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -135,9 +135,9 @@ public final class RaftMemberContext {
     return switch (member.getType()) {
       case PASSIVE -> log.openCommittedReader();
       case PROMOTABLE, ACTIVE -> log.openUncommittedReader();
-      default -> {
+      case INACTIVE -> {
         LoggerFactory.getLogger(RaftMemberContext.class)
-            .error("ResetState: No case for Member type {}", member.getType());
+            .error("Cannot open log reader for inactive member");
         yield null;
       }
     };

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderAppenderMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderAppenderMetrics.java
@@ -63,7 +63,7 @@ public class LeaderAppenderMetrics extends RaftMetrics implements CloseableSilen
   }
 
   public void observeAppend(
-      final String memberId, final int appendedEntries, final int appendedBytes) {
+      final String memberId, final int appendedEntries, final long appendedBytes) {
     getAppendRate(memberId).increment(appendedEntries);
     getAppendDataRate(memberId).increment(appendedBytes / 1024f);
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/PersistedRaftRecord.java
@@ -66,6 +66,12 @@ public class PersistedRaftRecord implements JournalRecord, ReplicatableRaftRecor
         "Serialized journal record is not available in PersistedRaftRecord");
   }
 
+  @Override
+  public int size() {
+    throw new UnsupportedOperationException(
+        "On-disk journal size is not available in PersistedRaftRecord");
+  }
+
   /**
    * Returns the term for this record
    *

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReplicatableJournalRecord.java
@@ -75,15 +75,4 @@ public record ReplicatableJournalRecord(
         + recordToString
         + '}';
   }
-
-  /**
-   * Returns the approximate size needed when serializing this class. The exact size depends on the
-   * serializer.
-   *
-   * @return approximate size
-   */
-  public int approximateSize() {
-    // serializedJournalRecord + index + term + checksum
-    return serializedJournalRecord.length + (3 * Long.BYTES);
-  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -178,10 +178,7 @@ final class LeaderAppender {
     // counted towards the size of the batch.
     // If there exists an entry in the log with size >= MAX_BATCH_SIZE the logic ensures that
     // entry will be sent in a batch of size one
-    int size = 0;
-    // Exact on-disk journal size of this request, tracked separately from the approximate wire
-    // size used for the batch cap so the lag accounting matches bytesUntilEnd() and never drifts.
-    long journalBytes = 0;
+    long size = 0;
 
     // Iterate through the log until the last index or the end of the log is reached.
     while (hasMoreEntries(member)) {
@@ -189,15 +186,14 @@ final class LeaderAppender {
       final IndexedRaftLogEntry entry = member.nextEntry();
       final var replicatableRecord = entry.getReplicatableJournalRecord();
       entries.add(replicatableRecord);
-      size += replicatableRecord.approximateSize();
-      journalBytes += entry.size();
+      size += entry.size();
       if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {
         break;
       }
     }
 
     // Add the entries to the request builder and build the request.
-    return new SizedAppendRequest(builder.withEntries(entries).build(), journalBytes);
+    return new SizedAppendRequest(builder.withEntries(entries).build(), size);
   }
 
   /** Connects to the member and sends a commit message. */
@@ -229,7 +225,7 @@ final class LeaderAppender {
 
                 if (error == null) {
                   LOGGER.trace("Received {} from {}", response, member.getMember().memberId());
-                  handleAppendResponse(member, request, response, appendWatermark, timestamp);
+                  handleAppendResponse(member, sizedRequest, response, appendWatermark, timestamp);
                 } else {
                   handleAppendResponseFailure(member, request, error);
                 }
@@ -713,21 +709,21 @@ final class LeaderAppender {
 
   private void handleAppendResponse(
       final RaftMemberContext member,
-      final VersionedAppendRequest request,
+      final SizedAppendRequest sizedRequest,
       final AppendResponse response,
       final long appendWatermark,
       final long timestamp) {
     if (response.status() == RaftResponse.Status.OK) {
-      handleAppendResponseOk(member, request, response, appendWatermark);
+      handleAppendResponseOk(member, sizedRequest, response, appendWatermark);
     } else {
-      handleAppendResponseError(member, request, response);
+      handleAppendResponseError(member, sizedRequest, response);
     }
     recordHeartbeat(member, timestamp);
   }
 
   private void handleAppendResponseOk(
       final RaftMemberContext member,
-      final VersionedAppendRequest request,
+      final SizedAppendRequest sizedRequest,
       final AppendResponse response,
       final long appendWatermark) {
     // Reset the member failure count and update the member's availability status if necessary.
@@ -740,10 +736,11 @@ final class LeaderAppender {
       member.appendSucceeded();
       member.acknowledgeInFlightAppends(appendWatermark);
       updateMatchIndex(member, response);
+
+      final var request = sizedRequest.request();
       metrics.observeAppend(
-          member.getMember().memberId().id(),
-          request.entries().size(),
-          request.entries().stream().mapToInt(ReplicatableJournalRecord::approximateSize).sum());
+          member.getMember().memberId().id(), request.entries().size(), sizedRequest.size());
+
       observeReplicationLag(member);
 
       commitEntries();
@@ -844,7 +841,7 @@ final class LeaderAppender {
 
   private void handleAppendResponseError(
       final RaftMemberContext member,
-      final VersionedAppendRequest request,
+      final SizedAppendRequest sizedRequest,
       final AppendResponse response) {
     // If we've received a greater term, update the term and transition back to follower.
     if (response.term() > raft.getTerm()) {
@@ -868,7 +865,7 @@ final class LeaderAppender {
       if (failures <= 3 || failures % 100 == 0) {
         LOGGER.warn(
             "{} to {} failed: {}",
-            request,
+            sizedRequest.request(),
             member.getMember().memberId(),
             response.error() != null ? response.error() : "");
       }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -102,7 +102,8 @@ final class LeaderAppender {
    * @param member The member to which to send the request.
    * @return The append request.
    */
-  private AppendBatch buildAppendRequest(final RaftMemberContext member, final long lastIndex) {
+  private SizedAppendRequest buildAppendRequest(
+      final RaftMemberContext member, final long lastIndex) {
     // If the log is empty then send an empty commit.
     // If the next index hasn't yet been set then we send an empty commit first.
     // If the next index is greater than the last index then send an empty commit.
@@ -122,7 +123,7 @@ final class LeaderAppender {
    *
    * <p>Empty append requests are used as heartbeats to followers.
    */
-  private AppendBatch buildAppendEmptyRequest(final RaftMemberContext member) {
+  private SizedAppendRequest buildAppendEmptyRequest(final RaftMemberContext member) {
     // Read the previous entry from the reader.
     // The reader can be null for RESERVE members.
     final IndexedRaftLogEntry prevEntry = member.getCurrentEntry();
@@ -135,7 +136,7 @@ final class LeaderAppender {
             .withEntries(Collections.emptyList())
             .withCommitIndex(raft.getCommitIndex())
             .build();
-    return new AppendBatch(request, 0L);
+    return new SizedAppendRequest(request, 0L);
   }
 
   private VersionedAppendRequest.Builder builderWithPreviousEntry(
@@ -157,7 +158,7 @@ final class LeaderAppender {
   }
 
   /** Builds a populated AppendEntries request. */
-  private AppendBatch buildAppendEntriesRequest(
+  private SizedAppendRequest buildAppendEntriesRequest(
       final RaftMemberContext member, final long lastIndex) {
     final IndexedRaftLogEntry prevEntry = member.getCurrentEntry();
 
@@ -178,8 +179,8 @@ final class LeaderAppender {
     // If there exists an entry in the log with size >= MAX_BATCH_SIZE the logic ensures that
     // entry will be sent in a batch of size one
     int size = 0;
-    // Exact on-disk journal bytes of this batch, tracked separately from the approximate wire size
-    // used for the batch cap so the lag accounting matches bytesUntilEnd() and never drifts.
+    // Exact on-disk journal size of this request, tracked separately from the approximate wire
+    // size used for the batch cap so the lag accounting matches bytesUntilEnd() and never drifts.
     long journalBytes = 0;
 
     // Iterate through the log until the last index or the end of the log is reached.
@@ -196,13 +197,14 @@ final class LeaderAppender {
     }
 
     // Add the entries to the request builder and build the request.
-    return new AppendBatch(builder.withEntries(entries).build(), journalBytes);
+    return new SizedAppendRequest(builder.withEntries(entries).build(), journalBytes);
   }
 
   /** Connects to the member and sends a commit message. */
-  private void sendAppendRequest(final RaftMemberContext member, final AppendBatch batch) {
-    final VersionedAppendRequest request = batch.request();
-    final long batchBytes = batch.bytes();
+  private void sendAppendRequest(
+      final RaftMemberContext member, final SizedAppendRequest sizedRequest) {
+    final VersionedAppendRequest request = sizedRequest.request();
+    final long requestSize = sizedRequest.size();
     // If this is a heartbeat message and a heartbeat is already in progress, skip the request.
     if (request.entries().isEmpty() && !member.canHeartbeat()) {
       return;
@@ -210,7 +212,7 @@ final class LeaderAppender {
 
     // Start the append to the member.
     member.startAppend();
-    final long appendWatermark = member.recordInFlightAppend(batchBytes);
+    final long appendWatermark = member.recordInFlightAppend(requestSize);
 
     final long timestamp = System.currentTimeMillis();
 
@@ -1101,9 +1103,9 @@ final class LeaderAppender {
   /**
    * An append request together with the exact journal-byte size of the entries it carries, so the
    * byte count computed at build time can be assigned a cumulative position when the request is
-   * sent. Empty heartbeat requests carry {@code 0} bytes and retain the current position.
+   * sent. Empty heartbeat requests have {@code 0} size and retain the current position.
    */
-  private record AppendBatch(VersionedAppendRequest request, long bytes) {}
+  private record SizedAppendRequest(VersionedAppendRequest request, long size) {}
 
   /** Timestamped completable future. */
   private static class TimestampedFuture<T> extends CompletableFuture<T> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -1098,9 +1098,8 @@ final class LeaderAppender {
   }
 
   /**
-   * An append request together with the exact journal-byte size of the entries it carries, so the
-   * byte count computed at build time can be assigned a cumulative position when the request is
-   * sent. Empty heartbeat requests have {@code 0} size and retain the current position.
+   * An append request together with the exact journal-byte size of the entries it carries. Empty
+   * heartbeat requests have {@code 0} size and retain the current position.
    */
   private record SizedAppendRequest(VersionedAppendRequest request, long size) {}
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -102,8 +102,7 @@ final class LeaderAppender {
    * @param member The member to which to send the request.
    * @return The append request.
    */
-  private VersionedAppendRequest buildAppendRequest(
-      final RaftMemberContext member, final long lastIndex) {
+  private AppendBatch buildAppendRequest(final RaftMemberContext member, final long lastIndex) {
     // If the log is empty then send an empty commit.
     // If the next index hasn't yet been set then we send an empty commit first.
     // If the next index is greater than the last index then send an empty commit.
@@ -123,18 +122,20 @@ final class LeaderAppender {
    *
    * <p>Empty append requests are used as heartbeats to followers.
    */
-  private VersionedAppendRequest buildAppendEmptyRequest(final RaftMemberContext member) {
+  private AppendBatch buildAppendEmptyRequest(final RaftMemberContext member) {
     // Read the previous entry from the reader.
     // The reader can be null for RESERVE members.
     final IndexedRaftLogEntry prevEntry = member.getCurrentEntry();
 
     final DefaultRaftMember leader = raft.getLeader();
-    return builderWithPreviousEntry(prevEntry)
-        .withTerm(raft.getTerm())
-        .withLeader(leader.memberId())
-        .withEntries(Collections.emptyList())
-        .withCommitIndex(raft.getCommitIndex())
-        .build();
+    final var request =
+        builderWithPreviousEntry(prevEntry)
+            .withTerm(raft.getTerm())
+            .withLeader(leader.memberId())
+            .withEntries(Collections.emptyList())
+            .withCommitIndex(raft.getCommitIndex())
+            .build();
+    return new AppendBatch(request, 0L);
   }
 
   private VersionedAppendRequest.Builder builderWithPreviousEntry(
@@ -156,7 +157,7 @@ final class LeaderAppender {
   }
 
   /** Builds a populated AppendEntries request. */
-  private VersionedAppendRequest buildAppendEntriesRequest(
+  private AppendBatch buildAppendEntriesRequest(
       final RaftMemberContext member, final long lastIndex) {
     final IndexedRaftLogEntry prevEntry = member.getCurrentEntry();
 
@@ -177,6 +178,9 @@ final class LeaderAppender {
     // If there exists an entry in the log with size >= MAX_BATCH_SIZE the logic ensures that
     // entry will be sent in a batch of size one
     int size = 0;
+    // Exact on-disk journal bytes of this batch, tracked separately from the approximate wire size
+    // used for the batch cap so the lag accounting matches bytesUntilEnd() and never drifts.
+    long journalBytes = 0;
 
     // Iterate through the log until the last index or the end of the log is reached.
     while (hasMoreEntries(member)) {
@@ -185,18 +189,20 @@ final class LeaderAppender {
       final var replicatableRecord = entry.getReplicatableJournalRecord();
       entries.add(replicatableRecord);
       size += replicatableRecord.approximateSize();
+      journalBytes += entry.size();
       if (entry.index() == lastIndex || size >= maxBatchSizePerAppend) {
         break;
       }
     }
 
     // Add the entries to the request builder and build the request.
-    return builder.withEntries(entries).build();
+    return new AppendBatch(builder.withEntries(entries).build(), journalBytes);
   }
 
   /** Connects to the member and sends a commit message. */
-  private void sendAppendRequest(
-      final RaftMemberContext member, final VersionedAppendRequest request) {
+  private void sendAppendRequest(final RaftMemberContext member, final AppendBatch batch) {
+    final VersionedAppendRequest request = batch.request();
+    final long batchBytes = batch.bytes();
     // If this is a heartbeat message and a heartbeat is already in progress, skip the request.
     if (request.entries().isEmpty() && !member.canHeartbeat()) {
       return;
@@ -204,6 +210,7 @@ final class LeaderAppender {
 
     // Start the append to the member.
     member.startAppend();
+    final long appendWatermark = member.recordInFlightAppend(batchBytes);
 
     final long timestamp = System.currentTimeMillis();
 
@@ -220,7 +227,7 @@ final class LeaderAppender {
 
                 if (error == null) {
                   LOGGER.trace("Received {} from {}", response, member.getMember().memberId());
-                  handleAppendResponse(member, request, response, timestamp);
+                  handleAppendResponse(member, request, response, appendWatermark, timestamp);
                 } else {
                   handleAppendResponseFailure(member, request, error);
                 }
@@ -420,9 +427,8 @@ final class LeaderAppender {
             e);
         return Optional.empty();
       }
-      member.setNextSnapshotIndex(persistedSnapshot.getIndex());
-      member.setNextSnapshotChunkId(null);
-      seedSnapshotReplicationLag(member, persistedSnapshot);
+      member.beginSnapshotInstall(raft.getLog(), persistedSnapshot);
+      observeReplicationLag(member);
     }
 
     final SnapshotChunkReader reader = member.getSnapshotChunkReader();
@@ -707,9 +713,10 @@ final class LeaderAppender {
       final RaftMemberContext member,
       final VersionedAppendRequest request,
       final AppendResponse response,
+      final long appendWatermark,
       final long timestamp) {
     if (response.status() == RaftResponse.Status.OK) {
-      handleAppendResponseOk(member, request, response);
+      handleAppendResponseOk(member, request, response, appendWatermark);
     } else {
       handleAppendResponseError(member, request, response);
     }
@@ -719,7 +726,8 @@ final class LeaderAppender {
   private void handleAppendResponseOk(
       final RaftMemberContext member,
       final VersionedAppendRequest request,
-      final AppendResponse response) {
+      final AppendResponse response,
+      final long appendWatermark) {
     // Reset the member failure count and update the member's availability status if necessary.
     succeedAttempt(member);
 
@@ -728,11 +736,13 @@ final class LeaderAppender {
     // If replication succeeded then trigger commit futures.
     if (response.succeeded()) {
       member.appendSucceeded();
+      member.acknowledgeInFlightAppends(appendWatermark);
       updateMatchIndex(member, response);
       metrics.observeAppend(
           member.getMember().memberId().id(),
           request.entries().size(),
           request.entries().stream().mapToInt(ReplicatableJournalRecord::approximateSize).sum());
+      observeReplicationLag(member);
 
       commitEntries();
 
@@ -1087,6 +1097,13 @@ final class LeaderAppender {
   void observeNonCommittedEntries(final long commitIndex) {
     metrics.observeNonCommittedEntries(raft.getLog().getLastIndex() - commitIndex);
   }
+
+  /**
+   * An append request together with the exact journal-byte size of the entries it carries, so the
+   * byte count computed at build time can be assigned a cumulative position when the request is
+   * sent. Empty heartbeat requests carry {@code 0} bytes and retain the current position.
+   */
+  private record AppendBatch(VersionedAppendRequest request, long bytes) {}
 
   /** Timestamped completable future. */
   private static class TimestampedFuture<T> extends CompletableFuture<T> {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -704,6 +704,10 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     final var indexedEntry = raft.getLog().append(entry);
     raft.getReplicationMetrics().setAppendIndex(indexedEntry.index());
     log.trace("Appended {}", indexedEntry);
+    final int entryBytes = indexedEntry.size();
+    raft.getCluster()
+        .getReplicationTargets()
+        .forEach(member -> member.recordAppendedBytes(entryBytes));
     appender.observeNonCommittedEntries(raft.getCommitIndex());
     return indexedEntry;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntry.java
@@ -65,4 +65,11 @@ public interface IndexedRaftLogEntry {
    * @return a record to replicate
    */
   ReplicatableJournalRecord getReplicatableJournalRecord();
+
+  /**
+   * Returns the total on-disk size of this entry in the journal, including framing and metadata.
+   *
+   * @return the entry size in bytes
+   */
+  int size();
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/IndexedRaftLogEntryImpl.java
@@ -54,4 +54,9 @@ record IndexedRaftLogEntryImpl(long index, long term, RaftEntry entry, JournalRe
     record.serializedRecord().getBytes(0, serializedRecord);
     return new ReplicatableJournalRecord(term, index, record.checksum(), serializedRecord);
   }
+
+  @Override
+  public int size() {
+    return record.size();
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogCommittedReader.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogCommittedReader.java
@@ -78,6 +78,11 @@ public class RaftLogCommittedReader implements RaftLogReader {
   }
 
   @Override
+  public long bytesUntilEnd() {
+    return reader.bytesUntilEnd();
+  }
+
+  @Override
   public void close() {
     reader.close();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogReader.java
@@ -47,6 +47,14 @@ public interface RaftLogReader extends java.util.Iterator<IndexedRaftLogEntry>, 
    */
   long seekToAsqn(final long asqn);
 
+  /**
+   * Returns the total bytes of entries between the reader's current position and the end of the
+   * log.
+   *
+   * @return the bytes until the end of the log
+   */
+  long bytesUntilEnd();
+
   @Override
   void close();
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogUncommittedReader.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogUncommittedReader.java
@@ -73,6 +73,11 @@ public class RaftLogUncommittedReader implements RaftLogReader {
   }
 
   @Override
+  public long bytesUntilEnd() {
+    return journalReader.bytesUntilEnd();
+  }
+
+  @Override
   public void close() {
     journalReader.close();
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationLagTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftReplicationLagTest.java
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class RaftSnapshotReplicationLagTest {
+public class RaftReplicationLagTest {
 
   @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
   private RaftServer leader;
@@ -89,21 +89,66 @@ public class RaftSnapshotReplicationLagTest {
   }
 
   @Test
+  public void shouldTrackLogReplicationLagWhileFollowerCatchesUp() throws Throwable {
+    // given
+    follower = raftRule.getFollower().orElseThrow();
+    final var followerId = MemberId.from(follower.name());
+    raftRule.partition(follower);
+
+    // when
+    raftRule.appendEntries(5);
+
+    // then
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(logReplicationLag(followerId))
+                    .describedAs("log lag accrues while the follower is unreachable")
+                    .isPositive());
+
+    // when
+    raftRule.reconnect(follower);
+
+    // then
+    final var registry = leader.getContext().getMeterRegistry();
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var member = leader.getContext().getCluster().getMemberContext(followerId);
+              assertThat(member.getLogReplicationLag())
+                  .describedAs("log lag drains once the follower catches up")
+                  .isZero();
+              assertThat(member.getReplicationLagBytes())
+                  .describedAs("total lag drains to zero with no snapshot involved")
+                  .isZero();
+              final var gauge = replicationLagGauge(registry, followerId);
+              assertThat(gauge).describedAs("the gauge remains published").isNotNull();
+              assertThat(gauge.value())
+                  .describedAs("the published gauge reflects the drained log lag")
+                  .isZero();
+            });
+  }
+
+  @Test
   public void shouldPublishReplicationLagThroughMeterRegistry() throws Throwable {
     // given
     final int numberOfChunks = 10;
-    final var snapshot = disconnectFollowerAndTakeSnapshot(numberOfChunks);
-    final long totalSnapshotSize = snapshot.getTotalSizeInBytes();
+    disconnectFollowerAndTakeSnapshot(numberOfChunks);
     final var followerId = MemberId.from(follower.name());
     final var registry = leader.getContext().getMeterRegistry();
 
     final List<Double> observedGauge = new CopyOnWriteArrayList<>();
+    final List<Double> observedInternalLag = new CopyOnWriteArrayList<>();
     leaderProtocol.interceptRequest(
         InstallRequest.class,
         request -> {
+          final var member = leader.getContext().getCluster().getMemberContext(followerId);
           final var gauge = replicationLagGauge(registry, followerId);
-          if (gauge != null) {
+          if (member != null && gauge != null) {
             observedGauge.add(gauge.value());
+            observedInternalLag.add((double) member.getReplicationLagBytes());
           }
         });
 
@@ -112,9 +157,9 @@ public class RaftSnapshotReplicationLagTest {
 
     // then
     assertThat(observedGauge).isNotEmpty();
-    assertThat(observedGauge.get(0))
-        .describedAs("the gauge is seeded with the full snapshot size before the first chunk")
-        .isEqualTo((double) totalSnapshotSize);
+    assertThat(observedGauge)
+        .describedAs("the published gauge mirrors the member's replication lag at every step")
+        .containsExactlyElementsOf(observedInternalLag);
     assertThat(observedGauge)
         .describedAs("the published gauge only ever decreases while the install progresses")
         .isSortedAccordingTo(Comparator.reverseOrder());
@@ -125,9 +170,61 @@ public class RaftSnapshotReplicationLagTest {
               final var gauge = replicationLagGauge(registry, followerId);
               assertThat(gauge).describedAs("the gauge remains published").isNotNull();
               assertThat(gauge.value())
-                  .describedAs("the gauge is zeroed once the install completes")
+                  .describedAs("the gauge is zeroed once replication catches up")
                   .isZero();
             });
+  }
+
+  @Test
+  public void shouldExcludePreSnapshotBytesFromLogLagDuringInstall() throws Throwable {
+    // given
+    follower = raftRule.getFollower().orElseThrow();
+    raftRule.partition(follower);
+    leader.getContext().setPreferSnapshotReplicationThreshold(1);
+
+    final var preSnapshotCommit = raftRule.appendEntries(20);
+    final var snapshot = raftRule.takeSnapshot(leader, preSnapshotCommit, 10, true).orElseThrow();
+    raftRule.appendEntries(2);
+
+    final var followerId = MemberId.from(follower.name());
+    final long snapshotSize = snapshot.getTotalSizeInBytes();
+    final long postSnapshotBytes = bytesAfterSnapshotIndex(leader, snapshot.getIndex());
+
+    final List<Long> logLagAtInstall = new CopyOnWriteArrayList<>();
+    final List<Long> totalLagAtInstall = new CopyOnWriteArrayList<>();
+    leaderProtocol.interceptRequest(
+        InstallRequest.class,
+        request -> {
+          final var member = leader.getContext().getCluster().getMemberContext(followerId);
+          if (member != null) {
+            logLagAtInstall.add(member.getLogReplicationLag());
+            totalLagAtInstall.add(member.getReplicationLagBytes());
+          }
+        });
+
+    // when
+    reconnectFollowerAndAwaitSnapshot();
+
+    // then
+    assertThat(logLagAtInstall).isNotEmpty();
+    assertThat(logLagAtInstall.get(0))
+        .describedAs("log lag at install start is the bytes after the snapshot, not the stale span")
+        .isEqualTo(postSnapshotBytes);
+    assertThat(totalLagAtInstall.get(0))
+        .describedAs("total lag is the remaining snapshot plus the post-snapshot log bytes")
+        .isEqualTo(snapshotSize + postSnapshotBytes);
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        leader
+                            .getContext()
+                            .getCluster()
+                            .getMemberContext(followerId)
+                            .getReplicationLagBytes())
+                    .describedAs("lag drains to zero once the install and log catch-up complete")
+                    .isZero());
   }
 
   @Test
@@ -162,12 +259,23 @@ public class RaftSnapshotReplicationLagTest {
         .gauge();
   }
 
+  private long bytesAfterSnapshotIndex(final RaftServer server, final long snapshotIndex) {
+    try (final var reader = server.getContext().getLog().openUncommittedReader()) {
+      reader.seek(snapshotIndex + 1);
+      return Math.max(0, reader.bytesUntilEnd());
+    }
+  }
+
   private long snapshotReplicationLag(final MemberId followerId) {
     return leader
         .getContext()
         .getCluster()
         .getMemberContext(followerId)
         .getSnapshotReplicationLag();
+  }
+
+  private long logReplicationLag(final MemberId followerId) {
+    return leader.getContext().getCluster().getMemberContext(followerId).getLogReplicationLag();
   }
 
   private PersistedSnapshot disconnectFollowerAndTakeSnapshot(final int numberOfChunks)

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -769,6 +769,11 @@ public final class RaftRule extends ExternalResource {
     public ReplicatableJournalRecord getReplicatableJournalRecord() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public int size() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   public interface Configurator {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
@@ -8,15 +8,226 @@
 package io.atomix.raft.cluster.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
+import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.raft.storage.log.RaftLogReader;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 final class RaftMemberContextTest {
+
+  @Test
+  void shouldStartWithZeroLogReplicationLag() {
+    // given / then
+    assertThat(newContext().getLogReplicationLag()).isZero();
+  }
+
+  @Test
+  void shouldIncrementLogLagOnRecordAppend() {
+    // given
+    final var context = newContext();
+
+    // when
+    context.recordAppendedBytes(250);
+    context.recordAppendedBytes(100);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isEqualTo(350);
+  }
+
+  @Test
+  void shouldSubtractInFlightBatchBytesOnAcknowledgement() {
+    // given
+    final var context = newContext();
+    context.recordAppendedBytes(500);
+    final long appendWatermark = context.recordInFlightAppend(200);
+
+    // when
+    context.acknowledgeInFlightAppends(appendWatermark);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isEqualTo(300);
+  }
+
+  @Test
+  void shouldNotSubtractTwiceWhenAcknowledgingSameWatermark() {
+    // given
+    final var context = newContext();
+    context.recordAppendedBytes(500);
+    final long appendWatermark = context.recordInFlightAppend(200);
+    context.acknowledgeInFlightAppends(appendWatermark);
+
+    // when
+    context.acknowledgeInFlightAppends(appendWatermark);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isEqualTo(300);
+  }
+
+  @Test
+  void shouldAcknowledgeTimedOutBatchWhenALaterBatchSucceeds() {
+    // given
+    final var context = newContext();
+    context.recordAppendedBytes(350);
+    final long batchAWatermark = context.recordInFlightAppend(200);
+    final long batchBWatermark = context.recordInFlightAppend(150);
+
+    // when
+    context.acknowledgeInFlightAppends(batchBWatermark);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isZero();
+
+    // when
+    context.acknowledgeInFlightAppends(batchAWatermark);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isZero();
+  }
+
+  @Test
+  void shouldRecalibrateLogLagFromReaderOnReset() {
+    // given
+    final var reader = mock(RaftLogReader.class);
+    when(reader.hasNext()).thenReturn(false);
+    when(reader.seek(anyLong())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(reader.bytesUntilEnd()).thenReturn(4321L);
+    final var log = mock(RaftLog.class);
+    when(log.openUncommittedReader()).thenReturn(reader);
+
+    final var context = newContext();
+    context.openReplicationContext(log);
+    context.recordAppendedBytes(99); // seed drift
+
+    // when
+    context.reset(100);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isEqualTo(4321L);
+  }
+
+  @Test
+  void shouldIgnoreAppendCallbackFromBeforeReset() {
+    // given
+    final var reader = mock(RaftLogReader.class);
+    when(reader.hasNext()).thenReturn(false);
+    when(reader.seek(anyLong())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(reader.bytesUntilEnd()).thenReturn(500L);
+    final var log = mock(RaftLog.class);
+    when(log.openUncommittedReader()).thenReturn(reader);
+
+    final var context = newContext();
+    context.openReplicationContext(log);
+    context.recordAppendedBytes(200);
+    final long appendWatermark = context.recordInFlightAppend(200);
+    context.reset(100);
+
+    // when
+    context.acknowledgeInFlightAppends(appendWatermark);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isEqualTo(500L);
+  }
+
+  @Test
+  void shouldBeginSnapshotInstallWithoutMovingReplicationReader() {
+    // given
+    final var replicationReader = mock(RaftLogReader.class);
+    final var lagReader = mock(RaftLogReader.class);
+    final var currentEntry = mock(IndexedRaftLogEntry.class);
+    when(replicationReader.hasNext()).thenReturn(true);
+    when(replicationReader.next()).thenReturn(currentEntry);
+    when(lagReader.bytesUntilEnd()).thenReturn(42L);
+    final var log = mock(RaftLog.class);
+    when(log.openUncommittedReader()).thenReturn(replicationReader, lagReader);
+    final var snapshot = mock(PersistedSnapshot.class);
+    when(snapshot.getIndex()).thenReturn(10L);
+    when(snapshot.getTotalSizeInBytes()).thenReturn(1_000L);
+
+    final var context = newContext();
+    context.openReplicationContext(log);
+    context.recordAppendedBytes(9_999);
+    context.setNextSnapshotChunkId(ByteBuffer.allocate(1));
+    final var replicationPosition = context.getCurrentEntry();
+
+    // when
+    context.beginSnapshotInstall(log, snapshot);
+
+    // then
+    assertThat(context.getNextSnapshotIndex()).isEqualTo(10L);
+    assertThat(context.getNextSnapshotChunk()).isNull();
+    assertThat(context.getSnapshotReplicationLag()).isEqualTo(1_000L);
+    assertThat(context.getLogReplicationLag()).isEqualTo(42L);
+    assertThat(context.getCurrentEntry()).isSameAs(replicationPosition);
+    verify(lagReader).seek(11L);
+    verify(lagReader).close();
+    verify(replicationReader, never()).reset();
+    verify(replicationReader, never()).seek(11L);
+  }
+
+  @Test
+  void shouldIgnoreAppendAcknowledgementsFromBeforeSnapshotInstallBegins() {
+    // given
+    final var replicationReader = mock(RaftLogReader.class);
+    final var lagReader = mock(RaftLogReader.class);
+    when(lagReader.bytesUntilEnd()).thenReturn(42L);
+    final var log = mock(RaftLog.class);
+    when(log.openUncommittedReader()).thenReturn(replicationReader, lagReader);
+    final var snapshot = mock(PersistedSnapshot.class);
+    when(snapshot.getIndex()).thenReturn(10L);
+    when(snapshot.getTotalSizeInBytes()).thenReturn(1_000L);
+
+    final var context = newContext();
+    context.openReplicationContext(log);
+    final long staleWatermark = context.recordInFlightAppend(20L);
+
+    // when
+    context.beginSnapshotInstall(log, snapshot);
+    context.acknowledgeInFlightAppends(staleWatermark);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldReportCombinedLogAndSnapshotLag() {
+    // given
+    final var context = newContext();
+
+    // when
+    context.recordAppendedBytes(700);
+    context.setSnapshotReplicationLag(300);
+
+    // then
+    assertThat(context.getReplicationLagBytes()).isEqualTo(1000);
+  }
+
+  @Test
+  void shouldClearBothCountersOnResetState() {
+    // given
+    final var log = mock(RaftLog.class);
+    final var context = newContext();
+    context.recordAppendedBytes(1234);
+    context.setSnapshotReplicationLag(5678);
+
+    // when
+    context.resetState(log);
+
+    // then
+    assertThat(context.getLogReplicationLag()).isZero();
+    assertThat(context.getSnapshotReplicationLag()).isZero();
+    assertThat(context.getReplicationLagBytes()).isZero();
+  }
 
   @Test
   void shouldStartWithZeroSnapshotReplicationLag() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -464,5 +464,10 @@ public class LeaderRoleTest {
     public ReplicatableJournalRecord getReplicatableJournalRecord() {
       return null;
     }
+
+    @Override
+    public int size() {
+      return 0;
+    }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestIndexedRaftLogEntry.java
@@ -60,4 +60,9 @@ public class TestIndexedRaftLogEntry implements IndexedRaftLogEntry {
   public ReplicatableJournalRecord getReplicatableJournalRecord() {
     return null;
   }
+
+  @Override
+  public int size() {
+    return 0;
+  }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalReader.java
@@ -107,6 +107,17 @@ public interface JournalReader extends Iterator<JournalRecord>, AutoCloseable {
   /** Get the index of the next record to be read. */
   long getNextIndex();
 
+  /**
+   * Returns the total bytes of journal records between the reader's current position and the end of
+   * the journal.
+   *
+   * <p>This method does not serialize with journal appends (which do not take a lock). The caller
+   * must ensure that the journal is not concurrently modified (e.g. through thread confinement).
+   *
+   * @return the bytes between the reader and the end of the journal (non-negative)
+   */
+  long bytesUntilEnd();
+
   @Override
   void close();
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalRecord.java
@@ -53,4 +53,12 @@ public interface JournalRecord {
    * @return serialized record
    */
   DirectBuffer serializedRecord();
+
+  /**
+   * Returns the total size in bytes occupied by this record in the journal, including the frame and
+   * metadata in addition to the record payload.
+   *
+   * @return the total on-disk size of the record in bytes
+   */
+  int size();
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/Segment.java
@@ -153,6 +153,18 @@ final class Segment implements AutoCloseable, FlushableSegment {
   }
 
   /**
+   * Returns the total bytes of records appended to this segment, excluding the descriptor.
+   *
+   * <p>For closed segments this value is stable after recovery; for the currently-active segment it
+   * advances as new entries are appended.
+   *
+   * @return the appended bytes in this segment
+   */
+  int appendedBytes() {
+    return writer.getAppendedBytes();
+  }
+
+  /**
    * Returns the segment file.
    *
    * @return The segment file.

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentReader.java
@@ -34,6 +34,11 @@ final class SegmentReader implements Iterator<JournalRecord> {
     reset();
   }
 
+  /** Returns the reader's byte offset within the segment, excluding the descriptor. */
+  int getOffsetInSegment() {
+    return buffer.position() - descriptorLength;
+  }
+
   @Override
   public boolean hasNext() {
     if (!segment.isOpen()) {
@@ -55,7 +60,7 @@ final class SegmentReader implements Iterator<JournalRecord> {
     // Read version so that buffer's position is advanced.
     FrameUtil.readVersion(buffer);
 
-    final var currentEntry = recordReader.read(buffer, getNextIndex());
+    final var currentEntry = recordReader.read(buffer, getNextIndex(), FrameUtil.getLength());
     // currentEntry should not be null as hasNext returns true
     currentIndex = currentEntry.index();
     return currentEntry;

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentWriter.java
@@ -101,6 +101,10 @@ final class SegmentWriter {
     return lastEntryPosition;
   }
 
+  int getAppendedBytes() {
+    return buffer.position() - descriptorLength;
+  }
+
   long getNextIndex() {
     if (lastEntry != null) {
       return lastEntry.index() + 1;
@@ -269,7 +273,8 @@ final class SegmentWriter {
             metadata,
             data,
             new UnsafeBuffer(
-                writeBuffer, startPosition + frameLength + metadataLength, recordLength));
+                writeBuffer, startPosition + frameLength + metadataLength, recordLength),
+            frameLength + metadataLength + recordLength);
     updateLastAsqn(lastEntry.asqn());
     index.index(lastEntry, startPosition);
     lastEntryPosition = startPosition;
@@ -346,7 +351,7 @@ final class SegmentWriter {
   private void advanceToNextEntry(final long nextIndex) {
     final int position = buffer.position();
     FrameUtil.readVersion(buffer);
-    lastEntry = recordUtil.read(buffer, nextIndex);
+    lastEntry = recordUtil.read(buffer, nextIndex, FrameUtil.getLength());
     updateLastAsqn(lastEntry.asqn());
     lastEntryPosition = position;
     index.index(lastEntry, position);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalReader.java
@@ -164,6 +164,25 @@ class SegmentedJournalReader implements JournalReader {
   }
 
   @Override
+  public long bytesUntilEnd() {
+    // Prevent segments from being removed or closed while traversing them.
+    // This lock does not serialize with appends, so getting a consistent view requires appropriate
+    // thread confinement.
+    final var stamp = journal.acquireReadlock();
+    try {
+      long bytes = (long) currentSegment.appendedBytes() - currentReader.getOffsetInSegment();
+      Segment next = journal.getNextSegment(currentSegment.index());
+      while (next != null) {
+        bytes += next.appendedBytes();
+        next = journal.getNextSegment(next.index());
+      }
+      return Math.max(0, bytes);
+    } finally {
+      journal.releaseReadlock(stamp);
+    }
+  }
+
+  @Override
   public void close() {
     currentReader.close();
     journal.closeReader(this);

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/JournalRecordReaderUtil.java
@@ -28,7 +28,8 @@ public final class JournalRecordReaderUtil {
    * Reads the JournalRecord in the buffer at the current position. After the methods returns, the
    * position of {@code buffer} will be advanced to the next record.
    */
-  public JournalRecord read(final ByteBuffer buffer, final long expectedIndex) {
+  public JournalRecord read(
+      final ByteBuffer buffer, final long expectedIndex, final int frameLength) {
     // Mark the buffer so it can be reset if necessary.
     buffer.mark();
 
@@ -82,6 +83,9 @@ public final class JournalRecordReaderUtil {
     //       if the underlying buffer is unmapped, any access to serializedRecord will crash the JVM
     //       link: https://github.com/camunda/camunda/issues/57609
     return new PersistedJournalRecord(
-        metadata, record, new UnsafeBuffer(buffer, startPosition + metadataLength, recordLength));
+        metadata,
+        record,
+        new UnsafeBuffer(buffer, startPosition + metadataLength, recordLength),
+        frameLength + metadataLength + recordLength);
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/PersistedJournalRecord.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/record/PersistedJournalRecord.java
@@ -17,7 +17,7 @@ import org.agrona.DirectBuffer;
  * RecordMetadata}. The second part is {@link RecordData}.
  */
 public record PersistedJournalRecord(
-    RecordMetadata metadata, RecordData record, DirectBuffer serializedRecord)
+    RecordMetadata metadata, RecordData record, DirectBuffer serializedRecord, int size)
     implements JournalRecord {
 
   @Override

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -198,7 +198,12 @@ final class JournalAppendTest {
       // when
       final var invalidChecksumRecord =
           new TestJournalRecord(
-              record.index(), record.asqn(), -1, record.data(), record.serializedRecord());
+              record.index(),
+              record.asqn(),
+              -1,
+              record.data(),
+              record.serializedRecord(),
+              record.size());
 
       // then
       assertThatThrownBy(() -> receiverJournal.append(invalidChecksumRecord))

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -569,13 +569,14 @@ final class JournalTest {
 
     if (record instanceof final PersistedJournalRecord p) {
       return new PersistedJournalRecord(
-          p.metadata(), data, BufferUtil.cloneBuffer(p.serializedRecord()));
+          p.metadata(), data, BufferUtil.cloneBuffer(p.serializedRecord()), p.size());
     }
 
     return new PersistedJournalRecord(
         new RecordMetadata(record.checksum(), data.data().capacity()),
         data,
-        BufferUtil.cloneBuffer(record.serializedRecord()));
+        BufferUtil.cloneBuffer(record.serializedRecord()),
+        record.size());
   }
 
   private SegmentedJournal openJournal() {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/LogCorrupter.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/LogCorrupter.java
@@ -81,7 +81,7 @@ public final class LogCorrupter {
     for (long index = 1;
         FrameUtil.hasValidVersion(buffer) && FrameUtil.readVersion(buffer) == 1;
         index++) {
-      final var record = reader.read(buffer, index);
+      final var record = reader.read(buffer, index, FrameUtil.getLength());
 
       if (record.index() > targetIndex) {
         break;

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -190,6 +190,92 @@ class SegmentedJournalReaderTest {
     assertThat(BufferUtil.bufferAsString(record.data())).isEqualTo("");
   }
 
+  @Test
+  void shouldReturnZeroBytesUntilEndForEmptyJournal() {
+    // given
+    assertThat(reader.bytesUntilEnd()).isZero();
+  }
+
+  @Test
+  void shouldReturnAllBytesUntilEndAtStart() {
+    // given
+    final int entrySize = FrameUtil.getLength() + getSerializedSize(data);
+    for (int i = 1; i <= ENTRIES_PER_SEGMENT; i++) {
+      journal.append(i, recordDataWriter);
+    }
+    reader.seekToFirst();
+
+    // then
+    assertThat(reader.bytesUntilEnd()).isEqualTo((long) ENTRIES_PER_SEGMENT * entrySize);
+  }
+
+  @Test
+  void shouldReturnZeroBytesUntilEndAfterConsumingAll() {
+    // given
+    for (int i = 1; i <= ENTRIES_PER_SEGMENT; i++) {
+      journal.append(i, recordDataWriter);
+    }
+    reader.seekToFirst();
+
+    // when
+    while (reader.hasNext()) {
+      reader.next();
+    }
+
+    // then
+    assertThat(reader.bytesUntilEnd()).isZero();
+  }
+
+  @Test
+  void shouldDecreaseBytesUntilEndByEntrySizePerRead() {
+    // given
+    final int entrySize = FrameUtil.getLength() + getSerializedSize(data);
+    for (int i = 1; i <= ENTRIES_PER_SEGMENT; i++) {
+      journal.append(i, recordDataWriter);
+    }
+    reader.seekToFirst();
+
+    // then
+    long expected = (long) ENTRIES_PER_SEGMENT * entrySize;
+    while (reader.hasNext()) {
+      assertThat(reader.bytesUntilEnd()).isEqualTo(expected);
+      reader.next();
+      expected -= entrySize;
+    }
+    assertThat(reader.bytesUntilEnd()).isZero();
+  }
+
+  @Test
+  void shouldSumBytesUntilEndAcrossSegments() {
+    // given
+    final int entrySize = FrameUtil.getLength() + getSerializedSize(data);
+    final int total = ENTRIES_PER_SEGMENT * 3;
+    for (int i = 1; i <= total; i++) {
+      journal.append(i, recordDataWriter);
+    }
+    reader.seekToFirst();
+
+    // then
+    assertThat(reader.bytesUntilEnd()).isEqualTo((long) total * entrySize);
+  }
+
+  @Test
+  void shouldReturnRemainingBytesUntilEndAfterSeekIntoLaterSegment() {
+    // given
+    final int entrySize = FrameUtil.getLength() + getSerializedSize(data);
+    final int total = ENTRIES_PER_SEGMENT * 3;
+    for (int i = 1; i <= total; i++) {
+      journal.append(i, recordDataWriter);
+    }
+
+    // when
+    final int seekIndex = ENTRIES_PER_SEGMENT + 2;
+    reader.seek(seekIndex);
+
+    // then
+    assertThat(reader.bytesUntilEnd()).isEqualTo((long) (total - seekIndex + 1) * entrySize);
+  }
+
   private int getSerializedSize(final DirectBuffer data) {
     final var record = new RecordData(Long.MAX_VALUE, Long.MAX_VALUE, data);
     final var serializer = new SBESerializer();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -598,7 +598,8 @@ class SegmentedJournalTest {
                 firstRecord.index(),
                 firstRecord.asqn(),
                 BufferUtil.cloneBuffer(firstRecord.data())),
-            BufferUtil.cloneBuffer(firstRecord.serializedRecord()));
+            BufferUtil.cloneBuffer(firstRecord.serializedRecord()),
+            firstRecord.size());
     journal.append(journalFactory.entry());
 
     // close the journal before corrupting the segment; since we "flush" when closing, we need to

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SparseJournalIndexTest.java
@@ -38,7 +38,7 @@ class SparseJournalIndexTest {
   }
 
   public static JournalRecord asJournalRecord(final long index, final long asqn) {
-    return new TestJournalRecord(index, asqn, 0, null, null);
+    return new TestJournalRecord(index, asqn, 0, null, null, 0);
   }
 
   @Test

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/util/TestJournalRecord.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/util/TestJournalRecord.java
@@ -11,5 +11,10 @@ import io.camunda.zeebe.journal.JournalRecord;
 import org.agrona.DirectBuffer;
 
 public record TestJournalRecord(
-    long index, long asqn, long checksum, DirectBuffer data, DirectBuffer serializedRecord)
+    long index,
+    long asqn,
+    long checksum,
+    DirectBuffer data,
+    DirectBuffer serializedRecord,
+    int size)
     implements JournalRecord {}


### PR DESCRIPTION
Extends the lag tracking from https://github.com/camunda/camunda/pull/58107 (which covered only pending/in-flight snapshot replication) with tracking for pending/in-flight log appends, which are now included in the total replication lag measurement.

Log replication lag is first updated by each local append - then, for each append request sent to a follower we track a
monotonically-increasing watermark (the cumulative number of log bytes sent to the follower in the entire lifetime of RaftMemberContext). On acknowledgement of an append we check the associated watermark against the current value - this lets us account for any previously replicated appends that weren't yet acknowledged as well as guarding against any stale callbacks.

We do need to interrogate the log reader for the outstanding bytes in some cases, but not on the hot path - only when installing a snapshot or resetting state.

Closes #56755.