### PR TITLE
test: add Tasklist E2E for user task with custom task headers

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_custom_headers.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/usertask_with_custom_headers.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_usertask_with_custom_headers" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.30.0-nightly.20241111">
+  <bpmn:process id="usertask_with_custom_headers" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0u665te</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0u665te" sourceRef="StartEvent_1" targetRef="Activity_0awbj0c0" />
+    <bpmn:endEvent id="Event_0gtkwhz" name="End">
+      <bpmn:incoming>Flow_1mtspc2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1mtspc2" sourceRef="Activity_0awbj0c0" targetRef="Event_0gtkwhz" />
+    <bpmn:userTask id="Activity_0awbj0c0" name="Task with custom headers">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+        <zeebe:taskHeaders>
+          <zeebe:header key="TaskHeaderTest" value="TaskHeaderValue" />
+        </zeebe:taskHeaders>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u665te</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mtspc2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="usertask_with_custom_headers">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gtkwhz_di" bpmnElement="Event_0gtkwhz">
+        <dc:Bounds x="482" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="490" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1svyo8o_di" bpmnElement="Activity_0awbj0c0">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0u665te_di" bpmnElement="Flow_0u665te">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mtspc2_di" bpmnElement="Flow_1mtspc2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="482" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -14,7 +14,8 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {findUserTask, expectProcessState} from '@requestHelpers';
-import {buildUrl, jsonHeaders} from '../../utils/http';
+import {buildUrl, jsonHeaders} from 'utils/http';
+import {defaultAssertionOptions} from 'utils/constants';
 
 test.beforeAll(async () => {
   await deploy([
@@ -621,12 +622,17 @@ test.describe('task details page', () => {
     await expect(async () => {
       const res = await request.post(buildUrl('/process-instances/search'), {
         headers: jsonHeaders(),
-        data: {filter: {processDefinitionId: 'usertask_with_custom_headers'}},
+        data: {
+          filter: {
+            processDefinitionId: 'usertask_with_custom_headers',
+            state: 'ACTIVE',
+          },
+        },
       });
       const body = await res.json();
       expect(body.items.length).toBe(1);
       processInstanceKey = body.items[0].processInstanceKey;
-    }).toPass();
+    }).toPass(defaultAssertionOptions);
 
     const userTaskKey = await findUserTask(
       request,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -13,6 +13,8 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
+import {findUserTask, expectProcessState} from '@requestHelpers';
+import {buildUrl, jsonHeaders} from '../../utils/http';
 
 test.beforeAll(async () => {
   await deploy([
@@ -50,6 +52,7 @@ test.beforeAll(async () => {
     './resources/employee_registration_no_output_mapping.bpmn',
     './resources/employee_details_form.form',
     './resources/employee_confirmation_form.form',
+    './resources/usertask_with_custom_headers.bpmn',
   ]);
   await sleep(1000);
 
@@ -87,6 +90,7 @@ test.beforeAll(async () => {
     createInstances('zeebe_and_job_worker_process', 1, 1),
     createInstances('bigVariableProcessWithForm', 1, 1),
     createInstances('employee_registration_no_output_mapping', 1, 1),
+    createInstances('usertask_with_custom_headers', 1, 1),
   ]);
 
   await sleep(1000);
@@ -606,6 +610,45 @@ test.describe('task details page', () => {
 
     await expect(taskDetailsPage.form).toContainText('Hello Jane');
     await expect(taskDetailsPage.form).toContainText('You are 50 years old');
+  });
+
+  test('user task with custom headers can be completed and process continues', async ({
+    request,
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    let processInstanceKey = '';
+    await expect(async () => {
+      const res = await request.post(buildUrl('/process-instances/search'), {
+        headers: jsonHeaders(),
+        data: {filter: {processDefinitionId: 'usertask_with_custom_headers'}},
+      });
+      const body = await res.json();
+      expect(body.items.length).toBe(1);
+      processInstanceKey = body.items[0].processInstanceKey;
+    }).toPass();
+
+    const userTaskKey = await findUserTask(
+      request,
+      processInstanceKey,
+      'CREATED',
+    );
+
+    const userTaskRes = await request.get(
+      buildUrl(`/user-tasks/${userTaskKey}`),
+      {headers: jsonHeaders()},
+    );
+    expect((await userTaskRes.json()).customHeaders).toEqual({
+      TaskHeaderTest: 'TaskHeaderValue',
+    });
+
+    await taskPanelPage.openTask('Task with custom headers');
+    await taskDetailsPage.clickAssignToMeButton();
+    await expect(taskDetailsPage.completeTaskButton).toBeEnabled();
+    await taskDetailsPage.clickCompleteTaskButton();
+    await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+
+    await expectProcessState(request, processInstanceKey, 'COMPLETED');
   });
 
   test('show process model', async ({taskPanelPage, taskDetailsPage}) => {


### PR DESCRIPTION
## Summary
- Automates #58056: a user task defined with `zeebe:taskHeaders` can be assigned and completed via the Tasklist UI, and the process instance continues past it.
- Adds `resources/usertask_with_custom_headers.bpmn` (single user task with a custom header, no form needed).
- Adds one test to the existing `tests/tasklist/task-details.spec.ts` suite (reuses its shared deploy/login setup, no new spec file):
  - deploys the process and creates an instance in the file's shared `beforeAll`
  - asserts `customHeaders` on `GET /v2/user-tasks/{key}`
  - assigns + completes the task via the Tasklist UI
  - asserts the process instance reaches `COMPLETED` via `/v2/process-instances/search`

## Test plan
- [x] Ran locally against a local c8run 8.10.0-SNAPSHOT cluster: `node --env-file=.env node_modules/.bin/playwright test tests/tasklist/task-details.spec.ts --project=chromium` — all 20 tests in the file pass, including the new one, no regressions.
- [x] `npx eslint tests/tasklist/task-details.spec.ts` — clean.
- [x] `npx tsc --noEmit` — no new errors.

Closes #58056

🤖 Generated with [Claude Code](https://claude.com/claude-code)