### PR TITLE
test: add coverage for job batch-update priority via REST API

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithJobPriorityForBatchUpdate.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/processWithJobPriorityForBatchUpdate.bpmn
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_processWithJobPriorityForBatchUpdate" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="processWithJobPriorityForBatchUpdate" name="Process with job priority for batch update" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0f1wqwc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:parallelGateway id="Gateway_1pph9x7">
+      <bpmn:incoming>Flow_0f1wqwc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zy2l70</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ockqzv</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0p4wn83</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0f1wqwc" sourceRef="StartEvent_1" targetRef="Gateway_1pph9x7" />
+    <bpmn:sequenceFlow id="Flow_0zy2l70" sourceRef="Gateway_1pph9x7" targetRef="Activity_PriorityHigh" />
+    <bpmn:serviceTask id="Activity_PriorityHigh" name="high priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="batchUpdatePriorityJobType" />
+        <zeebe:jobPriorityDefinition priority="90" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0zy2l70</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vumtxw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1ockqzv" sourceRef="Gateway_1pph9x7" targetRef="Activity_PriorityMid" />
+    <bpmn:serviceTask id="Activity_PriorityMid" name="mid priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="batchUpdatePriorityJobType" />
+        <zeebe:jobPriorityDefinition priority="50" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ockqzv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1skkueu</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0p4wn83" sourceRef="Gateway_1pph9x7" targetRef="Activity_PriorityLow" />
+    <bpmn:serviceTask id="Activity_PriorityLow" name="low priority task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="batchUpdatePriorityJobType" />
+        <zeebe:jobPriorityDefinition priority="10" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0p4wn83</bpmn:incoming>
+      <bpmn:outgoing>Flow_11hzfk4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="Gateway_1el4beg">
+      <bpmn:incoming>Flow_1skkueu</bpmn:incoming>
+      <bpmn:incoming>Flow_1vumtxw</bpmn:incoming>
+      <bpmn:incoming>Flow_11hzfk4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1sgfdsy</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1skkueu" sourceRef="Activity_PriorityMid" targetRef="Gateway_1el4beg" />
+    <bpmn:sequenceFlow id="Flow_1vumtxw" sourceRef="Activity_PriorityHigh" targetRef="Gateway_1el4beg" />
+    <bpmn:sequenceFlow id="Flow_11hzfk4" sourceRef="Activity_PriorityLow" targetRef="Gateway_1el4beg" />
+    <bpmn:endEvent id="Event_11eote1">
+      <bpmn:incoming>Flow_1sgfdsy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1sgfdsy" sourceRef="Gateway_1el4beg" targetRef="Event_11eote1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithJobPriorityForBatchUpdate">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1pph9x7_di" bpmnElement="Gateway_1pph9x7">
+        <dc:Bounds x="275" y="155" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_PriorityHigh_di" bpmnElement="Activity_PriorityHigh">
+        <dc:Bounds x="410" y="50" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_PriorityMid_di" bpmnElement="Activity_PriorityMid">
+        <dc:Bounds x="410" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_PriorityLow_di" bpmnElement="Activity_PriorityLow">
+        <dc:Bounds x="410" y="250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1el4beg_di" bpmnElement="Gateway_1el4beg">
+        <dc:Bounds x="595" y="155" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_11eote1_di" bpmnElement="Event_11eote1">
+        <dc:Bounds x="732" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0f1wqwc_di" bpmnElement="Flow_0f1wqwc">
+        <di:waypoint x="218" y="180" />
+        <di:waypoint x="275" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zy2l70_di" bpmnElement="Flow_0zy2l70">
+        <di:waypoint x="300" y="155" />
+        <di:waypoint x="300" y="90" />
+        <di:waypoint x="410" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ockqzv_di" bpmnElement="Flow_1ockqzv">
+        <di:waypoint x="325" y="180" />
+        <di:waypoint x="410" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p4wn83_di" bpmnElement="Flow_0p4wn83">
+        <di:waypoint x="300" y="205" />
+        <di:waypoint x="300" y="290" />
+        <di:waypoint x="410" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1skkueu_di" bpmnElement="Flow_1skkueu">
+        <di:waypoint x="510" y="180" />
+        <di:waypoint x="595" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vumtxw_di" bpmnElement="Flow_1vumtxw">
+        <di:waypoint x="510" y="90" />
+        <di:waypoint x="620" y="90" />
+        <di:waypoint x="620" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11hzfk4_di" bpmnElement="Flow_11hzfk4">
+        <di:waypoint x="510" y="290" />
+        <di:waypoint x="620" y="290" />
+        <di:waypoint x="620" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sgfdsy_di" bpmnElement="Flow_1sgfdsy">
+        <di:waypoint x="645" y="180" />
+        <di:waypoint x="732" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-batch-update-priority-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-batch-update-priority-api-tests.spec.ts
@@ -26,18 +26,22 @@ import {expectBatchState} from '@requestHelpers';
 /* eslint-disable playwright/expect-expect */
 test.describe('Job Batch Update Priority API Tests', () => {
   const runSuffix = randomUUID().slice(0, 8);
-  const processId = `processWithJobPriority-${runSuffix}`;
+  const processId = `processWithJobPriorityForBatchUpdate-${runSuffix}`;
   const batchPriorityJobType = `batchPriorityJobType-${runSuffix}`;
   const state: Record<string, unknown> = {};
 
-  // Reuses the processWithJobPriority.bpmn fixture (3 service tasks of one
-  // job type with distinct static priorities) that already backs the job
-  // priority search/activation coverage.
+  // Dedicated fixture (3 service tasks of one job type with distinct static
+  // priorities) so this suite's batch-update deploys/instances can't
+  // interfere with the sibling job-priority search/activation coverage that
+  // uses its own processWithJobPriority.bpmn.
   test.beforeAll(async () => {
-    await deployWithSubstitutions('./resources/processWithJobPriority.bpmn', {
-      processWithJobPriority: processId,
-      priorityJobType: batchPriorityJobType,
-    });
+    await deployWithSubstitutions(
+      './resources/processWithJobPriorityForBatchUpdate.bpmn',
+      {
+        processWithJobPriorityForBatchUpdate: processId,
+        batchUpdatePriorityJobType: batchPriorityJobType,
+      },
+    );
     const [processInstance] = await createInstances(processId, 1, 1);
     state['processInstanceKey'] = processInstance.processInstanceKey;
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-batch-update-priority-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-batch-update-priority-api-tests.spec.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {
+  cancelProcessInstance,
+  createInstances,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {defaultAssertionOptions} from 'utils/constants';
+import {validateResponse} from 'json-body-assertions';
+import {expectBatchState} from '@requestHelpers';
+
+/* eslint-disable playwright/expect-expect */
+test.describe('Job Batch Update Priority API Tests', () => {
+  const runSuffix = randomUUID().slice(0, 8);
+  const processId = `processWithJobPriority-${runSuffix}`;
+  const batchPriorityJobType = `batchPriorityJobType-${runSuffix}`;
+  const state: Record<string, unknown> = {};
+
+  // Reuses the processWithJobPriority.bpmn fixture (3 service tasks of one
+  // job type with distinct static priorities) that already backs the job
+  // priority search/activation coverage.
+  test.beforeAll(async () => {
+    await deployWithSubstitutions('./resources/processWithJobPriority.bpmn', {
+      processWithJobPriority: processId,
+      priorityJobType: batchPriorityJobType,
+    });
+    const [processInstance] = await createInstances(processId, 1, 1);
+    state['processInstanceKey'] = processInstance.processInstanceKey;
+  });
+
+  test.afterAll(async () => {
+    await cancelProcessInstance(state['processInstanceKey'] as string);
+  });
+
+  test('Batch update by type sets priority on all matching jobs and completes successfully', async ({
+    request,
+  }) => {
+    let jobKeys: string[] = [];
+    let batchOperationKey: string;
+
+    await test.step('Confirm 3 pending jobs of batchPriorityJobType exist', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/jobs/search'), {
+          headers: jsonHeaders(),
+          data: {filter: {type: batchPriorityJobType}},
+        });
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {path: '/jobs/search', method: 'POST', status: '200'},
+          res,
+        );
+        const json = await res.json();
+        expect(json.items).toHaveLength(3);
+        jobKeys = json.items.map((item: {jobKey: string}) =>
+          String(item.jobKey),
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Create batch operation to update priority of jobs matching the type filter', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/jobs/batch-update'), {
+          headers: jsonHeaders(),
+          data: {
+            filter: {type: batchPriorityJobType},
+            changeset: {priority: 99},
+          },
+        });
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {path: '/jobs/batch-update', method: 'POST', status: '200'},
+          res,
+        );
+        const json = await res.json();
+        expect(json.batchOperationType).toBe('UPDATE_JOB');
+        expect(json.batchOperationKey).toBeDefined();
+        batchOperationKey = json.batchOperationKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Poll until the batch operation completes', async () => {
+      await expectBatchState(request, batchOperationKey, 'COMPLETED');
+    });
+
+    await test.step('Every job of batchPriorityJobType now has priority 99', async () => {
+      await expect(async () => {
+        const res = await request.post(buildUrl('/jobs/search'), {
+          headers: jsonHeaders(),
+          data: {filter: {type: batchPriorityJobType}},
+        });
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        expect(json.items).toHaveLength(3);
+        for (const item of json.items) {
+          expect(item.priority).toBe(99);
+        }
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Batch operation items are all COMPLETED, one per updated job', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl('/batch-operation-items/search'),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {batchOperationKey}},
+          },
+        );
+        await assertStatusCode(res, 200);
+        await validateResponse(
+          {
+            path: '/batch-operation-items/search',
+            method: 'POST',
+            status: '200',
+          },
+          res,
+        );
+        const json = await res.json();
+        expect(json.items).toHaveLength(3);
+        const itemKeys = json.items.map((item: {itemKey: string}) =>
+          String(item.itemKey),
+        );
+        expect(itemKeys.sort()).toEqual([...jobKeys].sort());
+        for (const item of json.items) {
+          expect(item.operationType).toBe('UPDATE_JOB');
+          expect(item.state).toBe('COMPLETED');
+        }
+      }).toPass(defaultAssertionOptions);
+    });
+  });
+
+  test('Batch update jobs - unauthorized request returns 401', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/batch-update'), {
+      data: {
+        filter: {type: batchPriorityJobType},
+        changeset: {priority: 1},
+      },
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Playwright E2E coverage for `POST /jobs/batch-update` in `qa/c8-orchestration-cluster-e2e-test-suite`: creates 3 pending jobs of one type with distinct static priorities, batch-updates their priority via a type filter, polls the batch operation to `COMPLETED`, and verifies every job's priority was updated and every batch operation item completed successfully.
- Regenerates `json-body-assertions/_generated/*` from the current `main` OpenAPI spec so the new test (and other recently added routes) can validate response shapes against the current contract.

Closes #57924

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on the new spec
- [x] `npx prettier --check` passes on the new spec
- [x] Ran the new spec against a local Camunda 8.10 cluster (`docker-compose`, unified 8080) — both tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)