### PR TITLE
ci: test ubicloud-runners on some job on the unified-ci

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -63,18 +63,21 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner: ubicloud-standard-4
+          runner: ubicloud-standard-4-arm
+          fossa_cli_arch: linux_arm64
         - name: optimize
           path: ./optimize
-          runner: ublicloud-standard-16
+          runner: ubicloud-standard-16-arm
           maven-config: |
             -DskipQaBuild=true
+          fossa_cli_arch: linux_arm64
         - name: single-app
           path: ./
-          runner: ubicloud-standard-16
+          runner: ubicloud-standard-16-arm
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
+          fossa_cli_arch: linux_arm64
     steps:
     - uses: camunda/infra-global-github-actions/start-build-monitor@f063d613a0c7eb6d1b5a155722f09f336e39ccb5 # main
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -112,7 +115,9 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/setup@fossa-arm64
+      with:
+        arch: ${{ matrix.project.fossa_cli_arch }}
 
     - name: Get context info
       id: info

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -63,15 +63,15 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner: gcp-core-4-longrunning
+          runner: ubicloud-standard-4
         - name: optimize
           path: ./optimize
-          runner: gcp-core-16-longrunning
+          runner: ublicloud-standard-16
           maven-config: |
             -DskipQaBuild=true
         - name: single-app
           path: ./
-          runner: gcp-core-16-longrunning
+          runner: ubicloud-standard-16
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -65,18 +65,21 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner: ubicloud-standard-4
+          runner: ubicloud-standard-4-arm
+          fossa_cli_arch: linux_arm64
         - name: optimize
           path: ./optimize
-          runner: ublicloud-standard-16
+          runner: ubicloud-standard-16-arm
           maven-config: |
             -DskipQaBuild=true
+          fossa_cli_arch: linux_arm64
         - name: single-app
           path: ./
-          runner: ubicloud-standard-16
+          runner: ubicloud-standard-16-arm
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
+          fossa_cli_arch: linux_arm64
     steps:
     - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -116,7 +119,9 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/setup@fossa-arm64
+      with:
+        arch: ${{ matrix.project.fossa_cli_arch }}
 
     - name: Get context info
       id: info

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -65,15 +65,15 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner: gcp-core-4-longrunning
+          runner: ubicloud-standard-4
         - name: optimize
           path: ./optimize
-          runner: gcp-core-16-longrunning
+          runner: ublicloud-standard-16
           maven-config: |
             -DskipQaBuild=true
         - name: single-app
           path: ./
-          runner: gcp-core-16-longrunning
+          runner: ubicloud-standard-16
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,8 +472,6 @@ jobs:
     # is included because its filter is a superset of java-code-changes (adds rdbms-change). See #52693.
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
-    runs-on: ubicloud-standard-8
-    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
     needs: [ detect-changes ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
+    runs-on: ubicloud-standard-8 # gcp-perf-core-8-default
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@f063d613a0c7eb6d1b5a155722f09f336e39ccb5 # main
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -805,7 +805,7 @@ jobs:
               "maven-modules": "clients/camunda-spring-boot-starter,clients/camunda-spring-boot-3-starter,clients/camunda-spring-boot-starter-virtual-threads,clients/java",
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "owner": "@camunda/core-features",
               "module": "Clients",
               "stressRun": 1
@@ -1228,7 +1228,7 @@ jobs:
     needs: [ detect-changes, build-distball ]
     name: "General / Integration / RDBMS ITs"
     timeout-minutes: 30
-    runs-on: gcp-perf-core-8-default
+    runs-on: ubicloud-standard-8
     strategy:
       # In case of stress testing, we want the status from all jobs.
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
     if: ${{ false }}
     name: "Dependency Cycle Check"
     needs: [ detect-changes ]
-    runs-on: gcp-core-16-default
+    runs-on: ubicloud-standard-16
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     strategy:
@@ -472,6 +472,8 @@ jobs:
     # is included because its filter is a superset of java-code-changes (adds rdbms-change). See #52693.
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
+    runs-on: ubicloud-standard-8
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
@@ -662,7 +664,7 @@ jobs:
               "maven-modules": "'qa/acceptance-tests'",
               "maven-build-threads": 2,
               "maven-test-fork-count": 3,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/qa-engineering",
@@ -675,7 +677,7 @@ jobs:
               "maven-modules": "'qa/testcontainer'",
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/zeebe-distributed-platform",
@@ -688,7 +690,7 @@ jobs:
               "maven-modules": "${ZEEBE_IT_DISTRIBUTED_MODULES}",
               "maven-build-threads": 2,
               "maven-test-fork-count": 7,
-              "runs-on": "gcp-perf-core-16-longrunning",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/zeebe-distributed-platform",
@@ -701,7 +703,7 @@ jobs:
               "maven-modules": "${ZEEBE_IT_ENGINE_MODULES}",
               "maven-build-threads": 2,
               "maven-test-fork-count": 7,
-              "runs-on": "gcp-perf-core-16-longrunning",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/core-features",
@@ -714,7 +716,7 @@ jobs:
               "maven-modules": "${ZEEBE_IT_EXPORTER_MODULES}",
               "maven-build-threads": 2,
               "maven-test-fork-count": 7,
-              "runs-on": "gcp-perf-core-16-longrunning",
+              "runs-on": "ubicloud-standard-16",
               "owner": "@camunda/data-layer",
               "module": "Zeebe",
               "stressRun": 1
@@ -725,7 +727,7 @@ jobs:
               "maven-modules": "schema-manager",
               "maven-build-threads": 1,
               "maven-test-fork-count": 3,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/data-layer",
@@ -738,7 +740,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "owner": "@camunda/core-features",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.engine.**,!**/*${DOLLAR}*.java",
@@ -751,7 +753,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/zeebe-distributed-platform",
@@ -766,7 +768,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "owner": "@camunda/zeebe-distributed-platform",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest",
@@ -778,7 +780,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/engineering-operations",
@@ -792,7 +794,7 @@ jobs:
               "maven-modules": "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example",
               "maven-build-threads": 1,
               "maven-test-fork-count": 3,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/c8-testing",
@@ -816,7 +818,7 @@ jobs:
               "maven-modules": "zeebe/qa/update-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/core-features",
@@ -856,7 +858,7 @@ jobs:
     needs: [ detect-changes, setup-tests ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
+    runs-on: ubicloud-standard-16
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
@@ -923,7 +925,7 @@ jobs:
     needs: [ detect-changes, setup-tests ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
+    runs-on: ubicloud-standard-16
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
@@ -1094,7 +1096,7 @@ jobs:
       maven-profiles: "history"
       test-type: "history-tests"
       test-type-label: "History"
-      runs-on: "gcp-perf-core-8-default"
+      runs-on: "ubicloud-standard-8"
       use-shared-distball: true
 
   identity-tests:
@@ -1449,7 +1451,7 @@ jobs:
     needs: [ detect-changes ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
+    runs-on: ubicloud-standard-16
     env:
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
@@ -2539,7 +2541,7 @@ jobs:
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ check-results, build-platform-frontend, utils-get-concurrency-group-for-maven-snapshot ]
-    runs-on: gcp-perf-core-8-default
+    runs-on: ubicloud-standard-8
     timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
     if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,8 +502,6 @@ jobs:
     # is included because its filter is a superset of java-code-changes (adds rdbms-change). See #52693.
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
-    runs-on: ubicloud-standard-8
-    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
     needs: [ detect-changes ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-8-default
+    runs-on: ubicloud-standard-8 # gcp-perf-core-8-default
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@20384346f55213d43c85943363f40d29e3911f97 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -838,7 +838,7 @@ jobs:
               "maven-modules": "clients/camunda-spring-boot-starter,clients/camunda-spring-boot-3-starter,clients/camunda-spring-boot-starter-virtual-threads,clients/java",
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "owner": "@camunda/core-features",
               "module": "Clients",
               "stressRun": 1
@@ -1300,7 +1300,7 @@ jobs:
     needs: [ detect-changes, build-distball ]
     name: "General / Integration / RDBMS ITs"
     timeout-minutes: 30
-    runs-on: gcp-perf-core-8-default
+    runs-on: ubicloud-standard-8
     strategy:
       # In case of stress testing, we want the status from all jobs.
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,7 @@ jobs:
     if: false
     name: "Dependency Cycle Check"
     needs: [ detect-changes ]
-    runs-on: gcp-core-16-default
+    runs-on: ubicloud-standard-16
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
     strategy:
@@ -502,6 +502,8 @@ jobs:
     # is included because its filter is a superset of java-code-changes (adds rdbms-change). See #52693.
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
+    runs-on: ubicloud-standard-8
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
@@ -695,7 +697,7 @@ jobs:
               "maven-modules": "'qa/acceptance-tests'",
               "maven-build-threads": 2,
               "maven-test-fork-count": 3,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/qa-engineering",
@@ -708,7 +710,7 @@ jobs:
               "maven-modules": "'qa/testcontainer'",
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/zeebe-distributed-platform",
@@ -721,7 +723,7 @@ jobs:
               "maven-modules": "${ZEEBE_IT_DISTRIBUTED_MODULES}",
               "maven-build-threads": 2,
               "maven-test-fork-count": 7,
-              "runs-on": "gcp-perf-core-16-longrunning",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/zeebe-distributed-platform",
@@ -734,7 +736,7 @@ jobs:
               "maven-modules": "${ZEEBE_IT_ENGINE_MODULES}",
               "maven-build-threads": 2,
               "maven-test-fork-count": 7,
-              "runs-on": "gcp-perf-core-16-longrunning",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/core-features",
@@ -747,7 +749,7 @@ jobs:
               "maven-modules": "${ZEEBE_IT_EXPORTER_MODULES}",
               "maven-build-threads": 2,
               "maven-test-fork-count": 7,
-              "runs-on": "gcp-perf-core-16-longrunning",
+              "runs-on": "ubicloud-standard-16",
               "owner": "@camunda/data-layer",
               "module": "Zeebe",
               "stressRun": 1
@@ -758,7 +760,7 @@ jobs:
               "maven-modules": "schema-manager",
               "maven-build-threads": 1,
               "maven-test-fork-count": 3,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/data-layer",
@@ -771,7 +773,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "owner": "@camunda/core-features",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.engine.**,!**/*${DOLLAR}*.java",
@@ -784,7 +786,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/zeebe-distributed-platform",
@@ -799,7 +801,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "owner": "@camunda/zeebe-distributed-platform",
               "module": "Zeebe",
               "test-filter": "io.camunda.zeebe.it.cluster.clustering.dynamic.ScaleUpPartitionsTest",
@@ -811,7 +813,7 @@ jobs:
               "maven-modules": "zeebe/qa/integration-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/engineering-operations",
@@ -825,7 +827,7 @@ jobs:
               "maven-modules": "testing/camunda-process-test-java,testing/camunda-process-test-spring,testing/camunda-process-test-example",
               "maven-build-threads": 1,
               "maven-test-fork-count": 3,
-              "runs-on": "gcp-perf-core-8-default",
+              "runs-on": "ubicloud-standard-8",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/c8-testing",
@@ -849,7 +851,7 @@ jobs:
               "maven-modules": "zeebe/qa/update-tests",
               "maven-build-threads": 1,
               "maven-test-fork-count": 10,
-              "runs-on": "gcp-perf-core-16-default",
+              "runs-on": "ubicloud-standard-16",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
               "owner": "@camunda/core-features",
@@ -889,7 +891,7 @@ jobs:
     needs: [ detect-changes, setup-tests ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
+    runs-on: ubicloud-standard-16
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
@@ -958,7 +960,7 @@ jobs:
     needs: [ detect-changes, setup-tests ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
+    runs-on: ubicloud-standard-16
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     env:
@@ -1136,7 +1138,7 @@ jobs:
       maven-profiles: "history"
       test-type: "history-tests"
       test-type-label: "History"
-      runs-on: "gcp-perf-core-8-default"
+      runs-on: "ubicloud-standard-8"
       # Fork PRs can't authenticate to GCS (no Vault access, see gcs-build-cache-auth),
       # so fall back to each reusable workflow's build-zeebe path instead of the shared distball.
       use-shared-distball: ${{ github.event.pull_request.head.repo.fork != true }}
@@ -1691,7 +1693,7 @@ jobs:
     needs: [ detect-changes ]
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
-    runs-on: gcp-perf-core-16-default
+    runs-on: ubicloud-standard-16
     env:
       TEST_PRODUCT: Camunda
       TEST_TYPE: Unit
@@ -2839,7 +2841,7 @@ jobs:
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ check-results, build-platform-frontend, utils-get-concurrency-group-for-maven-snapshot ]
-    runs-on: gcp-perf-core-8-default
+    runs-on: ubicloud-standard-8
     timeout-minutes: 25
     permissions: { }  # GITHUB_TOKEN unused in this job
     if: always() && needs.check-results.result == 'success' && github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))


### PR DESCRIPTION
## Description

Testing ubicloud-runners on some jobs of the unified-ci 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
