### PR TITLE
feat: stop unmounting agent details when element instance completes

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
@@ -9,6 +9,7 @@
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
@@ -46,7 +47,7 @@ describe('<LatestAgentMessage />', () => {
     render(
       <LatestAgentMessage
         agentInstanceKey={AGENT_INSTANCE_KEY}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
       />,
       {wrapper: createWrapper()},
     );
@@ -64,7 +65,7 @@ describe('<LatestAgentMessage />', () => {
     render(
       <LatestAgentMessage
         agentInstanceKey={AGENT_INSTANCE_KEY}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
       />,
       {wrapper: createWrapper()},
     );
@@ -84,7 +85,7 @@ describe('<LatestAgentMessage />', () => {
     render(
       <LatestAgentMessage
         agentInstanceKey={AGENT_INSTANCE_KEY}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
       />,
       {wrapper: createWrapper()},
     );
@@ -112,7 +113,7 @@ describe('<LatestAgentMessage />', () => {
     render(
       <LatestAgentMessage
         agentInstanceKey={AGENT_INSTANCE_KEY}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
       />,
       {wrapper: createWrapper()},
     );
@@ -126,6 +127,38 @@ describe('<LatestAgentMessage />', () => {
       message.getByRole('heading', {name: 'Assistant'}),
     ).toBeInTheDocument();
     expect(message.getByText('I will help you with that.')).toBeInTheDocument();
+  });
+
+  it('should trigger a refetch when the agent instance status changes', async () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({historyItemKey: 'msg-2'})]),
+    );
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({historyItemKey: 'msg-1'})]),
+    );
+
+    const {rerender} = render(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        agentInstanceStatus="IDLE"
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('conversation-message-msg-1')).toBeVisible(),
+    );
+
+    rerender(
+      <LatestAgentMessage
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        agentInstanceStatus="TOOL_CALLING"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('conversation-message-msg-2')).toBeVisible(),
+    );
   });
 
   it('should render tool call intents for a message with tool calls', async () => {
@@ -156,7 +189,7 @@ describe('<LatestAgentMessage />', () => {
     render(
       <LatestAgentMessage
         agentInstanceKey={AGENT_INSTANCE_KEY}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
       />,
       {wrapper: createWrapper()},
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
@@ -6,23 +6,36 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useEffect, useRef} from 'react';
 import {SkeletonText} from '@carbon/react';
 import {useLatestAgentMessage} from 'modules/queries/agentInstances/useLatestAgentMessage';
 import {ConversationMessage} from '../ConversationMessage';
 import {StatusHint} from './styled';
+import type {AgentInstanceStatus} from '@camunda/camunda-api-zod-schemas/8.10';
+import {isActiveAgentInstanceStatus} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 type LatestAgentMessageProps = {
   agentInstanceKey: string;
-  enablePeriodicRefetch: boolean;
+  agentInstanceStatus: AgentInstanceStatus;
 };
 
 const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
   agentInstanceKey,
-  enablePeriodicRefetch,
+  agentInstanceStatus,
 }) => {
-  const {data, status} = useLatestAgentMessage(agentInstanceKey, {
-    enablePeriodicRefetch,
-  });
+  const {data, status, refetch, isEnabled} = useLatestAgentMessage(
+    agentInstanceKey,
+    {enablePeriodicRefetch: isActiveAgentInstanceStatus(agentInstanceStatus)},
+  );
+
+  const lastAgentStatus = useRef(agentInstanceStatus);
+  useEffect(() => {
+    // Trigger refetch to show up-to-date data faster once agent status changes are known.
+    if (isEnabled && lastAgentStatus.current !== agentInstanceStatus) {
+      refetch();
+    }
+    lastAgentStatus.current = agentInstanceStatus;
+  }, [agentInstanceStatus, isEnabled, refetch]);
 
   if (status === 'pending') {
     return (

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -54,7 +54,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -74,7 +74,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -98,7 +98,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -135,7 +135,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -180,7 +180,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -227,7 +227,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -246,6 +246,46 @@ describe('<ConversationHistory />', () => {
       toolResultMessage.getByRole('heading', {name: 'search'}),
     ).toBeInTheDocument();
     expect(toolResultMessage.getByText('Tool output here')).toBeInTheDocument();
+  });
+
+  it('should trigger a refetch when the agent instance status changes', async () => {
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({historyItemKey: 'msg-2'})]),
+    );
+    mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({historyItemKey: 'msg-1'})]),
+    );
+
+    const {rerender} = render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
+        agentInstanceStatus="IDLE"
+        isVisible
+        selectedElementInstanceKey={null}
+        agentsElementInstanceKeys={[]}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('conversation-message-msg-1')).toBeVisible(),
+    );
+
+    rerender(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
+        agentInstanceStatus="TOOL_CALLING"
+        isVisible
+        selectedElementInstanceKey={null}
+        agentsElementInstanceKeys={[]}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('conversation-message-msg-2')).toBeVisible(),
+    );
   });
 
   it('should toggle the history sort order when the sort button is clicked', async () => {
@@ -267,7 +307,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -329,7 +369,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -409,7 +449,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -460,7 +500,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -505,7 +545,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -549,7 +589,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey="111"
         agentsElementInstanceKeys={['111']}
@@ -569,7 +609,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey="111"
         agentsElementInstanceKeys={['111', '222']}
@@ -588,7 +628,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey="111"
         agentsElementInstanceKeys={['111', '222']}
@@ -626,7 +666,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey="111"
         agentsElementInstanceKeys={['111', '222']}
@@ -686,7 +726,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}
@@ -750,7 +790,7 @@ describe('<ConversationHistory />', () => {
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
         availableTools={[]}
-        enablePeriodicRefetch={false}
+        agentInstanceStatus="COMPLETED"
         isVisible
         selectedElementInstanceKey={null}
         agentsElementInstanceKeys={[]}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -6,10 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import {SkeletonText} from '@carbon/react';
 import type {
   AgentInstanceHistoryItem,
+  AgentInstanceStatus,
   AgentTool,
   QueryAgentInstanceHistoryResponseBody,
   QuerySortOrder,
@@ -27,6 +28,7 @@ import {
 import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 import {ToolResultMessage} from '../ConversationMessage/ToolResultMessage';
 import type {InfiniteData} from '@tanstack/react-query';
+import {isActiveAgentInstanceStatus} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 function mapIntoLoopIterationChunks(
   pages: InfiniteData<QueryAgentInstanceHistoryResponseBody>,
@@ -51,18 +53,18 @@ function mapIntoLoopIterationChunks(
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
+  agentInstanceStatus: AgentInstanceStatus;
   availableTools: AgentTool[];
   isVisible: boolean;
-  enablePeriodicRefetch: boolean;
   selectedElementInstanceKey: string | null;
   agentsElementInstanceKeys: string[];
 };
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
+  agentInstanceStatus,
   availableTools,
   isVisible,
-  enablePeriodicRefetch,
   selectedElementInstanceKey,
   agentsElementInstanceKeys,
 }) => {
@@ -75,18 +77,29 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   const {
     data,
     status,
+    refetch,
+    isEnabled,
     isPlaceholderData,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
   } = useAgentInstanceHistory(agentInstanceKey, {
     enabled: isVisible,
-    enablePeriodicRefetch,
+    enablePeriodicRefetch: isActiveAgentInstanceStatus(agentInstanceStatus),
     sortOrder,
     elementInstanceKey:
       canBeScoped && isScoped ? selectedElementInstanceKey : null,
     select: mapIntoLoopIterationChunks,
   });
+
+  const lastAgentStatus = useRef(agentInstanceStatus);
+  useEffect(() => {
+    // Trigger refetch to show up-to-date data faster once agent status changes are known.
+    if (isEnabled && lastAgentStatus.current !== agentInstanceStatus) {
+      refetch();
+    }
+    lastAgentStatus.current = agentInstanceStatus;
+  }, [agentInstanceStatus, isEnabled, refetch]);
 
   if (status === 'pending') {
     return (

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -42,7 +42,6 @@ import {ConversationMessage} from './ConversationMessage';
 import {ConversationHistory} from './ConversationHistory';
 import {LatestAgentMessage} from './ConversationHistory/LatestAgentMessage';
 import {AvailableTools} from './AvailableTools';
-import {isAgentInstanceActive} from 'modules/queries/agentInstances/agentInstanceStatus';
 
 const STATUS_LABELS: Record<AgentInstanceStatus, string> = {
   UNKNOWN: 'Unknown',
@@ -186,7 +185,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         >
           <LatestAgentMessage
             agentInstanceKey={agentInstance.agentInstanceKey}
-            enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
+            agentInstanceStatus={agentInstance.status}
           />
         </AccordionItem>
         <AccordionItem
@@ -233,9 +232,9 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         >
           <ConversationHistory
             agentInstanceKey={agentInstance.agentInstanceKey}
+            agentInstanceStatus={agentInstance.status}
             availableTools={agentInstance.tools}
             isVisible={isConversationHistoryOpen}
-            enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
             selectedElementInstanceKey={selectedElementInstanceKey}
             agentsElementInstanceKeys={agentInstance.elementInstanceKeys}
           />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -61,6 +61,7 @@ const DetailsTab: React.FC = () => {
     hasSelection,
     resolvedElementInstance,
     selectedElementId,
+    selectedElementInstanceKey,
     selectedAnchorElementId,
     selectedInstancesCount,
     isSelectedInstanceMultiInstanceBody,
@@ -171,12 +172,19 @@ const DetailsTab: React.FC = () => {
 
   const messageSubscription = messageSubscriptionResult?.items?.[0] ?? null;
 
-  // Multi-instance bodies have no agent instance associated with the multi-instance
-  // element instance. Agents are assigned to the spawned inner instances.
-  // Fall back to elementId-only filtering when multi-instance body is selected.
+  /**
+   * Alias to {@linkcode selectedElementInstanceKey} if non multi-instance elements
+   * are selected. For multi-instance elements, agent instances data is linked to
+   * the inner instances and not the multi-instance element instance.
+   *
+   * **Note:** Intentionally uses {@linkcode selectedElementInstanceKey} and not the resolved
+   * element-instance key to keep agent details stable when an element is activated again.
+   * An agent instance can be reused across multiple element activations, and the agent details
+   * can be viewed just fine without an explicit element instance being selected/resolved.
+   */
   const agentElementInstanceKey = isSelectedInstanceMultiInstanceBody
     ? null
-    : elementInstanceKey;
+    : selectedElementInstanceKey;
 
   const {
     data: agentInstancesResult,
@@ -524,10 +532,6 @@ const DetailsTab: React.FC = () => {
     );
   }
 
-  if (isFetchingElement) {
-    return <StructuredListSkeleton rowCount={5} />;
-  }
-
   const hasMultipleInstances =
     selectedInstancesCount !== null && selectedInstancesCount > 1;
 
@@ -573,7 +577,9 @@ const DetailsTab: React.FC = () => {
       )}
       <SectionContainer>
         <SectionHeading>Element Instance</SectionHeading>
-        {resolvedElementInstance === null ? (
+        {isFetchingElement ? (
+          <StructuredListSkeleton rowCount={5} />
+        ) : resolvedElementInstance === null ? (
           <ElementInstanceHint>
             {hasMultipleInstances
               ? 'To view the details, select a single element instance in the instance history.'

--- a/operate/client/src/modules/queries/agentInstances/agentInstanceStatus.ts
+++ b/operate/client/src/modules/queries/agentInstances/agentInstanceStatus.ts
@@ -30,11 +30,17 @@ const isAgentInstanceRunning = (agentInstance: AgentInstance): boolean => {
   return RUNNING_STATUSES.has(agentInstance.status);
 };
 
-const isAgentInstanceActive = (agentInstance: AgentInstance): boolean => {
-  return ACTIVE_STATUSES.has(agentInstance.status);
+const isActiveAgentInstanceStatus = (
+  agentInstanceStatus: AgentInstanceStatus,
+): boolean => {
+  return ACTIVE_STATUSES.has(agentInstanceStatus);
 };
 
 const ACTIVE_STATUSES_ARRAY: AgentInstanceStatus[] =
   Array.from(ACTIVE_STATUSES);
 
-export {isAgentInstanceRunning, isAgentInstanceActive, ACTIVE_STATUSES_ARRAY};
+export {
+  isAgentInstanceRunning,
+  isActiveAgentInstanceStatus,
+  ACTIVE_STATUSES_ARRAY,
+};

--- a/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts
+++ b/operate/client/src/modules/queries/agentInstances/useLatestAgentMessage.ts
@@ -36,6 +36,7 @@ const useLatestAgentMessage = (
       throw error;
     },
     select: (data) => data.items[0] ?? null,
+    staleTime: 5000,
     refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
   });
 };

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -48,8 +48,8 @@ const queryKeys = {
     ) => ['agentInstanceHistorySearch', agentInstanceKey, payload],
     latestAgentMessage: (agentInstanceKey: string) => [
       'agentInstanceHistorySearch',
-      'latestAgentMessage',
       agentInstanceKey,
+      'latestAgentMessage',
     ],
   },
   variables: {


### PR DESCRIPTION
## Description

This PR addresses UX drawbacks 2 & 3 from #58180, i.e. the agent details accordion collapses when the focused element is left by the process execution or the browser-tab is refocused again.

To this date, both Opus and I are not completely sure of the exact details for the root cause. When the queries in `useProcessInstanceElementSelection` are stale (always the case for `useElementInstance`) and the execution token moves to the next element, _something_ is causing these queries to refetch. Likely a component unmounting and remounting somewhere that calls `useProcessInstanceElementSelection`. This caused the whole `DetailsTab` to early return it's loading UI, thus unmounting the `AgentDetails`.

Several adjustments have been implemented in this PR to improve the user experience:

- `DetailsTab` no longer returns a loading state early. The loading state is inlined with the element-instance details section. This continues rendering the `AgentDetails` and stops briefly unmounting it.
- Agent-instances now rely on `selectedElementInstanceKey` instead of a resolved `elementInstanceKey`. This keeps the query and `AgentDetails` stable when an element with one element-instance (resolved key) is selected and a second instance gets activated (key no longer resolved). In both cases `AgentDetails` can show UI and will now keep it's current UI once a second instance is activated (agent-instances query key no longer changes). The `elementInstanceKey` is used for drilling into agent details for a specific element instance when **users explicitly select such element instance**. `selectedElementInstanceKey` reflects this use case much better than the resolved element instance key.
- The previous UX drawback had the upside that the conversation history was refetched after agent instance became IDLE. Fixing it resulted in potentially stale conversation messages that are not periodically refetched (since agent is not active). This has been a race-condition between which queries updated first... 
  - => This PR keeps the conversation history up-to-date by refetching it when the agent-instance status changes. The explicit refetch has the added benefit if showing new messages faster (status change likely correspond to new messages). This improves the perceived realtime aspect of the feature.

## Related issues

closes #58180
