### PR TITLE
ci: ensure early Git checkout for better build duration estimates

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -180,6 +180,11 @@ get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
         job_id != "operate-fe-visual-regression-merge"
         job_id != "generate-db-versions"
         job_id != "generate-matrix"
+        # not enforced on wait jobs from load tests
+        job_id != "warmup-grpc"
+        job_id != "warmup-rest"
+        job_id != "soak-grpc"
+        job_id != "soak-rest"
         # temporary for docker-build-helm-integration.yml workflow from alwaysgreen
         job_id != "format-identifier"
         job_id != "should-run"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -71,6 +71,12 @@ jobs:
       slack_base_text: ${{ steps.slack.outputs.base_text }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
       - name: Import Vault secrets
         id: secrets
         uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c
@@ -609,10 +615,6 @@ jobs:
             /tmp/failed_runs.json
           retention-days: 14
           if-no-files-found: warn
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/camunda-daily-load-tests.yml
+++ b/.github/workflows/camunda-daily-load-tests.yml
@@ -113,19 +113,6 @@ jobs:
     steps:
       - name: Wait 15 minutes for warmup period
         run: sleep 900
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   warmup-rest:
     name: Warmup before profiling (REST)
@@ -137,19 +124,6 @@ jobs:
     steps:
       - name: Wait 15 minutes for warmup period
         run: sleep 900
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   # Profile the first 30 minutes post-warmup of each run via async-profiler.
   # Runs concurrently with soak (not on its critical path).
@@ -211,19 +185,6 @@ jobs:
       - name: Record soak end time
         id: timing
         run: echo "soak_end_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   soak-rest:
     name: REST soak
@@ -240,19 +201,6 @@ jobs:
       - name: Record soak end time
         id: timing
         run: echo "soak_end_epoch=$(date +%s)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   # Gated on its own setup: if the gRPC setup failed, its namespace was never
   # created, so skip metrics collection rather than query a missing namespace.

--- a/.github/workflows/camunda-pr-load-test.yaml
+++ b/.github/workflows/camunda-pr-load-test.yaml
@@ -52,6 +52,12 @@ jobs:
       sanitized-name: ${{ steps.compute-namespace.outputs.namespace }}
       storage-type: ${{ inputs.secondary-storage-type }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
       - id: sanitize-author
         name: Sanitize author name
         uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0
@@ -78,11 +84,6 @@ jobs:
           AUTHOR: ${{ steps.sanitize-author.outputs.branch_name }}
           DB_TYPE: ${{ steps.sanitize-db-type.outputs.branch_name }}
 
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -119,6 +119,11 @@ jobs:
     # preflight failures pass through here would defeat the entire rationale.
     permissions: { }
     steps:
+      - name: Checkout (for observe-build-status)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Verify required org secrets are set
         id: check-secrets
         env:
@@ -213,9 +218,6 @@ jobs:
 
       # Same CI Health observability hook every other job in this workflow
       # uses. Without it the Monorepo CI Health linter flags this job.
-      - name: Checkout (for observe-build-status)
-        if: always()
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -176,6 +176,14 @@ jobs:
       host-name: ${{ steps.set-host-name.outputs.host-name }}
     steps:
     #########################################################################
+    # Checkout the same ref used for image tagging to ensure chart files match
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ needs.resolve-image-tag.outputs.checkout-ref }}
+        persist-credentials: false
+
+    #########################################################################
     # Validate app-name length (only for workflow_call input)
     - name: Validate app-name length
       if: inputs.app-name != ''
@@ -224,13 +232,6 @@ jobs:
         secretId: ${{ secrets.VAULT_SECRET_ID }}
         secrets: |
           secret/data/products/camunda/ci/camunda ARGOCD_TOKEN;
-
-    #########################################################################
-    # Checkout the same ref used for image tagging to ensure chart files match
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        ref: ${{ needs.resolve-image-tag.outputs.checkout-ref }}
 
     #########################################################################
     # Determine the argocd arguments that need to be passed to the create app command

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -188,6 +188,14 @@ jobs:
         - deployment:
             run: false
     steps:
+      # Sparse-checkout .github so local composite actions (npm-ci-with-retry,
+      # observe-build-status) resolve.
+      - name: Check out .github for local actions
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
       - name: Install Teleport
         uses: teleport-actions/setup@b638ff596557cc3959eb6b5287d5e58e0c8ac6a6 # v1.1.1
         with:
@@ -268,13 +276,6 @@ jobs:
           vault-url: ${{ secrets.VAULT_ADDR }}
           owner: camunda
           repositories: c8-cross-component-e2e-tests
-
-      # Sparse-checkout .github so local composite actions (npm-ci-with-retry,
-      # observe-build-status) resolve.
-      - name: Check out .github for local actions
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
 
       - name: Checkout Smoke Tests
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -413,6 +414,12 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
       - name: Import secrets
         id: secrets
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -471,10 +478,6 @@ jobs:
                 }
               ]
             }
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -37,6 +37,15 @@ jobs:
     timeout-minutes: 20
     steps:
     #########################################################################
+    # Checkout the specified workflow_call ref when provided; for pull_request
+    # runs, an empty inputs.ref lets checkout fall back to the event ref
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ inputs.ref }}
+        persist-credentials: false
+
+    #########################################################################
     # Sanitize the branch name to remove dependabot/,renovate/ and transform the name
     - id: sanitize
       if: inputs.app-name == ''
@@ -72,14 +81,6 @@ jobs:
         vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
         vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
         vault-url: ${{ secrets.VAULT_ADDR }}
-
-    #########################################################################
-    # Checkout the specified workflow_call ref when provided; for pull_request
-    # runs, an empty inputs.ref lets checkout fall back to the event ref
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        ref: ${{ inputs.ref }}
 
     #########################################################################
     # Tear down preview environment

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -92,6 +92,12 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+
       - name: Determine action type and extract data
         id: extract-data
         env:
@@ -284,10 +290,6 @@ jobs:
             echo "⚠️ Slack notification failed but workflow continues"
             echo "::warning::Failed to notify #top-monorepo-release about ${{ steps.extract-data.outputs.action_type }} on ${{ steps.extract-data.outputs.branch_name }}"
           fi
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

When discussing https://github.com/camunda/infra-global-github-actions/pull/751 I realized that some Monorepo CI jobs are only doing Git checkout only shortly before running `observe-build-status` action which uses file modification time to estimate the build duration.

By placing Git checkout as early as possible, the estimate gets better.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to https://github.com/camunda/infra-global-github-actions/pull/751
