### PR TITLE
fix: make cluster topology initialization resilient during member startup

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -304,13 +304,15 @@ public interface ClusterConfigurationInitializer {
     @Override
     public ActorFuture<ClusterConfiguration> initialize() {
       if (knownMembersToSync.get().isEmpty()) {
-        completeAsUninitialized();
+        completeAsUninitialized("no known members to sync");
       } else {
         LOGGER.debug(
             "Querying members {} before initializing ClusterConfiguration",
             knownMembersToSync.get());
         clusterConfigurationUpdateNotifier.addUpdateListener(this);
-        executor.schedule(bootstrapTimeout, this::completeAsUninitialized);
+        executor.schedule(
+            bootstrapTimeout,
+            () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
         refreshAndSync();
       }
       return initialized;
@@ -357,7 +359,7 @@ public interface ClusterConfigurationInitializer {
         final var members = knownMembersToSync.get();
         if (uninitializedMembers.containsAll(members)
             && requestsInFlight.stream().noneMatch(members::contains)) {
-          completeAsUninitialized();
+          completeAsUninitialized("Polled all members and none of them is initialized");
         } else {
           scheduleRetry();
         }
@@ -380,11 +382,11 @@ public interface ClusterConfigurationInitializer {
           });
     }
 
-    private void completeAsUninitialized() {
+    private void completeAsUninitialized(final String cause) {
       if (!initialized.isDone()) {
         LOGGER.debug(
-            "No initialized cluster configuration was found within {}. Falling back to static initialization.",
-            bootstrapTimeout);
+            "No initialized cluster configuration: {}. Falling back to static initialization.",
+            cause);
         initialized.complete(ClusterConfiguration.uninitialized());
         clusterConfigurationUpdateNotifier.removeUpdateListener(this);
       }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.Cluste
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
@@ -251,8 +252,8 @@ public interface ClusterConfigurationInitializer {
   /**
    * Initializes configuration by sending sync requests to other members. If any of them returns a
    * valid configuration, it will be initialized. Uninitialized or failed responses are retried
-   * until the bootstrap timeout, after which the coordinator may fall back to static
-   * initialization.
+   * until the bootstrap timeout, after which this initializer completes with an uninitialized
+   * configuration, letting the caller's initializer chain decide how to proceed.
    */
   class SyncInitializer
       implements ClusterConfigurationInitializer, ClusterConfigurationUpdateListener {
@@ -267,6 +268,7 @@ public interface ClusterConfigurationInitializer {
     private final Set<MemberId> uninitializedMembers = new HashSet<>();
     private final Set<MemberId> requestsInFlight = new HashSet<>();
     private boolean retryScheduled;
+    private ScheduledTimer bootstrapTimeoutTimer;
     private final ConcurrencyControl executor;
     private final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester;
 
@@ -310,9 +312,10 @@ public interface ClusterConfigurationInitializer {
             "Querying members {} before initializing ClusterConfiguration",
             knownMembersToSync.get());
         clusterConfigurationUpdateNotifier.addUpdateListener(this);
-        executor.schedule(
-            bootstrapTimeout,
-            () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
+        bootstrapTimeoutTimer =
+            executor.schedule(
+                bootstrapTimeout,
+                () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
         refreshAndSync();
       }
       return initialized;
@@ -388,7 +391,15 @@ public interface ClusterConfigurationInitializer {
             "No initialized cluster configuration: {}. Falling back to static initialization.",
             cause);
         initialized.complete(ClusterConfiguration.uninitialized());
+        cancelBootstrapTimeout();
         clusterConfigurationUpdateNotifier.removeUpdateListener(this);
+      }
+    }
+
+    private void cancelBootstrapTimeout() {
+      if (bootstrapTimeoutTimer != null) {
+        bootstrapTimeoutTimer.cancel();
+        bootstrapTimeoutTimer = null;
       }
     }
 
@@ -405,6 +416,7 @@ public interface ClusterConfigurationInitializer {
             }
             if (!clusterConfiguration.isUninitialized()) {
               initialized.complete(clusterConfiguration);
+              cancelBootstrapTimeout();
               clusterConfigurationUpdateNotifier.removeUpdateListener(this);
             }
           });

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -388,7 +388,8 @@ public interface ClusterConfigurationInitializer {
     private void completeAsUninitialized(final String cause) {
       if (!initialized.isDone()) {
         LOGGER.debug(
-            "No initialized cluster configuration: {}. Falling back to static initialization.",
+            "No initialized cluster configuration found: {}. Completing as uninitialized; "
+                + "the initializer chain will decide how to proceed.",
             cause);
         initialized.complete(ClusterConfiguration.uninitialized());
         cancelBootstrapTimeout();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -312,10 +312,6 @@ public interface ClusterConfigurationInitializer {
             "Querying members {} before initializing ClusterConfiguration",
             knownMembersToSync.get());
         clusterConfigurationUpdateNotifier.addUpdateListener(this);
-        bootstrapTimeoutTimer =
-            executor.schedule(
-                bootstrapTimeout,
-                () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
         refreshAndSync();
       }
       return initialized;
@@ -358,6 +354,14 @@ public interface ClusterConfigurationInitializer {
         scheduleRetry();
       } else if (configuration.isUninitialized()) {
         LOGGER.trace("Cluster configuration is uninitialized in {}", memberId);
+
+        // start timeout after first uninitialized
+        if (bootstrapTimeoutTimer == null && uninitializedMembers.isEmpty()) {
+          bootstrapTimeoutTimer =
+              executor.schedule(
+                  bootstrapTimeout,
+                  () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
+        }
         uninitializedMembers.add(memberId);
         final var members = knownMembersToSync.get();
         if (uninitializedMembers.containsAll(members)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -17,9 +17,12 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,11 +37,11 @@ import org.slf4j.LoggerFactory;
  * <p>Both coordinator and other members first check the local persisted configuration to determine
  * the configuration. If one exists, that is used to initialize the configuration. See {@link
  * FileInitializer}. On bootstrap of the cluster, the local persisted configuration is empty.
- * <li>When the local configuration is empty, all members query cluster members in the static
- *     configuration for the current configuration. See {@link SyncInitializer}. If any member
- *     replies with a valid configuration, it uses that one. If all members reply with an
- *     uninitialized configuration, the coordinator generates a new configuration from the provided
- *     static configuration. See {@link StaticInitializer}.
+ * <li>When the local configuration is empty, all members query known cluster members for the
+ *     current configuration. See {@link SyncInitializer}. If any member replies with a valid
+ *     configuration, it uses that one. If no initialized configuration is found before the
+ *     bootstrap timeout, the coordinator generates a new configuration from the provided static
+ *     configuration. See {@link StaticInitializer}.
  * <li>When the local configuration is empty, a non-coordinating member waits until it receives a
  *     valid configuration from the coordinator via gossip. See {@link GossipInitializer}.
  * <li>After initialization, the configuration can be modified using {@link
@@ -246,78 +249,145 @@ public interface ClusterConfigurationInitializer {
   }
 
   /**
-   * Initializes configuration by sending sync requests to other members. If any of them return a
-   * valid configuration, it will be initialized. If any of them returns an uninitialized
-   * configuration, the future returned by initialize completes as failed.
+   * Initializes configuration by sending sync requests to other members. If any of them returns a
+   * valid configuration, it will be initialized. Uninitialized or failed responses are retried
+   * until the bootstrap timeout, after which the coordinator may fall back to static
+   * initialization.
    */
   class SyncInitializer
       implements ClusterConfigurationInitializer, ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SyncInitializer.class);
+    private static final Duration DEFAULT_BOOTSTRAP_TIMEOUT = Duration.ofSeconds(30);
     private final Duration syncDelay;
     private final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier;
     private final ActorFuture<ClusterConfiguration> initialized;
-    private final List<MemberId> knownMembersToSync;
+    private final Supplier<List<MemberId>> knownMembersToSync;
+    private final Duration bootstrapTimeout;
+    private final Set<MemberId> uninitializedMembers = new HashSet<>();
+    private final Set<MemberId> requestsInFlight = new HashSet<>();
+    private boolean retryScheduled;
     private final ConcurrencyControl executor;
     private final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester;
 
     public SyncInitializer(
         final Duration syncDelay,
         final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
-        final List<MemberId> knownMembersToSync,
+        final Supplier<List<MemberId>> knownMembersToSync,
         final ConcurrencyControl executor,
         final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester) {
+      this(
+          syncDelay,
+          clusterConfigurationUpdateNotifier,
+          knownMembersToSync,
+          executor,
+          syncRequester,
+          DEFAULT_BOOTSTRAP_TIMEOUT);
+    }
+
+    SyncInitializer(
+        final Duration syncDelay,
+        final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
+        final Supplier<List<MemberId>> knownMembersToSync,
+        final ConcurrencyControl executor,
+        final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester,
+        final Duration bootstrapTimeout) {
       this.syncDelay = syncDelay;
       this.clusterConfigurationUpdateNotifier = clusterConfigurationUpdateNotifier;
       this.knownMembersToSync = knownMembersToSync;
       this.executor = executor;
       this.syncRequester = syncRequester;
+      this.bootstrapTimeout = bootstrapTimeout;
       initialized = new CompletableActorFuture<>();
     }
 
     @Override
     public ActorFuture<ClusterConfiguration> initialize() {
-      if (knownMembersToSync.isEmpty()) {
-        initialized.complete(ClusterConfiguration.uninitialized());
+      if (knownMembersToSync.get().isEmpty()) {
+        completeAsUninitialized();
       } else {
         LOGGER.debug(
-            "Querying members {} before initializing ClusterConfiguration", knownMembersToSync);
+            "Querying members {} before initializing ClusterConfiguration",
+            knownMembersToSync.get());
         clusterConfigurationUpdateNotifier.addUpdateListener(this);
-        knownMembersToSync.forEach(this::tryInitializeFrom);
+        executor.schedule(bootstrapTimeout, this::completeAsUninitialized);
+        refreshAndSync();
       }
       return initialized;
     }
 
+    private void refreshAndSync() {
+      if (initialized.isDone()) {
+        return;
+      }
+      final var members = knownMembersToSync.get();
+      uninitializedMembers.retainAll(members);
+      members.forEach(this::tryInitializeFrom);
+    }
+
     private void tryInitializeFrom(final MemberId memberId) {
+      if (initialized.isDone() || !requestsInFlight.add(memberId)) {
+        return;
+      }
+
       requestSync(memberId)
           .onComplete(
-              (configuration, error) -> {
-                if (initialized.isDone()) {
-                  return;
-                }
-                if (error != null) {
-                  LOGGER.trace(
-                      "Failed to get a response for cluster configuration sync query to {}. Will retry.",
-                      memberId,
-                      error);
-                } else if (configuration == null) {
-                  LOGGER.trace(
-                      "Received null cluster configuration from {}. Will retry.", memberId);
-                } else if (configuration.isUninitialized()) {
-                  LOGGER.trace("Cluster configuration is uninitialized in {}", memberId);
-                  initialized.complete(configuration);
-                  return;
-                } else {
-                  LOGGER.debug(
-                      "Received cluster configuration {} from {}", configuration, memberId);
-                  onClusterConfigurationUpdated(configuration);
-                  return;
-                }
-                // retry
-                if (!initialized.isDone()) {
-                  executor.schedule(syncDelay, () -> tryInitializeFrom(memberId));
-                }
-              });
+              (configuration, error) ->
+                  executor.run(() -> handleSyncResponse(memberId, configuration, error)));
+    }
+
+    private void handleSyncResponse(
+        final MemberId memberId, final ClusterConfiguration configuration, final Throwable error) {
+      requestsInFlight.remove(memberId);
+      if (initialized.isDone()) {
+        return;
+      }
+      if (error != null) {
+        LOGGER.trace(
+            "Failed to get a response for cluster configuration sync query to {}. Will retry.",
+            memberId,
+            error);
+        scheduleRetry();
+      } else if (configuration == null) {
+        LOGGER.trace("Received null cluster configuration from {}. Will retry.", memberId);
+        scheduleRetry();
+      } else if (configuration.isUninitialized()) {
+        LOGGER.trace("Cluster configuration is uninitialized in {}", memberId);
+        uninitializedMembers.add(memberId);
+        final var members = knownMembersToSync.get();
+        if (uninitializedMembers.containsAll(members)
+            && requestsInFlight.stream().noneMatch(members::contains)) {
+          completeAsUninitialized();
+        } else {
+          scheduleRetry();
+        }
+      } else {
+        LOGGER.debug("Received cluster configuration {} from {}", configuration, memberId);
+        onClusterConfigurationUpdated(configuration);
+      }
+    }
+
+    private void scheduleRetry() {
+      if (initialized.isDone() || retryScheduled) {
+        return;
+      }
+      retryScheduled = true;
+      executor.schedule(
+          syncDelay,
+          () -> {
+            retryScheduled = false;
+            refreshAndSync();
+          });
+    }
+
+    private void completeAsUninitialized() {
+      if (!initialized.isDone()) {
+        LOGGER.debug(
+            "No initialized cluster configuration was found within {}. Falling back to static initialization.",
+            bootstrapTimeout);
+        initialized.complete(ClusterConfiguration.uninitialized());
+        clusterConfigurationUpdateNotifier.removeUpdateListener(this);
+      }
     }
 
     private ActorFuture<ClusterConfiguration> requestSync(final MemberId memberId) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -46,8 +46,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 
 public final class ClusterConfigurationManagerService
@@ -65,6 +68,7 @@ public final class ClusterConfigurationManagerService
   private final ClusterChangeExecutor clusterChangeExecutor;
   private final TopologyMetrics topologyMetrics;
   private final TopologyManagerMetrics topologyManagerMetrics;
+  private final ClusterMembershipService membershipService;
   private final MemberId localMemberId;
   private final RequestValidatorRegistry validators = new RequestValidatorRegistry();
   private ModeChangeExecutor modeChangeExecutor;
@@ -86,6 +90,7 @@ public final class ClusterConfigurationManagerService
       throw new UncheckedIOException("Failed to create data directory", e);
     }
 
+    membershipService = memberShipService;
     localMemberId = memberShipService.getLocalMember().id();
     configurationFile = dataRootDirectory.resolve(TOPOLOGY_FILE_NAME);
     persistedClusterConfiguration =
@@ -120,10 +125,7 @@ public final class ClusterConfigurationManagerService
 
   private ClusterConfigurationInitializer getNonCoordinatorInitializer(
       final StaticConfiguration staticConfiguration) {
-    final var otherKnownMembers =
-        staticConfiguration.clusterMembers().stream()
-            .filter(m -> !m.equals(staticConfiguration.localMemberId()))
-            .toList();
+    final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
     return new FileInitializer(configurationFile, new ProtoBufSerializer())
         // Recover via sync to ensure that we don't gossip an uninitialized configuration.
         // This is important so that we don't silently revert to uninitialized configuration when
@@ -160,10 +162,7 @@ public final class ClusterConfigurationManagerService
 
   private ClusterConfigurationInitializer getCoordinatorInitializer(
       final StaticConfiguration staticConfiguration) {
-    final var otherKnownMembers =
-        staticConfiguration.clusterMembers().stream()
-            .filter(m -> !m.equals(staticConfiguration.localMemberId()))
-            .toList();
+    final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
     return new FileInitializer(configurationFile, new ProtoBufSerializer())
         .orThen(
             new SyncInitializer(
@@ -183,6 +182,17 @@ public final class ClusterConfigurationManagerService
         // Must be initialized by the coordinator only
         .andThen(new PartitionDistributorInitializer(staticConfiguration))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));
+  }
+
+  private Supplier<List<MemberId>> initializationMembers(
+      final StaticConfiguration staticConfiguration) {
+    return () ->
+        Stream.concat(
+                staticConfiguration.clusterMembers().stream(),
+                membershipService.getMembers().stream().map(member -> member.id()))
+            .filter(memberId -> !memberId.equals(localMemberId))
+            .distinct()
+            .toList();
   }
 
   /** Starts ClusterConfigurationManager which initializes ClusterConfiguration */

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -154,8 +155,8 @@ final class ClusterConfigurationInitializerTest {
         new SyncInitializer(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
-            knownMembers,
-            new TestConcurrencyControl(),
+            () -> knownMembers,
+            new TestConcurrencyControl(true),
             syncRequester);
 
     // when
@@ -180,24 +181,122 @@ final class ClusterConfigurationInitializerTest {
     final ActorFuture<ClusterConfiguration> syncResponseFuture = new TestActorFuture<>();
     final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
         id -> syncResponseFuture;
+    final var concurrencyControl = new TestConcurrencyControl(true);
     final var initializer =
         new SyncInitializer(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
-            knownMembers,
-            new TestConcurrencyControl(),
+            () -> knownMembers,
+            concurrencyControl,
             syncRequester);
 
     // when
     final var initializeFuture = initializer.initialize();
     assertThat(initializeFuture.isDone()).isFalse();
     syncResponseFuture.complete(ClusterConfiguration.uninitialized());
+    concurrencyControl.runAll();
 
     // Simulate gossip received
     persistedClusterConfiguration.update(initialClusterConfiguration);
 
     // then
     assertThatClusterTopology(initializeFuture.join()).isUninitialized();
+  }
+
+  @Test
+  void shouldPreferInitializedTopologyWhenAnotherMemberIsUninitialized() {
+    // given
+    final var uninitializedMember = MemberId.from("1");
+    final var initializedMember = MemberId.from("2");
+    final var uninitializedResponse = new TestActorFuture<ClusterConfiguration>();
+    final var initializedResponse = new TestActorFuture<ClusterConfiguration>();
+    final var syncResponses =
+        Map.of(uninitializedMember, uninitializedResponse, initializedMember, initializedResponse);
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofSeconds(5),
+            new TestClusterConfigurationNotifier(),
+            () -> List.of(uninitializedMember, initializedMember),
+            new TestConcurrencyControl(true),
+            syncResponses::get);
+
+    // when
+    final var initializeFuture = initializer.initialize();
+    uninitializedResponse.complete(ClusterConfiguration.uninitialized());
+
+    // then
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // when
+    initializedResponse.complete(initialClusterConfiguration);
+
+    // then
+    assertThatClusterTopology(initializeFuture.join()).isInitialized();
+  }
+
+  @Test
+  void shouldFallBackToUninitializedAfterBootstrapTimeout() {
+    // given - a member that never responds to sync requests
+    final var unresponsiveMember = MemberId.from("1");
+    final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
+        id -> new TestActorFuture<>();
+    final var concurrencyControl = new TestConcurrencyControl(true);
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofSeconds(5),
+            new TestClusterConfigurationNotifier(),
+            () -> List.of(unresponsiveMember),
+            concurrencyControl,
+            syncRequester,
+            Duration.ofSeconds(1));
+
+    // when
+    final var initializeFuture = initializer.initialize();
+
+    // then - stays pending while no member has replied
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // when - the bootstrap timeout elapses
+    concurrencyControl.runAll();
+
+    // then - falls back to uninitialized so the coordinator can use static initialization
+    assertThatClusterTopology(initializeFuture.join()).isUninitialized();
+  }
+
+  @Test
+  void shouldInitializeWhenMemberBecomesInitializedOnRetry() {
+    // given
+    final var unreachableMember = MemberId.from("1");
+    final var recoveringMember = MemberId.from("2");
+    final var recoveringMemberCalls = new AtomicInteger();
+    final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
+        id -> {
+          if (id.equals(unreachableMember)) {
+            return TestActorFuture.failedFuture(new RuntimeException("unreachable"));
+          }
+          // uninitialized on the first query, then a valid configuration once re-queried
+          return recoveringMemberCalls.getAndIncrement() == 0
+              ? CompletableActorFuture.completed(ClusterConfiguration.uninitialized())
+              : CompletableActorFuture.completed(initialClusterConfiguration);
+        };
+    final var concurrencyControl = new TestConcurrencyControl(true);
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofSeconds(5),
+            new TestClusterConfigurationNotifier(),
+            () -> List.of(unreachableMember, recoveringMember),
+            concurrencyControl,
+            syncRequester);
+
+    // when - first round: one member fails, the other is uninitialized -> stays pending
+    final var initializeFuture = initializer.initialize();
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // when - retry re-queries the members and the recovering member now returns a configuration
+    concurrencyControl.runAll();
+
+    // then
+    assertThatClusterTopology(initializeFuture.join()).isInitialized();
   }
 
   private ClusterConfigurationInitializer getStaticInitializer() {
@@ -333,8 +432,8 @@ final class ClusterConfigurationInitializerTest {
           new SyncInitializer(
               Duration.ofSeconds(5),
               new TestClusterConfigurationNotifier(),
-              knownMembers,
-              new TestConcurrencyControl(),
+              () -> knownMembers,
+              new TestConcurrencyControl(true),
               syncRequester);
 
       final var initializer =
@@ -358,12 +457,13 @@ final class ClusterConfigurationInitializerTest {
       final ActorFuture<ClusterConfiguration> syncResponseFuture = new TestActorFuture<>();
       final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
           id -> syncResponseFuture;
+      final var concurrencyControl = new TestConcurrencyControl(true);
       final var syncInitializer =
           new SyncInitializer(
               Duration.ofSeconds(5),
               new TestClusterConfigurationNotifier(),
-              knownMembers,
-              new TestConcurrencyControl(),
+              () -> knownMembers,
+              concurrencyControl,
               syncRequester);
 
       final var initializer =
@@ -377,6 +477,7 @@ final class ClusterConfigurationInitializerTest {
 
       // Simulate gossip received
       syncResponseFuture.complete(ClusterConfiguration.uninitialized());
+      concurrencyControl.runAll();
 
       // then
       assertThatClusterTopology(initializeFuture.join()).isInitialized();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -46,9 +46,11 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
+@Timeout(120)
 final class ClusterConfigurationInitializerTest {
   @TempDir Path rootDir;
   private final ClusterConfiguration initialClusterConfiguration =
@@ -235,19 +237,56 @@ final class ClusterConfigurationInitializerTest {
   }
 
   @Test
-  void shouldFallBackToUninitializedAfterBootstrapTimeout() {
+  void shouldNotFallBackToUninitializedAfterBootstrapTimeoutWhenNoMemberIsReachable() {
     // given - a member that never responds to sync requests
     final var unresponsiveMember = MemberId.from("1");
-    final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
-        id -> new TestActorFuture<>();
     final var concurrencyControl = new TestConcurrencyControl(true);
+    final var bootstrapTimeout = Duration.ofSeconds(1);
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofSeconds(1),
+            new TestClusterConfigurationNotifier(),
+            () -> List.of(unresponsiveMember),
+            concurrencyControl,
+            ignored -> new TestActorFuture<>(),
+            bootstrapTimeout);
+
+    // when
+    final var initializeFuture = initializer.initialize();
+
+    // then - stays pending while no member has replied
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // when - the bootstrap timeout elapses
+    concurrencyControl.runAll();
+    final var testTimeout = bootstrapTimeout.toMillis() * 5;
+    // there's no easy way to verify that a future does not terminates, so we fail the future
+    // with an exception that we check later.
+    concurrencyControl.schedule(
+        testTimeout, () -> initializeFuture.completeExceptionally(new Exception("expected")));
+    concurrencyControl.runAll();
+
+    // then - falls back to uninitialized so the coordinator can use static initialization
+    assertThat(initializeFuture)
+        .failsWithin(Duration.ofMillis(testTimeout + 1000))
+        .withThrowableThat()
+        .withMessageContaining("expected");
+  }
+
+  @Test
+  void shouldFallBackToUninitializedAfterBootstrapTimeoutAfterOneUninitializedReturns() {
+    // given - a member that never responds to sync requests
+    final var unresponsiveMember = MemberId.from("1");
+    final var concurrencyControl = new TestConcurrencyControl(true);
+    final var uninitializedResponse = new TestActorFuture<ClusterConfiguration>();
+    final var syncResponses = Map.of(unresponsiveMember, uninitializedResponse);
     final var initializer =
         new SyncInitializer(
             Duration.ofSeconds(5),
             new TestClusterConfigurationNotifier(),
             () -> List.of(unresponsiveMember),
             concurrencyControl,
-            syncRequester,
+            m -> syncResponses.getOrDefault(m, new TestActorFuture<>()),
             Duration.ofSeconds(1));
 
     // when
@@ -257,6 +296,7 @@ final class ClusterConfigurationInitializerTest {
     assertThat(initializeFuture.isDone()).isFalse();
 
     // when - the bootstrap timeout elapses
+    uninitializedResponse.complete(ClusterConfiguration.uninitialized());
     concurrencyControl.runAll();
 
     // then - falls back to uninitialized so the coordinator can use static initialization


### PR DESCRIPTION
The SyncInitializer used by the coordinator terminates as soon as one member returns uninitialized.
However, in edge cases such as when migrating a cluster to be zoned, the coordinator might decide to initialize the configuration from static configuration too soon, ignoring then the actual cluster configuration.
With these changes, the coordinator tries to initialize from all known members (both from static config and from cluster membership).
When all members are polled and are uninitialized then it completes with an uninitialized configuration. To keep the startup time bound, the step terminates with uninitialized after a configured timeout (30s).
The timeout can be made configurable as a followup

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
