### PR TITLE
ci: run physical-tenant acceptance tests against OpenSearch

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -43,6 +43,15 @@ on:
           separate Elasticsearch instance instead of reusing the default tenant's connection, by
           passing -Dtest.integration.camunda.physical-tenant.elasticsearch.url=<value>. Requires the
           "elasticsearch-tenant" docker-compose service to be running.
+      physical-tenant-opensearch-url:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          When set (together with physical-tenant), the PT's secondary storage is pointed at this
+          separate OpenSearch instance instead of reusing the default tenant's connection, by
+          passing -Dtest.integration.camunda.physical-tenant.opensearch.url=<value>. Requires the
+          "opensearch-tenant" docker-compose service to be running.
       test-suite-name:
         required: false
         type: string
@@ -139,7 +148,7 @@ jobs:
       - name: Start Database service
         if: ${{ inputs.database-type != 'h2' }}
         run: |
-          docker compose -f db/docker-compose.yml up -d --wait ${{ env.DATABASE_CONTAINER }} ${{ inputs.physical-tenant-elasticsearch-url != '' && 'elasticsearch-tenant' || '' }} || {
+          docker compose -f db/docker-compose.yml up -d --wait ${{ env.DATABASE_CONTAINER }} ${{ inputs.physical-tenant-elasticsearch-url != '' && 'elasticsearch-tenant' || '' }} ${{ inputs.physical-tenant-opensearch-url != '' && 'opensearch-tenant' || '' }} || {
             docker compose -f db/docker-compose.yml logs
             exit 1
           }
@@ -177,6 +186,7 @@ jobs:
           -D test.integration.camunda.database.fast-init=true
           ${{ inputs.physical-tenant != '' && format('-D test.integration.camunda.physical-tenant={0}', inputs.physical-tenant) || '' }}
           ${{ inputs.physical-tenant-elasticsearch-url != '' && format('-D test.integration.camunda.physical-tenant.elasticsearch.url={0}', inputs.physical-tenant-elasticsearch-url) || '' }}
+          ${{ inputs.physical-tenant-opensearch-url != '' && format('-D test.integration.camunda.physical-tenant.opensearch.url={0}', inputs.physical-tenant-opensearch-url) || '' }}
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,${{inputs.maven-profiles}}
           -pl 'qa/acceptance-tests'
           verify

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -144,6 +144,11 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           # Authenticate gcloud when consuming the shared distball (see restore step below)
           gcs-build-cache-auth: ${{ inputs.use-shared-distball }}
+      - name: Fail fast on ambiguous physical-tenant backend
+        if: ${{ inputs.physical-tenant-elasticsearch-url != '' && inputs.physical-tenant-opensearch-url != '' }}
+        run: |
+          echo "::error::Both physical-tenant-elasticsearch-url and physical-tenant-opensearch-url are set - the physical-tenant backend must be unambiguous, configure only one (both tenant services publish host port 9201)."
+          exit 1
       # start the required database service
       - name: Start Database service
         if: ${{ inputs.database-type != 'h2' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1044,6 +1044,7 @@ jobs:
     outputs:
       ci-database-matrix: ${{ steps.db-versions.outputs.ci-database-matrix }}
       elasticsearch-8: ${{ steps.db-versions.outputs.elasticsearch-8 }}
+      opensearch-3: ${{ steps.db-versions.outputs.opensearch-3 }}
     steps:
       - uses: actions/checkout@v7
         timeout-minutes: 1
@@ -1142,6 +1143,13 @@ jobs:
             # Points the PT at a genuinely separate ES instance (db/docker-compose.yml's
             # elasticsearch-tenant service) instead of the default tenant's cluster.
             physical-tenant-elasticsearch-url: "http://localhost:9201"
+          - database-type: "opensearch"
+            database-name: "OS 3.x"
+            it-database-type: "os"
+            database-image-version: "${{ needs.generate-db-versions.outputs.opensearch-3 }}"
+            # Points the PT at a genuinely separate OS instance (db/docker-compose.yml's
+            # opensearch-tenant service) instead of the default tenant's cluster.
+            physical-tenant-opensearch-url: "http://localhost:9201"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -1151,6 +1159,7 @@ jobs:
       it-database-type: "${{ matrix.it-database-type }}"
       physical-tenant: "tenanta"
       physical-tenant-elasticsearch-url: "${{ matrix.physical-tenant-elasticsearch-url }}"
+      physical-tenant-opensearch-url: "${{ matrix.physical-tenant-opensearch-url }}"
       # Scope to the tests that pass under physical-tenant mode; known gaps are excluded in the
       # physical-tenant profile.
       maven-profiles: "physical-tenant"
@@ -1176,6 +1185,11 @@ jobs:
             it-database-type: "es"
             database-image-version: "${{ needs.generate-db-versions.outputs.elasticsearch-8 }}"
             physical-tenant-elasticsearch-url: "http://localhost:9201"
+          - database-type: "opensearch"
+            database-name: "OS 3.x"
+            it-database-type: "os"
+            database-image-version: "${{ needs.generate-db-versions.outputs.opensearch-3 }}"
+            physical-tenant-opensearch-url: "http://localhost:9201"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -1185,6 +1199,7 @@ jobs:
       it-database-type: "${{ matrix.it-database-type }}"
       physical-tenant: "tenanta"
       physical-tenant-elasticsearch-url: "${{ matrix.physical-tenant-elasticsearch-url }}"
+      physical-tenant-opensearch-url: "${{ matrix.physical-tenant-opensearch-url }}"
       maven-profiles: "physical-tenant-identity"
       test-type: "physical-tenant-identity-tests"
       test-type-label: "Physical Tenant Acceptance Identity"
@@ -1208,6 +1223,11 @@ jobs:
             it-database-type: "es"
             database-image-version: "${{ needs.generate-db-versions.outputs.elasticsearch-8 }}"
             physical-tenant-elasticsearch-url: "http://localhost:9201"
+          - database-type: "opensearch"
+            database-name: "OS 3.x"
+            it-database-type: "os"
+            database-image-version: "${{ needs.generate-db-versions.outputs.opensearch-3 }}"
+            physical-tenant-opensearch-url: "http://localhost:9201"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
@@ -1217,6 +1237,7 @@ jobs:
       it-database-type: "${{ matrix.it-database-type }}"
       physical-tenant: "tenanta"
       physical-tenant-elasticsearch-url: "${{ matrix.physical-tenant-elasticsearch-url }}"
+      physical-tenant-opensearch-url: "${{ matrix.physical-tenant-opensearch-url }}"
       maven-profiles: "physical-tenant-history"
       test-type: "physical-tenant-history-tests"
       test-type-label: "Physical Tenant Acceptance History"

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -181,6 +181,29 @@ services:
     networks:
       - zeebe_network
 
+  opensearch-tenant:
+    image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.5}
+    container_name: opensearch-tenant
+    environment:
+      - cluster.name=opensearch-tenant
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - bootstrap.memory_lock=true
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx1024m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
+      - action.destructive_requires_name=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - 9201:9200
+    networks:
+      - zeebe_network
+
   postgres-primary:
     image: bitnamilegacy/postgresql:17
     container_name: pg-primary

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -189,7 +189,10 @@ services:
       - discovery.type=single-node
       - plugins.security.disabled=true
       - bootstrap.memory_lock=true
-      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx1024m"
+      # matches the root opensearch service: the PT node handles one full schema per concurrent
+      # test fork, and at 1g heap its shard initialization falls behind in CI, leaving every
+      # fork's SchemaManager.startup in a permanent "all shards failed" retry loop
+      - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx2048m"
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
       - action.destructive_requires_name=false
     ulimits:

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -69,11 +70,19 @@ public class ActivateJobIT {
     // where gateway-issued FAIL commands can take longer to propagate.
     RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
     grpcClient = BROKER.newClientBuilder().preferRestOverGrpc(false).build();
-    grpcClient
-        .newDeployResourceCommand()
-        .addProcessModel(BPMN_MODEL_INSTANCE, "foo.bpmn")
-        .send()
-        .join();
+    // gRPC calls are not retried and basic auth validates the demo user against secondary
+    // storage, whose export can lag behind broker start on a loaded cluster — retry until
+    // authentication is ready. Deploying the same resource twice is idempotent.
+    Awaitility.await("gRPC deploy succeeds once demo user is visible in secondary storage")
+        .timeout(Duration.ofMinutes(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                grpcClient
+                    .newDeployResourceCommand()
+                    .addProcessModel(BPMN_MODEL_INSTANCE, "foo.bpmn")
+                    .send()
+                    .join());
   }
 
   @AfterAll

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
@@ -75,6 +75,7 @@ public class ActivateJobIT {
     // authentication is ready. Deploying the same resource twice is idempotent.
     Awaitility.await("gRPC deploy succeeds once demo user is visible in secondary storage")
         .timeout(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofMillis(500))
         .ignoreExceptions()
         .untilAsserted(
             () ->

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -789,6 +789,7 @@ public class CamundaMultiDBExtension
             false);
         final var expectedDescriptors = new IndexDescriptors(testPrefix, false).all();
         setupHelper = new OpenSearchSetupHelper(DEFAULT_OS_URL, expectedDescriptors);
+        ptSetupHelper = physicalTenantSetupHelper();
       }
       case RDBMS_H2 ->
           multiDbConfigurator.configureRDBMSSupport(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -227,6 +227,8 @@ public class CamundaMultiDBExtension
       "test.integration.camunda.physical-tenant";
   public static final String TEST_INTEGRATION_PHYSICAL_TENANT_ELASTICSEARCH_URL =
       "test.integration.camunda.physical-tenant.elasticsearch.url";
+  public static final String TEST_INTEGRATION_PHYSICAL_TENANT_OPENSEARCH_URL =
+      "test.integration.camunda.physical-tenant.opensearch.url";
   public static final Duration TIMEOUT_DATA_AVAILABILITY =
       Optional.ofNullable(System.getProperty(PROP_TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
           .map(val -> Duration.ofSeconds(Long.parseLong(val)))
@@ -322,11 +324,21 @@ public class CamundaMultiDBExtension
     return value == null || value.isBlank() ? null : value;
   }
 
+  public static String getPhysicalTenantOpensearchUrl() {
+    final String value = System.getProperty(TEST_INTEGRATION_PHYSICAL_TENANT_OPENSEARCH_URL);
+    return value == null || value.isBlank() ? null : value;
+  }
+
   private static MultiDbSetupHelper physicalTenantSetupHelper() {
     final String ptElasticsearchUrl = getPhysicalTenantElasticsearchUrl();
-    return ptElasticsearchUrl != null
-        ? new ElasticsearchSetupHelper(ptElasticsearchUrl, List.of())
-        : new NoopDBSetupHelper();
+    if (ptElasticsearchUrl != null) {
+      return new ElasticsearchSetupHelper(ptElasticsearchUrl, List.of());
+    }
+    final String ptOpensearchUrl = getPhysicalTenantOpensearchUrl();
+    if (ptOpensearchUrl != null) {
+      return new OpenSearchSetupHelper(ptOpensearchUrl, List.of());
+    }
+    return new NoopDBSetupHelper();
   }
 
   private DatabaseType currentMultiDbDatabaseType(final ExtensionContext context) {
@@ -450,24 +462,30 @@ public class CamundaMultiDBExtension
 
     // Derive per-PT storage config based on the active database type.
     final Consumer<SecondaryStorage> configurePtStorage;
-    if (databaseType.storageType().isElasticSearch()) {
+    if (databaseType.storageType().isElasticSearch() || databaseType.storageType().isOpenSearch()) {
       // Same cluster by default (per-PT index prefix); if
-      // test.integration.camunda.physical-tenant.elasticsearch.url is set, the PT points at that
-      // separate cluster instead. Extending testPrefix keeps the PT's indices covered by the
-      // delete-by-prefix cleanup in afterAll, and the distinct prefix/URL satisfies the
-      // storage-isolation validation (SecondaryStorageIsolationValidation).
-      final var baseElasticsearch =
-          springApplication.unifiedConfig().getData().getSecondaryStorage().getElasticsearch();
+      // test.integration.camunda.physical-tenant.<elasticsearch|opensearch>.url is set, the PT
+      // points at that separate cluster instead. Extending testPrefix keeps the PT's indices
+      // covered by the delete-by-prefix cleanup in afterAll, and the distinct prefix/URL satisfies
+      // the storage-isolation validation (SecondaryStorageIsolationValidation).
+      final boolean elastic = databaseType.storageType().isElasticSearch();
+      final var baseSecondaryStorage =
+          springApplication.unifiedConfig().getData().getSecondaryStorage();
+      final var baseDatabase =
+          elastic ? baseSecondaryStorage.getElasticsearch() : baseSecondaryStorage.getOpensearch();
       final String ptUrl =
-          Optional.ofNullable(getPhysicalTenantElasticsearchUrl())
-              .orElseGet(baseElasticsearch::getUrl);
-      final String ptIndexPrefix = baseElasticsearch.getIndexPrefix() + "-" + tenantId;
+          Optional.ofNullable(
+                  elastic ? getPhysicalTenantElasticsearchUrl() : getPhysicalTenantOpensearchUrl())
+              .orElseGet(baseDatabase::getUrl);
+      final String ptIndexPrefix = baseDatabase.getIndexPrefix() + "-" + tenantId;
       configurePtStorage =
           secondaryStorage -> {
-            secondaryStorage.setType(SecondaryStorageType.elasticsearch);
-            final var elasticsearch = secondaryStorage.getElasticsearch();
-            elasticsearch.setUrl(ptUrl);
-            elasticsearch.setIndexPrefix(ptIndexPrefix);
+            secondaryStorage.setType(
+                elastic ? SecondaryStorageType.elasticsearch : SecondaryStorageType.opensearch);
+            final var database =
+                elastic ? secondaryStorage.getElasticsearch() : secondaryStorage.getOpensearch();
+            database.setUrl(ptUrl);
+            database.setIndexPrefix(ptIndexPrefix);
           };
     } else if (databaseType == DatabaseType.RDBMS_H2) {
       // Fresh in-memory database per PT — DBs are already separate, so no prefix needed.
@@ -716,19 +734,23 @@ public class CamundaMultiDBExtension
     }
     if (physicalTenantId != null
         && !databaseType.storageType().isRdbms()
-        && !databaseType.storageType().isElasticSearch()) {
+        && !databaseType.storageType().isElasticSearch()
+        && !databaseType.storageType().isOpenSearch()) {
       throw new IllegalStateException(
-          "Physical-tenant mode (%s) is only supported on RDBMS or Elasticsearch storage; got %s."
-              .formatted(TEST_INTEGRATION_PHYSICAL_TENANT, databaseType));
+          "Physical-tenant mode (%s) is only supported on RDBMS, Elasticsearch or OpenSearch"
+              + " storage; got %s.".formatted(TEST_INTEGRATION_PHYSICAL_TENANT, databaseType));
     }
 
     // Multi-PT mode: @MultiDbPhysicalTenants overrides the single-PT path
     final MultiDbPhysicalTenants multiPtAnnotation =
         AnnotationSupport.findAnnotation(testClass, MultiDbPhysicalTenants.class).orElse(null);
     if (multiPtAnnotation != null) {
-      if (!databaseType.storageType().isRdbms() && !databaseType.storageType().isElasticSearch()) {
+      if (!databaseType.storageType().isRdbms()
+          && !databaseType.storageType().isElasticSearch()
+          && !databaseType.storageType().isOpenSearch()) {
         throw new IllegalStateException(
-            "@MultiDbPhysicalTenants is only supported on RDBMS or Elasticsearch storage; got "
+            "@MultiDbPhysicalTenants is only supported on RDBMS, Elasticsearch or OpenSearch"
+                + " storage; got "
                 + databaseType);
       }
       multiPhysicalTenantIds = validatedPhysicalTenantIds(multiPtAnnotation.value());
@@ -823,6 +845,7 @@ public class CamundaMultiDBExtension
         case OS:
           setupHelper.applyIndexPoliciesPollInterval(
               Duration.ofMinutes(1)); // OpenSearch can't go lower
+          ptSetupHelper.applyIndexPoliciesPollInterval(Duration.ofMinutes(1));
           break;
         default:
           break;

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -331,10 +331,17 @@ public class CamundaMultiDBExtension
 
   private static MultiDbSetupHelper physicalTenantSetupHelper() {
     final String ptElasticsearchUrl = getPhysicalTenantElasticsearchUrl();
+    final String ptOpensearchUrl = getPhysicalTenantOpensearchUrl();
+    if (ptElasticsearchUrl != null && ptOpensearchUrl != null) {
+      throw new IllegalStateException(
+          "Both %s and %s are set - the physical-tenant backend must be unambiguous, configure only one"
+              .formatted(
+                  TEST_INTEGRATION_PHYSICAL_TENANT_ELASTICSEARCH_URL,
+                  TEST_INTEGRATION_PHYSICAL_TENANT_OPENSEARCH_URL));
+    }
     if (ptElasticsearchUrl != null) {
       return new ElasticsearchSetupHelper(ptElasticsearchUrl, List.of());
     }
-    final String ptOpensearchUrl = getPhysicalTenantOpensearchUrl();
     if (ptOpensearchUrl != null) {
       return new OpenSearchSetupHelper(ptOpensearchUrl, List.of());
     }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -54,7 +54,6 @@ public final class EntityManager {
   /** Will wait until all entities are created and permissions are assigned. */
   public void await(final @NonNull ConfigurationTestEntities testEntities) {
     LOGGER.debug("Awaiting visibility of all entities and permissions");
-    awaitAdminAuthReady();
     awaitSearchVisibility(
         "users",
         () -> wrap(defaultClient.newUsersSearchRequest()),
@@ -208,22 +207,6 @@ public final class EntityManager {
 
   private <T> Function<T, Stream<String>> extractField(final Function<T, String> fieldExtractor) {
     return obj -> Stream.of(fieldExtractor.apply(obj));
-  }
-
-  /**
-   * Gates on the admin user's authentication being usable. The visibility waits below only issue
-   * requests for classes that configure entities; a class without configured entities would
-   * otherwise make its first authenticated call from test code — possibly over gRPC, which is not
-   * retried — racing the admin user's export into secondary storage.
-   */
-  private void awaitAdminAuthReady() {
-    Awaitility.await("admin authentication ready")
-        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
-        .ignoreExceptions()
-        .untilAsserted(
-            () ->
-                assertThat(defaultClient.newUsersSearchRequest().send().join().items())
-                    .isNotNull());
   }
 
   private <T> void awaitSearchVisibility(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/EntityManager.java
@@ -54,6 +54,7 @@ public final class EntityManager {
   /** Will wait until all entities are created and permissions are assigned. */
   public void await(final @NonNull ConfigurationTestEntities testEntities) {
     LOGGER.debug("Awaiting visibility of all entities and permissions");
+    awaitAdminAuthReady();
     awaitSearchVisibility(
         "users",
         () -> wrap(defaultClient.newUsersSearchRequest()),
@@ -207,6 +208,22 @@ public final class EntityManager {
 
   private <T> Function<T, Stream<String>> extractField(final Function<T, String> fieldExtractor) {
     return obj -> Stream.of(fieldExtractor.apply(obj));
+  }
+
+  /**
+   * Gates on the admin user's authentication being usable. The visibility waits below only issue
+   * requests for classes that configure entities; a class without configured entities would
+   * otherwise make its first authenticated call from test code — possibly over gRPC, which is not
+   * retried — racing the admin user's export into secondary storage.
+   */
+  private void awaitAdminAuthReady() {
+    Awaitility.await("admin authentication ready")
+        .timeout(CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(defaultClient.newUsersSearchRequest().send().join().items())
+                    .isNotNull());
   }
 
   private <T> void awaitSearchVisibility(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbPhysicalTenants.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbPhysicalTenants.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Tag;
  * and is rejected by the production isolation check). See {@link PhysicalTenantSchemaProvisioner}
  * for the per-dialect details.
  *
- * <p>Only valid in combination with {@link MultiDbTest} and an RDBMS or Elasticsearch database type
- * (per-PT secondary-storage provisioning is not available for OpenSearch yet).
+ * <p>Only valid in combination with {@link MultiDbTest} and an RDBMS, Elasticsearch or OpenSearch
+ * database type.
  *
  * <p>The extension injects a {@code static MultiPhysicalTenantClients} field on the test class,
  * which provides per-PT admin clients via {@link MultiPhysicalTenantClients#admin(String)}.


### PR DESCRIPTION
Closes #58308

Extends the physical-tenant acceptance-test setup from #57286 to OpenSearch:

- `CamundaMultiDBExtension`: the document-storage branch of `provisionPhysicalTenant` now covers OpenSearch (per-tenant index prefix on the shared cluster by default; `-Dtest.integration.camunda.physical-tenant.opensearch.url` points the PT at a separate cluster), and `physicalTenantSetupHelper` provisions an `OpenSearchSetupHelper` for separate-cluster cleanup/ILM cadence.
- `db/docker-compose.yml`: new `opensearch-tenant` service (host port 9201, mirroring `elasticsearch-tenant`).
- Reusable workflow: new `physical-tenant-opensearch-url` input, mirroring the ES input (system property + tenant compose service).
- `ci.yml`: `OS 3.x` matrix entries for the three PT jobs (general/identity/history), each pointing the PT at the separate `opensearch-tenant` cluster.

Verified locally: `BasicAuthenticationIT` under `-Dtest.integration.camunda.database.type=os -Dtest.integration.camunda.physical-tenant=tenanta` with the separate cluster passes 3/3; the tenant cluster received the PT writes (591 indexing ops) and was cleaned up after the run.

**Stacked on #57286** — only the last two commits are new; review after that PR merges, then this rebases onto `main`.

