### PR TITLE
feat: align agent details loading behavior with waiting status

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -52,7 +52,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -72,7 +71,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[{...agentInstance, status: 'THINKING'}]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -91,7 +89,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[{...agentInstance, status: 'IDLE'}]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -108,7 +105,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[{...agentInstance, status: 'COMPLETED'}]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -127,7 +123,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[{...agentInstance, status: 'INITIALIZING'}]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -146,7 +141,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[{...agentInstance, status: 'TOOL_DISCOVERY'}]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -159,29 +153,12 @@ describe('<AgentDetails />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render loading state', () => {
-    render(
-      <AgentDetails
-        agentInstances={[]}
-        totalAgentsCount={0}
-        hasMoreTotalItems={false}
-        isLoading={true}
-        isError={false}
-        selectedElementInstanceKey={null}
-      />,
-    );
-
-    expect(screen.getByText('AI Agent')).toBeInTheDocument();
-    expect(screen.getByTestId('agent-details-skeleton')).toBeInTheDocument();
-  });
-
   it('should render error state when fetch fails', () => {
     render(
       <AgentDetails
         agentInstances={[]}
         totalAgentsCount={0}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={true}
         selectedElementInstanceKey={null}
       />,
@@ -203,7 +180,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -232,7 +208,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -276,7 +251,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -305,7 +279,6 @@ describe('<AgentDetails />', () => {
         ]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -328,7 +301,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -363,7 +335,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -395,7 +366,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[agentInstance]}
         totalAgentsCount={1}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -426,7 +396,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[thinkingAgent, completedAgent]}
         totalAgentsCount={2}
         hasMoreTotalItems={false}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,
@@ -472,7 +441,6 @@ describe('<AgentDetails />', () => {
         agentInstances={[thinkingAgent, completedAgent]}
         totalAgentsCount={10}
         hasMoreTotalItems={true}
-        isLoading={false}
         isError={false}
         selectedElementInstanceKey={null}
       />,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -11,7 +11,7 @@ import type {
   AgentInstance,
   AgentInstanceStatus,
 } from '@camunda/camunda-api-zod-schemas/8.10';
-import {Accordion, AccordionItem, AccordionSkeleton, Tag} from '@carbon/react';
+import {Accordion, AccordionItem, Tag} from '@carbon/react';
 import {
   CircleDash,
   WarningFilled,
@@ -74,7 +74,6 @@ type AgentDetailsProps = {
   agentInstances: AgentInstance[];
   totalAgentsCount: number;
   hasMoreTotalItems: boolean;
-  isLoading: boolean;
   isError: boolean;
 };
 
@@ -83,7 +82,6 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
   agentInstances,
   totalAgentsCount,
   hasMoreTotalItems,
-  isLoading,
   isError,
 }) => {
   const [isConversationHistoryOpen, setIsConversationHistoryOpen] =
@@ -114,20 +112,6 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
       }),
     [agentInstances],
   );
-
-  if (isLoading) {
-    return (
-      <AgentDetailsContainer>
-        <AgentHeading>AI Agent</AgentHeading>
-        <AccordionSkeleton
-          align="start"
-          count={4}
-          open={false}
-          data-testid="agent-details-skeleton"
-        />
-      </AgentDetailsContainer>
-    );
-  }
 
   if (isError || !agentInstance) {
     return (

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -186,20 +186,16 @@ const DetailsTab: React.FC = () => {
     ? null
     : selectedElementInstanceKey;
 
-  const {
-    data: agentInstancesResult,
-    isLoading: isAgentLoading,
-    isError: isAgentError,
-  } = useAgentInstancesForElement({
-    processInstanceKey: processInstance?.processInstanceKey ?? '',
-    elementId: effectiveElementId ?? '',
-    elementInstanceKey: agentElementInstanceKey,
-    enabled: !!processInstance?.processInstanceKey && !!effectiveElementId,
-    enablePeriodicRefetch: true,
-  });
+  const {data: agentInstancesResult, isError: isAgentError} =
+    useAgentInstancesForElement({
+      processInstanceKey: processInstance?.processInstanceKey ?? '',
+      elementId: effectiveElementId ?? '',
+      elementInstanceKey: agentElementInstanceKey,
+      enabled: !!processInstance?.processInstanceKey && !!effectiveElementId,
+      enablePeriodicRefetch: true,
+    });
   const showAgentInstance =
     (agentInstancesResult && agentInstancesResult.items.length > 0) ||
-    isAgentLoading ||
     isAgentError;
 
   const calledDecisionInstance = decisionInstanceSearchResult?.items?.find(
@@ -535,7 +531,11 @@ const DetailsTab: React.FC = () => {
   const hasMultipleInstances =
     selectedInstancesCount !== null && selectedInstancesCount > 1;
 
-  if (resolvedElementInstance === null && !showAgentInstance) {
+  if (
+    resolvedElementInstance === null &&
+    !isFetchingElement &&
+    !showAgentInstance
+  ) {
     return (
       <EmptyMessageContainer>
         <EmptyMessage
@@ -567,7 +567,6 @@ const DetailsTab: React.FC = () => {
           hasMoreTotalItems={
             agentInstancesResult?.page.hasMoreTotalItems ?? false
           }
-          isLoading={isAgentLoading}
           isError={isAgentError}
           selectedElementInstanceKey={agentElementInstanceKey}
         />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -186,14 +186,17 @@ const DetailsTab: React.FC = () => {
     ? null
     : selectedElementInstanceKey;
 
-  const {data: agentInstancesResult, isError: isAgentError} =
-    useAgentInstancesForElement({
-      processInstanceKey: processInstance?.processInstanceKey ?? '',
-      elementId: effectiveElementId ?? '',
-      elementInstanceKey: agentElementInstanceKey,
-      enabled: !!processInstance?.processInstanceKey && !!effectiveElementId,
-      enablePeriodicRefetch: true,
-    });
+  const {
+    data: agentInstancesResult,
+    isLoading: isAgentInstancesLoading,
+    isError: isAgentError,
+  } = useAgentInstancesForElement({
+    processInstanceKey: processInstance?.processInstanceKey ?? '',
+    elementId: effectiveElementId ?? '',
+    elementInstanceKey: agentElementInstanceKey,
+    enabled: !!processInstance?.processInstanceKey && !!effectiveElementId,
+    enablePeriodicRefetch: true,
+  });
   const showAgentInstance =
     (agentInstancesResult && agentInstancesResult.items.length > 0) ||
     isAgentError;
@@ -534,6 +537,7 @@ const DetailsTab: React.FC = () => {
   if (
     resolvedElementInstance === null &&
     !isFetchingElement &&
+    !isAgentInstancesLoading &&
     !showAgentInstance
   ) {
     return (


### PR DESCRIPTION
## Description

This PR addresses UX drawback 1 in https://github.com/camunda/camunda/issues/58180, i.e. flickering loading states. Currently, we are showing a AI agent loading states for **every**  element and hide it again when no agent is found. In contrast, the waiting status has no loading status and just pops in when available. There is no good clear solution for solving this...

- I decided to remove the agent details loading state and align it with the waiting status behavior. While popping in isn't perfect either, it is less obstrusive for every element that does not have an AI agent...
- I actively decided against any `Suspense` shenanigans with the goal of a single `DetailsTab` loading boundary (unclear whether or not it's even possible...). Having content (e.g. element instances) throw into the loading boundary would unload the `AgentDetails` again, which is a regression for #58314. 

## Related issues

closes #58180
