### PR TITLE
fix(operate): set explicit scroll page size for getProcessesGrouped

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.store.elasticsearch;
 
+import static io.camunda.operate.util.ElasticsearchUtil.QUERY_MAX_SIZE;
 import static io.camunda.operate.util.ElasticsearchUtil.QueryType.ALL;
 import static io.camunda.operate.util.ElasticsearchUtil.QueryType.ONLY_RUNTIME;
 import static io.camunda.operate.util.ElasticsearchUtil.UPDATE_RETRY_COUNT;
@@ -238,6 +239,9 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
     final SearchSourceBuilder sourceBuilder =
         new SearchSourceBuilder()
+            // Set an explicit page size to avoid the Elasticsearch scroll default of 10 hits per
+            // round-trip, which is very slow for deployments with many process definitions.
+            .size(QUERY_MAX_SIZE)
             .query(buildQuery(tenantId, allowedBPMNProcessIds))
             .fetchSource(
                 new String[] {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.store.opensearch;
 
+import static io.camunda.operate.store.opensearch.client.OpenSearchOperation.QUERY_MAX_SIZE;
 import static io.camunda.operate.store.opensearch.client.sync.OpenSearchRetryOperation.UPDATE_RETRY_COUNT;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.cardinalityAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.filtersAggregation;
@@ -132,6 +133,9 @@ public class OpensearchProcessStore implements ProcessStore {
 
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
+            // Set an explicit page size to avoid the OpenSearch scroll default of 10 hits per
+            // round-trip, which is very slow for deployments with many process definitions.
+            .size(QUERY_MAX_SIZE)
             .query(withTenantCheck(withTenantIdQuery(tenantId, query)))
             .source(
                 sourceInclude(

--- a/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
@@ -19,6 +19,7 @@ import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.tenant.TenantAwareElasticsearchClient;
+import io.camunda.operate.util.ElasticsearchUtil;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -519,5 +520,21 @@ public class ElasticsearchProcessStoreTest {
 
     // Verify no includes are set (all other fields should be returned)
     assertThat(capturedRequest.source().fetchSource().includes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedSetsExplicitPageSize() throws IOException {
+    // Given
+    when(processIndex.getAlias()).thenReturn("process-index");
+    when(tenantAwareClient.search(any(SearchRequest.class), any())).thenReturn(List.of());
+
+    // When
+    underTest.getProcessesGrouped("<default>", null);
+
+    // Then - the scroll search must set an explicit page size to avoid the Elasticsearch scroll
+    // default of 10 hits per round-trip (see issue #58282)
+    final ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.verify(tenantAwareClient).search(captor.capture(), any());
+    assertThat(captor.getValue().source().size()).isEqualTo(ElasticsearchUtil.QUERY_MAX_SIZE);
   }
 }

--- a/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/opensearch/OpensearchProcessStoreTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.store.opensearch;
 
+import static io.camunda.operate.store.opensearch.client.OpenSearchOperation.QUERY_MAX_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -142,5 +143,22 @@ public class OpensearchProcessStoreTest {
 
     // Verify no includes are set (all other fields should be returned)
     assertThat(builtRequest.source().filter().includes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void testGetProcessesGroupedSetsExplicitPageSize() {
+    // Given
+    when(documentOperations.scrollValues(any(SearchRequest.Builder.class), eq(ProcessEntity.class)))
+        .thenReturn(List.of());
+
+    // When
+    underTest.getProcessesGrouped("<default>", null);
+
+    // Then - the scroll search must set an explicit page size to avoid the OpenSearch scroll
+    // default of 10 hits per round-trip (see issue #58282)
+    final ArgumentCaptor<SearchRequest.Builder> captor =
+        ArgumentCaptor.forClass(SearchRequest.Builder.class);
+    verify(documentOperations).scrollValues(captor.capture(), eq(ProcessEntity.class));
+    assertThat(captor.getValue().build().size()).isEqualTo(QUERY_MAX_SIZE);
   }
 }


### PR DESCRIPTION
## Description

`ElasticsearchProcessStore.getProcessesGrouped` (and its OpenSearch counterpart) scroll the process index without an explicit page `size`, so both search backends fall back to the default of **10 hits per scroll round-trip**. With more than a few thousand process definitions this turns into hundreds of sequential round-trips, so `/api/processes/grouped` and `/api/incidents/byProcess` take >10s to respond. Regression introduced in 8.8.10 (#43503).

Both endpoints funnel through `ProcessStore.getProcessesGrouped`, so the fix is applied once per storage backend and covers all four combinations.

## Fix

Set the scroll page size to `QUERY_MAX_SIZE` (10000) on the Elasticsearch and OpenSearch stores. The value equals the default `index.max_result_window`, so `from(0) + size(10000)` stays exactly at the boundary and cannot trigger a "result window too large" error. Each hit fetches only 6 small fields (id, name, version, versionTag, bpmnProcessId, tenantId), so a 10k page is cheap and collapses the scroll to essentially a single round-trip for typical deployments.

## Tests

- Added `testGetProcessesGroupedSetsExplicitPageSize` to both `ElasticsearchProcessStoreTest` and `OpensearchProcessStoreTest`, capturing the search request and asserting the page size equals `QUERY_MAX_SIZE`.
- `operate/schema` module: 38 tests pass, 0 failures. Spotless check passes.

closes #58282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
