### PR TITLE
feat: emit RESOLUTION_REQUESTED and park jobs with uncached secrets on activation

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.DbPositionSupplier;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
+import io.camunda.zeebe.broker.secret.CachedSecretResolver;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -107,6 +108,11 @@ public final class ZeebePartitionFactory {
   private final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter;
   private final ClusterConfigurationService clusterConfigurationService;
   private final RocksDbResources rocksDbResources;
+
+  // Broker-shared secret resolver: one instance across partitions, caching resolved secret
+  // values keyed by their secret reference. Populated by the background secret-resolution flow
+  // and read on job activation to inject resolved secrets.
+  private final CachedSecretResolver cachedSecretResolver = new CachedSecretResolver();
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -278,7 +284,8 @@ public final class ZeebePartitionFactory {
           featureFlags,
           jobStreamer,
           searchClientsProxy,
-          brokerRequestAuthorizationConverter);
+          brokerRequestAuthorizationConverter,
+          cachedSecretResolver);
     };
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/secret/CachedSecretResolver.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/secret/CachedSecretResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.secret;
+
+import io.camunda.zeebe.engine.processing.job.SecretResolver;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A {@link SecretResolver} backed by an in-memory cache of resolved secret values, keyed by the
+ * {@link SecretReference} record. A reference resolves only when the background secret-resolution
+ * flow has already stored its value via {@link #put}. The broker shares one instance across
+ * partitions.
+ *
+ * <p>The backing map is a {@link ConcurrentHashMap}, so it is safe to populate and read
+ * concurrently and rejects {@code null} keys and values.
+ */
+public final class CachedSecretResolver implements SecretResolver {
+
+  private final Map<SecretReference, String> secretCache = new ConcurrentHashMap<>();
+
+  /** Stores the resolved value for the reference so subsequent activations can resolve it. */
+  public void put(final SecretReference reference, final String value) {
+    secretCache.put(reference, value);
+  }
+
+  @Override
+  public Map<SecretReference, String> resolve(final Set<SecretReference> references) {
+    final Map<SecretReference, String> values = HashMap.newHashMap(references.size());
+    for (final SecretReference reference : references) {
+      final String value = secretCache.get(reference);
+      if (value != null) {
+        values.put(reference, value);
+      }
+    }
+    return values;
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/secret/CachedSecretResolverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/secret/CachedSecretResolverTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.secret;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.job.SecretResolver.SecretReference;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class CachedSecretResolverTest {
+
+  private final CachedSecretResolver resolver = new CachedSecretResolver();
+
+  @Test
+  void shouldResolveCachedSecretsInOneCall() {
+    // given
+    final var token = new SecretReference("store", "token");
+    final var apiKey = new SecretReference("store", "apiKey");
+    resolver.put(token, "resolved-token");
+    resolver.put(apiKey, "resolved-key");
+
+    // when
+    final var values = resolver.resolve(Set.of(token, apiKey));
+
+    // then
+    assertThat(values).containsEntry(token, "resolved-token").containsEntry(apiKey, "resolved-key");
+  }
+
+  @Test
+  void shouldOmitReferenceMissingFromCache() {
+    // given - only one of the requested references is cached
+    final var token = new SecretReference("store", "token");
+    final var missing = new SecretReference("store", "missing");
+    resolver.put(token, "resolved-token");
+
+    // when
+    final var values = resolver.resolve(Set.of(token, missing));
+
+    // then - only the cached reference is returned
+    assertThat(values).containsOnly(Map.entry(token, "resolved-token"));
+  }
+
+  @Test
+  void shouldDistinguishSecretsByStore() {
+    // given - the same reference name cached under a different store
+    final var sameStore = new SecretReference("store-a", "token");
+    final var otherStore = new SecretReference("store-b", "token");
+    resolver.put(sameStore, "value-a");
+
+    // when
+    final var values = resolver.resolve(Set.of(sameStore, otherStore));
+
+    // then
+    assertThat(values).containsOnly(Map.entry(sameStore, "value-a"));
+  }
+
+  @Test
+  void shouldNotCollideOnStoreAndReferenceBoundary() {
+    // given - two pairs whose naive concatenation would be identical ("ab" + "c" vs "a" + "bc")
+    final var first = new SecretReference("ab", "c");
+    final var second = new SecretReference("a", "bc");
+    resolver.put(first, "first");
+
+    // when
+    final var values = resolver.resolve(Set.of(first, second));
+
+    // then - references are compared field by field, so the pairs stay distinct
+    assertThat(values).containsOnly(Map.entry(first, "first"));
+  }
+}

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -247,8 +247,7 @@
 
     <dependency>
       <groupId>org.msgpack</groupId>
-      <artifactId>msgpack-core</artifactId>
-      <scope>test</scope>
+      <artifactId>jackson-dataformat-msgpack</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -65,6 +65,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
+import io.camunda.zeebe.engine.processing.job.SecretResolver;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.metrics.job.JobMetricsProcessors;
@@ -123,7 +124,8 @@ public final class EngineProcessors {
       final FeatureFlags featureFlags,
       final JobStreamer jobStreamer,
       final SearchClientsProxy searchClientsProxy,
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final SecretResolver secretResolver) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
     final var keyGenerator = processingState.getKeyGenerator();
@@ -342,7 +344,8 @@ public final class EngineProcessors {
         config,
         clock,
         cslCheck,
-        incidentMetrics);
+        incidentMetrics,
+        secretResolver);
 
     final var userTaskProcessor =
         createUserTaskProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -17,7 +17,8 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
-import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
+import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
+import io.camunda.zeebe.engine.processing.job.JobSecretInjector.Preparation;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -41,13 +42,16 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
-import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
 @ExcludeAuthorizationCheck
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
+
+  /** Scratch copy of the batch that carries the injected secret values to the response only. */
+  private final JobBatchRecord responseValue = new JobBatchRecord();
 
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -59,6 +63,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final ProcessState processState;
   private final CslAuthorizationCheck cslCheck;
   private final IncidentMetrics incidentMetrics;
+  private final JobSecretInjector jobSecretInjector;
 
   public JobBatchActivateProcessor(
       final Writers writers,
@@ -67,12 +72,14 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final JobProcessingMetrics jobMetrics,
       final CslAuthorizationCheck cslCheck,
       final InstantSource clock,
-      final IncidentMetrics incidentMetrics) {
+      final IncidentMetrics incidentMetrics,
+      final SecretResolver secretResolver) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.cslCheck = cslCheck;
+    jobSecretInjector = new JobSecretInjector(secretResolver);
     jobBatchCollector =
         new JobBatchCollector(
             state, stateWriter::canWriteEventOfLength, cslCheck, clock, jobMetrics);
@@ -170,15 +177,14 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final JobBatchRecord value = record.getValue();
     final long jobBatchKey = keyGenerator.nextKey();
 
-    final Either<TooLargeJob, Map<JobKind, Integer>> result =
-        jobBatchCollector.collectJobs(record, tenantIds);
-    final var activatedJobCountPerJobKind = result.getOrElse(Collections.emptyMap());
-    result.ifLeft(
-        largeJob ->
-            raiseIncidentJobTooLargeForMessageSize(
-                largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
+    jobBatchCollector
+        .collectJobs(record, tenantIds)
+        .ifLeft(
+            largeJob ->
+                raiseIncidentJobTooLargeForMessageSize(
+                    largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
 
-    activateJobBatch(record, value, jobBatchKey, activatedJobCountPerJobKind);
+    activateJobBatch(record, value, jobBatchKey);
   }
 
   private void rejectCommand(final TypedRecord<JobBatchRecord> record, final Rejection rejection) {
@@ -189,12 +195,51 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private void activateJobBatch(
       final TypedRecord<JobBatchRecord> record,
       final JobBatchRecord value,
-      final long jobBatchKey,
-      final Map<JobKind, Integer> activatedJobsCountPerJobKind) {
+      final long jobBatchKey) {
+    // jobs whose secret references are not all cached must not be activated: remove them from the
+    // batch before the ACTIVATED event is appended, so they stay activatable
+    final var preparation = jobSecretInjector.removeJobsWithUncachedSecrets(value);
+    // building the response can drop further jobs from the batch (those whose injected secret
+    // values would exceed the max message size), so it must also happen before the event
+    final var response = responseValueFor(record, value, preparation);
+    // append (and apply to state) the ACTIVATED event with the unresolved placeholders
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
     responseWriter.writeAcceptedResponseOnCommand(
-        jobBatchKey, JobBatchIntent.ACTIVATED, value, record);
-    activatedJobsCountPerJobKind.forEach(
+        jobBatchKey, JobBatchIntent.ACTIVATED, response, record);
+    countActivatedJobs(value);
+  }
+
+  /**
+   * Returns the batch value to write to the activation response. Secret values must reach the
+   * worker via the response only, never the persisted event, state, exported records, or logs: the
+   * values are injected into a copy of the batch, so the command value always keeps the
+   * placeholders.
+   *
+   * <p>Jobs whose injected values would exceed the max message size are dropped from the response
+   * and the command value alike, to be activated in a later batch; a job whose values can never fit
+   * gets a message-size incident instead, like a job that is too large without secrets.
+   */
+  private JobBatchRecord responseValueFor(
+      final TypedRecord<JobBatchRecord> record,
+      final JobBatchRecord value,
+      final Preparation preparation) {
+    if (!record.hasRequestMetadata() || preparation.pendingJobs().isEmpty()) {
+      return value;
+    }
+    responseValue.wrap(value);
+    jobSecretInjector
+        .injectSecretValues(responseValue, value, preparation)
+        .ifPresent(this::raiseIncidentJobSecretValuesTooLargeForMessageSize);
+    return responseValue;
+  }
+
+  /** Counts the activated-job metrics from the batch as it was actually activated. */
+  private void countActivatedJobs(final JobBatchRecord value) {
+    final Map<JobKind, Integer> countPerJobKind = new EnumMap<>(JobKind.class);
+    for (final JobRecord job : value.jobs()) {
+      countPerJobKind.merge(job.getJobKind(), 1, Integer::sum);
+    }
+    countPerJobKind.forEach(
         (jobKind, count) ->
             jobMetrics.countJobEvent(JobAction.ACTIVATED, jobKind, value.getType(), count));
   }
@@ -202,12 +247,30 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private void raiseIncidentJobTooLargeForMessageSize(
       final long jobKey, final JobRecord job, final int expectedJobRecordSize) {
     final String jobSize = ByteValue.prettyPrint(expectedJobRecordSize);
-    final DirectBuffer incidentMessage =
-        wrapString(
-            String.format(
-                "The job with key '%s' can not be activated, because with %s it is larger than the configured message size (per default is 4 MB). "
-                    + "Try to reduce the size by reducing the number of fetched variables or modifying the variable values.",
-                jobKey, jobSize));
+    raiseMessageSizeExceededIncident(
+        jobKey,
+        job,
+        String.format(
+            "The job with key '%s' can not be activated, because with %s it is larger than the configured message size (per default is 4 MB). "
+                + "Try to reduce the size by reducing the number of fetched variables or modifying the variable values.",
+            jobKey, jobSize));
+  }
+
+  private void raiseIncidentJobSecretValuesTooLargeForMessageSize(final OversizedJob oversized) {
+    final String growth = ByteValue.prettyPrint(oversized.growth());
+    raiseMessageSizeExceededIncident(
+        oversized.jobKey(),
+        oversized.job(),
+        String.format(
+            "The job with key '%s' can not be activated, because injecting its secret values would grow the activation batch by %s, "
+                + "more than any batch can grow without exceeding the configured message size (per default is 4 MB). "
+                + "Try to reduce the size of the secret values or of the job variables.",
+            oversized.jobKey(), growth));
+  }
+
+  private void raiseMessageSizeExceededIncident(
+      final long jobKey, final JobRecord job, final String message) {
+    final DirectBuffer incidentMessage = wrapString(message);
 
     final var treePathProperties =
         new ElementTreePathBuilder()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -30,9 +30,11 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
@@ -197,16 +199,41 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final JobBatchRecord value,
       final long jobBatchKey) {
     // jobs whose secret references are not all cached must not be activated: remove them from the
-    // batch before the ACTIVATED event is appended, so they stay activatable
+    // batch before the ACTIVATED event is appended
     final var preparation = jobSecretInjector.removeJobsWithUncachedSecrets(value);
     // building the response can drop further jobs from the batch (those whose injected secret
     // values would exceed the max message size), so it must also happen before the event
     final var response = responseValueFor(record, value, preparation);
     // append (and apply to state) the ACTIVATED event with the unresolved placeholders
     stateWriter.appendFollowUpEvent(jobBatchKey, JobBatchIntent.ACTIVATED, value);
+    // request the background resolution of the uncached secrets of the removed jobs; the applier
+    // also marks those jobs not activatable so a long poll does not collect them again right away
+    requestSecretResolution(preparation);
     responseWriter.writeAcceptedResponseOnCommand(
         jobBatchKey, JobBatchIntent.ACTIVATED, response, record);
     countActivatedJobs(value);
+  }
+
+  /**
+   * Writes one {@code SecretReference.RESOLUTION_REQUESTED} event per uncached reference of the
+   * removed jobs, carrying the keys of the jobs that await it, so the background task resolves it
+   * into the cache and the jobs are reactivated once every reference they wait for is resolved.
+   */
+  private void requestSecretResolution(final Preparation preparation) {
+    preparation
+        .missingSecrets()
+        .forEach(
+            (reference, jobKeys) -> {
+              final var request =
+                  new SecretReferenceRecord()
+                      .setStoreId(reference.storeId())
+                      .setSecretReference(reference.secretReference());
+              for (final long jobKey : jobKeys) {
+                request.addJobKey(jobKey);
+              }
+              stateWriter.appendFollowUpEvent(
+                  keyGenerator.nextKey(), SecretReferenceIntent.RESOLUTION_REQUESTED, request);
+            });
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -35,7 +35,8 @@ public final class JobEventProcessors {
       final EngineConfiguration config,
       final InstantSource clock,
       final CslAuthorizationCheck cslCheck,
-      final IncidentMetrics incidentMetrics) {
+      final IncidentMetrics incidentMetrics,
+      final SecretResolver secretResolver) {
 
     final var keyGenerator = processingState.getKeyGenerator();
 
@@ -127,7 +128,8 @@ public final class JobEventProcessors {
                 jobMetrics,
                 cslCheck,
                 clock,
-                incidentMetrics))
+                incidentMetrics,
+                secretResolver))
         .withListener(
             new JobTimeoutCheckScheduler(
                 scheduledTaskStateFactory.get().getJobState(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobSecretReference;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -75,9 +76,10 @@ public final class JobSecretInjector {
   /**
    * Removes every job with a secret reference that has no cached value from the batch (together
    * with its job key), so those jobs are not activated. Must run before the ACTIVATED event is
-   * appended; the removed jobs stay activatable. If the cache lookup fails, every job with secret
-   * references is removed. Returns the preparation for {@link #injectSecretValues}: the cached
-   * values and the surviving jobs with secret references, materialized once.
+   * appended. If the cache lookup fails, every job with secret references is removed. Returns the
+   * preparation for {@link #injectSecretValues} and the caller's {@code RESOLUTION_REQUESTED}
+   * requests: the cached values, the surviving jobs with secret references materialized once, and
+   * the uncached references grouped with the keys of the removed jobs that await them.
    */
   public Preparation removeJobsWithUncachedSecrets(final JobBatchRecord batch) {
     final List<PendingJob> candidates = collectPendingJobs(batch);
@@ -86,18 +88,19 @@ public final class JobSecretInjector {
     }
     final Map<SecretReference, String> values = resolve(referencesOf(candidates));
 
-    // TODO(https://github.com/camunda/camunda/issues/57846): instead of leaving the removed jobs
-    //  activatable (which can make a long poll collect them again right away), append an event
-    //  that marks them as waiting for secret resolution (e.g. WAITING_FOR_SECRET_RESOLUTION) and
-    //  request the background resolution of their secrets.
     final List<PendingJob> pendingJobs = new ArrayList<>(candidates.size());
     final List<Integer> uncachedJobs = new ArrayList<>();
+    final Map<SecretReference, List<Long>> missingSecrets = new LinkedHashMap<>();
     for (final PendingJob candidate : candidates) {
-      if (hasUncachedReference(candidate, values)) {
-        uncachedJobs.add(candidate.index());
-      } else {
+      final List<SecretReference> uncached = uncachedReferences(candidate, values);
+      if (uncached.isEmpty()) {
         // only the removed jobs before a surviving job shift its index to the left
         pendingJobs.add(candidate.atIndex(candidate.index() - uncachedJobs.size()));
+      } else {
+        uncachedJobs.add(candidate.index());
+        for (final SecretReference reference : uncached) {
+          missingSecrets.computeIfAbsent(reference, k -> new ArrayList<>()).add(candidate.jobKey());
+        }
       }
     }
     // remove in descending index order so the remaining indices stay valid
@@ -106,7 +109,7 @@ public final class JobSecretInjector {
       batch.jobs().remove(uncachedIndex);
       batch.jobKeys().remove(uncachedIndex);
     }
-    return new Preparation(values, pendingJobs);
+    return new Preparation(values, pendingJobs, missingSecrets);
   }
 
   /**
@@ -158,14 +161,17 @@ public final class JobSecretInjector {
     }
   }
 
-  private static boolean hasUncachedReference(
+  /** Returns the job's distinct references without a cached value, in first-seen order. */
+  private static List<SecretReference> uncachedReferences(
       final PendingJob pendingJob, final Map<SecretReference, String> values) {
+    final List<SecretReference> uncached = new ArrayList<>();
     for (final Secret secret : pendingJob.secrets()) {
-      if (!values.containsKey(secret.reference())) {
-        return true;
+      final SecretReference reference = secret.reference();
+      if (!values.containsKey(reference) && !uncached.contains(reference)) {
+        uncached.add(reference);
       }
     }
-    return false;
+    return uncached;
   }
 
   /**
@@ -262,7 +268,8 @@ public final class JobSecretInjector {
     int index = 0;
     for (final JobRecord job : batch.jobs()) {
       if (job.hasSecretReferences()) {
-        pendingJobs.add(new PendingJob(index, job, secretsOf(job)));
+        final long jobKey = batch.jobKeys().get(index).getValue();
+        pendingJobs.add(new PendingJob(index, jobKey, job, secretsOf(job)));
       }
       index++;
     }
@@ -302,18 +309,23 @@ public final class JobSecretInjector {
   private record Secret(SecretReference reference, String path, String placeholder) {}
 
   /**
-   * The preparation of an activation batch for {@link #injectSecretValues}: the cached secret
-   * values and the surviving jobs with secret references, each with its secrets materialized once
-   * by {@link #removeJobsWithUncachedSecrets}.
+   * The preparation of an activation batch produced by {@link #removeJobsWithUncachedSecrets}: the
+   * cached secret values, the surviving jobs with secret references (each with its secrets
+   * materialized once) for {@link #injectSecretValues}, and the uncached references of the removed
+   * jobs grouped with the keys of the jobs that await them, for the caller to request their
+   * background resolution.
    */
-  public record Preparation(Map<SecretReference, String> values, List<PendingJob> pendingJobs) {
-    static final Preparation NONE = new Preparation(Map.of(), List.of());
+  public record Preparation(
+      Map<SecretReference, String> values,
+      List<PendingJob> pendingJobs,
+      Map<SecretReference, List<Long>> missingSecrets) {
+    static final Preparation NONE = new Preparation(Map.of(), List.of(), Map.of());
   }
 
-  /** A job with secret references: its index in the batch, the job, and its secrets. */
-  record PendingJob(int index, JobRecord job, List<Secret> secrets) {
+  /** A job with secret references: its index in the batch, its key, the job, and its secrets. */
+  record PendingJob(int index, long jobKey, JobRecord job, List<Secret> secrets) {
     private PendingJob atIndex(final int index) {
-      return new PendingJob(index, job, secrets);
+      return new PendingJob(index, jobKey, job, secrets);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static java.util.Comparator.comparingInt;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.job.SecretResolver.SecretReference;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobSecretReference;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+import org.agrona.io.DirectBufferInputStream;
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Injects cached secret values into the variables of activated jobs, in two steps before the
+ * ACTIVATED event is appended:
+ *
+ * <ol>
+ *   <li>{@link #removeJobsWithUncachedSecrets} looks up the secret references of every job (stored
+ *       on the {@link JobRecord} at creation) in the secret cache via the {@link SecretResolver}
+ *       and removes the jobs with an uncached reference from the batch, so they are not activated.
+ *   <li>{@link #injectSecretValues} replaces the placeholder text {@code camunda.secrets.<name>} of
+ *       the remaining jobs with the cached value on a response-only copy of the batch, at the JSON
+ *       pointer recorded for each reference. Jobs whose values would grow the response beyond the
+ *       max message size are dropped from the activation instead.
+ * </ol>
+ *
+ * <p>Both steps modify the given batches in place. The injected values must only ever reach the
+ * record that is written to the activation response and nowhere else. That keeps the secret values
+ * on the response only: state, records, and logs keep the placeholders.
+ *
+ * <p>The replacement is textual: every occurrence of the placeholder in the addressed leaf is
+ * replaced, including text that merely spells out the placeholder next to a real reference at the
+ * same path. This can only surface a secret in a leaf that already receives that secret.
+ *
+ * <p>Only the long-poll activation response is covered. The job-push path (see {@code
+ * BpmnJobActivationBehavior#publishWork}) is out of scope for this change and still streams the
+ * unresolved placeholders.
+ */
+public final class JobSecretInjector {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(JobSecretInjector.class.getPackageName());
+  private static final String SECRET_REFERENCE_PREFIX = "camunda.secrets.";
+
+  /** Reads and writes the msgpack encoding of job variables as Jackson trees. */
+  private final ObjectMapper variablesMapper = new ObjectMapper(new MessagePackFactory());
+
+  private final SecretResolver secretResolver;
+
+  public JobSecretInjector(final SecretResolver secretResolver) {
+    this.secretResolver = secretResolver;
+  }
+
+  /**
+   * Removes every job with a secret reference that has no cached value from the batch (together
+   * with its job key), so those jobs are not activated. Must run before the ACTIVATED event is
+   * appended; the removed jobs stay activatable. If the cache lookup fails, every job with secret
+   * references is removed. Returns the preparation for {@link #injectSecretValues}: the cached
+   * values and the surviving jobs with secret references, materialized once.
+   */
+  public Preparation removeJobsWithUncachedSecrets(final JobBatchRecord batch) {
+    final List<PendingJob> candidates = collectPendingJobs(batch);
+    if (candidates.isEmpty()) {
+      return Preparation.NONE;
+    }
+    final Map<SecretReference, String> values = resolve(referencesOf(candidates));
+
+    // TODO(https://github.com/camunda/camunda/issues/57846): instead of leaving the removed jobs
+    //  activatable (which can make a long poll collect them again right away), append an event
+    //  that marks them as waiting for secret resolution (e.g. WAITING_FOR_SECRET_RESOLUTION) and
+    //  request the background resolution of their secrets.
+    final List<PendingJob> pendingJobs = new ArrayList<>(candidates.size());
+    final List<Integer> uncachedJobs = new ArrayList<>();
+    for (final PendingJob candidate : candidates) {
+      if (hasUncachedReference(candidate, values)) {
+        uncachedJobs.add(candidate.index());
+      } else {
+        // only the removed jobs before a surviving job shift its index to the left
+        pendingJobs.add(candidate.atIndex(candidate.index() - uncachedJobs.size()));
+      }
+    }
+    // remove in descending index order so the remaining indices stay valid
+    for (int i = uncachedJobs.size() - 1; i >= 0; i--) {
+      final int uncachedIndex = uncachedJobs.get(i);
+      batch.jobs().remove(uncachedIndex);
+      batch.jobKeys().remove(uncachedIndex);
+    }
+    return new Preparation(values, pendingJobs);
+  }
+
+  /**
+   * Injects the cached values into the secret placeholders of the prepared jobs, replacing the
+   * variables of the response batch in place. Errors are contained per job (the job keeps its
+   * placeholders) and only logged, so no secret-related data can end up in persisted records.
+   *
+   * <p>The collector sized the batch against the max message size with {@link
+   * EngineConfiguration#BATCH_SIZE_CALCULATION_BUFFER} bytes of slack, which the injected values
+   * may consume. The first job whose values would grow the response further is dropped together
+   * with every job after it, from the response batch and the to-be-activated batch alike (both must
+   * still contain the same jobs), so the dropped jobs stay activatable and the next activation,
+   * with a fresh budget, picks them up right away. Must run before the ACTIVATED event is appended.
+   * Returns the dropped job when its values can never fit, for an incident.
+   */
+  public Optional<OversizedJob> injectSecretValues(
+      final JobBatchRecord responseBatch,
+      final JobBatchRecord activatedBatch,
+      final Preparation preparation) {
+    int remainingGrowth = EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER;
+    for (final PendingJob pendingJob : preparation.pendingJobs()) {
+      final byte[] injected = injectedVariablesOf(pendingJob, preparation.values());
+      if (injected == null) {
+        continue;
+      }
+      final int growth = injected.length - pendingJob.job().getVariablesBuffer().capacity();
+      if (growth > remainingGrowth) {
+        return dropJobsThatNoLongerFit(
+            responseBatch, activatedBatch, pendingJob.index(), growth, remainingGrowth);
+      }
+      // the pending job belongs to the to-be-activated batch; the response element at the same
+      // index carries the same variables until they are replaced here
+      responseBatch.jobs().get(pendingJob.index()).setVariables(BufferUtil.wrapArray(injected));
+      remainingGrowth -= growth;
+    }
+    return Optional.empty();
+  }
+
+  private Map<SecretReference, String> resolve(final Set<SecretReference> references) {
+    try {
+      return secretResolver.resolve(references);
+    } catch (final RuntimeException e) {
+      LOGGER.warn(
+          "Failed to look up the {} secret reference(s) of a job activation batch; "
+              + "the affected jobs are not activated",
+          references.size(),
+          e);
+      return Map.of();
+    }
+  }
+
+  private static boolean hasUncachedReference(
+      final PendingJob pendingJob, final Map<SecretReference, String> values) {
+    for (final Secret secret : pendingJob.secrets()) {
+      if (!values.containsKey(secret.reference())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns the pending job's variables with every secret placeholder replaced by its cached value,
+   * or {@code null} when no placeholder was found. A failed injection also returns {@code null} and
+   * is only logged, so the job is activated with its placeholders instead of failing the batch.
+   */
+  private byte[] injectedVariablesOf(
+      final PendingJob pendingJob, final Map<SecretReference, String> values) {
+    try {
+      final DirectBuffer variables = pendingJob.job().getVariablesBuffer();
+      final JsonNode document = variablesMapper.readTree(new DirectBufferInputStream(variables));
+      boolean changed = false;
+      for (final Secret secret : pendingJob.secrets()) {
+        changed |= replaceInLeaf(document, secret, values.get(secret.reference()));
+      }
+      return changed ? variablesMapper.writeValueAsBytes(document) : null;
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Failed to inject secret values into the variables of the job of element '{}' of "
+              + "process instance {}; the job keeps its placeholders",
+          pendingJob.job().getElementId(),
+          pendingJob.job().getProcessInstanceKey(),
+          e);
+      return null;
+    }
+  }
+
+  /**
+   * Drops the job at the given index and every job after it from both batches, so none of them are
+   * activated and all stay activatable, and marks both batches as truncated so the client polls for
+   * the dropped jobs right away. A job dropped as the first of the batch had the full growth budget
+   * to itself, so its values can never fit any batch: it is returned so the caller can raise an
+   * incident for it, just like for a job that is too large to activate without secrets.
+   */
+  private static Optional<OversizedJob> dropJobsThatNoLongerFit(
+      final JobBatchRecord responseBatch,
+      final JobBatchRecord activatedBatch,
+      final int index,
+      final int growth,
+      final int remainingGrowth) {
+    JobRecord oversizedJob = null;
+    long oversizedJobKey = -1;
+    for (int i = activatedBatch.jobs().size() - 1; i >= index; i--) {
+      responseBatch.jobs().remove(i);
+      responseBatch.jobKeys().remove(i);
+      oversizedJob = activatedBatch.jobs().remove(i);
+      oversizedJobKey = activatedBatch.jobKeys().remove(i).getValue();
+    }
+    responseBatch.setTruncated(true);
+    activatedBatch.setTruncated(true);
+    LOGGER.warn(
+        "Not activating the job of element '{}' of process instance {} and the jobs after it in "
+            + "the batch: injecting the job's secret values would grow the activation batch by {} "
+            + "bytes but only {} bytes remain before the response could exceed the max message "
+            + "size. The dropped jobs stay activatable",
+        oversizedJob.getElementId(),
+        oversizedJob.getProcessInstanceKey(),
+        growth,
+        remainingGrowth);
+    return index == 0
+        ? Optional.of(new OversizedJob(oversizedJobKey, oversizedJob, growth))
+        : Optional.empty();
+  }
+
+  /**
+   * Replaces the placeholder in the text leaf addressed by the secret's JSON pointer. Pointers that
+   * do not address a text leaf of an object (e.g. the path no longer matches the variables, or it
+   * runs into an array) are skipped defensively.
+   */
+  private static boolean replaceInLeaf(
+      final JsonNode document, final Secret secret, final String value) {
+    if (!secret.path().startsWith("/")) {
+      return false;
+    }
+    final JsonPointer pointer = JsonPointer.compile(secret.path());
+    final JsonNode parent = document.at(pointer.head());
+    final JsonNode leaf = document.at(pointer);
+    if (!parent.isObject() || !leaf.isTextual()) {
+      return false;
+    }
+    final String text = leaf.textValue();
+    final String replaced = text.replace(secret.placeholder(), value);
+    if (replaced.equals(text)) {
+      return false;
+    }
+    ((ObjectNode) parent).put(pointer.last().getMatchingProperty(), replaced);
+    return true;
+  }
+
+  /** Collects the jobs with secret references, materializing each job's secrets exactly once. */
+  private static List<PendingJob> collectPendingJobs(final JobBatchRecord batch) {
+    final List<PendingJob> pendingJobs = new ArrayList<>();
+    int index = 0;
+    for (final JobRecord job : batch.jobs()) {
+      if (job.hasSecretReferences()) {
+        pendingJobs.add(new PendingJob(index, job, secretsOf(job)));
+      }
+      index++;
+    }
+    return pendingJobs;
+  }
+
+  private static Set<SecretReference> referencesOf(final List<PendingJob> pendingJobs) {
+    final Set<SecretReference> references = new LinkedHashSet<>();
+    for (final PendingJob pendingJob : pendingJobs) {
+      for (final Secret secret : pendingJob.secrets()) {
+        references.add(secret.reference());
+      }
+    }
+    return references;
+  }
+
+  /**
+   * Materializes the job's secret references, longest placeholder first so a reference name that is
+   * a prefix of another (e.g. {@code token} vs {@code token2}) cannot corrupt the longer
+   * placeholder when both are injected into the same leaf.
+   */
+  private static List<Secret> secretsOf(final JobRecord job) {
+    final List<Secret> secrets = new ArrayList<>();
+    for (final JobSecretReference reference : job.secretReferences()) {
+      secrets.add(
+          new Secret(
+              new SecretReference(reference.getStoreId(), reference.getSecretReference()),
+              reference.getPath(),
+              SECRET_REFERENCE_PREFIX + reference.getSecretReference()));
+    }
+    if (secrets.size() > 1) {
+      secrets.sort(comparingInt((Secret secret) -> secret.placeholder().length()).reversed());
+    }
+    return secrets;
+  }
+
+  private record Secret(SecretReference reference, String path, String placeholder) {}
+
+  /**
+   * The preparation of an activation batch for {@link #injectSecretValues}: the cached secret
+   * values and the surviving jobs with secret references, each with its secrets materialized once
+   * by {@link #removeJobsWithUncachedSecrets}.
+   */
+  public record Preparation(Map<SecretReference, String> values, List<PendingJob> pendingJobs) {
+    static final Preparation NONE = new Preparation(Map.of(), List.of());
+  }
+
+  /** A job with secret references: its index in the batch, the job, and its secrets. */
+  record PendingJob(int index, JobRecord job, List<Secret> secrets) {
+    private PendingJob atIndex(final int index) {
+      return new PendingJob(index, job, secrets);
+    }
+  }
+
+  /**
+   * A job dropped from the batch whose secret values can never fit: injecting them would grow the
+   * batch by {@code growth} bytes, more than the whole budget any activation batch has to spare.
+   */
+  public record OversizedJob(long jobKey, JobRecord job, int growth) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/SecretResolver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/SecretResolver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Looks up the values of secret references from the broker's secret cache so they can be injected
+ * into the variables of activated jobs. Resolution never blocks: a reference either has a cached
+ * value or it does not.
+ */
+@FunctionalInterface
+public interface SecretResolver {
+
+  /**
+   * Returns the cached value for every given reference that is currently cached. References without
+   * a cached value are absent from the returned map.
+   */
+  Map<SecretReference, String> resolve(Set<SecretReference> references);
+
+  /** A resolver without any cached values; used until the secret cache is wired in. */
+  static SecretResolver noop() {
+    return references -> Map.of();
+  }
+
+  /** Identifies a secret by the store that holds it and the reference name within that store. */
+  record SecretReference(String storeId, String secretReference) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -456,6 +456,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.CANCELED, 1, new JobCanceledV1Applier(state));
     register(JobIntent.CANCELED, 2, new JobCanceledV2Applier(state));
     register(JobIntent.CANCELED, 3, new JobCanceledV3Applier(state));
+    register(JobIntent.CANCELED, 4, new JobCanceledV4Applier(state));
     register(JobIntent.COMPLETED, 1, new JobCompletedV1Applier(state));
     register(JobIntent.COMPLETED, 2, new JobCompletedV2Applier(state));
     register(JobIntent.COMPLETED, 3, new JobCompletedV3Applier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -177,7 +177,7 @@ public final class EventAppliers implements EventApplier {
   private void registerSecretReferenceEventAppliers(final MutableProcessingState state) {
     register(
         SecretReferenceIntent.RESOLUTION_REQUESTED,
-        new SecretReferenceResolutionRequestedApplier(state.getSecretReferenceState()));
+        new SecretReferenceResolutionRequestedApplier(state));
     register(SecretReferenceIntent.RESOLUTION_COMPLETED, NOOP_EVENT_APPLIER);
     register(SecretReferenceIntent.RESOLUTION_FAILED, NOOP_EVENT_APPLIER);
     register(SecretReferenceIntent.BATCH_JOBS_REACTIVATED, NOOP_EVENT_APPLIER);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4Applier.java
@@ -51,15 +51,18 @@ public class JobCanceledV4Applier implements TypedEventApplier<JobIntent, JobRec
    */
   private void removeWaitingSecretReferenceEntries(final long jobKey) {
     // collect first: the column family must not be modified while iterating it
-    final List<String[]> waitingEntries = new ArrayList<>();
+    final List<WaitingEntry> waitingEntries = new ArrayList<>();
     secretReferenceState.visitSecretReferencesByJob(
         jobKey,
         (storeId, secretReference) -> {
-          waitingEntries.add(new String[] {storeId, secretReference});
+          waitingEntries.add(new WaitingEntry(storeId, secretReference));
           return true;
         });
-    for (final String[] entry : waitingEntries) {
-      secretReferenceState.removeWaitingJob(entry[0], entry[1], jobKey);
+    for (final WaitingEntry entry : waitingEntries) {
+      secretReferenceState.removeWaitingJob(entry.storeId(), entry.secretReference(), jobKey);
     }
   }
+
+  /** A secret reference the canceled job was waiting for. */
+  private record WaitingEntry(String storeId, String secretReference) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4Applier.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobCanceledV4Applier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableSecretReferenceState secretReferenceState;
+
+  JobCanceledV4Applier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+    secretReferenceState = state.getSecretReferenceState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.cancel(key, value);
+    removeWaitingSecretReferenceEntries(key);
+
+    if (value.isJobToUserTaskMigration()) {
+      final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+      if (elementInstance != null) {
+        elementInstance.setJobKey(-1L);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+
+  /**
+   * Removes the waiting entries of a job parked for secret resolution (see {@link
+   * SecretReferenceResolutionRequestedApplier}), so the canceled job is not reactivated and gets no
+   * incident once the resolution completes or fails. The pending secret reference itself is kept:
+   * the background resolution removes it through its own terminal events.
+   */
+  private void removeWaitingSecretReferenceEntries(final long jobKey) {
+    // collect first: the column family must not be modified while iterating it
+    final List<String[]> waitingEntries = new ArrayList<>();
+    secretReferenceState.visitSecretReferencesByJob(
+        jobKey,
+        (storeId, secretReference) -> {
+          waitingEntries.add(new String[] {storeId, secretReference});
+          return true;
+        });
+    for (final String[] entry : waitingEntries) {
+      secretReferenceState.removeWaitingJob(entry[0], entry[1], jobKey);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -8,7 +8,10 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 
@@ -16,10 +19,11 @@ public final class SecretReferenceResolutionRequestedApplier
     implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
 
   private final MutableSecretReferenceState secretReferenceState;
+  private final MutableJobState jobState;
 
-  public SecretReferenceResolutionRequestedApplier(
-      final MutableSecretReferenceState secretReferenceState) {
-    this.secretReferenceState = secretReferenceState;
+  public SecretReferenceResolutionRequestedApplier(final MutableProcessingState processingState) {
+    secretReferenceState = processingState.getSecretReferenceState();
+    jobState = processingState.getJobState();
   }
 
   @Override
@@ -31,6 +35,15 @@ public final class SecretReferenceResolutionRequestedApplier
 
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+      // stop a waiting job from being collected by a long poll again until it is reactivated once
+      // its secrets resolve. The job stays in state ACTIVATABLE and is only removed from the
+      // activatable index. A concurrent priority update re-inserts it there (see
+      // DbJobState#updateJobPriority), but the next activation removes it again and re-requests
+      // resolution, so the parking self-heals.
+      final JobRecord job = jobState.getJob(jobKey);
+      if (job != null) {
+        jobState.makeJobNotActivatable(jobKey, job);
+      }
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -34,6 +34,13 @@ public final class SecretReferenceResolutionRequestedApplier
     secretReferenceState.addPendingSecretReference(storeId, secretReference);
 
     for (final long jobKey : value.getJobKeys()) {
+      final JobRecord job = jobState.getJob(jobKey);
+      if (job == null) {
+        // a job that no longer exists must not wait for the resolution: without its waiting
+        // entries the reactivation flow cannot touch it, and no orphan entries are left behind.
+        // The pending reference is still added above, so the remaining jobs resolve normally
+        continue;
+      }
       secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
       // stop a waiting job from being collected by a long poll again until it is reactivated once
       // its secrets resolve. The job stays in state ACTIVATABLE and is only removed from the
@@ -44,10 +51,7 @@ public final class SecretReferenceResolutionRequestedApplier
       // the reactivation flow (see #57852) must only make a job activatable again if it still
       // exists and is in state ACTIVATABLE, and must remove the waiting entries of every job
       // regardless.
-      final JobRecord job = jobState.getJob(jobKey);
-      if (job != null) {
-        jobState.makeJobNotActivatable(jobKey, job);
-      }
+      jobState.makeJobNotActivatable(jobKey, job);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -38,8 +38,12 @@ public final class SecretReferenceResolutionRequestedApplier
       // stop a waiting job from being collected by a long poll again until it is reactivated once
       // its secrets resolve. The job stays in state ACTIVATABLE and is only removed from the
       // activatable index. A concurrent priority update re-inserts it there (see
-      // DbJobState#updateJobPriority), but the next activation removes it again and re-requests
-      // resolution, so the parking self-heals.
+      // DbJobState#updateJobPriority). If the secret is still uncached at the next activation,
+      // the job is parked again and the parking self-heals. If the secret got cached by then, the
+      // job activates normally while its waiting entries remain in the SecretReferenceState, so
+      // the reactivation flow (see #57852) must only make a job activatable again if it still
+      // exists and is in state ACTIVATABLE, and must remove the waiting entries of every job
+      // regardless.
       final JobRecord job = jobState.getJob(jobKey);
       if (job != null) {
         jobState.makeJobNotActivatable(jobKey, job);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
+import io.camunda.zeebe.engine.processing.job.SecretResolver;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -90,7 +91,8 @@ public final class TestEngine {
                             JobStreamer.noop(),
                             SearchClientsProxy.noop(),
                             new BrokerRequestAuthorizationConverter(
-                                EngineSecurityConfigurations.defaultConfig()))
+                                EngineSecurityConfigurations.defaultConfig()),
+                            SecretResolver.noop())
                         .withListener(
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -135,6 +135,15 @@ public final class JobSecretActivationInjectionTest {
     final Record<JobBatchRecordValue> secondAttempt =
         engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
     assertThat(secondAttempt.getValue().getJobs()).isEmpty();
+
+    // and - the parked job does not re-request the resolution on later polls: cancelling the
+    // instance fences the record stream, and only the first activation requested the resolution
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel();
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .filter(r -> r.getIntent() == SecretReferenceIntent.RESOLUTION_REQUESTED))
+        .hasSize(1);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -21,9 +21,11 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -94,10 +96,15 @@ public final class JobSecretActivationInjectionTest {
   }
 
   @Test
-  public void shouldNotActivateJobWhenSecretIsNotCached() {
+  public void shouldNotActivateJobAndRequestResolutionWhenSecretIsNotCached() {
     // given - the secret has no cached value (empty resolver)
     deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
-    createInstanceAndAwaitJob();
+    final long processInstanceKey = createInstanceAndAwaitJob();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
 
     // when
     final Record<JobBatchRecordValue> activated =
@@ -111,17 +118,23 @@ public final class JobSecretActivationInjectionTest {
         .untilAsserted(() -> assertThat(activationResponse).isNotNull());
     assertThat(activationResponse.getJobs()).isEmpty();
 
-    // and - the job stays activatable: once the secret value is cached, a later activation hands
-    // it out with the resolved value on the response
+    // and - a RESOLUTION_REQUESTED event is written for the missing secret, carrying the job key
+    final Record<SecretReferenceRecordValue> requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .getFirst();
+    assertThat(requested.getValue().getStoreId()).isEmpty();
+    assertThat(requested.getValue().getSecretReference()).isEqualTo("token");
+    assertThat(requested.getValue().getJobKeys()).containsExactly(jobKey);
+    // and - it is written after the JobBatch ACTIVATED event
+    assertThat(requested.getPosition()).isGreaterThan(activated.getPosition());
+
+    // and - the job is now waiting for resolution and no longer activatable: even once the secret
+    // value is cached, a later poll does not hand it out (the job is reactivated only after the
+    // resolution flow completes, which is out of this component's scope)
     cachedSecrets.put("token", "resolved-secret");
     final Record<JobBatchRecordValue> secondAttempt =
         engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
-    assertThat(secondAttempt.getValue().getJobs()).hasSize(1);
-    Awaitility.await("until the second activation response is written")
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(() -> assertThat(activationResponse.getJobs()).hasSize(1));
-    assertThat(activationResponse.getJobs().get(0).getVariables())
-        .containsEntry("authorization", "Bearer resolved-secret");
+    assertThat(secondAttempt.getValue().getJobs()).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.job.SecretResolver.SecretReference;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+public final class JobSecretActivationInjectionTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TASK_ID = "task";
+  private static final String JOB_TYPE = "task-type";
+
+  private final Map<String, String> cachedSecrets = new HashMap<>();
+  private boolean failResolution;
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition().withSecretResolver(this::resolveFromCachedSecrets);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private CommandResponseWriter mockResponseWriter;
+  private volatile JobBatchRecord activationResponse;
+
+  @Before
+  public void setUp() {
+    mockResponseWriter = engine.getCommandResponseWriter();
+    interceptResponseWriter();
+  }
+
+  @Test
+  public void shouldInjectCachedSecretIntoResponseOnly() {
+    // given
+    cachedSecrets.put("token", "resolved-secret");
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    createInstanceAndAwaitJob();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the persisted ACTIVATED event keeps the unresolved placeholder (no secret in the log)
+    assertThat(activated.getValue().getJobs().get(0).getVariables())
+        .containsEntry("authorization", "Bearer camunda.secrets.token");
+
+    // and - the worker response carries the resolved secret value
+    Awaitility.await("until the activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse).isNotNull());
+    assertThat(activationResponse.getJobs().get(0).getVariables())
+        .containsEntry("authorization", "Bearer resolved-secret");
+
+    // and - no exported record (state, log) leaks the resolved secret value
+    assertThat(RecordingExporter.getRecords())
+        .noneMatch(record -> record.toString().contains("resolved-secret"));
+  }
+
+  @Test
+  public void shouldNotActivateJobWhenSecretIsNotCached() {
+    // given - the secret has no cached value (empty resolver)
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    createInstanceAndAwaitJob();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the job is not handed out, neither in the event nor in the response
+    assertThat(activated.getValue().getJobs()).isEmpty();
+    assertThat(activated.getValue().getJobKeys()).isEmpty();
+    Awaitility.await("until the activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse).isNotNull());
+    assertThat(activationResponse.getJobs()).isEmpty();
+
+    // and - the job stays activatable: once the secret value is cached, a later activation hands
+    // it out with the resolved value on the response
+    cachedSecrets.put("token", "resolved-secret");
+    final Record<JobBatchRecordValue> secondAttempt =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(secondAttempt.getValue().getJobs()).hasSize(1);
+    Awaitility.await("until the second activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse.getJobs()).hasSize(1));
+    assertThat(activationResponse.getJobs().get(0).getVariables())
+        .containsEntry("authorization", "Bearer resolved-secret");
+  }
+
+  @Test
+  public void shouldNotActivateJobWhenResolverThrows() {
+    // given
+    failResolution = true;
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    createInstanceAndAwaitJob();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the job is not handed out
+    assertThat(activated.getValue().getJobs()).isEmpty();
+    Awaitility.await("until the activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse).isNotNull());
+    assertThat(activationResponse.getJobs()).isEmpty();
+
+    // and - the resolver error stays out of every exported record
+    assertThat(RecordingExporter.getRecords())
+        .noneMatch(record -> record.toString().contains("resolver exploded"));
+  }
+
+  @Test
+  public void shouldNotChangeVariablesForJobWithoutSecrets() {
+    // given
+    cachedSecrets.put("token", "resolved-secret");
+    deploy(t -> t.zeebeInputExpression("\"plain-value\"", "authorization"));
+    createInstanceAndAwaitJob();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - variables are unchanged in both the event and the response
+    assertThat(activated.getValue().getJobs().get(0).getVariables())
+        .containsEntry("authorization", "plain-value");
+    Awaitility.await("until the activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse).isNotNull());
+    assertThat(activationResponse.getJobs().get(0).getVariables())
+        .containsEntry("authorization", "plain-value");
+  }
+
+  @Test
+  public void shouldDropJobExceedingMessageSizeBudgetAndHandItOutOnNextActivation() {
+    // given - two jobs referencing the same secret; the injected value fits the batch growth
+    // budget once, but not twice
+    final var value = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER / 2 + 1000);
+    cachedSecrets.put("token", value);
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    createInstanceAndAwaitJob();
+    createInstanceAndAwaitJob();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - only the first job is activated; the second is dropped and the batch is marked
+    // truncated so the client polls again right away
+    assertThat(activated.getValue().getJobs()).hasSize(1);
+    assertThat(activated.getValue().isTruncated()).isTrue();
+    Awaitility.await("until the activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse).isNotNull());
+    assertThat(activationResponse.getJobs()).hasSize(1);
+    assertThat(activationResponse.getTruncated()).isTrue();
+    assertThat(activationResponse.getJobs().get(0).getVariables())
+        .containsEntry("authorization", "Bearer " + value);
+
+    // and - the dropped job stays activatable: the next activation hands it out with the value
+    final Record<JobBatchRecordValue> secondAttempt =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(secondAttempt.getValue().getJobs()).hasSize(1);
+    Awaitility.await("until the second activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(activationResponse.getJobs().get(0).getVariables())
+                    .containsEntry("authorization", "Bearer " + value));
+
+    // and - no exported record leaks the resolved secret value
+    assertThat(RecordingExporter.getRecords())
+        .noneMatch(record -> record.toString().contains(value));
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenSecretValueCanNeverFitMessageSizeBudget() {
+    // given - the injected value alone exceeds the whole batch growth budget, so no activation
+    // batch could ever carry this job
+    final var value = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER + 1000);
+    cachedSecrets.put("token", value);
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    final long processInstanceKey = createInstanceAndAwaitJob();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - the job is not handed out and a message-size incident is raised for it, like for a
+    // job that is too large to activate without secrets
+    assertThat(activated.getValue().getJobs()).isEmpty();
+    Awaitility.await("until the activation response is written")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(activationResponse).isNotNull());
+    assertThat(activationResponse.getJobs()).isEmpty();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).withJobKey(jobKey).getFirst();
+    assertThat(incident.getValue().getErrorType()).isEqualTo(ErrorType.MESSAGE_SIZE_EXCEEDED);
+
+    // and - the incident disables the job: a later activation does not hand it out either
+    final Record<JobBatchRecordValue> secondAttempt =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
+    assertThat(secondAttempt.getValue().getJobs()).isEmpty();
+
+    // and - no exported record (including the incident) leaks the resolved secret value
+    assertThat(RecordingExporter.getRecords())
+        .noneMatch(record -> record.toString().contains(value));
+  }
+
+  private Map<SecretReference, String> resolveFromCachedSecrets(
+      final Set<SecretReference> references) {
+    if (failResolution) {
+      throw new IllegalStateException("resolver exploded");
+    }
+    final Map<SecretReference, String> values = new HashMap<>();
+    for (final SecretReference reference : references) {
+      final String value = cachedSecrets.get(reference.secretReference());
+      if (value != null) {
+        values.put(reference, value);
+      }
+    }
+    return values;
+  }
+
+  private long createInstanceAndAwaitJob() {
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+    return processInstanceKey;
+  }
+
+  private void deploy(final Consumer<ServiceTaskBuilder> modifier) {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t -> {
+                  t.zeebeJobType(JOB_TYPE);
+                  modifier.accept(t);
+                })
+            .endEvent()
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+  }
+
+  private void interceptResponseWriter() {
+    doAnswer(
+            (Answer<CommandResponseWriter>)
+                invocation -> {
+                  final var arguments = invocation.getArguments();
+                  if (arguments != null
+                      && arguments.length == 1
+                      && arguments[0] instanceof final JobBatchRecord jobBatchRecord) {
+                    // copy the record: engine record objects are reused across commands, so the
+                    // captured reference could otherwise be overwritten by a later command
+                    final var copy = new JobBatchRecord();
+                    final MutableDirectBuffer buffer =
+                        new UnsafeBuffer(new byte[jobBatchRecord.getLength()]);
+                    jobBatchRecord.write(buffer, 0);
+                    copy.wrap(buffer);
+                    activationResponse = copy;
+                  }
+                  return mockResponseWriter;
+                })
+        .when(mockResponseWriter)
+        .valueWriter(any());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
@@ -162,6 +163,124 @@ final class JobSecretInjectorTest {
       assertThat(jobKeysOf(batch)).containsExactly(100L, 101L);
       assertThat(preparation.values()).isEmpty();
       assertThat(preparation.pendingJobs()).isEmpty();
+      assertThat(preparation.missingSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldReportNoMissingSecretsWhenAllCached() {
+      // given
+      final var injector = injector(Map.of("token", "t"));
+      final var batch =
+          batchWith(job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then
+      assertThat(preparation.missingSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldGroupMissingSecretByReferenceWithWaitingJobKeys() {
+      // given - two jobs waiting for the same uncached secret, one for a different uncached secret
+      final var injector = injector(Map.of());
+      final var batch =
+          batchWith(
+              job(Map.of("a", "camunda.secrets.token"), ref("token", "/a")),
+              job(Map.of("b", "camunda.secrets.token"), ref("token", "/b")),
+              job(Map.of("c", "camunda.secrets.other"), ref("other", "/c")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then - one entry per reference, carrying the keys of the jobs that await it
+      assertThat(preparation.missingSecrets())
+          .containsOnly(
+              entry(new SecretReference(STORE_ID, "token"), List.of(100L, 101L)),
+              entry(new SecretReference(STORE_ID, "other"), List.of(102L)));
+      assertThat(jobKeysOf(batch)).isEmpty();
+    }
+
+    @Test
+    void shouldReportOnlyUncachedReferencesOfRemovedJob() {
+      // given - a job with one cached and one uncached reference
+      final var injector = injector(Map.of("token", "t"));
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("auth", "camunda.secrets.token", "key", "camunda.secrets.apiKey"),
+                  ref("token", "/auth"),
+                  ref("apiKey", "/key")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then - only the uncached reference is requested
+      assertThat(preparation.missingSecrets())
+          .containsExactly(entry(new SecretReference(STORE_ID, "apiKey"), List.of(100L)));
+    }
+
+    @Test
+    void shouldReportJobKeyOnceForReferenceRepeatedWithinAJob() {
+      // given - one job referencing the same uncached secret at two paths
+      final var injector = injector(Map.of());
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("a", "camunda.secrets.token", "b", "camunda.secrets.token"),
+                  ref("token", "/a"),
+                  ref("token", "/b")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then - the job key appears once for the shared reference, not once per path
+      assertThat(preparation.missingSecrets())
+          .containsExactly(entry(new SecretReference(STORE_ID, "token"), List.of(100L)));
+    }
+
+    @Test
+    void shouldReportEachUncachedReferenceOfASingleJobWithItsKey() {
+      // given - one job waiting on two distinct uncached secrets
+      final var injector = injector(Map.of());
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("a", "camunda.secrets.token", "b", "camunda.secrets.apiKey"),
+                  ref("token", "/a"),
+                  ref("apiKey", "/b")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then - one entry per reference, each carrying the job's key
+      assertThat(preparation.missingSecrets())
+          .containsOnly(
+              entry(new SecretReference(STORE_ID, "token"), List.of(100L)),
+              entry(new SecretReference(STORE_ID, "apiKey"), List.of(100L)));
+    }
+
+    @Test
+    void shouldReportAllReferencesMissingWhenResolverThrows() {
+      // given
+      final SecretResolver throwingResolver =
+          references -> {
+            throw new IllegalStateException("resolver is broken");
+          };
+      final var batch =
+          batchWith(
+              job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")),
+              job(Map.of("key", "camunda.secrets.apiKey"), ref("apiKey", "/key")));
+
+      // when
+      final var preparation =
+          new JobSecretInjector(throwingResolver).removeJobsWithUncachedSecrets(batch);
+
+      // then - every reference is requested for background resolution
+      assertThat(preparation.missingSecrets())
+          .containsOnly(
+              entry(new SecretReference(STORE_ID, "token"), List.of(100L)),
+              entry(new SecretReference(STORE_ID, "apiKey"), List.of(101L)));
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
+import io.camunda.zeebe.engine.processing.job.SecretResolver.SecretReference;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class JobSecretInjectorTest {
+
+  private static final String STORE_ID = "";
+
+  @Nested
+  final class RemoveJobsWithUncachedSecrets {
+
+    @Test
+    void shouldRemoveJobWhoseSecretIsNotCached() {
+      // given - a cached job, an uncached job, and a job without references
+      final var injector = injector(Map.of("token", "resolved"));
+      final var batch =
+          batchWith(
+              job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")),
+              job(Map.of("auth", "camunda.secrets.other"), ref("other", "/auth")),
+              job(Map.of("foo", "bar")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then - the uncached job and its key are removed, the others stay aligned
+      assertThat(variablesOfAllJobs(batch))
+          .containsExactly(Map.of("auth", "camunda.secrets.token"), Map.of("foo", "bar"));
+      assertThat(jobKeysOf(batch)).containsExactly(100L, 102L);
+      assertThat(preparation.values())
+          .containsEntry(new SecretReference(STORE_ID, "token"), "resolved");
+    }
+
+    @Test
+    void shouldKeepAllJobsWhenAllSecretsAreCached() {
+      // given
+      final var injector = injector(Map.of("token", "t", "apiKey", "k"));
+      final var batch =
+          batchWith(
+              job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")),
+              job(Map.of("key", "camunda.secrets.apiKey"), ref("apiKey", "/key")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then
+      assertThat(jobKeysOf(batch)).containsExactly(100L, 101L);
+      assertThat(preparation.values())
+          .containsEntry(new SecretReference(STORE_ID, "token"), "t")
+          .containsEntry(new SecretReference(STORE_ID, "apiKey"), "k");
+    }
+
+    @Test
+    void shouldRemoveJobWhenOnlySomeOfItsSecretsAreCached() {
+      // given - one of the job's two references has no cached value
+      final var injector = injector(Map.of("token", "t"));
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("auth", "camunda.secrets.token", "key", "camunda.secrets.apiKey"),
+                  ref("token", "/auth"),
+                  ref("apiKey", "/key")));
+
+      // when
+      injector.removeJobsWithUncachedSecrets(batch);
+
+      // then
+      assertThat(jobKeysOf(batch)).isEmpty();
+      assertThat(variablesOfAllJobs(batch)).isEmpty();
+    }
+
+    @Test
+    void shouldRemoveNonAdjacentJobsAndKeepKeysAligned() {
+      // given - uncached jobs at index 0 and 2
+      final var injector = injector(Map.of("token", "t"));
+      final var batch =
+          batchWith(
+              job(Map.of("a", "camunda.secrets.other"), ref("other", "/a")),
+              job(Map.of("b", "camunda.secrets.token"), ref("token", "/b")),
+              job(Map.of("c", "camunda.secrets.another"), ref("another", "/c")),
+              job(Map.of("d", "plain")));
+
+      // when
+      injector.removeJobsWithUncachedSecrets(batch);
+
+      // then
+      assertThat(variablesOfAllJobs(batch))
+          .containsExactly(Map.of("b", "camunda.secrets.token"), Map.of("d", "plain"));
+      assertThat(jobKeysOf(batch)).containsExactly(101L, 103L);
+    }
+
+    @Test
+    void shouldRemoveAllSecretJobsWhenResolverThrows() {
+      // given
+      final SecretResolver throwingResolver =
+          references -> {
+            throw new IllegalStateException("resolver is broken");
+          };
+      final var batch =
+          batchWith(
+              job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")),
+              job(Map.of("foo", "bar")));
+
+      // when
+      final var preparation =
+          new JobSecretInjector(throwingResolver).removeJobsWithUncachedSecrets(batch);
+
+      // then - only the job without references stays
+      assertThat(variablesOfAllJobs(batch)).containsExactly(Map.of("foo", "bar"));
+      assertThat(jobKeysOf(batch)).containsExactly(101L);
+      assertThat(preparation.values()).isEmpty();
+      assertThat(preparation.pendingJobs()).isEmpty();
+    }
+
+    @Test
+    void shouldRemoveSecretJobsWithNoopResolver() {
+      // given - the noop resolver has no cached values
+      final var batch =
+          batchWith(
+              job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")),
+              job(Map.of("foo", "bar")));
+
+      // when
+      new JobSecretInjector(SecretResolver.noop()).removeJobsWithUncachedSecrets(batch);
+
+      // then
+      assertThat(variablesOfAllJobs(batch)).containsExactly(Map.of("foo", "bar"));
+    }
+
+    @Test
+    void shouldNotTouchBatchWithoutSecretReferences() {
+      // given
+      final var injector = injector(Map.of());
+      final var batch = batchWith(job(Map.of("foo", "bar")), job(Map.of("baz", "qux")));
+
+      // when
+      final var preparation = injector.removeJobsWithUncachedSecrets(batch);
+
+      // then
+      assertThat(jobKeysOf(batch)).containsExactly(100L, 101L);
+      assertThat(preparation.values()).isEmpty();
+      assertThat(preparation.pendingJobs()).isEmpty();
+    }
+  }
+
+  @Nested
+  final class InjectSecretValues {
+
+    @Test
+    void shouldInjectCachedSecretAtPath() {
+      // given
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("tokens", Map.of("externalSystemToken", "camunda.secrets.token")),
+                  ref("token", "/tokens/externalSystemToken")));
+
+      // when
+      inject(batch, Map.of("token", "resolved-token"));
+
+      // then
+      assertThat(variablesOf(batch, 0))
+          .isEqualTo(Map.of("tokens", Map.of("externalSystemToken", "resolved-token")));
+    }
+
+    @Test
+    void shouldReplaceReferenceEmbeddedInString() {
+      // given
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("authorization", "Bearer camunda.secrets.token"),
+                  ref("token", "/authorization")));
+
+      // when
+      inject(batch, Map.of("token", "xyz"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("authorization", "Bearer xyz"));
+    }
+
+    @Test
+    void shouldInjectMultipleReferencesAtSamePath() {
+      // given
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("h", "camunda.secrets.token camunda.secrets.postfix"),
+                  ref("token", "/h"),
+                  ref("postfix", "/h")));
+
+      // when
+      inject(batch, Map.of("token", "A", "postfix", "B"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("h", "A B"));
+    }
+
+    @Test
+    void shouldInjectReferencesAtDifferentPaths() {
+      // given
+      final var batch =
+          batchWith(
+              job(
+                  Map.of(
+                      "auth",
+                      Map.of("token", "camunda.secrets.token", "key", "camunda.secrets.apiKey")),
+                  ref("token", "/auth/token"),
+                  ref("apiKey", "/auth/key")));
+
+      // when
+      inject(batch, Map.of("token", "t", "apiKey", "k"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("auth", Map.of("token", "t", "key", "k")));
+    }
+
+    @Test
+    void shouldNotCorruptPlaceholderThatIsPrefixOfAnother() {
+      // given - "token" is a prefix of "token2", both injected into the same leaf
+      final var batch =
+          batchWith(
+              job(
+                  Map.of("h", "camunda.secrets.token camunda.secrets.token2"),
+                  ref("token", "/h"),
+                  ref("token2", "/h")));
+
+      // when
+      inject(batch, Map.of("token", "A", "token2", "BB"));
+
+      // then - the longer placeholder is replaced first, so neither value is mangled
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("h", "A BB"));
+    }
+
+    @Test
+    void shouldInjectAtDeeplyNestedPathAndPreserveSiblings() {
+      // given - siblings of every type around the addressed leaf
+      final var variables =
+          Map.of(
+              "count",
+              42,
+              "ratio",
+              1.5,
+              "flag",
+              true,
+              "list",
+              List.of(1, "two", Map.of("three", 3)),
+              "outer",
+              Map.of("inner", Map.of("leaf", "camunda.secrets.token", "keep", "as-is")));
+      final var batch = batchWith(job(variables, ref("token", "/outer/inner/leaf")));
+
+      // when
+      inject(batch, Map.of("token", "secret-value"));
+
+      // then - only the addressed leaf changed, everything else survives the injection untouched
+      assertThat(variablesOf(batch, 0))
+          .isEqualTo(
+              Map.of(
+                  "count",
+                  42,
+                  "ratio",
+                  1.5,
+                  "flag",
+                  true,
+                  "list",
+                  List.of(1, "two", Map.of("three", 3)),
+                  "outer",
+                  Map.of("inner", Map.of("leaf", "secret-value", "keep", "as-is"))));
+    }
+
+    @Test
+    void shouldUnescapePointerSegments() {
+      // given - the variable name contains the characters escaped by RFC 6901
+      final var batch =
+          batchWith(job(Map.of("a/b~c", "camunda.secrets.token"), ref("token", "/a~1b~0c")));
+
+      // when
+      inject(batch, Map.of("token", "xyz"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(Map.of("a/b~c", "xyz"));
+    }
+
+    @Test
+    void shouldLeaveJobWithoutSecretReferencesUntouched() {
+      // given
+      final var original = Map.of("foo", "bar");
+      final var batch = batchWith(job(original));
+
+      // when
+      inject(batch, Map.of("token", "t"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldInjectOnlyFullyCachedJobsInMultiJobBatch() {
+      // given - a cached job, a job without references, and a job with an uncached reference
+      final Map<String, Object> withSecret = Map.of("auth", "camunda.secrets.token");
+      final Map<String, Object> withoutSecret = Map.of("foo", "bar");
+      final Map<String, Object> uncached = Map.of("auth", "camunda.secrets.other");
+      final var activated =
+          batchWith(
+              job(withSecret, ref("token", "/auth")),
+              job(withoutSecret),
+              job(uncached, ref("other", "/auth")));
+
+      // when - mirroring the processor: remove the uncached jobs, then inject into a response copy
+      final var injector = injector(Map.of("token", "resolved"));
+      final var preparation = injector.removeJobsWithUncachedSecrets(activated);
+      final var response = copyOf(activated);
+      injector.injectSecretValues(response, activated, preparation);
+
+      // then - the uncached job is removed and only the first job gets its value injected
+      assertThat(variablesOfAllJobs(response))
+          .containsExactly(Map.of("auth", "resolved"), withoutSecret);
+      assertThat(variablesOfAllJobs(activated)).containsExactly(withSecret, withoutSecret);
+    }
+
+    @Test
+    void shouldDropAndReportFirstJobWhoseValueGrowthCanNeverFit() {
+      // given - injecting the cached value grows the first job beyond the whole batch budget, so
+      // no batch could ever carry it
+      final var oversized = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER + 100);
+      final var original = Map.of("auth", "camunda.secrets.token");
+      final var response = batchWith(job(original, ref("token", "/auth")));
+      final var activated = copyOf(response);
+
+      // when
+      final var oversizedJob = inject(response, activated, Map.of("token", oversized));
+
+      // then - the job is dropped from both batches and reported for an incident
+      assertThat(variablesOfAllJobs(response)).isEmpty();
+      assertThat(jobKeysOf(response)).isEmpty();
+      assertThat(variablesOfAllJobs(activated)).isEmpty();
+      assertThat(jobKeysOf(activated)).isEmpty();
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(oversizedJob)
+          .hasValueSatisfying(
+              job -> {
+                assertThat(job.jobKey()).isEqualTo(100L);
+                assertThat(job.growth())
+                    .isGreaterThan(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER);
+              });
+    }
+
+    @Test
+    void shouldDropExceedingAndRemainingJobsFromBothBatches() {
+      // given - the first job's value fits, the second job's value exceeds the remaining budget,
+      // and a third job without secret references follows
+      final var oversized = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER + 100);
+      final Map<String, Object> fitting = Map.of("auth", "camunda.secrets.small");
+      final var exceeding = Map.of("auth", "camunda.secrets.big");
+      final var plain = Map.of("foo", "bar");
+      final var response =
+          batchWith(
+              job(fitting, ref("small", "/auth")), job(exceeding, ref("big", "/auth")), job(plain));
+      final var activated = copyOf(response);
+
+      // when
+      final var oversizedJob =
+          inject(response, activated, Map.of("small", "resolved", "big", oversized));
+
+      // then - the exceeding job and every job after it are dropped from both batches, even jobs
+      // that would fit; the first job stays and only the response copy carries its secret value
+      assertThat(variablesOfAllJobs(response)).containsExactly(Map.of("auth", "resolved"));
+      assertThat(jobKeysOf(response)).containsExactly(100L);
+      assertThat(variablesOfAllJobs(activated)).containsExactly(fitting);
+      assertThat(jobKeysOf(activated)).containsExactly(100L);
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+
+      // and - the dropped job is not reported for an incident: it was not first, so a next batch
+      // with a fresh budget may still carry it
+      assertThat(oversizedJob).isEmpty();
+    }
+
+    @Test
+    void shouldDropJobWhenEarlierJobsConsumedTheGrowthBudget() {
+      // given - each value fits into the budget on its own, but not both together
+      final var firstValue = "x".repeat(EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER - 1000);
+      final var secondValue = "y".repeat(2000);
+      final Map<String, Object> first = Map.of("auth", "camunda.secrets.first");
+      final var second = Map.of("auth", "camunda.secrets.second");
+      final var response =
+          batchWith(job(first, ref("first", "/auth")), job(second, ref("second", "/auth")));
+      final var activated = copyOf(response);
+
+      // when
+      final var oversizedJob =
+          inject(response, activated, Map.of("first", firstValue, "second", secondValue));
+
+      // then - only the first job is activated with its value injected; the second is dropped
+      // without an incident report
+      assertThat(variablesOfAllJobs(response)).containsExactly(Map.of("auth", firstValue));
+      assertThat(variablesOfAllJobs(activated)).containsExactly(first);
+      assertThat(jobKeysOf(activated)).containsExactly(100L);
+      assertThat(response.getTruncated()).isTrue();
+      assertThat(activated.getTruncated()).isTrue();
+      assertThat(oversizedJob).isEmpty();
+    }
+
+    @Test
+    void shouldNotTruncateWhenInjectedValuesFit() {
+      // given
+      final var response =
+          batchWith(
+              job(Map.of("auth", "camunda.secrets.token"), ref("token", "/auth")),
+              job(Map.of("foo", "bar")));
+      final var activated = copyOf(response);
+
+      // when
+      final var oversizedJob = inject(response, activated, Map.of("token", "resolved"));
+
+      // then - nothing is dropped and the activated batch keeps its placeholders
+      assertThat(variablesOfAllJobs(response))
+          .containsExactly(Map.of("auth", "resolved"), Map.of("foo", "bar"));
+      assertThat(variablesOfAllJobs(activated))
+          .containsExactly(Map.of("auth", "camunda.secrets.token"), Map.of("foo", "bar"));
+      assertThat(jobKeysOf(activated)).containsExactly(100L, 101L);
+      assertThat(response.getTruncated()).isFalse();
+      assertThat(activated.getTruncated()).isFalse();
+      assertThat(oversizedJob).isEmpty();
+    }
+
+    @Test
+    void shouldSkipWhenPointerDoesNotAddressATextLeaf() {
+      // given - the pointer addresses a container, not a text leaf
+      final var original = Map.of("cfg", Map.of("a", "camunda.secrets.token"));
+      final var batch = batchWith(job(original, ref("token", "/cfg")));
+
+      // when
+      inject(batch, Map.of("token", "resolved"));
+
+      // then - defensively left untouched
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldSkipWhenIntermediateSegmentIsMissing() {
+      // given - the recorded path no longer matches the variables document
+      final var original = Map.of("auth", "camunda.secrets.token");
+      final var batch = batchWith(job(original, ref("token", "/auth/nested")));
+
+      // when
+      inject(batch, Map.of("token", "resolved"));
+
+      // then - defensively left untouched
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldSkipWhenLeafIsMissing() {
+      // given
+      final var original = Map.of("present", "camunda.secrets.token");
+      final var batch = batchWith(job(original, ref("token", "/absent")));
+
+      // when
+      inject(batch, Map.of("token", "resolved"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldSkipWhenPointerHasNoLeadingSlash() {
+      // given - an empty pointer is not a valid leaf pointer
+      final var original = Map.of("authorization", "Bearer camunda.secrets.token");
+      final var batch = batchWith(job(original, ref("token", "")));
+
+      // when
+      inject(batch, Map.of("token", "resolved"));
+
+      // then
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    @Test
+    void shouldSkipArraysOnThePointerPath() {
+      // given - the pointer runs into an array element
+      final var original = Map.of("items", List.of("camunda.secrets.token"));
+      final var batch = batchWith(job(original, ref("token", "/items/0")));
+
+      // when
+      inject(batch, Map.of("token", "resolved"));
+
+      // then - array elements are never addressed; the document is untouched
+      assertThat(variablesOf(batch, 0)).isEqualTo(original);
+    }
+
+    private static void inject(final JobBatchRecord batch, final Map<String, String> secrets) {
+      inject(batch, copyOf(batch), secrets);
+    }
+
+    /**
+     * Mirrors the processor flow: prepare on the to-be-activated batch, inject into the response.
+     */
+    private static Optional<OversizedJob> inject(
+        final JobBatchRecord response,
+        final JobBatchRecord activated,
+        final Map<String, String> secrets) {
+      final var injector = injector(secrets);
+      final var preparation = injector.removeJobsWithUncachedSecrets(activated);
+      return injector.injectSecretValues(response, activated, preparation);
+    }
+  }
+
+  private static JobSecretInjector injector(final Map<String, String> cachedSecrets) {
+    return new JobSecretInjector(
+        references -> {
+          final Map<SecretReference, String> values = new HashMap<>();
+          for (final SecretReference reference : references) {
+            final String value = cachedSecrets.get(reference.secretReference());
+            if (value != null) {
+              values.put(reference, value);
+            }
+          }
+          return values;
+        });
+  }
+
+  private static JobBatchRecord batchWith(final JobRecord... jobs) {
+    final var batch = new JobBatchRecord().setType("task-type");
+    long key = 100;
+    for (final JobRecord job : jobs) {
+      batch.jobKeys().add().setValue(key++);
+      batch.jobs().add().copyFrom(job);
+    }
+    return batch;
+  }
+
+  private static JobBatchRecord copyOf(final JobBatchRecord batch) {
+    final var copy = new JobBatchRecord();
+    copy.copyFrom(batch);
+    return copy;
+  }
+
+  private static JobRecord job(final Map<String, ?> variables, final SecretRef... refs) {
+    final var job =
+        new JobRecord()
+            .setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(variables)));
+    for (final SecretRef ref : refs) {
+      job.addSecretReference(ref.storeId(), ref.name(), ref.path());
+    }
+    return job;
+  }
+
+  private static SecretRef ref(final String name, final String path) {
+    return new SecretRef(STORE_ID, name, path);
+  }
+
+  private static Map<String, Object> variablesOf(final JobBatchRecord batch, final int index) {
+    final var variables = variablesOfAllJobs(batch);
+    if (index >= variables.size()) {
+      throw new IllegalArgumentException("no job at index " + index);
+    }
+    return variables.get(index);
+  }
+
+  private static List<Map<String, Object>> variablesOfAllJobs(final JobBatchRecord batch) {
+    final List<Map<String, Object>> variables = new ArrayList<>();
+    for (final JobRecord job : batch.jobs()) {
+      variables.add(job.getVariables());
+    }
+    return variables;
+  }
+
+  private static List<Long> jobKeysOf(final JobBatchRecord batch) {
+    final List<Long> keys = new ArrayList<>();
+    for (final LongValue key : batch.jobKeys()) {
+      keys.add(key.getValue());
+    }
+    return keys;
+  }
+
+  private record SecretRef(String storeId, String name, String path) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretReferenceTest.java
@@ -21,13 +21,22 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobSecretReferenceV
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public final class JobSecretReferenceTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  /** Every reference resolves, so jobs with secret references stay activatable in these tests. */
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecretResolver(
+              references ->
+                  references.stream()
+                      .collect(Collectors.toMap(Function.identity(), reference -> "cached")));
 
   private static final String PROCESS_ID = "process";
   private static final String TASK_ID = "task";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4ApplierTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class JobCanceledV4ApplierTest {
+
+  private static final String STORE_ID = "store-1";
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableJobState jobState;
+  private MutableSecretReferenceState secretReferenceState;
+  private JobCanceledV4Applier applier;
+
+  @BeforeEach
+  void setUp() {
+    jobState = processingState.getJobState();
+    secretReferenceState = processingState.getSecretReferenceState();
+    applier = new JobCanceledV4Applier(processingState);
+  }
+
+  @Test
+  void shouldRemoveWaitingSecretReferenceEntriesOfCanceledJob() {
+    // given - a parked job waiting for two secrets, and another job waiting for one of them
+    final long jobKey = 1L;
+    final long otherJobKey = 2L;
+    final var job = createJob(jobKey);
+    createJob(otherJobKey);
+    secretReferenceState.addPendingSecretReference(STORE_ID, "secret-a");
+    secretReferenceState.addPendingSecretReference(STORE_ID, "secret-b");
+    secretReferenceState.addWaitingJob(STORE_ID, "secret-a", jobKey);
+    secretReferenceState.addWaitingJob(STORE_ID, "secret-b", jobKey);
+    secretReferenceState.addWaitingJob(STORE_ID, "secret-a", otherJobKey);
+
+    // when
+    applier.applyState(jobKey, job);
+
+    // then - the canceled job no longer waits for any secret, in either index direction
+    assertThat(secretReferencesOf(jobKey)).isEmpty();
+    assertThat(waitingJobsFor("secret-a")).containsExactly(otherJobKey);
+    assertThat(waitingJobsFor("secret-b")).isEmpty();
+    // and - the other job and the pending references are untouched: the background resolution
+    // still resolves them and cleans them up through its own terminal events
+    assertThat(secretReferencesOf(otherJobKey)).containsExactly("secret-a");
+    assertThat(secretReferenceState.isPending(STORE_ID, "secret-a")).isTrue();
+    assertThat(secretReferenceState.isPending(STORE_ID, "secret-b")).isTrue();
+  }
+
+  @Test
+  void shouldCancelJobWithoutWaitingSecretReferences() {
+    // given - a job that does not wait for any secret
+    final long jobKey = 3L;
+    final var job = createJob(jobKey);
+
+    // when
+    applier.applyState(jobKey, job);
+
+    // then - the job is canceled like with the previous applier version
+    assertThat(jobState.getState(jobKey)).isEqualTo(State.NOT_FOUND);
+  }
+
+  private JobRecord createJob(final long key) {
+    final var job =
+        new JobRecord().setType("task-type").setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    jobState.insertJobRecordActivatable(key, job);
+    jobState.makeJobActivatableByPriority(
+        job.getTypeBuffer(), key, job.getTenantId(), job.getPriority());
+    return job;
+  }
+
+  private List<String> secretReferencesOf(final long jobKey) {
+    final List<String> references = new ArrayList<>();
+    secretReferenceState.visitSecretReferencesByJob(
+        jobKey,
+        (storeId, reference) -> {
+          references.add(reference);
+          return true;
+        });
+    return references;
+  }
+
+  private List<Long> waitingJobsFor(final String reference) {
+    final List<Long> jobKeys = new ArrayList<>();
+    secretReferenceState.visitJobsBySecretReference(
+        STORE_ID,
+        reference,
+        jobKey -> {
+          jobKeys.add(jobKey);
+          return true;
+        });
+    return jobKeys;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/JobCanceledV4ApplierTest.java
@@ -10,11 +10,16 @@ package io.camunda.zeebe.engine.state.appliers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,12 +37,14 @@ final class JobCanceledV4ApplierTest {
 
   private MutableJobState jobState;
   private MutableSecretReferenceState secretReferenceState;
+  private MutableElementInstanceState elementInstanceState;
   private JobCanceledV4Applier applier;
 
   @BeforeEach
   void setUp() {
     jobState = processingState.getJobState();
     secretReferenceState = processingState.getSecretReferenceState();
+    elementInstanceState = processingState.getElementInstanceState();
     applier = new JobCanceledV4Applier(processingState);
   }
 
@@ -81,6 +88,27 @@ final class JobCanceledV4ApplierTest {
     assertThat(jobState.getState(jobKey)).isEqualTo(State.NOT_FOUND);
   }
 
+  @Test
+  void shouldResetElementInstanceJobKeyForJobToUserTaskMigration() {
+    // given - a job canceled as part of a job-to-user-task migration, like the previous applier
+    // version handles it
+    final long jobKey = 4L;
+    final long elementInstanceKey = 10L;
+    final var elementInstance = createElementInstance(elementInstanceKey);
+    elementInstance.setJobKey(jobKey);
+    elementInstanceState.updateInstance(elementInstance);
+    final var job =
+        createJob(jobKey)
+            .setElementInstanceKey(elementInstanceKey)
+            .setIsJobToUserTaskMigration(true);
+
+    // when
+    applier.applyState(jobKey, job);
+
+    // then - the element instance no longer references the canceled job
+    assertThat(elementInstanceState.getInstance(elementInstanceKey).getJobKey()).isEqualTo(-1L);
+  }
+
   private JobRecord createJob(final long key) {
     final var job =
         new JobRecord().setType("task-type").setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -88,6 +116,17 @@ final class JobCanceledV4ApplierTest {
     jobState.makeJobActivatableByPriority(
         job.getTypeBuffer(), key, job.getTenantId(), job.getPriority());
     return job;
+  }
+
+  private ElementInstance createElementInstance(final long key) {
+    final var processInstanceRecord =
+        new ProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setElementId("task")
+            .setBpmnProcessId("process")
+            .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    return elementInstanceState.newInstance(
+        key, processInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
   }
 
   private List<String> secretReferencesOf(final long jobKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.engine.state.appliers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.groups.Tuple;
@@ -26,12 +29,14 @@ final class SecretReferenceResolutionRequestedApplierTest {
 
   private MutableProcessingState processingState;
   private MutableSecretReferenceState state;
+  private MutableJobState jobState;
   private SecretReferenceResolutionRequestedApplier applier;
 
   @BeforeEach
   void setUp() {
     state = processingState.getSecretReferenceState();
-    applier = new SecretReferenceResolutionRequestedApplier(state);
+    jobState = processingState.getJobState();
+    applier = new SecretReferenceResolutionRequestedApplier(processingState);
   }
 
   @Test
@@ -206,5 +211,47 @@ final class SecretReferenceResolutionRequestedApplierTest {
         });
     assertThat(pairs)
         .containsExactlyInAnyOrder(tuple("store-1", "secret-a"), tuple("store-1", "secret-b"));
+  }
+
+  @Test
+  void shouldMakeWaitingJobNotActivatable() {
+    // given — an activatable job that references a not-yet-resolved secret
+    final long jobKey = 1L;
+    final var job =
+        new JobRecord().setType("task-type").setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    jobState.create(jobKey, job);
+    assertThat(activatableJobKeys(job)).contains(jobKey);
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(jobKey);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then — the job is no longer handed out until it is reactivated after resolution
+    assertThat(activatableJobKeys(job)).doesNotContain(jobKey);
+  }
+
+  @Test
+  void shouldNotFailWhenWaitingJobDoesNotExist() {
+    // given — a record for a job that is absent from the job state
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(999L);
+
+    // when / then — applying does not fail and still records the pending reference
+    applier.applyState(100L, record);
+    assertThat(state.isPending("store-1", "secret-a")).isTrue();
+  }
+
+  private List<Long> activatableJobKeys(final JobRecord job) {
+    final List<Long> keys = new ArrayList<>();
+    jobState.forEachActivatableJobs(
+        job.getTypeBuffer(), List.of(job.getTenantId()), (k, j) -> keys.add(k));
+    return keys;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -58,6 +58,8 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldAddAllJobsWaitingForSecretReference() {
     // given
+    createJob(1L);
+    createJob(2L);
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -84,6 +86,8 @@ final class SecretReferenceResolutionRequestedApplierTest {
   void shouldAccumulateJobsAcrossSeparateResolutionRequestedEvents() {
     // given — two separate RESOLUTION_REQUESTED events for the same secret, each adding a different
     // job
+    createJob(1L);
+    createJob(2L);
     final var record1 =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -115,6 +119,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldIndexSecretReferenceByJob() {
     // given
+    createJob(1L);
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -138,6 +143,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldNotDuplicateJobOnRepeatedResolutionRequest() {
     // given
+    createJob(1L);
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -186,6 +192,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldIndexMultipleSecretReferencesByJob() {
     // given — the same job key waiting on two different secret references
+    createJob(1L);
     final var record1 =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -217,11 +224,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   void shouldMakeWaitingJobNotActivatable() {
     // given — an activatable job that references a not-yet-resolved secret
     final long jobKey = 1L;
-    final var job =
-        new JobRecord().setType("task-type").setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    jobState.insertJobRecordActivatable(jobKey, job);
-    jobState.makeJobActivatableByPriority(
-        job.getTypeBuffer(), jobKey, job.getTenantId(), job.getPriority());
+    final var job = createJob(jobKey);
     assertThat(activatableJobKeys(job)).contains(jobKey);
     final var record =
         new SecretReferenceRecord()
@@ -237,17 +240,47 @@ final class SecretReferenceResolutionRequestedApplierTest {
   }
 
   @Test
-  void shouldNotFailWhenWaitingJobDoesNotExist() {
-    // given — a record for a job that is absent from the job state
+  void shouldNotAddWaitingEntriesWhenJobDoesNotExist() {
+    // given - a record with an existing job and a job that is absent from the job state
+    createJob(1L);
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
             .setSecretReference("secret-a")
+            .addJobKey(1L)
             .addJobKey(999L);
 
-    // when / then — applying does not fail and still records the pending reference
+    // when - applying does not fail
     applier.applyState(100L, record);
+
+    // then - the reference is pending and only the existing job waits for it, in both directions
     assertThat(state.isPending("store-1", "secret-a")).isTrue();
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(waitingJobs).containsExactly(1L);
+    final List<Tuple> pairs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        999L,
+        (storeId, secretReference) -> {
+          pairs.add(tuple(storeId, secretReference));
+          return true;
+        });
+    assertThat(pairs).isEmpty();
+  }
+
+  private JobRecord createJob(final long key) {
+    final var job =
+        new JobRecord().setType("task-type").setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    jobState.insertJobRecordActivatable(key, job);
+    jobState.makeJobActivatableByPriority(
+        job.getTypeBuffer(), key, job.getTenantId(), job.getPriority());
+    return job;
   }
 
   private List<Long> activatableJobKeys(final JobRecord job) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -219,7 +219,9 @@ final class SecretReferenceResolutionRequestedApplierTest {
     final long jobKey = 1L;
     final var job =
         new JobRecord().setType("task-type").setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    jobState.create(jobKey, job);
+    jobState.insertJobRecordActivatable(jobKey, job);
+    jobState.makeJobActivatableByPriority(
+        job.getTypeBuffer(), jobKey, job.getTenantId(), job.getPriority());
     assertThat(activatableJobKeys(job)).contains(jobKey);
     final var record =
         new SecretReferenceRecord()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
+import io.camunda.zeebe.engine.processing.job.SecretResolver;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -132,6 +133,7 @@ public final class EngineRule extends ExternalResource {
 
   private long lastProcessedPosition = -1L;
   private JobStreamer jobStreamer = JobStreamer.noop();
+  private SecretResolver secretResolver = SecretResolver.noop();
 
   private final FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
@@ -245,6 +247,11 @@ public final class EngineRule extends ExternalResource {
 
   public EngineRule withJobStreamer(final JobStreamer jobStreamer) {
     this.jobStreamer = jobStreamer;
+    return this;
+  }
+
+  public EngineRule withSecretResolver(final SecretResolver secretResolver) {
+    this.secretResolver = secretResolver;
     return this;
   }
 
@@ -374,7 +381,8 @@ public final class EngineRule extends ExternalResource {
                         featureFlags,
                         jobStreamer,
                         searchClientsProxy,
-                        brokerRequestAuthorizationConverter)
+                        brokerRequestAuthorizationConverter,
+                        secretResolver)
                     .withListener(
                         new ProcessingExporterTransistor(
                             environmentRule.getLogStream(partitionId)));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -47,6 +47,8 @@ public final class JobActivationClient {
   private final JobBatchRecord jobBatchRecord;
 
   private int partitionId;
+  private Integer requestStreamId;
+  private Long requestId;
   private BiFunction<Integer, Long, Record<JobBatchRecordValue>> expectation =
       SUCCESS_EXPECTATION_SUPPLIER;
 
@@ -115,14 +117,41 @@ public final class JobActivationClient {
     return this;
   }
 
+  public JobActivationClient withRequestStreamId(final int requestStreamId) {
+    this.requestStreamId = requestStreamId;
+    return this;
+  }
+
+  public JobActivationClient withRequestId(final long requestId) {
+    this.requestId = requestId;
+    return this;
+  }
+
   public JobActivationClient expectRejection() {
     expectation = REJECTION_EXPECTATION_SUPPLIER;
     return this;
   }
 
   public Record<JobBatchRecordValue> activate() {
+    if ((requestStreamId == null) != (requestId == null)) {
+      throw new IllegalStateException(
+          "Expected both request stream id and request id to be set together, or neither, but got "
+              + "requestStreamId=%s and requestId=%s".formatted(requestStreamId, requestId));
+    }
+    // when a request id is set, the command carries request metadata so the engine writes a
+    // command response; both variants write on the configured partition
     final long position =
-        writer.writeCommandOnPartition(partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord);
+        requestStreamId != null && requestId != null
+            ? writer.writeCommandOnPartition(
+                partitionId,
+                builder ->
+                    builder
+                        .intent(JobBatchIntent.ACTIVATE)
+                        .requestStreamId(requestStreamId)
+                        .requestId(requestId)
+                        .authorizations()
+                        .event(jobBatchRecord))
+            : writer.writeCommandOnPartition(partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord);
 
     return expectation.apply(partitionId, position);
   }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Job_CANCELED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Job_CANCELED_v4.golden
@@ -51,15 +51,18 @@ public class JobCanceledV4Applier implements TypedEventApplier<JobIntent, JobRec
    */
   private void removeWaitingSecretReferenceEntries(final long jobKey) {
     // collect first: the column family must not be modified while iterating it
-    final List<String[]> waitingEntries = new ArrayList<>();
+    final List<WaitingEntry> waitingEntries = new ArrayList<>();
     secretReferenceState.visitSecretReferencesByJob(
         jobKey,
         (storeId, secretReference) -> {
-          waitingEntries.add(new String[] {storeId, secretReference});
+          waitingEntries.add(new WaitingEntry(storeId, secretReference));
           return true;
         });
-    for (final String[] entry : waitingEntries) {
-      secretReferenceState.removeWaitingJob(entry[0], entry[1], jobKey);
+    for (final WaitingEntry entry : waitingEntries) {
+      secretReferenceState.removeWaitingJob(entry.storeId(), entry.secretReference(), jobKey);
     }
   }
+
+  /** A secret reference the canceled job was waiting for. */
+  private record WaitingEntry(String storeId, String secretReference) {}
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Job_CANCELED_v4.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Job_CANCELED_v4.golden
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobCanceledV4Applier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+  private final MutableSecretReferenceState secretReferenceState;
+
+  JobCanceledV4Applier(final MutableProcessingState state) {
+    jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
+    secretReferenceState = state.getSecretReferenceState();
+  }
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    jobState.cancel(key, value);
+    removeWaitingSecretReferenceEntries(key);
+
+    if (value.isJobToUserTaskMigration()) {
+      final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+      if (elementInstance != null) {
+        elementInstance.setJobKey(-1L);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+
+  /**
+   * Removes the waiting entries of a job parked for secret resolution (see {@link
+   * SecretReferenceResolutionRequestedApplier}), so the canceled job is not reactivated and gets no
+   * incident once the resolution completes or fails. The pending secret reference itself is kept:
+   * the background resolution removes it through its own terminal events.
+   */
+  private void removeWaitingSecretReferenceEntries(final long jobKey) {
+    // collect first: the column family must not be modified while iterating it
+    final List<String[]> waitingEntries = new ArrayList<>();
+    secretReferenceState.visitSecretReferencesByJob(
+        jobKey,
+        (storeId, secretReference) -> {
+          waitingEntries.add(new String[] {storeId, secretReference});
+          return true;
+        });
+    for (final String[] entry : waitingEntries) {
+      secretReferenceState.removeWaitingJob(entry[0], entry[1], jobKey);
+    }
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -8,7 +8,10 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 
@@ -16,10 +19,11 @@ public final class SecretReferenceResolutionRequestedApplier
     implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
 
   private final MutableSecretReferenceState secretReferenceState;
+  private final MutableJobState jobState;
 
-  public SecretReferenceResolutionRequestedApplier(
-      final MutableSecretReferenceState secretReferenceState) {
-    this.secretReferenceState = secretReferenceState;
+  public SecretReferenceResolutionRequestedApplier(final MutableProcessingState processingState) {
+    secretReferenceState = processingState.getSecretReferenceState();
+    jobState = processingState.getJobState();
   }
 
   @Override
@@ -31,6 +35,15 @@ public final class SecretReferenceResolutionRequestedApplier
 
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+      // stop a waiting job from being collected by a long poll again until it is reactivated once
+      // its secrets resolve. The job stays in state ACTIVATABLE and is only removed from the
+      // activatable index. A concurrent priority update re-inserts it there (see
+      // DbJobState#updateJobPriority), but the next activation removes it again and re-requests
+      // resolution, so the parking self-heals.
+      final JobRecord job = jobState.getJob(jobKey);
+      if (job != null) {
+        jobState.makeJobNotActivatable(jobKey, job);
+      }
     }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -34,6 +34,13 @@ public final class SecretReferenceResolutionRequestedApplier
     secretReferenceState.addPendingSecretReference(storeId, secretReference);
 
     for (final long jobKey : value.getJobKeys()) {
+      final JobRecord job = jobState.getJob(jobKey);
+      if (job == null) {
+        // a job that no longer exists must not wait for the resolution: without its waiting
+        // entries the reactivation flow cannot touch it, and no orphan entries are left behind.
+        // The pending reference is still added above, so the remaining jobs resolve normally
+        continue;
+      }
       secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
       // stop a waiting job from being collected by a long poll again until it is reactivated once
       // its secrets resolve. The job stays in state ACTIVATABLE and is only removed from the
@@ -44,10 +51,7 @@ public final class SecretReferenceResolutionRequestedApplier
       // the reactivation flow (see #57852) must only make a job activatable again if it still
       // exists and is in state ACTIVATABLE, and must remove the waiting entries of every job
       // regardless.
-      final JobRecord job = jobState.getJob(jobKey);
-      if (job != null) {
-        jobState.makeJobNotActivatable(jobKey, job);
-      }
+      jobState.makeJobNotActivatable(jobKey, job);
     }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -38,8 +38,12 @@ public final class SecretReferenceResolutionRequestedApplier
       // stop a waiting job from being collected by a long poll again until it is reactivated once
       // its secrets resolve. The job stays in state ACTIVATABLE and is only removed from the
       // activatable index. A concurrent priority update re-inserts it there (see
-      // DbJobState#updateJobPriority), but the next activation removes it again and re-requests
-      // resolution, so the parking self-heals.
+      // DbJobState#updateJobPriority). If the secret is still uncached at the next activation,
+      // the job is parked again and the parking self-heals. If the secret got cached by then, the
+      // job activates normally while its waiting entries remain in the SecretReferenceState, so
+      // the reactivation flow (see #57852) must only make a job activatable again if it still
+      // exists and is in state ACTIVATABLE, and must remove the waiting entries of every job
+      // regardless.
       final JobRecord job = jobState.getJob(jobKey);
       if (job != null) {
         jobState.makeJobNotActivatable(jobKey, job);

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/ArrayProperty.java
@@ -59,6 +59,16 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
   }
 
   @Override
+  public T get(final int index) {
+    return value.get(index);
+  }
+
+  @Override
+  public T remove(final int index) {
+    return value.remove(index);
+  }
+
+  @Override
   public Stream<T> stream() {
     // ArrayValue is not a thread-safe Iterable
     final var parallel = false;
@@ -69,6 +79,7 @@ public final class ArrayProperty<T extends BaseValue> extends BaseProperty<Array
     return value.isEmpty();
   }
 
+  @Override
   public int size() {
     return value.size();
   }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ValueArray.java
@@ -15,5 +15,21 @@ public interface ValueArray<T> extends Iterable<T>, RandomAccess {
 
   T add(final int index);
 
+  /**
+   * Returns the element at the given index.
+   *
+   * @throws IndexOutOfBoundsException if the index is out of range
+   */
+  T get(final int index);
+
+  /**
+   * Removes and returns the element at the given index; subsequent elements shift left.
+   *
+   * @throws IndexOutOfBoundsException if the index is out of range
+   */
+  T remove(final int index);
+
+  int size();
+
   Stream<T> stream();
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -75,6 +75,26 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .declareProperty(tenantFilterProp);
   }
 
+  /**
+   * Wraps this record around another record's data. Unlike {@link #copyFrom}, the other record's
+   * buffers are shared instead of copied, so this record is only valid as long as the other record
+   * is neither modified nor reset.
+   */
+  public void wrap(final JobBatchRecord record) {
+    reset();
+    typeProp.setValue(record.getTypeBuffer());
+    workerProp.setValue(record.getWorkerBuffer());
+    timeoutProp.setValue(record.getTimeout());
+    maxJobsToActivateProp.setValue(record.getMaxJobsToActivate());
+    truncatedProp.setValue(record.getTruncated());
+    withLeaseProp.setValue(record.isWithLease());
+    tenantFilterProp.setValue(record.getTenantFilter());
+    record.jobKeys().forEach(jobKey -> jobKeysProp.add().setValue(jobKey.getValue()));
+    record.jobs().forEach(job -> jobsProp.add().wrap(job));
+    record.tenantIds().forEach(tenantId -> tenantIdsProp.add().wrap(tenantId.getValue()));
+    record.variables().forEach(variable -> variablesProp.add().wrap(variable.getValue()));
+  }
+
   public JobBatchRecord setType(final DirectBuffer buf, final int offset, final int length) {
     typeProp.setValue(buf, offset, length);
     return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -410,7 +411,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   @Override
   public List<JobSecretReferenceValue> getSecretReferences() {
-    // copy each element while iterating the ArrayProperty because the inner values are reused
+    // detach copies so the returned list stays valid if this record is reused or reset later
     return secretReferencesProp.stream()
         .map(
             element -> {
@@ -431,6 +432,20 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
                   reference.getStoreId(), reference.getSecretReference(), reference.getPath()));
     }
     return this;
+  }
+
+  /**
+   * Direct access to the secret reference elements, without the detached copies of {@link
+   * #getSecretReferences()}. The elements stay owned by this record; do not hold on to them.
+   */
+  @JsonIgnore
+  public ValueArray<JobSecretReference> secretReferences() {
+    return secretReferencesProp;
+  }
+
+  @JsonIgnore
+  public boolean hasSecretReferences() {
+    return !secretReferencesProp.isEmpty();
   }
 
   public JobRecord addSecretReference(

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecordTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class JobBatchRecordTest {
+
+  @Test
+  void shouldWrapEquivalentlyToCopyFrom() {
+    // given - a record with every property populated
+    final JobBatchRecord record = fullyPopulated();
+    final var copied = new JobBatchRecord();
+    copied.copyFrom(record);
+
+    // when
+    final var wrapped = new JobBatchRecord();
+    wrapped.wrap(record);
+
+    // then - wrapping shares the source's buffers but serializes to the same bytes as copying
+    assertThat(serialized(wrapped)).isEqualTo(serialized(copied));
+  }
+
+  @Test
+  void shouldResetPreviousStateOnWrap() {
+    // given - a reused record that already wraps another, larger batch
+    final var reused = new JobBatchRecord();
+    reused.wrap(fullyPopulated());
+    final var smallBatch = new JobBatchRecord().setType("small-type");
+    smallBatch.jobKeys().add().setValue(42L);
+    smallBatch.jobs().add().setType("small-type");
+
+    // when
+    reused.wrap(smallBatch);
+
+    // then - no state of the previous batch leaks into the reused record
+    final var copied = new JobBatchRecord();
+    copied.copyFrom(smallBatch);
+    assertThat(serialized(reused)).isEqualTo(serialized(copied));
+  }
+
+  private static JobBatchRecord fullyPopulated() {
+    final var record =
+        new JobBatchRecord()
+            .setType("test-type")
+            .setWorker("test-worker")
+            .setTimeout(1000L)
+            .setMaxJobsToActivate(10)
+            .setTruncated(true)
+            .setWithLease(true)
+            .setTenantFilter(TenantFilter.ASSIGNED)
+            .setTenantIds(List.of("tenant-1", "tenant-2"));
+    record.variables().add().wrap(BufferUtil.wrapString("fetchedVariable"));
+    record.jobKeys().add().setValue(1L);
+    record.jobKeys().add().setValue(2L);
+    record
+        .jobs()
+        .add()
+        .setType("test-type")
+        .setWorker("test-worker")
+        .setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack("{\"foo\":\"bar\"}")))
+        .addSecretReference("store-1", "token", "/auth/token");
+    record.jobs().add().setType("test-type").setRetries(3);
+    return record;
+  }
+
+  private static byte[] serialized(final JobBatchRecord record) {
+    final var buffer = new UnsafeBuffer(new byte[record.getLength()]);
+    record.write(buffer, 0);
+    return buffer.byteArray();
+  }
+}


### PR DESCRIPTION
## Description

Completes the entry point for async secret resolution on the long-poll job activation path. PR #57966 already excludes jobs whose secret references are not all cached from the activation batch. This change adds the resolution trigger and parking:

- `JobSecretInjector` now reports, per uncached secret reference, the keys of the removed jobs that await it (grouped, deduplicated per job, only uncached references).
- `JobBatchActivateProcessor` writes one `SecretReference.RESOLUTION_REQUESTED` event per uncached reference (store id, reference name, job keys), after the `JobBatch.ACTIVATED` event.
- `SecretReferenceResolutionRequestedApplier` marks each waiting job not activatable, so a long poll does not collect it again on every poll and re-request resolution. The job is reactivated once resolution completes, which is handled by #57852.
- `JobCanceledV4Applier` removes a canceled job's waiting entries from the `SecretReferenceState`, so a job canceled while parked is not reactivated and gets no incident once resolution completes or fails.

## Notes for reviewers

- **Parking vs "stays activatable".** The parent issue text says the job "stays activatable", but that busy-loops the long poll (collect, exclude, re-request every poll). The TODO left in the #57850 branch and #57852's `makeActivatable` reactivation both require the job to be parked first. This change parks it by removing it from the activatable index; the job keeps state `ACTIVATABLE`.
- **Interaction with priority updates.** A concurrent job priority update re-inserts a parked job into the activatable index (`DbJobState#updateJobPriority` treats `ACTIVATABLE` as present in the index). If the secret is still uncached at the next activation, the job is parked again and the parking self-heals. If the secret got cached by then, the job activates normally while its waiting entries remain in the `SecretReferenceState`; the reactivation flow must guard for that, pinned as a requirement on #57852. Documented in the applier.
- **Canceling a parked job.** Cancellation is the only deletion path reachable for a parked job (complete/timeout/error all require state `ACTIVATED`). The new `Job.CANCELED` v4 applier cleans up the job's waiting entries; the pending secret reference itself is kept, as background resolution removes it through its own terminal events.
- **Golden files.** The `RESOLUTION_REQUESTED` applier v1 golden is updated rather than versioned, because the applier is unreleased (its commit is on `main` only, never on a stable or release branch, and no engine has ever emitted the event, as this PR introduces the first writer), so replay compatibility is unaffected. The `Job.CANCELED` applier is released, so it is extended as a new version (v4) with its own golden file.

## Stacking

Stacked on `bcan/57850-inject-secrets-on-activation` (PR #57966). Retarget to `main` once the base merges.

Closes #57846
