### PR TITLE
fix: refresh post-importer-queue write index before reading incident batch (backport of #56179)

### DIFF
--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -38,6 +38,8 @@ import io.camunda.operate.zeebeimport.post.*;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -103,6 +105,15 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
 
     final Map<Long, IncidentState> incidents2Process;
 
+    // Force a refresh of the post-importer-queue write index before reading the batch so that all
+    // of its shards expose their acknowledged writes. The queue is written without routing, so a
+    // single partition's entries are scattered across all shards, which refresh on independent
+    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
+    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
+    // would then advance past the lower entry and, because the lower bound is strict, never revisit
+    // it. See https://github.com/camunda/camunda/issues/56117.
+    refreshPostImporterQueueIndex();
+
     // query post importer queue
     QueryBuilder partitionQ = termQuery(PARTITION_ID, partitionId);
     // first partition will also process older data with partitionId = 0
@@ -111,6 +122,9 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
     }
     final SearchRequest listViewRequest =
         ElasticsearchUtil.createSearchRequest(postImporterQueueTemplate)
+            // an unavailable shard must fail the search (triggering a retry) instead of silently
+            // returning partial hits and letting the cursor skip the entries on the missing shard
+            .allowPartialSearchResults(false)
             .source(
                 new SearchSourceBuilder()
                     .query(
@@ -210,6 +224,31 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
     }
     pendingIncidentsBatch.setIncidents(incidents);
     return pendingIncidentsBatch;
+  }
+
+  private void refreshPostImporterQueueIndex() {
+    // refresh the write index (not the read alias, which would fan out across all archived dated
+    // indices)
+    final RefreshRequest refreshRequest =
+        new RefreshRequest(postImporterQueueTemplate.getFullQualifiedName());
+    try {
+      final RefreshResponse response =
+          esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
+      if (response.getFailedShards() > 0) {
+        // a failed refresh must abort the batch (and let it retry) rather than search a
+        // potentially stale, partially-refreshed index and advance the cursor past unseen entries
+        throw new OperateRuntimeException(
+            String.format(
+                "Refresh of %s failed on %d shard(s); aborting batch to avoid skipping pending updates",
+                postImporterQueueTemplate.getFullQualifiedName(), response.getFailedShards()));
+      }
+    } catch (final IOException e) {
+      throw new OperateRuntimeException(
+          String.format(
+              "Exception occurred while refreshing the post-importer-queue index: %s",
+              e.getMessage()),
+          e);
+    }
   }
 
   @Override

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
@@ -95,6 +95,15 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     final PendingIncidentsBatch pendingIncidentsBatch = new PendingIncidentsBatch();
     final Map<Long, IncidentState> incidents2Process;
 
+    // Force a refresh of the post-importer-queue write index before reading the batch so that all
+    // of its shards expose their acknowledged writes. The queue is written without routing, so a
+    // single partition's entries are scattered across all shards, which refresh on independent
+    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
+    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
+    // would then advance past the lower entry and, because the lower bound is strict, never revisit
+    // it. See https://github.com/camunda/camunda/issues/56117.
+    refreshPostImporterQueueIndex();
+
     record Result(Long key, Long position, String intent) {}
     // query post importer queue
     Query partitionQuery = term(PARTITION_ID, partitionId);
@@ -104,6 +113,9 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     }
     final var postImporterQueueRequest =
         searchRequestBuilder(postImporterQueueTemplate)
+            // an unavailable shard must fail the search (triggering a retry) instead of silently
+            // returning partial hits and letting the cursor skip the entries on the missing shard
+            .allowPartialSearchResults(false)
             .query(
                 and(
                     gt(POSITION, lastProcessedPosition == null ? 0 : lastProcessedPosition),
@@ -175,6 +187,15 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     pendingIncidentsBatch.setIncidents(
         new ArrayList<>(incidents)); // Batch incidents must be a mutable list
     return pendingIncidentsBatch;
+  }
+
+  private void refreshPostImporterQueueIndex() {
+    // refresh the write index (not the read alias, which would fan out across all archived dated
+    // indices); a failed refresh throws and aborts the batch (letting it retry) rather than search
+    // a potentially stale, partially-refreshed index and advance the cursor past unseen entries
+    richOpenSearchClient
+        .index()
+        .refreshWithFailOnPartial(postImporterQueueTemplate.getFullQualifiedName());
   }
 
   @Override

--- a/operate/importer/src/test/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportActionTest.java
+++ b/operate/importer/src/test/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportActionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebeimport.post.elasticsearch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
+import io.camunda.operate.zeebeimport.post.AdditionalData;
+import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.IndicesClient;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ElasticsearchIncidentPostImportActionTest {
+
+  private static final String QUEUE_ALIAS = "operate-post-importer-queue-alias";
+  private static final String QUEUE_WRITE_INDEX = "operate-post-importer-queue-8.7.0_";
+
+  private RestHighLevelClient esClient;
+  private IndicesClient indicesClient;
+  private PostImporterQueueTemplate postImporterQueueTemplate;
+  private ElasticsearchIncidentPostImportAction action;
+
+  @Before
+  public void setUp() {
+    esClient = mock(RestHighLevelClient.class);
+    indicesClient = mock(IndicesClient.class);
+    postImporterQueueTemplate = mock(PostImporterQueueTemplate.class);
+
+    when(esClient.indices()).thenReturn(indicesClient);
+    when(postImporterQueueTemplate.getAlias()).thenReturn(QUEUE_ALIAS);
+    when(postImporterQueueTemplate.getFullQualifiedName()).thenReturn(QUEUE_WRITE_INDEX);
+
+    action = new ElasticsearchIncidentPostImportAction(1);
+    ReflectionTestUtils.setField(action, "esClient", esClient);
+    ReflectionTestUtils.setField(action, "postImporterQueueTemplate", postImporterQueueTemplate);
+    ReflectionTestUtils.setField(action, "operateProperties", new OperateProperties());
+  }
+
+  @Test
+  public void shouldRefreshPostImporterQueueIndexBeforeReadingBatch() throws Exception {
+    // given
+    final RefreshResponse refreshResponse = refreshResponse(0);
+    final SearchResponse searchResponse = emptySearchResponse();
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenReturn(refreshResponse);
+    when(esClient.search(any(SearchRequest.class), any(RequestOptions.class)))
+        .thenReturn(searchResponse);
+
+    // when
+    action.getPendingIncidents(new AdditionalData(), 0L);
+
+    // then - the queue write index is refreshed before the batch search runs, so a lagging shard
+    // exposes its writes and no pending entry is skipped by the forward-only cursor
+    final InOrder inOrder = Mockito.inOrder(indicesClient, esClient);
+    inOrder.verify(indicesClient).refresh(any(RefreshRequest.class), any(RequestOptions.class));
+    inOrder.verify(esClient).search(any(SearchRequest.class), any(RequestOptions.class));
+  }
+
+  @Test
+  public void shouldFailBatchWithoutSearchingWhenRefreshReportsShardFailures() throws Exception {
+    // given
+    final RefreshResponse refreshResponse = refreshResponse(1);
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenReturn(refreshResponse);
+
+    // when / then - a partial refresh must abort the batch (and let it retry) rather than search a
+    // potentially stale, partially-refreshed index and advance the cursor past unseen entries
+    assertThrows(
+        OperateRuntimeException.class, () -> action.getPendingIncidents(new AdditionalData(), 0L));
+    verify(esClient, never()).search(any(SearchRequest.class), any(RequestOptions.class));
+  }
+
+  @Test
+  public void shouldDisablePartialResultsOnPendingBatchSearch() throws Exception {
+    // given
+    final RefreshResponse refreshResponse = refreshResponse(0);
+    final SearchResponse searchResponse = emptySearchResponse();
+    when(indicesClient.refresh(any(RefreshRequest.class), any(RequestOptions.class)))
+        .thenReturn(refreshResponse);
+    final ArgumentCaptor<SearchRequest> searchCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+    when(esClient.search(searchCaptor.capture(), any(RequestOptions.class)))
+        .thenReturn(searchResponse);
+
+    // when
+    action.getPendingIncidents(new AdditionalData(), 0L);
+
+    // then - an unavailable shard must fail the search (triggering a retry) instead of silently
+    // returning partial hits and letting the cursor skip the entries on the missing shard
+    assertFalse(searchCaptor.getValue().allowPartialSearchResults());
+  }
+
+  private RefreshResponse refreshResponse(final int failedShards) {
+    final RefreshResponse response = mock(RefreshResponse.class);
+    when(response.getFailedShards()).thenReturn(failedShards);
+    return response;
+  }
+
+  private SearchResponse emptySearchResponse() {
+    final SearchResponse response = mock(SearchResponse.class);
+    final SearchHits hits =
+        new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+    when(response.getHits()).thenReturn(hits);
+    return response;
+  }
+}

--- a/operate/importer/src/test/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportActionTest.java
+++ b/operate/importer/src/test/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportActionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebeimport.post.opensearch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchIndexOperations;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.zeebeimport.post.AdditionalData;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class OpensearchIncidentPostImportActionTest {
+
+  private static final String QUEUE_ALIAS = "operate-post-importer-queue-alias";
+  private static final String QUEUE_WRITE_INDEX = "operate-post-importer-queue-8.7.0_";
+
+  private RichOpenSearchClient richOpenSearchClient;
+  private OpenSearchIndexOperations indexOperations;
+  private OpenSearchDocumentOperations documentOperations;
+  private PostImporterQueueTemplate postImporterQueueTemplate;
+  private OpensearchIncidentPostImportAction action;
+
+  @Before
+  public void setUp() {
+    richOpenSearchClient = mock(RichOpenSearchClient.class);
+    indexOperations = mock(OpenSearchIndexOperations.class);
+    documentOperations = mock(OpenSearchDocumentOperations.class);
+    postImporterQueueTemplate = mock(PostImporterQueueTemplate.class);
+
+    when(richOpenSearchClient.index()).thenReturn(indexOperations);
+    when(richOpenSearchClient.doc()).thenReturn(documentOperations);
+    when(postImporterQueueTemplate.getAlias()).thenReturn(QUEUE_ALIAS);
+    when(postImporterQueueTemplate.getFullQualifiedName()).thenReturn(QUEUE_WRITE_INDEX);
+
+    action = new OpensearchIncidentPostImportAction(1);
+    ReflectionTestUtils.setField(action, "richOpenSearchClient", richOpenSearchClient);
+    ReflectionTestUtils.setField(action, "postImporterQueueTemplate", postImporterQueueTemplate);
+    ReflectionTestUtils.setField(action, "operateProperties", new OperateProperties());
+  }
+
+  @Test
+  public void shouldRefreshPostImporterQueueIndexBeforeReadingBatch() {
+    // given
+    doReturn(emptySearchResponse()).when(documentOperations).search(any(), any());
+
+    // when
+    action.getPendingIncidents(new AdditionalData(), 0L);
+
+    // then - the queue write index is refreshed before the batch search runs, so a lagging shard
+    // exposes its writes and no pending entry is skipped by the forward-only cursor
+    final InOrder inOrder = Mockito.inOrder(indexOperations, documentOperations);
+    inOrder.verify(indexOperations).refreshWithFailOnPartial(QUEUE_WRITE_INDEX);
+    inOrder.verify(documentOperations).search(any(), any());
+  }
+
+  @Test
+  public void shouldFailBatchWithoutSearchingWhenRefreshFails() {
+    // given
+    doThrow(new OperateRuntimeException("refresh failed"))
+        .when(indexOperations)
+        .refreshWithFailOnPartial(anyString());
+
+    // when / then - a failed refresh must abort the batch (and let it retry) rather than search a
+    // potentially stale, partially-refreshed index and advance the cursor past unseen entries
+    assertThrows(
+        OperateRuntimeException.class, () -> action.getPendingIncidents(new AdditionalData(), 0L));
+    verify(documentOperations, never()).search(any(), any());
+  }
+
+  @Test
+  public void shouldDisablePartialResultsOnPendingBatchSearch() {
+    // given
+    final ArgumentCaptor<SearchRequest.Builder> searchCaptor =
+        ArgumentCaptor.forClass(SearchRequest.Builder.class);
+    doReturn(emptySearchResponse()).when(documentOperations).search(searchCaptor.capture(), any());
+
+    // when
+    action.getPendingIncidents(new AdditionalData(), 0L);
+
+    // then - an unavailable shard must fail the search (triggering a retry) instead of silently
+    // returning partial hits and letting the cursor skip the entries on the missing shard
+    assertFalse(searchCaptor.getValue().build().allowPartialSearchResults());
+  }
+
+  private SearchResponse<Object> emptySearchResponse() {
+    return new SearchResponse.Builder<Object>()
+        .took(1)
+        .timedOut(false)
+        .shards(s -> s.total(1).successful(1).failed(0))
+        .hits(h -> h.total(t -> t.value(0).relation(TotalHitsRelation.Eq)).hits(List.of()))
+        .build();
+  }
+}

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
@@ -11,6 +11,7 @@ import static java.lang.String.format;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.schema.IndexMapping;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import java.io.IOException;
@@ -168,6 +169,28 @@ public class OpenSearchIndexOperations extends OpenSearchRetryOperation {
       }
     } catch (final Exception ex) {
       logger.warn(String.format("Unable to refresh indices: %s", List.of(indexPatterns)), ex);
+    }
+  }
+
+  /**
+   * Refreshes the given index and fails if any shard could not be refreshed. Unlike {@link
+   * #refresh(String)}, failures are not swallowed: callers reading a forward-only position cursor
+   * (e.g. the incident post-importer) must abort and retry rather than search a partially-refreshed
+   * index and advance the cursor past not-yet-visible entries. See
+   * https://github.com/camunda/camunda/issues/56117.
+   */
+  public void refreshWithFailOnPartial(final String index) {
+    final var refreshRequest = new RefreshRequest.Builder().index(List.of(index)).build();
+    try {
+      final RefreshResponse refresh = openSearchClient.indices().refresh(refreshRequest);
+      if (refresh.shards() != null && !refresh.shards().failures().isEmpty()) {
+        throw new OperateRuntimeException(
+            String.format(
+                "Refresh of %s failed on %d shard(s); aborting to avoid skipping pending updates",
+                index, refresh.shards().failures().size()));
+      }
+    } catch (final IOException e) {
+      throw new OperateRuntimeException(String.format("Failed to refresh index: %s", index), e);
     }
   }
 


### PR DESCRIPTION
## Description

Backport of #56179 to `stable/8.7`.

In 8.7 the incident post-import flow lives in the **Operate importer** (`ElasticsearchIncidentPostImportAction` / `OpensearchIncidentPostImportAction`), not the `camunda-exporter` where the original PR landed. The same bug applies: `getPendingIncidents` reads the `operate-post-importer-queue` index with a strict, forward-only position cursor. On a **multi-shard** queue index a single partition's entries are scattered across all primary shards (written without routing), which refresh on independent timers. A higher-position entry on an already-refreshed shard can be returned while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor then advances past the lower entry and, because the lower bound is strict (`position >`), **never revisits it** — the corresponding incident stays `PENDING` forever.

This hardens the read path (brownfield, code-only, no migration), mirrored across Elasticsearch and OpenSearch:

1. **Force-refresh the queue write index before each batch read** so all shards expose their acknowledged writes. The refresh targets `PostImporterQueueTemplate.getFullQualifiedName()` (the **write** index, not the read alias — the alias would fan out across all archived dated indices). A failed/partial refresh **aborts the batch** (letting it retry) instead of searching a stale, partially-refreshed index and advancing the cursor past unseen entries. For OpenSearch this is done via a new `OpenSearchIndexOperations.refreshWithFailOnPartial(...)` (the existing `refresh(...)` swallows failures).
2. **`allowPartialSearchResults(false)`** on the batch search so an unavailable/recovering shard makes the search **fail** (and retry) instead of silently returning partial hits and advancing the cursor past the missing shard's entries.


## Related issues

closes #56117
backport of #56179

## Tests

Unit tests for both ES and OS (`ElasticsearchIncidentPostImportActionTest`, `OpensearchIncidentPostImportActionTest`) mirroring the original PR's scenarios: the refresh runs **before** the batch search; a failed refresh aborts the batch **without** searching (no cursor advance); the batch search sets `allowPartialSearchResults = false`.

The existing `ElasticsearchPostImportActionIT` / `OpensearchPostImportActionIT` (real ES/OS via testcontainers) continue to exercise the full round and now also run the refresh path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
