### PR TITLE
fix: route C8SM preview /console traffic to webModeler.restapi service

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/httproute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/httproute.yml
@@ -45,7 +45,7 @@ spec:
   hostnames:
   - {{ include "ingress.domain" $ | quote }}
   rules:
-  # app-root: redirect "/" to Console.
+  # app-root: redirect "/" to Web Modeler.
   - matches:
     - path:
         type: Exact
@@ -56,12 +56,12 @@ spec:
         statusCode: 302
         path:
           type: ReplaceFullPath
-          replaceFullPath: {{ .Values.camundaPlatform.console.contextPath | quote }}
-  # Console
+          replaceFullPath: {{ .Values.camundaPlatform.webModeler.contextPath | quote }}
+  # Orchestration (REST gateway)
   - matches:
     - path:
         type: PathPrefix
-        value: {{ .Values.camundaPlatform.console.contextPath | quote }}
+        value: {{ .Values.camundaPlatform.orchestration.contextPath | quote }}
     # Vouch + error-pages filter set, anchored here and reused by every other
     # authenticated rule below via the *authFilters alias.
     filters: &authFilters
@@ -77,15 +77,6 @@ spec:
         kind: Middleware
         name: {{ $errorsMiddleware }}
     {{- end }}
-    backendRefs:
-    - name: {{ template "console.fullname" $camundaPlatform }}
-      port: {{ .Values.camundaPlatform.console.service.port }}
-  # Orchestration (REST gateway)
-  - matches:
-    - path:
-        type: PathPrefix
-        value: {{ .Values.camundaPlatform.orchestration.contextPath | quote }}
-    filters: *authFilters
     backendRefs:
     - name: {{ template "orchestration.fullname" $camundaPlatform }}-gateway
       port: {{ .Values.camundaPlatform.orchestration.service.httpPort }}

--- a/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
@@ -25,7 +25,6 @@
 {{- $clientIP := printf "ClientIP(`%s`)" (join "`, `" $sourceRanges) -}}
 {{- $host := include "ingress.domain" $ -}}
 {{- $backends := list
-    (dict "path" .Values.camundaPlatform.console.contextPath "name" (include "console.fullname" $camundaPlatform) "port" .Values.camundaPlatform.console.service.port)
     (dict "path" .Values.camundaPlatform.orchestration.contextPath "name" (printf "%s-gateway" (include "orchestration.fullname" $camundaPlatform)) "port" .Values.camundaPlatform.orchestration.service.httpPort)
     (dict "path" (include "identity.keycloak.contextPath" $camundaPlatform) "name" (include "identity.keycloak.service" $camundaPlatform) "port" (include "identity.keycloak.port" $camundaPlatform | int))
     (dict "path" .Values.camundaPlatform.identity.contextPath "name" (include "identity.fullname" $camundaPlatform) "port" .Values.camundaPlatform.identity.service.port)

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -414,7 +414,11 @@ class AbstractImportSchedulerTest {
 
   private ImportMediator readyMediator() {
     final ImportMediator mediator = mock(ImportMediator.class);
-    when(mediator.canImport()).thenReturn(true);
+    // lenient: stopImportScheduling() shutdownNow()s the executor, which cancels any
+    // not-yet-started mediator task. On a CPU-starved runner, a mediator's task may never reach
+    // its canImport() check before teardown — whether that happens is an unasserted timing race,
+    // not something every test using this helper cares about.
+    lenient().when(mediator.canImport()).thenReturn(true);
     return mediator;
   }
 }


### PR DESCRIPTION
## Summary

- The `camunda-platform` Helm chart consolidated the standalone Console component into Web Modeler (Camunda Hub migration) starting in `15.0.0-alpha3`, removing the `console.fullname` named template. `.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml` and `httproute.yml` still called `include/template "console.fullname"`, so any render of the C8SM preview-environment chart for 8.10 failed with `no template "console.fullname" associated with template "gotpl"`.
- This broke the scheduled `Preview Environment Smoke Test`'s 8.10 deploy job (see [run 29723637190](https://github.com/camunda/camunda/actions/runs/29723637190)); the 8.8/8.9 deploy jobs were unaffected since they run the reusable deploy workflow from `stable/8.8`/`stable/8.9`, which still pin an older chart version.
- After the deploy started succeeding, manual testing of the deployed preview environment found `/console` 404s after the app-root redirect. Root cause: Console isn't a separate app/URL anymore — the vendor chart itself emits a deprecation warning confirming this: `"console.enabled" is deprecated ... Console has been consolidated into Camunda Hub as an in-Modeler feature`. The `webModeler.restapi` pod only understands requests under its own `contextPath` (`/modeler`), so routing `/console` there (an intermediate fix) reached the pod but hit an application-level 404. Removed the now-meaningless `/console` route entirely from both templates and pointed the app-root `/` redirect straight at `/modeler`.
- Also fixes a flaky test surfaced while validating this change via the `deploy-preview` label: `AbstractImportSchedulerTest.shouldContinueRunningOtherMediatorsWhenOneFails` intermittently threw `UnnecessaryStubbingException`. `stopImportScheduling()` `shutdownNow()`s the mediator executor, cancelling any not-yet-started mediator task; on a CPU-starved runner a mediator's task can be cancelled before it ever reaches its `canImport()` check. Marked `readyMediator()`'s `canImport()` stub `lenient()`, matching this test file's existing convention for other unasserted timing races.

Clean run: https://github.com/camunda/camunda/actions/runs/29902205385

## Root cause (chart)

- `c89cf4b0c5c` (INC-6469) added `internal-bypass-ingressroute.yml` referencing `console.fullname`, valid at the time against `camunda-platform` `15.0.0-alpha2` (which still shipped a standalone `templates/console/` component).
- `e6d1115db35` (renovate) bumped `camunda-platform` to `15.0.0-alpha3`, which dropped the standalone Console templates entirely as part of the Hub consolidation.
- `httproute.yml`'s identical `console.fullname` reference was not actually gated behind `$errorsEnabled` as it first appeared (only an extra middleware filter is), so it broke on every 8.10 chart render, not just the smoke test's internal-bypass path.
- Confirmed the actual smoke-test suite (`camunda/c8-cross-component-e2e-tests`, `tests/SM-8.10/smoke-tests.spec.ts`) never visits `/console`, so this last gap wasn't blocking CI — but it's a real bug worth fixing since it was reachable and broken for anyone visiting the preview URL.

## Test plan

- [x] `helm dependency build` + `helm template` locally against the fixed chart with the same flags the failing job used (including `global.preview.ingress.internalAuthBypass.enabled=true`) — renders cleanly with no errors, no remaining `/console` references, app-root redirect resolves to `/modeler`.
- [x] `./mvnw verify -pl optimize/backend -Dtest=AbstractImportSchedulerTest -DskipTests=false -DskipITs` — `Tests run: 11, Failures: 0, Errors: 0` after the lenient-stub fix.
- [x] Deployed via the `deploy-preview` label; confirmed the chart renders and deploys, and that `/console`'s 404 is now understood and fixed (redirect target corrected).
- [ ] Next scheduled `Preview Environment Smoke Test` run (or another `deploy-preview` label cycle) should show the 8.10 deploy job passing and `/` redirecting cleanly to a working `/modeler` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)