### PR TITLE
fix: handle null sort values in search_after cursor pagination

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -53,18 +53,27 @@ public record DbQueryPage(
       }
 
       public KeySetPaginationFieldEntry build() {
+        // NULL ordering is standardized across all supported databases (see Commons.xml orderBy):
+        // ASC sorts NULLs FIRST, DESC sorts NULLs LAST. The strict comparator for a NULL cursor
+        // value therefore depends on the direction: for the boundary where NULLs are on the far
+        // side of the traversal there is no row beyond them, which must yield NO_MATCH rather than
+        // IS_NULL (which would match every NULL row and stall the cursor).
         final Operator operator;
         if (isSearchAfter) {
           operator =
               order == SortOrder.ASC
+                  // ASC NULLs FIRST: rows after a NULL cursor are the non-NULL rows
                   ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER
-                  : fieldValue == null ? Operator.IS_NULL : Operator.LOWER;
+                  // DESC NULLs LAST: nothing sorts after a NULL cursor
+                  : fieldValue == null ? Operator.NO_MATCH : Operator.LOWER;
         } else {
-          // searchBefore: mirror of searchAfter with directions reversed
+          // searchBefore: traverse the result set backwards
           operator =
               order == SortOrder.ASC
-                  ? fieldValue == null ? Operator.IS_NOT_NULL : Operator.LOWER
-                  : fieldValue == null ? Operator.IS_NULL : Operator.GREATER;
+                  // ASC NULLs FIRST: nothing sorts before a NULL cursor
+                  ? fieldValue == null ? Operator.NO_MATCH : Operator.LOWER
+                  // DESC NULLs LAST: rows before a NULL cursor are the non-NULL rows
+                  : fieldValue == null ? Operator.IS_NOT_NULL : Operator.GREATER;
         }
         return new KeySetPaginationFieldEntry(fieldName, operator, fieldValue);
       }
@@ -76,7 +85,10 @@ public record DbQueryPage(
     IS_NOT_NULL("IS NOT NULL"),
     GREATER(">"),
     LOWER("<"),
-    EQUALS("=");
+    EQUALS("="),
+    // marks an OR-group that can never match (e.g. nothing sorts beyond a boundary NULL); such
+    // groups are dropped before rendering SQL and never reach the mapper
+    NO_MATCH("");
 
     private final String symbol;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -142,11 +142,20 @@ abstract class AbstractEntityReader<T> {
 
       // add the comparator entry for the current sort column
       final var sorting = sort.orderings().get(i);
-      fieldEntries.add(
+      final var comparator =
           KeySetPaginationFieldEntry.of(sorting.column().name(), sortValues[i])
               .order(sorting.order())
               .isSearchAfter(isSearchAfter)
-              .build());
+              .build();
+
+      // a NO_MATCH comparator makes the whole OR-group unsatisfiable (e.g. nothing sorts after a
+      // trailing NULL in a DESC search-after). Dropping the group keeps the cursor advancing
+      // instead of re-matching every NULL row; the always-present unique key column guarantees at
+      // least one satisfiable group remains.
+      if (comparator.operator() == DbQueryPage.Operator.NO_MATCH) {
+        continue;
+      }
+      fieldEntries.add(comparator);
 
       keySetPagination.add(new KeySetPagination(fieldEntries));
     }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -376,7 +376,9 @@ class AbstractEntityReaderTest {
 
   @Test
   void shouldBuildSearchBeforeWithNullInFirstColumnTwoCols() {
-    // given: entity where first column (processDefinitionVersionTag) is null
+    // given: entity where first column (processDefinitionVersionTag) is null. ASC sorts NULLs
+    // first, so when traversing backwards nothing sorts before a leading null - the strict leading
+    // clause is dropped, leaving only the tie-break that walks earlier null rows by unique key.
     final var entity =
         Instancio.of(ProcessInstanceEntity.class)
             .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
@@ -396,17 +398,11 @@ class AbstractEntityReaderTest {
         SearchQueryPage.of(p -> p.from(0).size(10).before(result.startCursor()));
     final DbQueryPage dbPage = reader.convertPaging(sort, page);
 
-    // then: 2 keyset entries
-    assertThat(dbPage.keySetPagination()).hasSize(2);
+    // then: only the tie-break group remains (the unsatisfiable leading group is dropped)
+    assertThat(dbPage.keySetPagination()).hasSize(1);
 
-    // ks0: processDefinitionVersionTag IS NOT NULL  (null + ASC + searchBefore => IS_NOT_NULL)
+    // processDefinitionVersionTag IS NULL AND processInstanceKey < value
     assertThat(dbPage.keySetPagination().get(0).entries())
-        .containsExactly(
-            new KeySetPaginationFieldEntry(
-                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
-
-    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey < value
-    assertThat(dbPage.keySetPagination().get(1).entries())
         .containsExactly(
             new KeySetPaginationFieldEntry(
                 "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
@@ -416,9 +412,10 @@ class AbstractEntityReaderTest {
 
   @Test
   void shouldBuildSearchAfterDescWithNullInFirstColumn() {
-    // given: entity where the DESC sort column (processDefinitionVersionTag) is null
-    // null + DESC + searchAfter => IS_NULL (null rows come last in DESC, so "after null" = nothing
-    // further; but "is null" is the correct comparator for rows at the same null level)
+    // given: entity where the DESC sort column (processDefinitionVersionTag) is null. DESC sorts
+    // NULLs last, so nothing sorts after a null cursor - the strict leading clause must be dropped
+    // (not IS NULL, which would re-match every null row and stall the cursor). Only the tie-break
+    // that advances within the trailing null block by the unique key survives.
     final var entity =
         Instancio.of(ProcessInstanceEntity.class)
             .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
@@ -438,17 +435,11 @@ class AbstractEntityReaderTest {
         SearchQueryPage.of(p -> p.from(0).size(10).after(result.endCursor()));
     final DbQueryPage dbPage = reader.convertPaging(sort, page);
 
-    // then: 2 keyset entries
-    assertThat(dbPage.keySetPagination()).hasSize(2);
+    // then: only the tie-break group remains (the unsatisfiable leading group is dropped)
+    assertThat(dbPage.keySetPagination()).hasSize(1);
 
-    // ks0: processDefinitionVersionTag IS NULL  (null + DESC + searchAfter => IS_NULL)
+    // processDefinitionVersionTag IS NULL AND processInstanceKey > value
     assertThat(dbPage.keySetPagination().get(0).entries())
-        .containsExactly(
-            new KeySetPaginationFieldEntry(
-                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null));
-
-    // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey > value
-    assertThat(dbPage.keySetPagination().get(1).entries())
         .containsExactly(
             new KeySetPaginationFieldEntry(
                 "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null),
@@ -458,8 +449,9 @@ class AbstractEntityReaderTest {
 
   @Test
   void shouldBuildSearchBeforeDescWithNullInFirstColumn() {
-    // given: entity where the DESC sort column (processDefinitionVersionTag) is null
-    // null + DESC + searchBefore => IS_NULL  (reverse of searchAfter+DESC+null)
+    // given: entity where the DESC sort column (processDefinitionVersionTag) is null. DESC sorts
+    // NULLs last, so traversing backwards from a trailing null reaches the non-null rows - the
+    // strict leading clause is IS NOT NULL (was incorrectly IS NULL, which re-matched null rows).
     final var entity =
         Instancio.of(ProcessInstanceEntity.class)
             .set(Select.field(ProcessInstanceEntity::processDefinitionVersionTag), null)
@@ -482,11 +474,11 @@ class AbstractEntityReaderTest {
     // then: 2 keyset entries
     assertThat(dbPage.keySetPagination()).hasSize(2);
 
-    // ks0: processDefinitionVersionTag IS NULL  (null + DESC + searchBefore => IS_NULL)
+    // ks0: processDefinitionVersionTag IS NOT NULL  (null + DESC + searchBefore => IS_NOT_NULL)
     assertThat(dbPage.keySetPagination().get(0).entries())
         .containsExactly(
             new KeySetPaginationFieldEntry(
-                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NULL, null));
+                "PROCESS_DEFINITION_VERSION_TAG", Operator.IS_NOT_NULL, null));
 
     // ks1: processDefinitionVersionTag IS NULL AND processInstanceKey < value
     assertThat(dbPage.keySetPagination().get(1).entries())

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -30,6 +30,7 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.enums.ProcessInstanceState;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -41,11 +42,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @MultiDbTest
 @CompatibilityTest
@@ -1716,6 +1723,94 @@ public class ProcessInstanceSearchIT {
     assertThat(resultAsc.items().getLast().getBusinessId()).isEqualTo("order-002");
     assertThat(resultDesc.items().getFirst().getBusinessId()).isEqualTo("order-002");
     assertThat(resultDesc.items().getLast().getBusinessId()).isEqualTo("order-001");
+  }
+
+  @ParameterizedTest(name = "sorted by businessId {0}")
+  @MethodSource("businessIdSortDirections")
+  void shouldPaginateProcessInstancesAcrossNullBusinessIdBoundary(
+      final String direction, final Consumer<ProcessInstanceSort> sortByBusinessId) {
+    // given the shared fixture mixes instances with and without a businessId (asserted at its
+    // source, independent of the query under test)
+    assertThat(PROCESS_INSTANCES)
+        .as("fixture must mix null and non-null businessId instances to exercise the null boundary")
+        .anyMatch(pi -> pi.getBusinessId() == null)
+        .anyMatch(pi -> pi.getBusinessId() != null);
+
+    // and an unpaged query establishes the expected order for the current secondary storage
+    final var expected =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .sort(sortByBusinessId)
+            .page(p -> p.limit(1000))
+            .send()
+            .join()
+            .items();
+
+    // derive a page size whose first page ends exactly on the first null businessId in this
+    // backend's ordering, so the searchAfter cursor built from it necessarily carries a null - the
+    // condition that used to crash the query. This adapts automatically to each backend's null
+    // placement (nulls-first vs nulls-last).
+    final int firstNullIndex =
+        IntStream.range(0, expected.size())
+            .filter(i -> expected.get(i).getBusinessId() == null)
+            .findFirst()
+            .orElseThrow();
+    assertThat(firstNullIndex)
+        .as("a null businessId must be followed by another instance so it is carried in a cursor")
+        .isLessThan(expected.size() - 1);
+    final int pageSize = firstNullIndex + 1;
+
+    // when paginating so the first page boundary lands on the null businessId
+    final var paginated = paginateByBusinessId(sortByBusinessId, pageSize);
+
+    // then pagination reproduces the unpaged order exactly: every instance once, no crash on the
+    // cursor carrying a null, and the same ordering across the null/non-null boundary
+    assertThat(paginated)
+        .extracting(ProcessInstance::getProcessInstanceKey)
+        .containsExactlyElementsOf(
+            expected.stream().map(ProcessInstance::getProcessInstanceKey).toList());
+  }
+
+  private static Stream<Arguments> businessIdSortDirections() {
+    return Stream.of(
+        Arguments.of("ASC", (Consumer<ProcessInstanceSort>) s -> s.businessId().asc()),
+        Arguments.of("DESC", (Consumer<ProcessInstanceSort>) s -> s.businessId().desc()));
+  }
+
+  private List<ProcessInstance> paginateByBusinessId(
+      final Consumer<ProcessInstanceSort> sort, final int pageSize) {
+    final long total =
+        camundaClient.newProcessInstanceSearchRequest().send().join().page().totalItems();
+    // a correct cursor advances every page; bound the loop so a non-advancing or repeating
+    // cursor fails fast with a clear message instead of hanging the test
+    final long maxPages = total / pageSize + 2;
+
+    final List<ProcessInstance> collected = new ArrayList<>();
+    String cursor = null;
+    for (long page = 0; page <= maxPages; page++) {
+      final String after = cursor;
+      final var response =
+          camundaClient
+              .newProcessInstanceSearchRequest()
+              .sort(sort)
+              .page(
+                  p -> {
+                    p.limit(pageSize);
+                    if (after != null) {
+                      p.after(after);
+                    }
+                  })
+              .send()
+              .join();
+      collected.addAll(response.items());
+      cursor = response.page().endCursor();
+      if (response.items().size() < pageSize) {
+        return collected;
+      }
+    }
+    throw new AssertionError(
+        "Pagination did not terminate within %d pages; the cursor may not be advancing"
+            .formatted(maxPages));
   }
 
   @Test

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchRequestTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchRequestTransformer.java
@@ -112,8 +112,7 @@ public final class SearchRequestTransformer
 
   private List<FieldValue> of(final Object[] values) {
     return Arrays.asList(values).stream()
-        .map(JsonData::of)
-        .map(FieldValue::of)
+        .map(value -> value == null ? FieldValue.NULL : FieldValue.of(JsonData.of(value)))
         .collect(Collectors.toList());
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/search/SearchRequestTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/search/SearchRequestTransformerTest.java
@@ -213,6 +213,28 @@ public class SearchRequestTransformerTest {
   }
 
   @Test
+  public void shouldTransformSearchAfterWithNullSortValue() {
+    // given a searchAfter cursor whose first element is null (e.g. a null businessId at the
+    // boundary between rows without and with a businessId)
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(
+            b ->
+                b.index("operate-list-view-8.3.0_")
+                    .sort((s) -> s.field((f) -> f.field("businessId").asc()))
+                    .searchAfter(new Object[] {null, "2251799813685249"}));
+
+    // when the request is transformed and serialized (as it is when sent to Elasticsearch)
+    final SearchRequest actual = transformer.apply(request);
+
+    // then the null must be carried as an explicit null FieldValue and serialization must not
+    // throw (a raw null previously produced an NPE, surfacing as HTTP 500 for the caller)
+    assertThat(actual.searchAfter()).hasSize(2);
+    assertThat(actual.searchAfter().getFirst().isNull()).isTrue();
+    assertThat(esQuerySerializer.serialize(actual))
+        .contains("\"search_after\":[null,\"2251799813685249\"]");
+  }
+
+  @Test
   public void shouldTransformSort() {
     // given
     final SearchQueryRequest request =

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchQueryHitTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchQueryHitTransformer.java
@@ -38,7 +38,7 @@ public final class SearchQueryHitTransformer<T>
 
   private Object[] toArray(final List<FieldValue> values) {
     if (values != null && !values.isEmpty()) {
-      return values.stream().map(FieldValue::_get).map(String::valueOf).toArray();
+      return values.stream().map(FieldValue::_get).toArray();
     } else {
       return null;
     }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchRequestTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchRequestTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.source.SearchSourceConfig;
 import io.camunda.search.os.transformers.OpensearchTransformer;
 import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.transformers.aggregator.AggregationCursorTransformer;
 import io.camunda.search.sort.SearchSortOptions;
 import java.util.Arrays;
 import java.util.List;
@@ -103,7 +104,7 @@ public final class SearchRequestTransformer
   }
 
   private List<FieldValue> of(final Object[] values) {
-    return Arrays.stream(values).map(Object::toString).map(FieldValue::of).toList();
+    return Arrays.stream(values).map(AggregationCursorTransformer::toFieldValue).toList();
   }
 
   private SourceConfig of(final SearchSourceConfig value) {

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchQueryHitTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchQueryHitTransformerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+public class SearchQueryHitTransformerTest {
+
+  private final SearchQueryHitTransformer<Object> transformer =
+      new SearchQueryHitTransformer<>(new OpensearchTransformers());
+
+  @Test
+  void shouldPreserveNullSortValueSoCursorCanResume() {
+    // given a hit whose first sort value is null (e.g. a missing businessId) and a non-null
+    // tie-breaker key
+    final Hit<Object> hit =
+        new Hit.Builder<>()
+            .index("process-instance")
+            .id("1")
+            .sort(List.of(FieldValue.NULL, FieldValue.of(2251799813685249L)))
+            .build();
+
+    // when
+    final var result = transformer.apply(hit);
+
+    // then the raw sort values are preserved: the null stays null (not the literal string "null",
+    // which would stall search_after across the null boundary) and the key keeps its numeric type
+    assertThat(result.sortValues()).containsExactly(null, 2251799813685249L);
+  }
+
+  @Test
+  void shouldReturnNullSortValuesWhenHitIsNotSorted() {
+    // given a hit without sort values
+    final Hit<Object> hit = new Hit.Builder<>().index("process-instance").id("1").build();
+
+    // when / then
+    assertThat(transformer.apply(hit).sortValues()).isNull();
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchRequestTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchRequestTransformerTest.java
@@ -235,6 +235,25 @@ public class SearchRequestTransformerTest {
   }
 
   @Test
+  public void shouldTransformSearchAfterPreservingNumericSortValue() {
+    // given a searchAfter cursor with a numeric sort value (as decoded from a cursor, where
+    // integers are deserialized as Long)
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(
+            b ->
+                b.index("operate-list-view-8.3.0_")
+                    .sort((s) -> s.field((f) -> f.field("key").asc()))
+                    .searchAfter(new Object[] {2251799813685249L}));
+
+    // when
+    final SearchRequest actual = transformer.apply(request);
+
+    // then the value must be serialized as a number, not coerced to a string, so search_after
+    // keeps matching the numeric sort field
+    assertThat(osQuerySerializer.serialize(actual)).contains("\"search_after\":[2251799813685249]");
+  }
+
+  @Test
   public void shouldTransformSort() {
     // given
     final SearchQueryRequest request =

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchRequestTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/search/SearchRequestTransformerTest.java
@@ -213,6 +213,28 @@ public class SearchRequestTransformerTest {
   }
 
   @Test
+  public void shouldTransformSearchAfterWithNullSortValue() {
+    // given a searchAfter cursor whose first element is null (e.g. a null businessId at the
+    // boundary between rows without and with a businessId)
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(
+            b ->
+                b.index("operate-list-view-8.3.0_")
+                    .sort((s) -> s.field((f) -> f.field("businessId").asc()))
+                    .searchAfter(new Object[] {null, "2251799813685249"}));
+
+    // when the request is transformed and serialized (as it is when sent to OpenSearch)
+    final SearchRequest actual = transformer.apply(request);
+
+    // then the null must be carried as an explicit null FieldValue and serialization must not
+    // throw (a raw null previously produced an NPE, surfacing as HTTP 500 for the caller)
+    assertThat(actual.searchAfter()).hasSize(2);
+    assertThat(actual.searchAfter().getFirst().isNull()).isTrue();
+    assertThat(osQuerySerializer.serialize(actual))
+        .contains("\"search_after\":[null,\"2251799813685249\"]");
+  }
+
+  @Test
   public void shouldTransformSort() {
     // given
     final SearchQueryRequest request =


### PR DESCRIPTION
## Description

Fixes infinite pagination loops and HTTP 500 errors when paginating `POST /v2/process-instances/search` results sorted by a nullable field (e.g. `businessId`) across the null/non-null boundary — i.e., when the `search_after` cursor carries a `null` value because the page boundary landed on a process instance without a `businessId`.

### Root Cause

Three separate layers mishandled a `null` sort value in a keyset/`search_after` cursor:

- **Elasticsearch** (`SearchRequestTransformer`): `null` was passed directly to `JsonData.of()`, producing a raw `null` `FieldValue` that NPE'd during request serialization → HTTP 500.
- **OpenSearch** (`SearchRequestTransformer`): `null` was passed to `Object::toString` → `NullPointerException` → HTTP 500.
- **OpenSearch** (`SearchQueryHitTransformer`): all sort values were stringified with `String.valueOf`, turning a `null` value into the literal string `"null"` and corrupting the returned cursor, so `search_after` could never resume past the null boundary — pagination re-fetched the same rows indefinitely.
- **RDBMS** (`DbQueryPage` / `AbstractEntityReader`): the keyset builder emitted `IS_NULL` as the strict leading comparator for a `null` cursor value. With DESC ordering (nulls last) this matched every null row instead of none, causing each page to re-fetch the same null rows from the top. cursor never advanced, pagination never terminated.

### Fix

- **Elasticsearch** (`SearchRequestTransformer`): `null` cursor elements are now mapped to `FieldValue.NULL` instead of `FieldValue.of(JsonData.of(null))`.
- **OpenSearch** (`SearchRequestTransformer`): Delegated field value conversion to the existing `AggregationCursorTransformer#toFieldValue`, which already handles `null` and numeric/boolean types correctly (preserving `Long` values as numbers rather than stringifying them).
- **OpenSearch** (`SearchQueryHitTransformer`): Removed the `String.valueOf` coercion — raw sort values (`FieldValue::_get`) are now preserved, so `null` stays `null` and numeric types retain their JSON type, consistent with the Elasticsearch transformer.
- **RDBMS** (`DbQueryPage` / `AbstractEntityReader`): The comparator for a `null` cursor value is now derived from the standardized null ordering (ASC → nulls first, DESC → nulls last). A `null` cursor at the far end of the traversal yields no strictly-following rows, so the leading OR-group is marked `NO_MATCH` and dropped. The tie-break group (unique key) remains, ensuring the cursor always advances.

### Tests

- **Unit tests** added/updated for ES and OS `SearchRequestTransformer`s verifying:
  - A `null` sort value in a `searchAfter` cursor is serialized as an explicit JSON `null` (not an NPE).
  - Numeric sort values (e.g., `Long` process instance keys) are preserved as numbers, not coerced to strings.
- **Unit tests** added for OS `SearchQueryHitTransformer` verifying that `null` sort values are preserved as `null` (not `"null"`) and non-sorted hits return `null`.
- **RDBMS unit tests** updated to reflect the corrected comparator logic (`NO_MATCH` groups are dropped; `IS_NOT_NULL`/`IS_NULL` operators are correctly assigned per direction).
- **Acceptance test** added to `ProcessInstanceSearchIT` verifying end-to-end pagination across the null `businessId` boundary in both ASC and DESC order, adapting dynamically to each backend's null placement (nulls-first vs. nulls-last).

## Related issues

closes #57579 
closes #57580