### PR TITLE
feat: add TimeoutNow Raft message

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -54,6 +54,7 @@ import io.atomix.raft.protocol.RaftResponse.Builder;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.roles.ActiveRole;
@@ -369,6 +370,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         request ->
             handleRequestOnContext(
                 request, () -> role.onTransfer(request), TransferResponse::builder));
+    protocol.registerTimeoutNowHandler(
+        request ->
+            handleRequestOnContext(
+                request, () -> role.onTimeoutNow(request), TimeoutNowResponse::builder));
     protocol.registerAppendV1Handler(
         request ->
             handleRequestOnContext(
@@ -900,6 +905,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.unregisterJoinHandler();
     protocol.unregisterLeaveHandler();
     protocol.unregisterTransferHandler();
+    protocol.unregisterTimeoutNowHandler();
     protocol.unregisterAppendHandler();
     protocol.unregisterPollHandler();
     protocol.unregisterVoteHandler();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -33,6 +33,7 @@ class RaftMessageContext {
   final String leaveSubject;
   final String installSubject;
   final String transferSubject;
+  final String timeoutNowSubject;
   final String pollSubject;
   final String voteSubject;
   final String appendV1subject;
@@ -54,6 +55,7 @@ class RaftMessageContext {
     leaveSubject = getSubject(prefix, "leave");
     installSubject = getSubject(prefix, "install");
     transferSubject = getSubject(prefix, "transfer");
+    timeoutNowSubject = getSubject(prefix, "timeout-now");
     pollSubject = getSubject(prefix, "poll");
     voteSubject = getSubject(prefix, "vote");
     appendV1subject = getSubject(prefix, "append");
@@ -103,6 +105,10 @@ class RaftMessageContext {
 
   String getTransferSubject() {
     return transferSubject;
+  }
+
+  String getTimeoutNowSubject() {
+    return timeoutNowSubject;
   }
 
   private static String getSubject(final String prefix, final String type) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -40,6 +40,8 @@ import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.ReplicatableJournalRecord;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VersionedAppendRequest;
@@ -98,6 +100,8 @@ public final class RaftNamespaces {
           .register(LeaveResponse.class)
           .register(ForceConfigureRequest.class)
           .register(ForceConfigureResponse.class)
+          .register(TimeoutNowRequest.class)
+          .register(TimeoutNowResponse.class)
           .name("RaftProtocol")
           .build();
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -40,6 +40,8 @@ import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftServerProtocol;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VersionedAppendRequest;
@@ -130,6 +132,12 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<TimeoutNowResponse> timeoutNow(
+      final MemberId memberId, final TimeoutNowRequest request) {
+    return sendAndReceive(sendingSubject.getTimeoutNowSubject(), request, memberId);
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
     return sendAndReceive(sendingSubject.getPollSubject(), request, memberId);
   }
@@ -160,6 +168,17 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public void unregisterTransferHandler() {
     unregisterHandler(RaftMessageContext::getTransferSubject);
+  }
+
+  @Override
+  public void registerTimeoutNowHandler(
+      final Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> handler) {
+    registerHandler(RaftMessageContext::getTimeoutNowSubject, handler);
+  }
+
+  @Override
+  public void unregisterTimeoutNowHandler() {
+    unregisterHandler(RaftMessageContext::getTimeoutNowSubject);
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -88,6 +88,15 @@ public interface RaftServerProtocol {
   CompletableFuture<TransferResponse> transfer(MemberId memberId, TransferRequest request);
 
   /**
+   * Sends a timeout-now request to the given node, instructing it to start an election immediately.
+   *
+   * @param memberId the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<TimeoutNowResponse> timeoutNow(MemberId memberId, TimeoutNowRequest request);
+
+  /**
    * Sends a poll request to the given node.
    *
    * @param memberId the node to which to send the request
@@ -126,6 +135,17 @@ public interface RaftServerProtocol {
 
   /** Unregisters the transfer request handler. */
   void unregisterTransferHandler();
+
+  /**
+   * Registers a timeout-now request callback.
+   *
+   * @param handler the timeout-now request handler to register
+   */
+  void registerTimeoutNowHandler(
+      Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> handler);
+
+  /** Unregisters the timeout-now request handler. */
+  void unregisterTimeoutNowHandler();
 
   /**
    * Registers a configure request callback.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/TimeoutNowRequest.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/TimeoutNowRequest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.atomix.cluster.MemberId;
+import java.util.Objects;
+
+/**
+ * TimeoutNow request.
+ *
+ * <p>This instructs the recipient to immediately start an election (bypassing its election
+ * timeout), to enable deliberate leadership transfers. Should only be sent by the current leader -
+ * carries the leader's {@code term} and {@code leader} id so the recipient can reject a stale
+ * request.
+ */
+public final class TimeoutNowRequest extends AbstractRaftRequest {
+
+  private final long term;
+  private final MemberId leader;
+
+  private TimeoutNowRequest(final long term, final MemberId leader) {
+    this.term = term;
+    this.leader = leader;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** The term of the leader that requested the transfer. */
+  public long term() {
+    return term;
+  }
+
+  /** The leader that requested the transfer. */
+  public MemberId leader() {
+    return leader;
+  }
+
+  @Override
+  public MemberId from() {
+    return leader;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), term, leader);
+  }
+
+  @Override
+  public boolean equals(final Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    final TimeoutNowRequest other = (TimeoutNowRequest) object;
+    return term == other.term && leader.equals(other.leader);
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).add("term", term).add("leader", leader).toString();
+  }
+
+  /** TimeoutNow request builder. */
+  public static class Builder extends AbstractRaftRequest.Builder<Builder, TimeoutNowRequest> {
+
+    private long term;
+    private MemberId leader;
+
+    public Builder withTerm(final long term) {
+      this.term = term;
+      return this;
+    }
+
+    public Builder withLeader(final MemberId leader) {
+      this.leader = checkNotNull(leader, "leader cannot be null");
+      return this;
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkNotNull(leader, "leader cannot be null");
+    }
+
+    @Override
+    public TimeoutNowRequest build() {
+      validate();
+      return new TimeoutNowRequest(term, leader);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/TimeoutNowResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/TimeoutNowResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.raft.RaftError;
+
+/**
+ * TimeoutNow response.
+ *
+ * <p>A simple acknowledgement that the recipient accepted the request and will start an election.
+ * This does not signify that a leadership transfer was completed - the current leader should detect
+ * a successful transfer by observing the term advance (i.e. by losing leadership). See {@link
+ * TimeoutNowRequest}.
+ */
+public class TimeoutNowResponse extends AbstractRaftResponse {
+
+  public TimeoutNowResponse(final Status status, final RaftError error) {
+    super(status, error);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** TimeoutNow response builder. */
+  public static class Builder extends AbstractRaftResponse.Builder<Builder, TimeoutNowResponse> {
+
+    @Override
+    public TimeoutNowResponse build() {
+      validate();
+      return new TimeoutNowResponse(status, error);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.ElectionTimerFactory;
+import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
@@ -33,6 +34,9 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.RaftResponse;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -191,6 +195,31 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
+  public CompletableFuture<TimeoutNowResponse> onTimeoutNow(final TimeoutNowRequest request) {
+    logRequest(request);
+
+    if (!isTimeoutNowFromCurrentLeader(request.term(), request.leader())) {
+      return CompletableFuture.completedFuture(
+          logResponse(
+              TimeoutNowResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(RaftError.Type.ILLEGAL_MEMBER_STATE)
+                  .build()));
+    }
+
+    log.info(
+        "Received TimeoutNow from leader {} in term {}, starting election immediately",
+        request.leader(),
+        request.term());
+
+    final var response =
+        logResponse(TimeoutNowResponse.builder().withStatus(RaftResponse.Status.OK).build());
+    raft.transition(RaftServer.Role.CANDIDATE);
+
+    return CompletableFuture.completedFuture(response);
+  }
+
+  @Override
   protected VoteResponse handleVote(final VoteRequest request) {
     // Reset the heartbeat timeout if we voted for another candidate.
     final VoteResponse response = super.handleVote(request);
@@ -198,6 +227,27 @@ public final class FollowerRole extends ActiveRole {
       onHeartbeatFromLeader();
     }
     return response;
+  }
+
+  /**
+   * Stricter than {@link #isRequestFromCurrentLeader}: a TimeoutNow campaigns immediately, so it
+   * must prove the sender is the established leader of the <em>current</em> term. A higher term is
+   * rejected here (rather than accepted, as append/install/configure do) so it cannot bypass the
+   * normal leader-establishment path.
+   */
+  private boolean isTimeoutNowFromCurrentLeader(final long term, final MemberId leader) {
+    final long currentTerm = raft.getTerm();
+    final RaftMember currentLeader = raft.getLeader();
+    if (term != currentTerm || currentLeader == null || !leader.equals(currentLeader.memberId())) {
+      log.debug(
+          "Ignoring TimeoutNow from {} in term {}: expected the current leader {} in term {}",
+          leader,
+          term,
+          currentLeader,
+          currentTerm);
+      return false;
+    }
+    return true;
   }
 
   private boolean isRequestFromCurrentLeader(final long term, final MemberId leader) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -38,6 +38,8 @@ import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
@@ -148,6 +150,18 @@ public class InactiveRole extends AbstractRole {
     final var result =
         logResponse(
             TransferResponse.builder()
+                .withStatus(Status.ERROR)
+                .withError(RaftError.Type.UNAVAILABLE)
+                .build());
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public CompletableFuture<TimeoutNowResponse> onTimeoutNow(final TimeoutNowRequest request) {
+    logRequest(request);
+    final var result =
+        logResponse(
+            TimeoutNowResponse.builder()
                 .withStatus(Status.ERROR)
                 .withError(RaftError.Type.UNAVAILABLE)
                 .build());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -35,6 +35,8 @@ import io.atomix.raft.protocol.PollResponse;
 import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
 import io.atomix.raft.protocol.TransferRequest;
 import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
@@ -96,6 +98,16 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<TransferResponse> onTransfer(TransferRequest request);
+
+  /**
+   * Handles a timeout-now request: instructs this node to start an election immediately, bypassing
+   * its election timeout. Only a follower (the intended successor) accepts it; all other roles
+   * reject it.
+   *
+   * @param request The request to handle.
+   * @return A completable future to be completed with the request response.
+   */
+  CompletableFuture<TimeoutNowResponse> onTimeoutNow(TimeoutNowRequest request);
 
   /**
    * Handles an append request.

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -404,15 +404,15 @@ public final class ControllableRaftContexts {
     final var target =
         raftServers.keySet().stream()
             .filter(id -> !id.equals(memberId))
-            .min(java.util.Comparator.comparing(MemberId::id));
-    if (target.isEmpty()) {
+            .min(java.util.Comparator.comparing(MemberId::id))
+            .orElse(null);
+    if (target == null) {
       return;
     }
-    LOG.info(
-        "Transferring leadership from {} to {} via TimeoutNow", memberId.id(), target.get().id());
+    LOG.info("Transferring leadership from {} to {} via TimeoutNow", memberId.id(), target.id());
     final var request =
         TimeoutNowRequest.builder().withTerm(raftContext.getTerm()).withLeader(memberId).build();
-    raftContext.getProtocol().timeoutNow(target.get(), request);
+    raftContext.getProtocol().timeoutNow(target, request);
   }
 
   // Find current leader and execute an append request

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -17,6 +17,7 @@ package io.atomix.raft;
 
 import static io.atomix.raft.impl.RaftContext.State.READY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -394,25 +395,36 @@ public final class ControllableRaftContexts {
     }
   }
 
-  // Send a TimeoutNow from memberId (only when it is currently the leader) to another member,
-  // prompting an immediate leadership transfer. No-op when memberId is not a leader.
-  public void transferLeadership(final MemberId memberId) {
-    final var raftContext = getRaftContext(memberId);
-    if (raftContext == null || !(raftContext.getRaftRole() instanceof LeaderRole)) {
+  /**
+   * Send a TimeoutNow to the given member (only when it is not currently the leader), prompting an
+   * immediate leadership transfer.
+   *
+   * @param to The member to which leadership should be transferred.
+   */
+  public void transferLeadershipTo(final MemberId to) {
+    final var raftContext = getRaftContext(to);
+    if (raftContext.getRaftRole() instanceof LeaderRole) {
+      LOG.info("Not transferring leadership to {}: already leader", to.id());
       return;
     }
-    final var target =
-        raftServers.keySet().stream()
-            .filter(id -> !id.equals(memberId))
-            .min(java.util.Comparator.comparing(MemberId::id))
+
+    final MemberId from =
+        raftServers.entrySet().stream()
+            .filter(entry -> entry.getValue().isLeader())
+            .map(Entry::getKey)
+            .findFirst()
             .orElse(null);
-    if (target == null) {
+
+    if (from == null) {
+      LOG.info("Not transferring leadership to {}: no current leader", to);
       return;
     }
-    LOG.info("Transferring leadership from {} to {} via TimeoutNow", memberId.id(), target.id());
-    final var request =
-        TimeoutNowRequest.builder().withTerm(raftContext.getTerm()).withLeader(memberId).build();
-    raftContext.getProtocol().timeoutNow(target, request);
+
+    final var leader = getRaftContext(from);
+    LOG.info("Transferring leadership from {} to {} via TimeoutNow", from.id(), to.id());
+    getServerProtocol(from)
+        .timeoutNow(
+            to, TimeoutNowRequest.builder().withTerm(leader.getTerm()).withLeader(from).build());
   }
 
   // Find current leader and execute an append request

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -29,6 +29,7 @@ import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
+import io.atomix.raft.protocol.TimeoutNowRequest;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -391,6 +392,27 @@ public final class ControllableRaftContexts {
       final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, nextEntry++);
       leaderRole.appendEntry(nextEntry, nextEntry, data, dataLossChecker);
     }
+  }
+
+  // Send a TimeoutNow from memberId (only when it is currently the leader) to another member,
+  // prompting an immediate leadership transfer. No-op when memberId is not a leader.
+  public void transferLeadership(final MemberId memberId) {
+    final var raftContext = getRaftContext(memberId);
+    if (raftContext == null || !(raftContext.getRaftRole() instanceof LeaderRole)) {
+      return;
+    }
+    final var target =
+        raftServers.keySet().stream()
+            .filter(id -> !id.equals(memberId))
+            .min(java.util.Comparator.comparing(MemberId::id));
+    if (target.isEmpty()) {
+      return;
+    }
+    LOG.info(
+        "Transferring leadership from {} to {} via TimeoutNow", memberId.id(), target.get().id());
+    final var request =
+        TimeoutNowRequest.builder().withTerm(raftContext.getTerm()).withLeader(memberId).build();
+    raftContext.getProtocol().timeoutNow(target.get(), request);
   }
 
   // Find current leader and execute an append request

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -76,6 +76,13 @@ public final class RaftOperation {
     return operations;
   }
 
+  public static List<RaftOperation> getRaftOperationsWithTransfers() {
+    final List<RaftOperation> defaultRaftOperation = getDefaultRaftOperations();
+    defaultRaftOperation.add(
+        RaftOperation.of("Transfer leadership", ControllableRaftContexts::transferLeadership));
+    return defaultRaftOperation;
+  }
+
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -79,7 +79,7 @@ public final class RaftOperation {
   public static List<RaftOperation> getRaftOperationsWithTransfers() {
     final List<RaftOperation> defaultRaftOperation = getDefaultRaftOperations();
     defaultRaftOperation.add(
-        RaftOperation.of("Transfer leadership", ControllableRaftContexts::transferLeadership));
+        RaftOperation.of("Transfer leadership", ControllableRaftContexts::transferLeadershipTo));
     return defaultRaftOperation;
   }
 
@@ -103,6 +103,8 @@ public final class RaftOperation {
         RaftOperation.of(
             "Drop next message",
             (raftContexts, m) -> raftContexts.getServerProtocol(m).dropNextMessage()));
+    defaultRaftOperation.add(
+        RaftOperation.of("Transfer leadership", ControllableRaftContexts::transferLeadershipTo));
     return defaultRaftOperation;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftOperation.java
@@ -76,13 +76,6 @@ public final class RaftOperation {
     return operations;
   }
 
-  public static List<RaftOperation> getRaftOperationsWithTransfers() {
-    final List<RaftOperation> defaultRaftOperation = getDefaultRaftOperations();
-    defaultRaftOperation.add(
-        RaftOperation.of("Transfer leadership", ControllableRaftContexts::transferLeadershipTo));
-    return defaultRaftOperation;
-  }
-
   public static List<RaftOperation> getDefaultRaftOperations() {
     final List<RaftOperation> defaultRaftOperation = new ArrayList<>();
     defaultRaftOperation.add(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
@@ -18,6 +18,7 @@ package io.atomix.raft;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.impl.RaftNamespaces;
 import io.atomix.raft.protocol.PollRequest;
@@ -47,7 +48,7 @@ public class RaftTimeoutNowTest {
     final var target = raftRule.getFollower().orElseThrow();
     final var leaderId = memberId(leader);
     final var targetId = memberId(target);
-    final long term = target.getContext().getTerm();
+    final long term = leader.getContext().getTerm();
 
     final var targetProtocol = (TestRaftServerProtocol) target.getContext().getProtocol();
     final LongAdder pollCount = new LongAdder();
@@ -78,6 +79,34 @@ public class RaftTimeoutNowTest {
   public void shouldRejectTimeoutNowThatIsNotFromCurrentLeader() throws Exception {
     // given
     raftRule.appendEntries(10);
+    final var followers = raftRule.getServers().stream().filter(RaftServer::isFollower).toList();
+    assertThat(followers).hasSize(2);
+    final var source = followers.get(0);
+    final var target = followers.get(1);
+    final var targetId = memberId(target);
+    final long term = target.getContext().getTerm();
+    final var knownLeaderBefore = knownLeaderId(target);
+
+    // when
+    final var response =
+        source
+            .getContext()
+            .getProtocol()
+            .timeoutNow(targetId, timeoutNow(term, MemberId.from("not-the-leader")))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(response.status()).isEqualTo(Status.ERROR);
+    assertThat(response.error().type()).isEqualTo(Type.ILLEGAL_MEMBER_STATE);
+    assertThat(target.getRole()).isEqualTo(Role.FOLLOWER);
+    assertThat(target.getContext().getTerm()).isEqualTo(term);
+    assertThat(knownLeaderId(target)).isEqualTo(knownLeaderBefore);
+  }
+
+  @Test
+  public void shouldRejectTimeoutNowFromUnknownMember() throws Exception {
+    // given
+    raftRule.appendEntries(10);
     final var leader = raftRule.getLeader().orElseThrow();
     final var target = raftRule.getFollower().orElseThrow();
     final var targetId = memberId(target);
@@ -94,6 +123,7 @@ public class RaftTimeoutNowTest {
 
     // then
     assertThat(response.status()).isEqualTo(Status.ERROR);
+    assertThat(response.error().type()).isEqualTo(RaftError.Type.ILLEGAL_MEMBER_STATE);
     assertThat(target.getRole()).isEqualTo(Role.FOLLOWER);
     assertThat(target.getContext().getTerm()).isEqualTo(term);
     assertThat(knownLeaderId(target)).isEqualTo(knownLeaderBefore);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.impl.RaftNamespaces;
+import io.atomix.raft.protocol.PollRequest;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.protocol.TimeoutNowRequest;
+import io.atomix.raft.protocol.TimeoutNowResponse;
+import io.atomix.raft.protocol.VoteRequest;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Function;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RaftTimeoutNowTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldCampaignImmediatelyAndSkipPreVotePollOnTimeoutNow() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var leaderId = memberId(leader);
+    final var targetId = memberId(target);
+    final long term = target.getContext().getTerm();
+
+    final var targetProtocol = (TestRaftServerProtocol) target.getContext().getProtocol();
+    final LongAdder pollCount = new LongAdder();
+    final LongAdder voteCount = new LongAdder();
+    final AtomicReference<VoteRequest> firstVote = new AtomicReference<>();
+    targetProtocol.interceptRequest(
+        PollRequest.class,
+        request -> {
+          pollCount.increment();
+        });
+    targetProtocol.interceptRequest(
+        VoteRequest.class,
+        request -> {
+          voteCount.increment();
+          firstVote.compareAndSet(null, request);
+        });
+
+    // when
+    leader.getContext().getProtocol().timeoutNow(targetId, timeoutNow(term, leaderId));
+
+    // then
+    Awaitility.await("target becomes leader")
+        .atMost(Duration.ofSeconds(15))
+        .until(() -> target.getRole() == Role.LEADER);
+    assertThat(voteCount.sum()).as("target sent vote requests").isPositive();
+    assertThat(pollCount.sum()).as("target skipped the pre-vote poll").isZero();
+  }
+
+  @Test
+  public void shouldRejectTimeoutNowThatIsNotFromCurrentLeader() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+    final long term = target.getContext().getTerm();
+    final var knownLeaderBefore = knownLeaderId(target);
+
+    // when
+    final var response =
+        leader
+            .getContext()
+            .getProtocol()
+            .timeoutNow(targetId, timeoutNow(term, MemberId.from("not-the-leader")))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(response.status()).isEqualTo(Status.ERROR);
+    assertThat(target.getRole()).isEqualTo(Role.FOLLOWER);
+    assertThat(target.getContext().getTerm()).isEqualTo(term);
+    assertThat(knownLeaderId(target)).isEqualTo(knownLeaderBefore);
+  }
+
+  @Test
+  public void shouldRejectFutureTermTimeoutNow() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var leaderId = memberId(leader);
+    final var targetId = memberId(target);
+    final long term = target.getContext().getTerm();
+    final long futureTerm = term + 1;
+    final var knownLeaderBefore = knownLeaderId(target);
+
+    // when
+    final var response =
+        leader
+            .getContext()
+            .getProtocol()
+            .timeoutNow(targetId, timeoutNow(futureTerm, leaderId))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(response.status()).isEqualTo(Status.ERROR);
+    assertThat(target.getRole()).isEqualTo(Role.FOLLOWER);
+    assertThat(target.getContext().getTerm()).isEqualTo(term);
+    assertThat(knownLeaderId(target)).isEqualTo(knownLeaderBefore);
+  }
+
+  @Test
+  public void shouldRejectStaleTimeoutNow() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var leaderId = memberId(leader);
+    final var targetId = memberId(target);
+    final long term = target.getContext().getTerm();
+    final long staleTerm = term - 1;
+    final var knownLeaderBefore = knownLeaderId(target);
+
+    // when
+    final var response =
+        leader
+            .getContext()
+            .getProtocol()
+            .timeoutNow(targetId, timeoutNow(staleTerm, leaderId))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(response.status()).isEqualTo(Status.ERROR);
+    assertThat(target.getRole()).isEqualTo(Role.FOLLOWER);
+    assertThat(target.getContext().getTerm()).isEqualTo(term);
+    assertThat(knownLeaderId(target)).isEqualTo(knownLeaderBefore);
+  }
+
+  @Test
+  public void shouldRejectTimeoutNowWhenNotAFollower() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var follower = raftRule.getFollower().orElseThrow();
+    final var leaderId = memberId(leader);
+    final long term = leader.getContext().getTerm();
+
+    // when
+    final var response =
+        follower
+            .getContext()
+            .getProtocol()
+            .timeoutNow(leaderId, timeoutNow(term, leaderId))
+            .get(5, TimeUnit.SECONDS);
+
+    // then
+    assertThat(response.status()).isEqualTo(Status.ERROR);
+    assertThat(leader.getRole()).isEqualTo(Role.LEADER);
+    assertThat(leader.getContext().getTerm()).isEqualTo(term);
+  }
+
+  @Test
+  public void shouldRoundTripTimeoutNowMessagesThroughRaftNamespace() {
+    // given
+    final var request = timeoutNow(7, MemberId.from("2"));
+    final var response = TimeoutNowResponse.builder().withStatus(Status.OK).build();
+
+    // when
+    final TimeoutNowRequest deserializedRequest =
+        RaftNamespaces.RAFT_PROTOCOL.deserialize(RaftNamespaces.RAFT_PROTOCOL.serialize(request));
+    final TimeoutNowResponse deserializedResponse =
+        RaftNamespaces.RAFT_PROTOCOL.deserialize(RaftNamespaces.RAFT_PROTOCOL.serialize(response));
+
+    // then
+    assertThat(deserializedRequest).isEqualTo(request);
+    assertThat(deserializedResponse.status()).isEqualTo(Status.OK);
+  }
+
+  @Test
+  public void shouldKeepSenderAndReceiverHealthyWhenATimeoutNowIsUnprocessable() throws Exception {
+    // given
+    raftRule.appendEntries(10);
+    final var leader = raftRule.getLeader().orElseThrow();
+    final var target = raftRule.getFollower().orElseThrow();
+    final var targetId = memberId(target);
+    final var targetTermBefore = target.getContext().getTerm();
+
+    final var leaderProtocol = (TestRaftServerProtocol) leader.getContext().getProtocol();
+    final Function<TimeoutNowRequest, CompletableFuture<Void>> failRequest =
+        request ->
+            CompletableFuture.failedFuture(
+                new RuntimeException("simulated: receiver cannot handle TimeoutNow"));
+    leaderProtocol.interceptRequest(TimeoutNowRequest.class, failRequest);
+
+    // when
+    final var response =
+        leader
+            .getContext()
+            .getProtocol()
+            .timeoutNow(targetId, timeoutNow(targetTermBefore, memberId(leader)));
+
+    // then
+    assertThat(response).failsWithin(Duration.ofSeconds(5));
+    assertThat(leader.getRole()).isEqualTo(Role.LEADER);
+
+    assertThat(target.getRole()).isEqualTo(Role.FOLLOWER);
+    assertThat(target.getContext().getTerm()).isEqualTo(targetTermBefore);
+  }
+
+  private static MemberId memberId(final RaftServer server) {
+    return server.getContext().getCluster().getLocalMember().memberId();
+  }
+
+  private static MemberId knownLeaderId(final RaftServer server) {
+    return server.getContext().getLeader().memberId();
+  }
+
+  private static TimeoutNowRequest timeoutNow(final long term, final MemberId leader) {
+    return TimeoutNowRequest.builder().withTerm(term).withLeader(leader).build();
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTimeoutNowTest.java
@@ -29,7 +29,6 @@ import io.atomix.raft.protocol.VoteRequest;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Function;
 import org.awaitility.Awaitility;
@@ -53,7 +52,6 @@ public class RaftTimeoutNowTest {
     final var targetProtocol = (TestRaftServerProtocol) target.getContext().getProtocol();
     final LongAdder pollCount = new LongAdder();
     final LongAdder voteCount = new LongAdder();
-    final AtomicReference<VoteRequest> firstVote = new AtomicReference<>();
     targetProtocol.interceptRequest(
         PollRequest.class,
         request -> {
@@ -63,7 +61,6 @@ public class RaftTimeoutNowTest {
         VoteRequest.class,
         request -> {
           voteCount.increment();
-          firstVote.compareAndSet(null, request);
         });
 
     // when

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -52,7 +52,6 @@ public class RandomizedRaftTest {
   private List<RaftOperation> operationsWithRestarts;
   private List<RaftOperation> operationsWithSnapshotsAndRestarts;
   private List<RaftOperation> operationsWithSnapshotsAndRestartsWithDataLoss;
-  private List<RaftOperation> operationsWithTransfers;
 
   private List<MemberId> raftMembers;
   private Path raftDataDirectory;
@@ -71,7 +70,6 @@ public class RandomizedRaftTest {
     operationsWithSnapshotsAndRestarts = RaftOperation.getRaftOperationsWithSnapshotsAndRestarts();
     operationsWithSnapshotsAndRestartsWithDataLoss =
         RaftOperation.getRaftOperationsWithSnapshotsAndRestartsWithDataLoss();
-    operationsWithTransfers = RaftOperation.getRaftOperationsWithTransfers();
     raftMembers = servers;
   }
 
@@ -99,15 +97,6 @@ public class RandomizedRaftTest {
       @ForAll("seeds") final long seed)
       throws Exception {
 
-    consistencyTest(raftOperations, raftMembers, seed);
-  }
-
-  @Property
-  void consistencyTestWithLeadershipTransfers(
-      @ForAll("raftOperationsWithTransfers") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
     consistencyTest(raftOperations, raftMembers, seed);
   }
 
@@ -154,15 +143,6 @@ public class RandomizedRaftTest {
   @Property
   void livenessTestWithRestartsAndSnapshots(
       @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
-      @ForAll("raftMembers") final List<MemberId> raftMembers,
-      @ForAll("seeds") final long seed)
-      throws Exception {
-    livenessTest(raftOperations, raftMembers, seed);
-  }
-
-  @Property
-  void livenessTestWithLeadershipTransfers(
-      @ForAll("raftOperationsWithTransfers") final List<RaftOperation> raftOperations,
       @ForAll("raftMembers") final List<MemberId> raftMembers,
       @ForAll("seeds") final long seed)
       throws Exception {
@@ -316,12 +296,6 @@ public class RandomizedRaftTest {
     return Arbitraries.of(operationsWithSnapshotsAndRestartsWithDataLoss)
         .list()
         .ofSize(OPERATION_SIZE);
-  }
-
-  /** Basic raft operations plus coordinated leadership transfers via TimeoutNow. */
-  @Provide
-  Arbitrary<List<RaftOperation>> raftOperationsWithTransfers() {
-    return Arbitraries.of(operationsWithTransfers).list().ofSize(OPERATION_SIZE);
   }
 
   @Provide

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftTest.java
@@ -52,6 +52,7 @@ public class RandomizedRaftTest {
   private List<RaftOperation> operationsWithRestarts;
   private List<RaftOperation> operationsWithSnapshotsAndRestarts;
   private List<RaftOperation> operationsWithSnapshotsAndRestartsWithDataLoss;
+  private List<RaftOperation> operationsWithTransfers;
 
   private List<MemberId> raftMembers;
   private Path raftDataDirectory;
@@ -70,6 +71,7 @@ public class RandomizedRaftTest {
     operationsWithSnapshotsAndRestarts = RaftOperation.getRaftOperationsWithSnapshotsAndRestarts();
     operationsWithSnapshotsAndRestartsWithDataLoss =
         RaftOperation.getRaftOperationsWithSnapshotsAndRestartsWithDataLoss();
+    operationsWithTransfers = RaftOperation.getRaftOperationsWithTransfers();
     raftMembers = servers;
   }
 
@@ -97,6 +99,15 @@ public class RandomizedRaftTest {
       @ForAll("seeds") final long seed)
       throws Exception {
 
+    consistencyTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property
+  void consistencyTestWithLeadershipTransfers(
+      @ForAll("raftOperationsWithTransfers") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
     consistencyTest(raftOperations, raftMembers, seed);
   }
 
@@ -143,6 +154,15 @@ public class RandomizedRaftTest {
   @Property
   void livenessTestWithRestartsAndSnapshots(
       @ForAll("raftOperationsWithSnapshotsAndRestarts") final List<RaftOperation> raftOperations,
+      @ForAll("raftMembers") final List<MemberId> raftMembers,
+      @ForAll("seeds") final long seed)
+      throws Exception {
+    livenessTest(raftOperations, raftMembers, seed);
+  }
+
+  @Property
+  void livenessTestWithLeadershipTransfers(
+      @ForAll("raftOperationsWithTransfers") final List<RaftOperation> raftOperations,
       @ForAll("raftMembers") final List<MemberId> raftMembers,
       @ForAll("seeds") final long seed)
       throws Exception {
@@ -296,6 +316,12 @@ public class RandomizedRaftTest {
     return Arbitraries.of(operationsWithSnapshotsAndRestartsWithDataLoss)
         .list()
         .ofSize(OPERATION_SIZE);
+  }
+
+  /** Basic raft operations plus coordinated leadership transfers via TimeoutNow. */
+  @Provide
+  Arbitrary<List<RaftOperation>> raftOperationsWithTransfers() {
+    return Arbitraries.of(operationsWithTransfers).list().ofSize(OPERATION_SIZE);
   }
 
   @Provide

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -47,6 +47,7 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
 
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
+  private Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> timeoutNowHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
   private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
@@ -250,6 +251,21 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<TimeoutNowResponse> timeoutNow(
+      final MemberId memberId, final TimeoutNowRequest request) {
+    final var responseFuture = new CompletableFuture<TimeoutNowResponse>();
+    send(
+        memberId,
+        () ->
+            getServer(memberId)
+                .thenCompose(listener -> listener.timeoutNow(request))
+                .thenAccept(
+                    response -> send(localMemberId, () -> responseFuture.complete(response), null)),
+        responseFuture);
+    return responseFuture;
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
     final var responseFuture = new CompletableFuture<PollResponse>();
     send(
@@ -307,6 +323,17 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   @Override
   public void unregisterTransferHandler() {
     transferHandler = null;
+  }
+
+  @Override
+  public void registerTimeoutNowHandler(
+      final Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> handler) {
+    timeoutNowHandler = handler;
+  }
+
+  @Override
+  public void unregisterTimeoutNowHandler() {
+    timeoutNowHandler = null;
   }
 
   @Override
@@ -448,6 +475,14 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   CompletableFuture<TransferResponse> transfer(final TransferRequest request) {
     if (transferHandler != null) {
       return transferHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<TimeoutNowResponse> timeoutNow(final TimeoutNowRequest request) {
+    if (timeoutNowHandler != null) {
+      return timeoutNowHandler.apply(request);
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -43,6 +43,7 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   private Function<LeaveRequest, CompletableFuture<LeaveResponse>> leaveHandler;
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
   private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
+  private Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> timeoutNowHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
   private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
@@ -149,6 +150,16 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   }
 
   @Override
+  public CompletableFuture<TimeoutNowResponse> timeoutNow(
+      final MemberId memberId, final TimeoutNowRequest request) {
+    return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, TimeoutNowRequest.class))
+        .thenCompose(listener -> listener.timeoutNow(request))
+        .thenCompose(response -> transformResponse(response, TimeoutNowResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
     return getServer(memberId)
         .thenCompose(listener -> intercept(listener, request, PollRequest.class))
@@ -191,6 +202,17 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public void unregisterTransferHandler() {
     transferHandler = null;
+  }
+
+  @Override
+  public void registerTimeoutNowHandler(
+      final Function<TimeoutNowRequest, CompletableFuture<TimeoutNowResponse>> handler) {
+    timeoutNowHandler = handler;
+  }
+
+  @Override
+  public void unregisterTimeoutNowHandler() {
+    timeoutNowHandler = null;
   }
 
   @Override
@@ -335,6 +357,14 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   CompletableFuture<TransferResponse> transfer(final TransferRequest request) {
     if (transferHandler != null) {
       return transferHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<TimeoutNowResponse> timeoutNow(final TimeoutNowRequest request) {
+    if (timeoutNowHandler != null) {
+      return timeoutNowHandler.apply(request);
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }


### PR DESCRIPTION
Introduces support for the TimeoutNow message, which immediately triggers a leadership election on a receiving follower (bypassing any election timeout). This will be used to support deliberate leadership transfers as part of #56752.

The idea is taken from section 3.10 ("Leadership transfer extension") of [Ongaro's Raft dissertation](https://web.stanford.edu/~ouster/cgi-bin/papers/OngaroPhD.pdf). Some details specific to our implementation:
- Normally, our elections require polling the voting members to confirm that they would support the candidate (by checking that the candidate is up to date). Since TimeoutNow is intended to be sent by the current leader, we leave that responsibility to the sender and skip the pre-vote poll for this path.
- In order to validate that the request _did_ come from the current leader, we have a stricter check than usual - we check that the message's originator matches our view of the current leader, but we also check that the message's term is _exactly_ equal to the current term. Other messages will accept any sender as long as the accompanying term is higher, but we would not expect to receive a TimeoutNow from a leader that we didn't already know about.

Closes #56756.
