### PR TITLE
test: evaluate Elasticsearch 9.1 compatibility on 8.9

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -19,8 +19,7 @@ elasticsearch:
     - "8.19.0"
     - &saas "8.19.15"
   es9:
-    - "9.2.0"
-    - "9.3.0"
+    - "9.1.8"
   saas: *saas
 
 opensearch:

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.test.util.testcontainers;
 
 import java.time.Duration;
-import java.util.Objects;
 import org.opensearch.testcontainers.OpenSearchContainer;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.MariaDBContainer;
@@ -26,11 +25,7 @@ public final class TestSearchContainers {
   public static final String CAMUNDA_PASSWORD = "Camunda_Pass123!";
 
   private static final DockerImageName ELASTIC_IMAGE =
-      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
-          .withTag(
-              Objects.requireNonNullElse(
-                  org.elasticsearch.client.RestClient.class.getPackage().getImplementationVersion(),
-                  "8.19.11"));
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch").withTag("9.1.8");
   private static final DockerImageName OPENSEARCH_IMAGE =
       DockerImageName.parse("opensearchproject/opensearch").withTag("2.19.4");
   private static final DockerImageName POSTGRES_IMAGE =


### PR DESCRIPTION
## Summary

Experiment to get CI signal on whether Camunda 8.9 works against Elasticsearch 9.1. The `es9` CI matrix on `stable/8.9` currently only covers 9.2.0 and 9.3.0 - 9.1 has never been exercised on this branch.

This pins `.ci/db-versions.yml`'s `es9` list to `9.1.8` only, so the `elasticsearch9` CI jobs (database-integration-tests, history-tests, identity-tests) run against it.

Not intended to merge - throwaway experiment branch.

## Test plan

- [ ] `elasticsearch9` matrix jobs in `ci.yml` pass against 9.1.8
- [ ] Manually trigger `zeebe-search-integration-tests.yml` for acceptance-test coverage