### PR TITLE
feat: expose latest update metadata

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinition.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/DecisionDefinition.java
@@ -16,9 +16,16 @@
 package io.camunda.client.api.search.response;
 
 import io.camunda.client.api.response.Decision;
+import java.time.OffsetDateTime;
 
 public interface DecisionDefinition extends Decision {
   String getDecisionRequirementsName();
 
   int getDecisionRequirementsVersion();
+
+  /** Actor ID from the latest successful accessible audit log entry, or {@code null}. */
+  String getUpdatedBy();
+
+  /** Timestamp from the latest successful accessible audit log entry, or {@code null}. */
+  OffsetDateTime getUpdatedAt();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Incident.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Incident.java
@@ -55,4 +55,10 @@ public interface Incident {
   Long getJobKey();
 
   String getTenantId();
+
+  /** Actor ID from the latest successful accessible audit log entry, or {@code null}. */
+  String getUpdatedBy();
+
+  /** Timestamp from the latest successful accessible audit log entry, or {@code null}. */
+  OffsetDateTime getUpdatedAt();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/ProcessInstance.java
@@ -61,4 +61,10 @@ public interface ProcessInstance {
   Set<String> getTags();
 
   String getBusinessId();
+
+  /** Actor ID from the latest successful accessible audit log entry, or {@code null}. */
+  String getUpdatedBy();
+
+  /** Timestamp from the latest successful accessible audit log entry, or {@code null}. */
+  OffsetDateTime getUpdatedAt();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/UserTask.java
@@ -112,4 +112,10 @@ public interface UserTask {
 
   /** Tags associated with the task */
   Set<String> getTags();
+
+  /** Actor ID from the latest successful accessible audit log entry, or {@code null}. */
+  String getUpdatedBy();
+
+  /** Timestamp from the latest successful accessible audit log entry, or {@code null}. */
+  OffsetDateTime getUpdatedAt();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Variable.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.client.api.search.response;
 
+import java.time.OffsetDateTime;
+
 public interface Variable {
   /* The key of the variable */
   Long getVariableKey();
@@ -47,6 +49,12 @@ public interface Variable {
 
   /* Check if the variable is truncated */
   Boolean isTruncated();
+
+  /** Actor ID from the latest successful accessible audit log entry, or {@code null}. */
+  String getUpdatedBy();
+
+  /** Timestamp from the latest successful accessible audit log entry, or {@code null}. */
+  OffsetDateTime getUpdatedAt();
 
   /**
    * Deserializes the variable's JSON value into the given type.

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionDefinitionImpl.java
@@ -16,7 +16,9 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.DecisionDefinition;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DecisionDefinitionResult;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public final class DecisionDefinitionImpl implements DecisionDefinition {
@@ -30,6 +32,8 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
   private final String decisionRequirementsName;
   private final int decisionRequirementsVersion;
   private final String tenantId;
+  private final String updatedBy;
+  private final OffsetDateTime updatedAt;
 
   public DecisionDefinitionImpl(final DecisionDefinitionResult item) {
     this(
@@ -41,7 +45,9 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
         Long.parseLong(item.getDecisionRequirementsKey()),
         item.getDecisionRequirementsName(),
         item.getDecisionRequirementsVersion(),
-        item.getTenantId());
+        item.getTenantId(),
+        item.getUpdatedBy(),
+        ParseUtil.parseOffsetDateTimeOrNull(item.getUpdatedAt()));
   }
 
   public DecisionDefinitionImpl(
@@ -54,6 +60,32 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
       final String decisionRequirementsName,
       final int decisionRequirementsVersion,
       final String tenantId) {
+    this(
+        decisionDefinitionId,
+        name,
+        version,
+        decisionDefinitionKey,
+        decisionRequirementsId,
+        decisionRequirementsKey,
+        decisionRequirementsName,
+        decisionRequirementsVersion,
+        tenantId,
+        null,
+        null);
+  }
+
+  private DecisionDefinitionImpl(
+      final String decisionDefinitionId,
+      final String name,
+      final int version,
+      final long decisionDefinitionKey,
+      final String decisionRequirementsId,
+      final long decisionRequirementsKey,
+      final String decisionRequirementsName,
+      final int decisionRequirementsVersion,
+      final String tenantId,
+      final String updatedBy,
+      final OffsetDateTime updatedAt) {
     this.decisionDefinitionId = decisionDefinitionId;
     this.name = name;
     this.version = version;
@@ -63,6 +95,8 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
     this.decisionRequirementsName = decisionRequirementsName;
     this.decisionRequirementsVersion = decisionRequirementsVersion;
     this.tenantId = tenantId;
+    this.updatedBy = updatedBy;
+    this.updatedAt = updatedAt;
   }
 
   @Override
@@ -111,6 +145,16 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
   }
 
   @Override
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  @Override
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         decisionDefinitionId,
@@ -121,7 +165,9 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
         decisionRequirementsKey,
         decisionRequirementsName,
         decisionRequirementsVersion,
-        tenantId);
+        tenantId,
+        updatedBy,
+        updatedAt);
   }
 
   @Override
@@ -141,7 +187,9 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
         && Objects.equals(name, that.name)
         && Objects.equals(decisionRequirementsId, that.decisionRequirementsId)
         && Objects.equals(decisionRequirementsName, that.decisionRequirementsName)
-        && Objects.equals(tenantId, that.tenantId);
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(updatedBy, that.updatedBy)
+        && Objects.equals(updatedAt, that.updatedAt);
   }
 
   @Override
@@ -170,6 +218,11 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
         + ", tenantId='"
         + tenantId
         + '\''
+        + ", updatedBy='"
+        + updatedBy
+        + '\''
+        + ", updatedAt="
+        + updatedAt
         + '}';
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
@@ -41,6 +41,8 @@ public class IncidentImpl implements Incident {
   private final IncidentState state;
   private final Long jobKey;
   private final String tenantId;
+  private final String updatedBy;
+  private final OffsetDateTime updatedAt;
 
   public IncidentImpl(final IncidentResult item) {
     incidentKey = ParseUtil.parseLongOrNull(item.getIncidentKey());
@@ -58,6 +60,8 @@ public class IncidentImpl implements Incident {
             .orElse(IncidentState.UNKNOWN_ENUM_VALUE);
     jobKey = ParseUtil.parseLongOrNull(item.getJobKey());
     tenantId = item.getTenantId();
+    updatedBy = item.getUpdatedBy();
+    updatedAt = ParseUtil.parseOffsetDateTimeOrNull(item.getUpdatedAt());
   }
 
   @Override
@@ -126,6 +130,16 @@ public class IncidentImpl implements Incident {
   }
 
   @Override
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  @Override
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hash(
         incidentKey,
@@ -140,7 +154,9 @@ public class IncidentImpl implements Incident {
         creationTime,
         state,
         jobKey,
-        tenantId);
+        tenantId,
+        updatedBy,
+        updatedAt);
   }
 
   @Override
@@ -164,6 +180,8 @@ public class IncidentImpl implements Incident {
         && Objects.equals(creationTime, incident.creationTime)
         && state == incident.state
         && Objects.equals(jobKey, incident.jobKey)
-        && Objects.equals(tenantId, incident.tenantId);
+        && Objects.equals(tenantId, incident.tenantId)
+        && Objects.equals(updatedBy, incident.updatedBy)
+        && Objects.equals(updatedAt, incident.updatedAt);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
@@ -41,6 +41,8 @@ public class ProcessInstanceImpl implements ProcessInstance {
   private final String tenantId;
   private final Set<String> tags;
   private final String businessId;
+  private final String updatedBy;
+  private final OffsetDateTime updatedAt;
 
   public ProcessInstanceImpl(final ProcessInstanceResult item) {
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
@@ -59,6 +61,8 @@ public class ProcessInstanceImpl implements ProcessInstance {
     tenantId = item.getTenantId();
     tags = item.getTags();
     businessId = item.getBusinessId();
+    updatedBy = item.getUpdatedBy();
+    updatedAt = ParseUtil.parseOffsetDateTimeOrNull(item.getUpdatedAt());
   }
 
   @Override
@@ -139,5 +143,15 @@ public class ProcessInstanceImpl implements ProcessInstance {
   @Override
   public String getBusinessId() {
     return businessId;
+  }
+
+  @Override
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  @Override
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
@@ -52,6 +52,8 @@ public class UserTaskImpl implements UserTask {
   private final Map<String, String> customHeaders;
   private final Integer priority;
   private final Set<String> tags;
+  private final String updatedBy;
+  private final OffsetDateTime updatedAt;
 
   public UserTaskImpl(final UserTaskResult item) {
     userTaskKey = ParseUtil.parseLongOrNull(item.getUserTaskKey());
@@ -79,6 +81,8 @@ public class UserTaskImpl implements UserTask {
     customHeaders = item.getCustomHeaders();
     priority = item.getPriority();
     tags = item.getTags();
+    updatedBy = item.getUpdatedBy();
+    updatedAt = ParseUtil.parseOffsetDateTimeOrNull(item.getUpdatedAt());
   }
 
   @Override
@@ -204,5 +208,15 @@ public class UserTaskImpl implements UserTask {
   @Override
   public Set<String> getTags() {
     return tags;
+  }
+
+  @Override
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  @Override
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.VariableResult;
 import io.camunda.client.protocol.rest.VariableSearchResult;
+import java.time.OffsetDateTime;
 
 public class VariableImpl implements Variable {
 
@@ -32,6 +33,8 @@ public class VariableImpl implements Variable {
   private final Long rootProcessInstanceKey;
   private final String tenantId;
   private final Boolean isTruncated;
+  private final String updatedBy;
+  private final OffsetDateTime updatedAt;
   @JsonIgnore private final JsonMapper jsonMapper;
 
   public VariableImpl(final VariableSearchResult item, final JsonMapper jsonMapper) {
@@ -43,6 +46,8 @@ public class VariableImpl implements Variable {
     rootProcessInstanceKey = ParseUtil.parseLongOrNull(item.getRootProcessInstanceKey());
     tenantId = item.getTenantId();
     isTruncated = item.getIsTruncated();
+    updatedBy = item.getUpdatedBy();
+    updatedAt = ParseUtil.parseOffsetDateTimeOrNull(item.getUpdatedAt());
     this.jsonMapper = jsonMapper;
   }
 
@@ -55,6 +60,8 @@ public class VariableImpl implements Variable {
     rootProcessInstanceKey = ParseUtil.parseLongOrNull(item.getRootProcessInstanceKey());
     tenantId = item.getTenantId();
     isTruncated = false;
+    updatedBy = item.getUpdatedBy();
+    updatedAt = ParseUtil.parseOffsetDateTimeOrNull(item.getUpdatedAt());
     this.jsonMapper = jsonMapper;
   }
 
@@ -96,6 +103,16 @@ public class VariableImpl implements Variable {
   @Override
   public Boolean isTruncated() {
     return isTruncated;
+  }
+
+  @Override
+  public String getUpdatedBy() {
+    return updatedBy;
+  }
+
+  @Override
+  public OffsetDateTime getUpdatedAt() {
+    return updatedAt;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/decision/GetDecisionDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/GetDecisionDefinitionTest.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import io.camunda.client.util.ClientRestTest;
+import java.time.OffsetDateTime;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ public final class GetDecisionDefinitionTest extends ClientRestTest {
         decisionDefinitionKey,
         Instancio.create(DecisionDefinitionResult.class)
             .decisionDefinitionKey("1")
+            .updatedAt(OffsetDateTime.now().toString())
             .decisionRequirementsKey("3"));
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/impl/search/response/UpdateMetadataResponseTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/search/response/UpdateMetadataResponseTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.protocol.rest.DecisionDefinitionResult;
+import io.camunda.client.protocol.rest.IncidentResult;
+import io.camunda.client.protocol.rest.ProcessInstanceResult;
+import io.camunda.client.protocol.rest.UserTaskResult;
+import io.camunda.client.protocol.rest.VariableResult;
+import io.camunda.client.protocol.rest.VariableSearchResult;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+final class UpdateMetadataResponseTest {
+
+  private static final String UPDATED_BY = "demo";
+  private static final String UPDATED_AT_VALUE = "2026-07-21T12:34:56.789Z";
+  private static final OffsetDateTime UPDATED_AT = OffsetDateTime.parse(UPDATED_AT_VALUE);
+
+  @Test
+  void shouldMapUserTaskUpdateMetadata() {
+    final UserTaskImpl response =
+        new UserTaskImpl(new UserTaskResult().updatedBy(UPDATED_BY).updatedAt(UPDATED_AT_VALUE));
+
+    assertThat(response.getUpdatedBy()).isEqualTo(UPDATED_BY);
+    assertThat(response.getUpdatedAt()).isEqualTo(UPDATED_AT);
+  }
+
+  @Test
+  void shouldMapProcessInstanceUpdateMetadata() {
+    final ProcessInstanceImpl response =
+        new ProcessInstanceImpl(
+            new ProcessInstanceResult().updatedBy(UPDATED_BY).updatedAt(UPDATED_AT_VALUE));
+
+    assertThat(response.getUpdatedBy()).isEqualTo(UPDATED_BY);
+    assertThat(response.getUpdatedAt()).isEqualTo(UPDATED_AT);
+  }
+
+  @Test
+  void shouldMapVariableSearchUpdateMetadata() {
+    final VariableImpl response =
+        new VariableImpl(
+            new VariableSearchResult().updatedBy(UPDATED_BY).updatedAt(UPDATED_AT_VALUE),
+            mock(JsonMapper.class));
+
+    assertThat(response.getUpdatedBy()).isEqualTo(UPDATED_BY);
+    assertThat(response.getUpdatedAt()).isEqualTo(UPDATED_AT);
+  }
+
+  @Test
+  void shouldMapVariableGetUpdateMetadata() {
+    final VariableImpl response =
+        new VariableImpl(
+            new VariableResult().updatedBy(UPDATED_BY).updatedAt(UPDATED_AT_VALUE),
+            mock(JsonMapper.class));
+
+    assertThat(response.getUpdatedBy()).isEqualTo(UPDATED_BY);
+    assertThat(response.getUpdatedAt()).isEqualTo(UPDATED_AT);
+  }
+
+  @Test
+  void shouldMapIncidentUpdateMetadataAndIncludeItInValueSemantics() {
+    final IncidentResult result =
+        new IncidentResult().updatedBy(UPDATED_BY).updatedAt(UPDATED_AT_VALUE);
+    final IncidentImpl response = new IncidentImpl(result);
+    final IncidentImpl sameResponse = new IncidentImpl(result);
+    final IncidentImpl differentResponse =
+        new IncidentImpl(
+            new IncidentResult().updatedBy("another-user").updatedAt(UPDATED_AT_VALUE));
+
+    assertThat(response.getUpdatedBy()).isEqualTo(UPDATED_BY);
+    assertThat(response.getUpdatedAt()).isEqualTo(UPDATED_AT);
+    assertThat(response).isEqualTo(sameResponse).hasSameHashCodeAs(sameResponse);
+    assertThat(response).isNotEqualTo(differentResponse);
+  }
+
+  @Test
+  void shouldMapDecisionDefinitionUpdateMetadataAndIncludeItInValueSemantics() {
+    final DecisionDefinitionResult result = decisionDefinitionResult(UPDATED_BY);
+    final DecisionDefinitionImpl response = new DecisionDefinitionImpl(result);
+    final DecisionDefinitionImpl sameResponse = new DecisionDefinitionImpl(result);
+    final DecisionDefinitionImpl differentResponse =
+        new DecisionDefinitionImpl(decisionDefinitionResult("another-user"));
+
+    assertThat(response.getUpdatedBy()).isEqualTo(UPDATED_BY);
+    assertThat(response.getUpdatedAt()).isEqualTo(UPDATED_AT);
+    assertThat(response).isEqualTo(sameResponse).hasSameHashCodeAs(sameResponse);
+    assertThat(response).isNotEqualTo(differentResponse);
+    assertThat(response.toString())
+        .contains("updatedBy='" + UPDATED_BY + "'")
+        .contains("updatedAt=" + UPDATED_AT);
+  }
+
+  @Test
+  void shouldMapNullUpdateMetadata() {
+    final ProcessInstanceImpl response = new ProcessInstanceImpl(new ProcessInstanceResult());
+
+    assertThat(response.getUpdatedBy()).isNull();
+    assertThat(response.getUpdatedAt()).isNull();
+  }
+
+  private static DecisionDefinitionResult decisionDefinitionResult(final String updatedBy) {
+    return new DecisionDefinitionResult()
+        .decisionDefinitionId("decision")
+        .name("Decision")
+        .version(1)
+        .decisionDefinitionKey("1")
+        .decisionRequirementsId("requirements")
+        .decisionRequirementsKey("2")
+        .decisionRequirementsName("Requirements")
+        .decisionRequirementsVersion(1)
+        .tenantId("<default>")
+        .updatedBy(updatedBy)
+        .updatedAt(UPDATED_AT_VALUE);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -51,6 +51,7 @@ public class SearchIncidentTest extends ClientRestTest {
             .processDefinitionKey("4")
             .jobKey("5")
             .rootProcessInstanceKey("6")
+            .updatedAt(OffsetDateTime.now().toString())
             .creationTime(OffsetDateTime.now().toString()));
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/usertask/GetUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/GetUserTaskTest.java
@@ -43,6 +43,7 @@ public class GetUserTaskTest extends ClientRestTest {
             .completionDate(OffsetDateTime.now().toString())
             .dueDate(OffsetDateTime.now().toString())
             .followUpDate(OffsetDateTime.now().toString())
+            .updatedAt(OffsetDateTime.now().toString())
             .rootProcessInstanceKey("6"));
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/variable/GetVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/variable/GetVariableTest.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.protocol.rest.VariableResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
+import java.time.OffsetDateTime;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,7 @@ public class GetVariableTest extends ClientRestTest {
             .variableKey("1")
             .processInstanceKey("2")
             .scopeKey("3")
+            .updatedAt(OffsetDateTime.now().toString())
             .rootProcessInstanceKey("4"));
 
     // when

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/LatestAuditLogDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/LatestAuditLogDbQuery.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import java.util.List;
+
+public record LatestAuditLogDbQuery(
+    AuditLogEntityType entityType,
+    List<String> entityKeys,
+    AuditLogAuthorizationFilter authorizationFilter,
+    boolean tenantCheckEnabled,
+    List<String> authorizedTenantIds) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuditLogDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuditLogDbReader.java
@@ -10,15 +10,21 @@ package io.camunda.db.rdbms.read.service;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.AuditLogAuthorizationFilter;
 import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
+import io.camunda.db.rdbms.read.domain.LatestAuditLogDbQuery;
 import io.camunda.db.rdbms.read.mapper.AuditLogEntityMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.columns.AuditLogSearchColumn;
 import io.camunda.search.clients.reader.AuditLogReader;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -28,6 +34,7 @@ public class AuditLogDbReader extends AbstractEntityReader<AuditLogEntity>
     implements AuditLogReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuditLogDbReader.class);
+  private static final int MAX_ENTITY_KEYS_PER_QUERY = 900;
 
   private final AuditLogMapper auditLogMapper;
 
@@ -77,6 +84,46 @@ public class AuditLogDbReader extends AbstractEntityReader<AuditLogEntity>
         () -> auditLogMapper.search(dbQuery).stream().map(AuditLogEntityMapper::toEntity).toList(),
         dbPage,
         dbSort);
+  }
+
+  @Override
+  public List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      final AuditLogEntityType entityType,
+      final List<String> entityKeys,
+      final ResourceAccessChecks resourceAccessChecks) {
+    if (entityKeys.isEmpty() || noResourceAccess(resourceAccessChecks)) {
+      return List.of();
+    }
+
+    final var uniqueEntityKeys = List.copyOf(new LinkedHashSet<>(entityKeys));
+    final var authorizationFilter =
+        AuditLogAuthorizationFilter.of(resourceAccessChecks.authorizationCheck());
+    final Map<String, AuditLogEntity> latestByEntityKey = new LinkedHashMap<>();
+
+    for (int fromIndex = 0;
+        fromIndex < uniqueEntityKeys.size();
+        fromIndex += MAX_ENTITY_KEYS_PER_QUERY) {
+      final var keyChunk =
+          uniqueEntityKeys.subList(
+              fromIndex, Math.min(fromIndex + MAX_ENTITY_KEYS_PER_QUERY, uniqueEntityKeys.size()));
+      final var query =
+          new LatestAuditLogDbQuery(
+              entityType,
+              keyChunk,
+              authorizationFilter,
+              resourceAccessChecks.tenantCheck().enabled(),
+              resourceAccessChecks.getAuthorizedTenantIds());
+
+      LOG.trace(
+          "[RDBMS DB] Search latest successful audit logs for entity type {} and keys {}",
+          entityType,
+          query.entityKeys());
+      auditLogMapper.searchLatestSuccessfulByEntityKeys(query).stream()
+          .map(AuditLogEntityMapper::toEntity)
+          .forEach(entity -> latestByEntityKey.put(entity.entityKey(), entity));
+    }
+
+    return uniqueEntityKeys.stream().map(latestByEntityKey::get).filter(Objects::nonNull).toList();
   }
 
   public SearchQueryResult<AuditLogEntity> search(final AuditLogQuery query) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AuditLogMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
+import io.camunda.db.rdbms.read.domain.LatestAuditLogDbQuery;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.domain.Copyable;
 import io.camunda.db.rdbms.write.domain.HistoryDeletionDbModel.HistoryDeletionTypeDbModel;
@@ -25,6 +26,8 @@ public interface AuditLogMapper extends ProcessInstanceDependantMapper, HistoryC
   Long count(AuditLogDbQuery filter);
 
   List<AuditLogDbModel> search(AuditLogDbQuery filter);
+
+  List<AuditLogDbModel> searchLatestSuccessfulByEntityKeys(LatestAuditLogDbQuery query);
 
   int deleteProcessDefinitionRelatedData(List<Long> processDefinitionKeys, int limit);
 

--- a/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuditLogMapper.xml
@@ -72,60 +72,75 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.paging" />
   </select>
 
+  <select id="searchLatestSuccessfulByEntityKeys"
+    parameterType="io.camunda.db.rdbms.read.domain.LatestAuditLogDbQuery"
+    resultType="io.camunda.db.rdbms.write.domain.AuditLogDbModel"
+    statementType="PREPARED">
+    SELECT
+      AUDIT_LOG_KEY,
+      ENTITY_KEY,
+      ENTITY_TYPE,
+      OPERATION_TYPE,
+      ENTITY_VERSION,
+      ENTITY_VALUE_TYPE,
+      ENTITY_OPERATION_INTENT,
+      BATCH_OPERATION_KEY,
+      BATCH_OPERATION_TYPE,
+      TIMESTAMP,
+      ACTOR_TYPE,
+      ACTOR_ID,
+      AGENT_ELEMENT_ID,
+      TENANT_ID,
+      TENANT_SCOPE,
+      RESULT,
+      CATEGORY,
+      PROCESS_DEFINITION_ID,
+      DECISION_REQUIREMENTS_ID,
+      DECISION_DEFINITION_ID,
+      PROCESS_DEFINITION_KEY,
+      PROCESS_INSTANCE_KEY,
+      ROOT_PROCESS_INSTANCE_KEY,
+      ELEMENT_INSTANCE_KEY,
+      JOB_KEY,
+      USER_TASK_KEY,
+      DECISION_REQUIREMENTS_KEY,
+      DECISION_DEFINITION_KEY,
+      DECISION_EVALUATION_KEY,
+      DEPLOYMENT_KEY,
+      FORM_KEY,
+      RESOURCE_KEY,
+      RELATED_ENTITY_TYPE,
+      RELATED_ENTITY_KEY,
+      ENTITY_DESCRIPTION,
+      PARTITION_ID,
+      HISTORY_CLEANUP_DATE,
+      INBOUND_CHANNEL_TYPE,
+      INBOUND_CHANNEL_TOOL_NAME
+    FROM (
+      SELECT audit_log.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY ENTITY_KEY
+          <!-- Equal timestamps remain unordered: AUDIT_LOG_KEY is not numerically sortable. -->
+          ORDER BY TIMESTAMP DESC
+        ) AS ROW_NUM
+      FROM ${prefix}AUDIT_LOG audit_log
+      <where>
+        AND ENTITY_TYPE = #{entityType}
+        AND RESULT = 'SUCCESS'
+        AND ENTITY_KEY IN
+        <foreach collection="entityKeys" item="entityKey" open="(" separator="," close=")">
+          #{entityKey}
+        </foreach>
+        <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.latestTenantAuthorizationFilter" />
+        <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.resourceAuthorizationFilter" />
+      </where>
+    ) ranked
+    WHERE ROW_NUM = 1
+  </select>
+
   <sql id="searchFilter">
     <where>
-      <!-- tenant authorization filter -->
-      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
-        AND (TENANT_SCOPE = 'GLOBAL' OR TENANT_ID IN
-        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
-          #{tenantId}
-        </foreach>)
-      </if>
-      <!-- Deny all access when no authorizations are configured -->
-      <if test="authorizationFilter.authorizedCategories.isEmpty() and authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() and authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty()">
-        AND 1 = 0
-      </if>
-      <!-- composite authorization filter (OR of all authorization checks) -->
-      <!-- Only apply this filter if there are any authorizations configured -->
-      <if test="!authorizationFilter.authorizedCategories.isEmpty() or !authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() or !authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty()">
-        AND (
-          <trim prefixOverrides="OR">
-             <!-- AUDIT_LOG resource type: wildcard access to all categories -->
-            <if test="authorizationFilter.hasCategoryWildcard()">
-              OR CATEGORY IS NOT NULL
-            </if>
-            <!-- AUDIT_LOG resource type: specific authorized categories -->
-            <if test="!authorizationFilter.authorizedCategories.isEmpty() and !authorizationFilter.hasCategoryWildcard()">
-              OR CATEGORY IN
-              <foreach collection="authorizationFilter.authorizedCategories" item="category" open="(" separator="," close=")">
-                #{category}
-              </foreach>
-            </if>
-            <!-- PROCESS_DEFINITION + READ_PROCESS_INSTANCE: wildcard access -->
-            <if test="authorizationFilter.hasProcessInstanceWildcard()">
-              OR PROCESS_DEFINITION_ID IS NOT NULL
-            </if>
-            <!-- PROCESS_DEFINITION + READ_PROCESS_INSTANCE: specific process definition IDs -->
-            <if test="!authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() and !authorizationFilter.hasProcessInstanceWildcard()">
-              OR PROCESS_DEFINITION_ID IN
-              <foreach collection="authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance" item="processDefId" open="(" separator="," close=")">
-                #{processDefId}
-              </foreach>
-            </if>
-            <!-- PROCESS_DEFINITION + READ_USER_TASK: wildcard access -->
-            <if test="authorizationFilter.hasUserTaskWildcard()">
-              OR CATEGORY = 'USER_TASKS'
-            </if>
-            <!-- PROCESS_DEFINITION + READ_USER_TASK: specific process definition IDs -->
-            <if test="!authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty() and !authorizationFilter.hasUserTaskWildcard()">
-              OR (CATEGORY = 'USER_TASKS' AND PROCESS_DEFINITION_ID IN
-              <foreach collection="authorizationFilter.authorizedProcessDefinitionIdsForUserTask" item="processDefId" open="(" separator="," close=")">
-                #{processDefId}
-              </foreach>)
-            </if>
-          </trim>
-        )
-      </if>
+      <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.authorizationFilter" />
       <!-- basic filters -->
       <if test="filter.auditLogKeyOperations != null and !filter.auditLogKeyOperations.isEmpty()">
         <foreach collection="filter.auditLogKeyOperations" item="operation">
@@ -320,6 +335,76 @@
         </foreach>
       </if>
     </where>
+  </sql>
+
+  <sql id="authorizationFilter">
+    <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+      AND (TENANT_SCOPE = 'GLOBAL' OR TENANT_ID IN
+      <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+        #{tenantId}
+      </foreach>)
+    </if>
+    <include refid="io.camunda.db.rdbms.sql.AuditLogMapper.resourceAuthorizationFilter" />
+  </sql>
+
+  <sql id="latestTenantAuthorizationFilter">
+    <if test="tenantCheckEnabled">
+      AND (TENANT_SCOPE = 'GLOBAL'
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        OR TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>)
+    </if>
+  </sql>
+
+  <sql id="resourceAuthorizationFilter">
+    <!-- Deny all access when no authorizations are configured -->
+    <if test="authorizationFilter.authorizedCategories.isEmpty() and authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() and authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty()">
+      AND 1 = 0
+    </if>
+    <!-- composite authorization filter (OR of all authorization checks) -->
+    <!-- Only apply this filter if there are any authorizations configured -->
+    <if test="!authorizationFilter.authorizedCategories.isEmpty() or !authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() or !authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty()">
+      AND (
+        <trim prefixOverrides="OR">
+           <!-- AUDIT_LOG resource type: wildcard access to all categories -->
+          <if test="authorizationFilter.hasCategoryWildcard()">
+            OR CATEGORY IS NOT NULL
+          </if>
+          <!-- AUDIT_LOG resource type: specific authorized categories -->
+          <if test="!authorizationFilter.authorizedCategories.isEmpty() and !authorizationFilter.hasCategoryWildcard()">
+            OR CATEGORY IN
+            <foreach collection="authorizationFilter.authorizedCategories" item="category" open="(" separator="," close=")">
+              #{category}
+            </foreach>
+          </if>
+          <!-- PROCESS_DEFINITION + READ_PROCESS_INSTANCE: wildcard access -->
+          <if test="authorizationFilter.hasProcessInstanceWildcard()">
+            OR PROCESS_DEFINITION_ID IS NOT NULL
+          </if>
+          <!-- PROCESS_DEFINITION + READ_PROCESS_INSTANCE: specific process definition IDs -->
+          <if test="!authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance.isEmpty() and !authorizationFilter.hasProcessInstanceWildcard()">
+            OR PROCESS_DEFINITION_ID IN
+            <foreach collection="authorizationFilter.authorizedProcessDefinitionIdsForProcessInstance" item="processDefId" open="(" separator="," close=")">
+              #{processDefId}
+            </foreach>
+          </if>
+          <!-- PROCESS_DEFINITION + READ_USER_TASK: wildcard access -->
+          <if test="authorizationFilter.hasUserTaskWildcard()">
+            OR CATEGORY = 'USER_TASKS'
+          </if>
+          <!-- PROCESS_DEFINITION + READ_USER_TASK: specific process definition IDs -->
+          <if test="!authorizationFilter.authorizedProcessDefinitionIdsForUserTask.isEmpty() and !authorizationFilter.hasUserTaskWildcard()">
+            OR (CATEGORY = 'USER_TASKS' AND PROCESS_DEFINITION_ID IN
+            <foreach collection="authorizationFilter.authorizedProcessDefinitionIdsForUserTask" item="processDefId" open="(" separator="," close=")">
+              #{processDefId}
+            </foreach>)
+          </if>
+        </trim>
+      )
+    </if>
   </sql>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
@@ -626,4 +711,3 @@
   </delete>
 
 </mapper>
-

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AuditLogDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AuditLogDbReaderTest.java
@@ -10,18 +10,28 @@ package io.camunda.db.rdbms.read.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.read.domain.LatestAuditLogDbQuery;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationType;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationCheck;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.security.core.authz.TenantCheck;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class AuditLogDbReaderTest {
   private final AuditLogMapper auditLogMapper = mock(AuditLogMapper.class);
@@ -64,5 +74,107 @@ class AuditLogDbReaderTest {
     assertThat(result.total()).isEqualTo(21L);
     assertThat(result.items()).isEmpty();
     verify(auditLogMapper, times(0)).search(any());
+  }
+
+  @Test
+  void shouldReturnEmptyLatestAuditLogsForEmptyEntityKeys() {
+    final var result =
+        auditLogDbReader.searchLatestSuccessfulByEntityKeys(
+            AuditLogEntityType.USER_TASK, List.of(), ResourceAccessChecks.disabled());
+
+    assertThat(result).isEmpty();
+    verify(auditLogMapper, never()).searchLatestSuccessfulByEntityKeys(any());
+  }
+
+  @Test
+  void shouldReturnEmptyLatestAuditLogsWhenNoResourceAccess() {
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                RequiredAuthorization.of(a -> a.readProcessInstance().read())),
+            TenantCheck.disabled());
+
+    final var result =
+        auditLogDbReader.searchLatestSuccessfulByEntityKeys(
+            AuditLogEntityType.USER_TASK, List.of("1"), resourceAccessChecks);
+
+    assertThat(result).isEmpty();
+    verify(auditLogMapper, never()).searchLatestSuccessfulByEntityKeys(any());
+  }
+
+  @Test
+  void shouldDeduplicateKeysAndMapLatestAuditLogs() {
+    final var dbModel =
+        new AuditLogDbModel.Builder()
+            .auditLogKey("1-2")
+            .entityKey("entity-1")
+            .entityType(AuditLogEntityType.USER_TASK)
+            .operationType(AuditLogOperationType.UPDATE)
+            .timestamp(OffsetDateTime.parse("2026-07-21T12:00:00Z"))
+            .result(AuditLogOperationResult.SUCCESS)
+            .category(AuditLogOperationCategory.USER_TASKS)
+            .build();
+    when(auditLogMapper.searchLatestSuccessfulByEntityKeys(any())).thenReturn(List.of(dbModel));
+
+    final var result =
+        auditLogDbReader.searchLatestSuccessfulByEntityKeys(
+            AuditLogEntityType.USER_TASK,
+            List.of("entity-1", "entity-2", "entity-1"),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.disabled(), TenantCheck.enabled(List.of("tenant-1"))));
+
+    assertThat(result)
+        .singleElement()
+        .satisfies(entity -> assertThat(entity.auditLogKey()).isEqualTo("1-2"));
+    final var queryCaptor = ArgumentCaptor.forClass(LatestAuditLogDbQuery.class);
+    verify(auditLogMapper).searchLatestSuccessfulByEntityKeys(queryCaptor.capture());
+    assertThat(queryCaptor.getValue().entityType()).isEqualTo(AuditLogEntityType.USER_TASK);
+    assertThat(queryCaptor.getValue().entityKeys()).containsExactly("entity-1", "entity-2");
+    assertThat(queryCaptor.getValue().tenantCheckEnabled()).isTrue();
+    assertThat(queryCaptor.getValue().authorizedTenantIds()).containsExactly("tenant-1");
+    assertThat(queryCaptor.getValue().authorizationFilter().hasCategoryWildcard()).isTrue();
+  }
+
+  @Test
+  void shouldChunkLargeKeyListsAndMergeOneResultPerKey() {
+    final var entityKeys = IntStream.range(0, 10_000).mapToObj(index -> "entity-" + index).toList();
+    when(auditLogMapper.searchLatestSuccessfulByEntityKeys(any()))
+        .thenAnswer(
+            invocation -> {
+              final LatestAuditLogDbQuery query = invocation.getArgument(0);
+              return query.entityKeys().stream().map(AuditLogDbReaderTest::auditLog).toList();
+            });
+
+    final var result =
+        auditLogDbReader.searchLatestSuccessfulByEntityKeys(
+            AuditLogEntityType.USER_TASK, entityKeys, ResourceAccessChecks.disabled());
+
+    assertThat(result)
+        .extracting(entity -> entity.entityKey())
+        .containsExactlyElementsOf(entityKeys);
+    final var queryCaptor = ArgumentCaptor.forClass(LatestAuditLogDbQuery.class);
+    verify(auditLogMapper, times(12)).searchLatestSuccessfulByEntityKeys(queryCaptor.capture());
+    assertThat(queryCaptor.getAllValues())
+        .allSatisfy(
+            query -> {
+              assertThat(query.entityKeys()).hasSizeLessThanOrEqualTo(900);
+              assertThat(query.tenantCheckEnabled()).isFalse();
+            });
+    assertThat(queryCaptor.getAllValues())
+        .extracting(LatestAuditLogDbQuery::entityKeys)
+        .flatMap(keys -> keys)
+        .containsExactlyElementsOf(entityKeys);
+  }
+
+  private static AuditLogDbModel auditLog(final String entityKey) {
+    return new AuditLogDbModel.Builder()
+        .auditLogKey(entityKey)
+        .entityKey(entityKey)
+        .entityType(AuditLogEntityType.USER_TASK)
+        .operationType(AuditLogOperationType.UPDATE)
+        .timestamp(OffsetDateTime.parse("2026-07-21T12:00:00Z"))
+        .result(AuditLogOperationResult.SUCCESS)
+        .category(AuditLogOperationCategory.USER_TASKS)
+        .build();
   }
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/AuditLogMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/sql/AuditLogMapperTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.read.domain.AuditLogAuthorizationFilter;
+import io.camunda.db.rdbms.read.domain.LatestAuditLogDbQuery;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+class AuditLogMapperTest {
+
+  @Test
+  void shouldBuildLatestSuccessfulByEntityKeysAsSingleRankedQuery() throws IOException {
+    final var configuration = configuration();
+    final var query =
+        new LatestAuditLogDbQuery(
+            AuditLogEntityType.USER_TASK,
+            List.of("entity-1", "entity-2"),
+            AuditLogAuthorizationFilter.allowAll(),
+            true,
+            List.of("tenant-1"));
+
+    final var sql = latestAuditLogSql(configuration, query);
+
+    assertThat(sql)
+        .containsOnlyOnce("FROM AUDIT_LOG")
+        .contains("ROW_NUMBER() OVER ( PARTITION BY ENTITY_KEY ORDER BY TIMESTAMP DESC )")
+        .doesNotContain("AUDIT_LOG_KEY DESC")
+        .contains("ENTITY_TYPE = ?")
+        .contains("RESULT = 'SUCCESS'")
+        .contains("ENTITY_KEY IN ( ? , ? )")
+        .contains("TENANT_SCOPE = 'GLOBAL' OR TENANT_ID IN ( ? )")
+        .contains("WHERE ROW_NUM = 1");
+  }
+
+  @Test
+  void shouldNotFilterTenantsWhenTenantCheckIsDisabled() throws IOException {
+    final var configuration = configuration();
+    final var query =
+        new LatestAuditLogDbQuery(
+            AuditLogEntityType.USER_TASK,
+            List.of("entity-1"),
+            AuditLogAuthorizationFilter.allowAll(),
+            false,
+            List.of("ignored-tenant"));
+
+    assertThat(latestAuditLogSql(configuration, query))
+        .doesNotContain("AND (TENANT_SCOPE")
+        .doesNotContain("OR TENANT_ID IN");
+  }
+
+  @Test
+  void shouldFilterGlobalTenantScopeWhenTenantCheckIsEnabledWithoutTenants() throws IOException {
+    final var configuration = configuration();
+    final var query =
+        new LatestAuditLogDbQuery(
+            AuditLogEntityType.USER_TASK,
+            List.of("entity-1"),
+            AuditLogAuthorizationFilter.allowAll(),
+            true,
+            List.of());
+
+    assertThat(latestAuditLogSql(configuration, query))
+        .contains("AND (TENANT_SCOPE = 'GLOBAL' )")
+        .doesNotContain("OR TENANT_ID IN");
+  }
+
+  private static Configuration configuration() throws IOException {
+    final var configuration = new Configuration();
+    final var variables = new Properties();
+    variables.setProperty("prefix", "");
+    configuration.setVariables(variables);
+    parseMapper(configuration, "mapper/Commons.xml");
+    parseMapper(configuration, "mapper/AuditLogMapper.xml");
+    return configuration;
+  }
+
+  private static String latestAuditLogSql(
+      final Configuration configuration, final LatestAuditLogDbQuery query) {
+    return configuration
+        .getMappedStatement(AuditLogMapper.class.getName() + ".searchLatestSuccessfulByEntityKeys")
+        .getBoundSql(query)
+        .getSql()
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private static void parseMapper(final Configuration configuration, final String resource)
+      throws IOException {
+    try (final var inputStream = Resources.getResourceAsStream(resource)) {
+      new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments())
+          .parse();
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -162,15 +162,27 @@ public class CamundaServicesConfiguration {
               final var form =
                   new FormServices(
                       tenantId, brokerClient, securityContextProvider, search, executor, converter);
-              final var incident =
-                  new IncidentServices(
-                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
-              final var variable =
-                  new VariableServices(
-                      tenantId, brokerClient, securityContextProvider, search, executor, converter);
               final var auditLog =
                   new AuditLogServices(
                       tenantId, brokerClient, securityContextProvider, search, executor, converter);
+              final var incident =
+                  new IncidentServices(
+                      tenantId,
+                      brokerClient,
+                      securityContextProvider,
+                      search,
+                      auditLog,
+                      executor,
+                      converter);
+              final var variable =
+                  new VariableServices(
+                      tenantId,
+                      brokerClient,
+                      securityContextProvider,
+                      search,
+                      auditLog,
+                      executor,
+                      converter);
               final var decisionRequirements =
                   new DecisionRequirementsServices(
                       tenantId, brokerClient, securityContextProvider, search, executor, converter);
@@ -207,6 +219,7 @@ public class CamundaServicesConfiguration {
                       search,
                       search,
                       incident,
+                      auditLog,
                       executor,
                       converter,
                       maxNameFieldLength);
@@ -292,6 +305,7 @@ public class CamundaServicesConfiguration {
                           securityContextProvider,
                           search,
                           decisionRequirements,
+                          auditLog,
                           executor,
                           converter))
                   .decisionInstanceServices(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -982,6 +982,8 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(p.rootProcessInstanceKey()))
         .tags(p.tags())
         .businessId(emptyToNull(p.businessId()))
+        .updatedBy(p.updatedBy())
+        .updatedAt(formatDateOrNull(p.updatedAt()))
         .build();
   }
 
@@ -1229,6 +1231,8 @@ public final class SearchQueryResponseMapper {
         .name(d.name())
         .tenantId(d.tenantId())
         .version(d.version())
+        .updatedBy(d.updatedBy())
+        .updatedAt(formatDateOrNull(d.updatedAt()))
         .build();
   }
 
@@ -1280,6 +1284,8 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(t.rootProcessInstanceKey()))
         .jobKey(keyToStringOrNull(t.jobKey()))
         .tenantId(t.tenantId())
+        .updatedBy(t.updatedBy())
+        .updatedAt(formatDateOrNull(t.updatedAt()))
         .build();
   }
 
@@ -1379,6 +1385,8 @@ public final class SearchQueryResponseMapper {
         .followUpDate(formatDateOrNull(t.followUpDate()))
         .processDefinitionVersion(t.processDefinitionVersion())
         .formKey(keyToStringOrNull(t.formKey()))
+        .updatedBy(t.updatedBy())
+        .updatedAt(formatDateOrNull(t.updatedAt()))
         .build();
   }
 
@@ -1579,6 +1587,8 @@ public final class SearchQueryResponseMapper {
         .variableKey(keyToString(variableEntity.variableKey()))
         .scopeKey(keyToString(variableEntity.scopeKey()))
         .rootProcessInstanceKey(keyToStringOrNull(variableEntity.rootProcessInstanceKey()))
+        .updatedBy(variableEntity.updatedBy())
+        .updatedAt(formatDateOrNull(variableEntity.updatedAt()))
         .isTruncated(truncateValues && variableEntity.isPreview())
         .value(!truncateValues ? getFullValueIfPresent(variableEntity) : variableEntity.value())
         .build();
@@ -1610,6 +1620,8 @@ public final class SearchQueryResponseMapper {
         .variableKey(keyToString(variableEntity.variableKey()))
         .scopeKey(keyToString(variableEntity.scopeKey()))
         .rootProcessInstanceKey(keyToStringOrNull(variableEntity.rootProcessInstanceKey()))
+        .updatedBy(variableEntity.updatedBy())
+        .updatedAt(formatDateOrNull(variableEntity.updatedAt()))
         .value(getFullValueIfPresent(variableEntity))
         .build();
   }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -45,6 +45,7 @@ import io.camunda.search.entities.ClusterVariableEntity.MetadataEntry;
 import io.camunda.search.entities.ClusterVariableKind;
 import io.camunda.search.entities.ClusterVariableScope;
 import io.camunda.search.entities.CorrelatedMessageSubscriptionEntity;
+import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
@@ -76,10 +77,135 @@ import io.camunda.security.api.model.user.CamundaUserDTO;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class SearchQueryResponseMapperTest {
+
+  private static final OffsetDateTime UPDATED_AT = OffsetDateTime.parse("2026-07-21T12:34:56Z");
+
+  @Test
+  void shouldMapUpdateMetadataForResponseEntities() {
+    final var processInstance =
+        new ProcessInstanceEntity(
+            1L,
+            null,
+            "process",
+            "Process",
+            1,
+            null,
+            2L,
+            null,
+            null,
+            UPDATED_AT,
+            null,
+            ProcessInstanceState.ACTIVE,
+            false,
+            "tenant",
+            null,
+            Set.of(),
+            null,
+            null,
+            "process-actor",
+            UPDATED_AT);
+    final var userTask =
+        new UserTaskEntity(
+            3L,
+            "task",
+            "Task",
+            "process",
+            "Process",
+            UPDATED_AT,
+            null,
+            null,
+            UserTaskState.CREATED,
+            null,
+            2L,
+            1L,
+            null,
+            null,
+            4L,
+            "tenant",
+            null,
+            null,
+            List.of(),
+            List.of(),
+            null,
+            1,
+            Map.of(),
+            50,
+            Set.of(),
+            "task-actor",
+            UPDATED_AT);
+    final var variable =
+        new VariableEntity(
+            5L,
+            "variable",
+            "value",
+            null,
+            false,
+            1L,
+            1L,
+            null,
+            "process",
+            "tenant",
+            "variable-actor",
+            UPDATED_AT);
+    final var incident =
+        new IncidentEntity(
+            6L,
+            2L,
+            "process",
+            1L,
+            null,
+            ErrorType.JOB_NO_RETRIES,
+            "error",
+            "task",
+            4L,
+            UPDATED_AT,
+            IncidentState.ACTIVE,
+            null,
+            "tenant",
+            "incident-actor",
+            UPDATED_AT);
+    final var decisionDefinition =
+        new DecisionDefinitionEntity(
+            7L,
+            "decision",
+            "Decision",
+            1,
+            "requirements",
+            8L,
+            "Requirements",
+            1,
+            "tenant",
+            "decision-actor",
+            UPDATED_AT);
+
+    assertThat(SearchQueryResponseMapper.toProcessInstance(processInstance))
+        .extracting("updatedBy", "updatedAt")
+        .containsExactly("process-actor", "2026-07-21T12:34:56.000Z");
+    assertThat(SearchQueryResponseMapper.toUserTask(userTask))
+        .extracting("updatedBy", "updatedAt")
+        .containsExactly("task-actor", "2026-07-21T12:34:56.000Z");
+    assertThat(SearchQueryResponseMapper.toVariableItem(variable))
+        .extracting("updatedBy", "updatedAt")
+        .containsExactly("variable-actor", "2026-07-21T12:34:56.000Z");
+    assertThat(
+            SearchQueryResponseMapper.toVariableSearchQueryResponse(
+                    new SearchQueryResult<>(1, false, List.of(variable), null, null), true)
+                .getItems()
+                .getFirst())
+        .extracting("updatedBy", "updatedAt")
+        .containsExactly("variable-actor", "2026-07-21T12:34:56.000Z");
+    assertThat(SearchQueryResponseMapper.toIncident(incident))
+        .extracting("updatedBy", "updatedAt")
+        .containsExactly("incident-actor", "2026-07-21T12:34:56.000Z");
+    assertThat(SearchQueryResponseMapper.toDecisionDefinition(decisionDefinition))
+        .extracting("updatedBy", "updatedAt")
+        .containsExactly("decision-actor", "2026-07-21T12:34:56.000Z");
+  }
 
   @Test
   void shouldConvertBatchOperationItemEntity() {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogProcessOperationsIT.java
@@ -44,6 +44,7 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -157,6 +158,27 @@ public class AuditLogProcessOperationsIT {
         processInstanceKey,
         processInstance.getProcessDefinitionKey(),
         SERVICE_TASKS_PROCESS_ID);
+
+    Awaitility.await("Process instance update metadata is exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  client
+                      .newProcessInstanceSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst();
+              final var detail =
+                  client.newProcessInstanceGetRequest(processInstanceKey).send().join();
+
+              assertUpdateMetadata(
+                  searchResult.getUpdatedBy(), searchResult.getUpdatedAt(), auditLog);
+              assertUpdateMetadata(detail.getUpdatedBy(), detail.getUpdatedAt(), auditLog);
+            });
   }
 
   @Test
@@ -561,6 +583,27 @@ public class AuditLogProcessOperationsIT {
         processInstance.getProcessDefinitionKey(),
         SERVICE_TASKS_PROCESS_ID,
         "existingVar");
+
+    final long variableKey = Long.parseLong(auditLog.getEntityKey());
+    Awaitility.await("Variable update metadata is exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  client
+                      .newVariableSearchRequest()
+                      .filter(f -> f.variableKey(variableKey))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst();
+              final var detail = client.newVariableGetRequest(variableKey).send().join();
+
+              assertUpdateMetadata(
+                  searchResult.getUpdatedBy(), searchResult.getUpdatedAt(), auditLog);
+              assertUpdateMetadata(detail.getUpdatedBy(), detail.getUpdatedAt(), auditLog);
+            });
   }
 
   @Test
@@ -615,6 +658,28 @@ public class AuditLogProcessOperationsIT {
                       "variables set during job completion should not produce variable audit log entries"
                           + " because their source is not API")
                   .isEmpty();
+            });
+
+    Awaitility.await("Variable without an audit event is exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  client
+                      .newVariableSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey).name("jobOutputVar"))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst();
+              final var detail =
+                  client.newVariableGetRequest(searchResult.getVariableKey()).send().join();
+
+              assertThat(searchResult.getUpdatedBy()).isNull();
+              assertThat(searchResult.getUpdatedAt()).isNull();
+              assertThat(detail.getUpdatedBy()).isNull();
+              assertThat(detail.getUpdatedAt()).isNull();
             });
   }
 
@@ -711,6 +776,27 @@ public class AuditLogProcessOperationsIT {
         processInstanceKey,
         processInstance.getProcessDefinitionKey(),
         INCIDENT_PROCESS_ID);
+
+    Awaitility.await("Incident update metadata is exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  client
+                      .newIncidentSearchRequest()
+                      .filter(f -> f.incidentKey(incident.getIncidentKey()))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst();
+              final var detail =
+                  client.newIncidentGetRequest(incident.getIncidentKey()).send().join();
+
+              assertUpdateMetadata(
+                  searchResult.getUpdatedBy(), searchResult.getUpdatedAt(), auditLog);
+              assertUpdateMetadata(detail.getUpdatedBy(), detail.getUpdatedAt(), auditLog);
+            });
   }
 
   // ========================================================================================
@@ -721,13 +807,14 @@ public class AuditLogProcessOperationsIT {
   void shouldTrackStandaloneDecisionEvaluation(
       @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
     // when - evaluate a decision
-    client
-        .newEvaluateDecisionCommand()
-        .decisionId(DECISION_ID)
-        .tenantId(TENANT_A)
-        .variables(Map.of("age", 25, "income", 30000))
-        .send()
-        .join();
+    final var evaluation =
+        client
+            .newEvaluateDecisionCommand()
+            .decisionId(DECISION_ID)
+            .tenantId(TENANT_A)
+            .variables(Map.of("age", 25, "income", 30000))
+            .send()
+            .join();
 
     // then - wait for audit log entry and verify
     final var auditLogItems =
@@ -737,6 +824,36 @@ public class AuditLogProcessOperationsIT {
     assertThat(auditLogItems).isNotEmpty();
     final var auditLog = auditLogItems.getFirst();
     assertDecisionAuditLog(auditLog, AuditLogOperationTypeEnum.EVALUATE);
+
+    final long decisionDefinitionKey = evaluation.getDecisionKey();
+    final var decisionCreateAuditLog =
+        awaitAuditLogEntry(
+                client,
+                AuditLogEntityTypeEnum.DECISION,
+                AuditLogOperationTypeEnum.CREATE,
+                String.valueOf(decisionDefinitionKey))
+            .getFirst();
+    Awaitility.await("Decision definition update metadata is exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  client
+                      .newDecisionDefinitionSearchRequest()
+                      .filter(f -> f.decisionDefinitionKey(decisionDefinitionKey))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst();
+              final var detail =
+                  client.newDecisionDefinitionGetRequest(decisionDefinitionKey).send().join();
+
+              assertUpdateMetadata(
+                  searchResult.getUpdatedBy(), searchResult.getUpdatedAt(), decisionCreateAuditLog);
+              assertUpdateMetadata(
+                  detail.getUpdatedBy(), detail.getUpdatedAt(), decisionCreateAuditLog);
+            });
   }
 
   @Test
@@ -1287,5 +1404,11 @@ public class AuditLogProcessOperationsIT {
               return !auditLogItems.items().isEmpty() ? auditLogItems.items() : null;
             },
             Objects::nonNull);
+  }
+
+  private void assertUpdateMetadata(
+      final String updatedBy, final OffsetDateTime updatedAt, final AuditLogResult auditLog) {
+    assertThat(updatedBy).isEqualTo(auditLog.getActorId());
+    assertThat(updatedAt).isEqualTo(auditLog.getTimestamp());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogUserTaskOperationsIT.java
@@ -83,6 +83,41 @@ public class AuditLogUserTaskOperationsIT {
   }
 
   @Test
+  void shouldExposeLatestUserTaskAuditLogAsUpdateMetadata(
+      @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
+    final long userTaskKey = userTask.getUserTaskKey();
+    final var auditLog =
+        client
+            .newUserTaskAuditLogSearchRequest(userTaskKey)
+            .filter(f -> f.operationType(AuditLogOperationTypeEnum.COMPLETE))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    Awaitility.await("User task update metadata is exported")
+        .ignoreExceptionsInstanceOf(ProblemException.class)
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var searchResult =
+                  client
+                      .newUserTaskSearchRequest()
+                      .filter(f -> f.userTaskKey(userTaskKey))
+                      .send()
+                      .join()
+                      .items()
+                      .getFirst();
+              final var detail = client.newUserTaskGetRequest(userTaskKey).send().join();
+
+              assertThat(searchResult.getUpdatedBy()).isEqualTo(auditLog.getActorId());
+              assertThat(searchResult.getUpdatedAt()).isEqualTo(auditLog.getTimestamp());
+              assertThat(detail.getUpdatedBy()).isEqualTo(auditLog.getActorId());
+              assertThat(detail.getUpdatedAt()).isEqualTo(auditLog.getTimestamp());
+            });
+  }
+
+  @Test
   void shouldSearchUserTaskAuditLogByKeyWithAssignOperation(
       @Authenticated(DEFAULT_USERNAME) final CamundaClient client) {
     // given

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "92f58b73254fb9dacf2966f2e80252f2a4c497d9",
-    "generatedAt": "2026-07-21T13:47:32.155Z",
+    "commit": "local",
+    "generatedAt": "2026-07-21T19:06:04.378Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "553ff63f5439366f1d39eae8f01606ed17f5ab86f3f2e9f669c1527aae2cfb2c"
+    "specSha256": "a72d31ea31e804eab58607628646eb2b689f3770decada52ef92ee5a5d924ab2"
   },
   "responses": [
     {
@@ -2352,6 +2352,16 @@
                   "type": "string"
                 },
                 {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
                   "name": "version",
                   "type": "number"
                 }
@@ -2427,6 +2437,16 @@
           {
             "name": "tenantId",
             "type": "string"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "version",
@@ -3814,6 +3834,16 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -4569,6 +4599,16 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -4689,6 +4729,16 @@
           {
             "name": "tenantId",
             "type": "string"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []
@@ -6849,6 +6899,16 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "schema",
                   "wrapper": true
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -7003,6 +7063,16 @@
             "underlyingPrimitive": "string",
             "rawRefName": "schema",
             "wrapper": true
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []
@@ -7139,6 +7209,16 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -8392,6 +8472,10 @@
             "children": {
               "required": [
                 {
+                  "name": "brokerId",
+                  "type": "string"
+                },
+                {
                   "name": "host",
                   "type": "string"
                 },
@@ -8811,6 +8895,16 @@
                   "wrapper": true
                 },
                 {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
                   "name": "userTaskKey",
                   "type": "string"
                 }
@@ -8975,6 +9069,16 @@
             "underlyingPrimitive": "string",
             "rawRefName": "schema",
             "wrapper": true
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "userTaskKey",
@@ -9273,6 +9377,16 @@
                   "type": "string"
                 },
                 {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
                   "name": "value",
                   "type": "string"
                 },
@@ -9382,6 +9496,16 @@
                   "type": "string"
                 },
                 {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
                   "name": "value",
                   "type": "string"
                 },
@@ -9461,6 +9585,16 @@
                   "type": "string"
                 },
                 {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
                   "name": "value",
                   "type": "string"
                 },
@@ -9529,6 +9663,16 @@
           {
             "name": "tenantId",
             "type": "string"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           },
           {
             "name": "value",

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AuditLogDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/AuditLogDocumentReader.java
@@ -7,12 +7,21 @@
  */
 package io.camunda.search.clients.reader;
 
+import io.camunda.search.aggregation.result.AuditLogLatestSuccessfulAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult;
+import io.camunda.search.filter.AuditLogFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AuditLogLatestSuccessfulQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 public class AuditLogDocumentReader extends DocumentBasedReader implements AuditLogReader {
 
@@ -27,6 +36,30 @@ public class AuditLogDocumentReader extends DocumentBasedReader implements Audit
         .getByQuery(
             AuditLogQuery.of(b -> b.filter(f -> f.auditLogKeys(id)).singleResult()),
             io.camunda.webapps.schema.entities.auditlog.AuditLogEntity.class);
+  }
+
+  @Override
+  public List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      final AuditLogEntityType entityType,
+      final List<String> entityKeys,
+      final ResourceAccessChecks resourceAccessChecks) {
+    final var uniqueEntityKeys = List.copyOf(new LinkedHashSet<>(entityKeys));
+    if (uniqueEntityKeys.isEmpty()) {
+      return List.of();
+    }
+
+    final var filter =
+        AuditLogFilter.of(
+            f ->
+                f.entityKeyOperations(Operation.in(uniqueEntityKeys))
+                    .entityTypes(entityType.name())
+                    .results(AuditLogOperationResult.SUCCESS.name()));
+    final var query =
+        new AuditLogLatestSuccessfulQuery(
+            filter, SearchQueryPage.of(page -> page.size(uniqueEntityKeys.size())));
+    return getSearchExecutor()
+        .aggregate(query, AuditLogLatestSuccessfulAggregationResult.class, resourceAccessChecks)
+        .items();
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers;
 
 import io.camunda.search.aggregation.AggregationBase;
+import io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation;
 import io.camunda.search.aggregation.DecisionDefinitionLatestVersionAggregation;
 import io.camunda.search.aggregation.GlobalJobStatisticsAggregation;
 import io.camunda.search.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregation;
@@ -27,6 +28,7 @@ import io.camunda.search.aggregation.UsageMetricsTUAggregation;
 import io.camunda.search.aggregation.VariableNameAggregation;
 import io.camunda.search.aggregation.WaitStateStatisticsAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
+import io.camunda.search.aggregation.result.AuditLogLatestSuccessfulAggregationResult;
 import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggregationResult;
 import io.camunda.search.aggregation.result.GlobalJobStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResult;
@@ -50,6 +52,7 @@ import io.camunda.search.clients.core.AggregationResult;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.aggregation.AggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.AuditLogLatestSuccessfulAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.DecisionDefinitionLatestVersionAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.GlobalJobStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.IncidentProcessInstanceStatisticsByDefinitionAggregationTransformer;
@@ -69,6 +72,7 @@ import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregat
 import io.camunda.search.clients.transformers.aggregation.VariableNameAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.WaitStateStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.AuditLogLatestSuccessfulAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinitionLatestVersionAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.GlobalJobStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.IncidentProcessInstanceStatisticsByDefinitionAggregationResultTransformer;
@@ -252,6 +256,7 @@ import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.search.filter.WaitStateStatisticsFilter;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
+import io.camunda.search.query.AuditLogLatestSuccessfulQuery;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.BatchOperationItemQuery;
@@ -470,6 +475,7 @@ public final class ServiceTransformers {
     Stream.of(
             AgentInstanceHistoryQuery.class,
             AgentInstanceQuery.class,
+            AuditLogLatestSuccessfulQuery.class,
             AuthorizationQuery.class,
             BatchOperationQuery.class,
             BatchOperationItemQuery.class,
@@ -762,6 +768,9 @@ public final class ServiceTransformers {
         ProcessInstanceFlowNodeStatisticsAggregation.class,
         new ProcessInstanceFlowNodeStatisticsAggregationTransformer());
     mappers.put(
+        AuditLogLatestSuccessfulAggregation.class,
+        new AuditLogLatestSuccessfulAggregationTransformer());
+    mappers.put(
         ProcessDefinitionLatestVersionAggregation.class,
         new ProcessDefinitionLatestVersionAggregationTransformer());
     mappers.put(UsageMetricsAggregation.class, new UsageMetricsAggregationTransformer());
@@ -806,6 +815,9 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessInstanceFlowNodeStatisticsAggregationResult.class,
         new ProcessInstanceFlowNodeStatisticsAggregationResultTransformer());
+    mappers.put(
+        AuditLogLatestSuccessfulAggregationResult.class,
+        new AuditLogLatestSuccessfulAggregationResultTransformer());
     mappers.put(
         ProcessDefinitionLatestVersionAggregationResult.class,
         new ProcessDefinitionLatestVersionAggregationResultTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/AuditLogLatestSuccessfulAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/AuditLogLatestSuccessfulAggregationTransformer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_BY_ENTITY_KEY;
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_LATEST_AUDIT_LOG;
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_SOURCE_NAME_ENTITY_KEY;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.composite;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.topHits;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ENTITY_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.TIMESTAMP;
+
+import io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator.Builder;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class AuditLogLatestSuccessfulAggregationTransformer
+    implements AggregationTransformer<AuditLogLatestSuccessfulAggregation> {
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<AuditLogLatestSuccessfulAggregation, ServiceTransformers> value) {
+    final Builder<AuditLogEntity> topHits = topHits();
+    // Audit-log documents do not persist numeric partition and record position fields.
+    // Their partition-position ID is a keyword, so it cannot chronologically break timestamp ties.
+    final var latestAuditLog =
+        topHits
+            .name(AGGREGATION_NAME_LATEST_AUDIT_LOG)
+            .sortOption(() -> List.of(new FieldSorting(TIMESTAMP, SortOrder.DESC)))
+            .documentClass(AuditLogEntity.class)
+            .build();
+    final var entityKeySource =
+        terms().name(AGGREGATION_SOURCE_NAME_ENTITY_KEY).field(ENTITY_KEY).build();
+
+    return List.of(
+        composite()
+            .name(AGGREGATION_NAME_BY_ENTITY_KEY)
+            .size(value.getLeft().page().size())
+            .sources(List.of(entityKeySource))
+            .aggregations(latestAuditLog)
+            .build());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/AuditLogLatestSuccessfulAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/AuditLogLatestSuccessfulAggregationResultTransformer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_BY_ENTITY_KEY;
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_LATEST_AUDIT_LOG;
+
+import io.camunda.search.aggregation.result.AuditLogLatestSuccessfulAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.transformers.entity.AuditLogEntityTransformer;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class AuditLogLatestSuccessfulAggregationResultTransformer
+    implements AggregationResultTransformer<AuditLogLatestSuccessfulAggregationResult> {
+
+  @Override
+  public AuditLogLatestSuccessfulAggregationResult apply(
+      final Map<String, AggregationResult> aggregations) {
+    final var byEntityKey = aggregations.get(AGGREGATION_NAME_BY_ENTITY_KEY);
+    if (byEntityKey == null || byEntityKey.aggregations() == null) {
+      return new AuditLogLatestSuccessfulAggregationResult(List.of());
+    }
+
+    final var entityTransformer = new AuditLogEntityTransformer();
+    final var items =
+        byEntityKey.aggregations().values().stream()
+            .map(AggregationResult::aggregations)
+            .filter(Objects::nonNull)
+            .map(bucketAggregations -> bucketAggregations.get(AGGREGATION_NAME_LATEST_AUDIT_LOG))
+            .filter(Objects::nonNull)
+            .flatMap(latest -> latest.hits().stream())
+            .map(SearchQueryHit::source)
+            .filter(AuditLogEntity.class::isInstance)
+            .map(AuditLogEntity.class::cast)
+            .map(entityTransformer::apply)
+            .toList();
+    return new AuditLogLatestSuccessfulAggregationResult(items);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/AuditLogDocumentReaderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/AuditLogDocumentReaderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.USER_TASK;
+import static io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS;
+import static io.camunda.search.filter.Operator.EQUALS;
+import static io.camunda.search.filter.Operator.IN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.aggregation.result.AuditLogLatestSuccessfulAggregationResult;
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.query.AuditLogLatestSuccessfulQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class AuditLogDocumentReaderTest {
+
+  @Test
+  void shouldReturnEmptyWithoutExecutingAggregation() {
+    final var executor = mock(SearchClientBasedQueryExecutor.class);
+    final var reader = new AuditLogDocumentReader(executor, mock(IndexDescriptor.class));
+
+    assertThat(
+            reader.searchLatestSuccessfulByEntityKeys(
+                USER_TASK, List.of(), ResourceAccessChecks.disabled()))
+        .isEmpty();
+    verifyNoInteractions(executor);
+  }
+
+  @Test
+  void shouldDeduplicateKeysAndPreserveResourceAccessChecks() {
+    final var executor = mock(SearchClientBasedQueryExecutor.class);
+    final var reader = new AuditLogDocumentReader(executor, mock(IndexDescriptor.class));
+    final var accessChecks = ResourceAccessChecks.disabled();
+    final var expected = mock(AuditLogEntity.class);
+    final var queryCaptor = ArgumentCaptor.forClass(AuditLogLatestSuccessfulQuery.class);
+    when(executor.aggregate(
+            queryCaptor.capture(),
+            eq(AuditLogLatestSuccessfulAggregationResult.class),
+            eq(accessChecks)))
+        .thenReturn(new AuditLogLatestSuccessfulAggregationResult(List.of(expected)));
+
+    final var result =
+        reader.searchLatestSuccessfulByEntityKeys(
+            USER_TASK, List.of("key-1", "key-2", "key-1"), accessChecks);
+
+    assertThat(result).containsExactly(expected);
+    final var query = queryCaptor.getValue();
+    assertThat(query.page().size()).isEqualTo(2);
+    assertThat(query.filter().entityKeyOperations())
+        .singleElement()
+        .satisfies(
+            operation -> {
+              assertThat(operation.operator()).isEqualTo(IN);
+              assertThat(operation.values()).containsExactly("key-1", "key-2");
+            });
+    assertThat(query.filter().entityTypeOperations())
+        .singleElement()
+        .satisfies(
+            operation -> {
+              assertThat(operation.operator()).isEqualTo(EQUALS);
+              assertThat(operation.value()).isEqualTo(USER_TASK.name());
+            });
+    assertThat(query.filter().resultOperations())
+        .singleElement()
+        .satisfies(
+            operation -> {
+              assertThat(operation.operator()).isEqualTo(EQUALS);
+              assertThat(operation.value()).isEqualTo(SUCCESS.name());
+            });
+    verify(executor)
+        .aggregate(query, AuditLogLatestSuccessfulAggregationResult.class, accessChecks);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/AuditLogLatestSuccessfulAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/AuditLogLatestSuccessfulAggregationTransformerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_BY_ENTITY_KEY;
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_LATEST_AUDIT_LOG;
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_SOURCE_NAME_ENTITY_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.ENTITY_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AuditLogTemplate.TIMESTAMP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation;
+import io.camunda.search.aggregation.result.AuditLogLatestSuccessfulAggregationResult;
+import io.camunda.search.clients.aggregator.SearchCompositeAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.aggregator.SearchTopHitsAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.clients.transformers.aggregation.result.AuditLogLatestSuccessfulAggregationResultTransformer;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AuditLogLatestSuccessfulQuery;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
+import io.camunda.zeebe.util.collection.Tuple;
+import org.junit.jupiter.api.Test;
+
+class AuditLogLatestSuccessfulAggregationTransformerTest {
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  @Test
+  void shouldRegisterQueryAggregationAndResultTransformers() {
+    assertThat(transformers.getTypedSearchQueryTransformer(AuditLogLatestSuccessfulQuery.class))
+        .isNotNull();
+    assertThat(transformers.getAggregationTransformer(AuditLogLatestSuccessfulAggregation.class))
+        .isInstanceOf(AuditLogLatestSuccessfulAggregationTransformer.class);
+    assertThat(
+            transformers.getSearchAggregationResultTransformer(
+                AuditLogLatestSuccessfulAggregationResult.class))
+        .isInstanceOf(AuditLogLatestSuccessfulAggregationResultTransformer.class);
+  }
+
+  @Test
+  void shouldGroupByPhysicalEntityKeyAndSelectLatestAuditLog() {
+    final var aggregation =
+        new AuditLogLatestSuccessfulAggregation(
+            FilterBuilders.auditLog().build(), SearchQueryPage.of(b -> b.size(3)));
+
+    final var result =
+        new AuditLogLatestSuccessfulAggregationTransformer()
+            .apply(Tuple.of(aggregation, transformers));
+
+    assertThat(result).singleElement().isInstanceOf(SearchCompositeAggregator.class);
+    final var composite = (SearchCompositeAggregator) result.getFirst();
+    assertThat(composite.name()).isEqualTo(AGGREGATION_NAME_BY_ENTITY_KEY);
+    assertThat(composite.size()).isEqualTo(3);
+    assertThat(composite.sources())
+        .singleElement()
+        .isInstanceOfSatisfying(
+            SearchTermsAggregator.class,
+            source -> {
+              assertThat(source.name()).isEqualTo(AGGREGATION_SOURCE_NAME_ENTITY_KEY);
+              assertThat(source.field()).isEqualTo(ENTITY_KEY);
+            });
+    assertThat(composite.aggregations())
+        .singleElement()
+        .isInstanceOfSatisfying(
+            SearchTopHitsAggregator.class,
+            topHits -> {
+              assertThat(topHits.name()).isEqualTo(AGGREGATION_NAME_LATEST_AUDIT_LOG);
+              assertThat(topHits.size()).isEqualTo(1);
+              assertThat(topHits.documentClass()).isEqualTo(AuditLogEntity.class);
+              assertThat(topHits.sortOption().getFieldSortings())
+                  .extracting(sorting -> sorting.field(), sorting -> sorting.order())
+                  .containsExactly(org.assertj.core.groups.Tuple.tuple(TIMESTAMP, SortOrder.DESC));
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/AuditLogLatestSuccessfulAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/AuditLogLatestSuccessfulAggregationResultTransformerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_BY_ENTITY_KEY;
+import static io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation.AGGREGATION_NAME_LATEST_AUDIT_LOG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.AggregationResult;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogOperationCategory;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogOperationResult;
+import io.camunda.webapps.schema.entities.auditlog.AuditLogOperationType;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AuditLogLatestSuccessfulAggregationResultTransformerTest {
+
+  @Test
+  void shouldExtractOneLatestAuditLogPerEntityKey() {
+    final var first = document("1", "entity-1");
+    final var second = document("2", "entity-2");
+    final var buckets = new LinkedHashMap<String, AggregationResult>();
+    buckets.put("entity-1", bucket(first));
+    buckets.put("entity-2", bucket(second));
+
+    final var result =
+        new AuditLogLatestSuccessfulAggregationResultTransformer()
+            .apply(Map.of(AGGREGATION_NAME_BY_ENTITY_KEY, new AggregationResult(null, buckets)));
+
+    assertThat(result.items())
+        .extracting(entity -> entity.auditLogKey(), entity -> entity.entityKey())
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple("1", "entity-1"),
+            org.assertj.core.groups.Tuple.tuple("2", "entity-2"));
+  }
+
+  @Test
+  void shouldReturnEmptyResultWhenAggregationIsMissing() {
+    assertThat(new AuditLogLatestSuccessfulAggregationResultTransformer().apply(Map.of()).items())
+        .isEmpty();
+  }
+
+  private static AggregationResult bucket(
+      final io.camunda.webapps.schema.entities.auditlog.AuditLogEntity entity) {
+    final var hit = new SearchQueryHit.Builder<>().source(entity).build();
+    final var topHit = new AggregationResult.Builder().hits(List.of(hit)).build();
+    return new AggregationResult(1L, Map.of(AGGREGATION_NAME_LATEST_AUDIT_LOG, topHit));
+  }
+
+  private static io.camunda.webapps.schema.entities.auditlog.AuditLogEntity document(
+      final String id, final String entityKey) {
+    return new io.camunda.webapps.schema.entities.auditlog.AuditLogEntity()
+        .setId(id)
+        .setEntityKey(entityKey)
+        .setEntityType(AuditLogEntityType.USER_TASK)
+        .setOperationType(AuditLogOperationType.UPDATE)
+        .setTimestamp(OffsetDateTime.parse("2026-07-21T12:00:00Z"))
+        .setResult(AuditLogOperationResult.SUCCESS)
+        .setCategory(AuditLogOperationCategory.USER_TASKS);
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AuditLogReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/AuditLogReader.java
@@ -8,6 +8,15 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.query.AuditLogQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.List;
 
-public interface AuditLogReader extends SearchEntityReader<AuditLogEntity, AuditLogQuery> {}
+public interface AuditLogReader extends SearchEntityReader<AuditLogEntity, AuditLogQuery> {
+
+  List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      AuditLogEntityType entityType,
+      List<String> entityKeys,
+      ResourceAccessChecks resourceAccessChecks);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/AuditLogSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AuditLogSearchClient.java
@@ -8,15 +8,20 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.auth.SecurityContext;
+import java.util.List;
 
 public interface AuditLogSearchClient {
 
   AuditLogEntity getAuditLog(final String id);
 
   SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query);
+
+  List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      AuditLogEntityType entityType, List<String> entityKeys);
 
   AuditLogSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -17,6 +17,7 @@ import io.camunda.search.clients.reader.SearchQueryStatisticsReader;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
@@ -124,6 +125,7 @@ import io.camunda.security.core.auth.SecurityContext;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.security.core.authz.TenantCheck;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -270,6 +272,20 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query) {
     return doSearchWithReader(requireScopedReaders().auditLogReader(), query);
+  }
+
+  @Override
+  public List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      final AuditLogEntityType entityType, final List<String> entityKeys) {
+    final var uniqueEntityKeys = List.copyOf(new LinkedHashSet<>(entityKeys));
+    if (uniqueEntityKeys.isEmpty()) {
+      return List.of();
+    }
+    return doReadWithResourceAccessController(
+        access ->
+            requireScopedReaders()
+                .auditLogReader()
+                .searchLatestSuccessfulByEntityKeys(entityType, uniqueEntityKeys, access));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
@@ -406,6 +407,15 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      final AuditLogEntityType entityType, final List<String> entityKeys) {
+    if (entityKeys.isEmpty()) {
+      return List.of();
+    }
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
@@ -409,6 +410,12 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<AuditLogEntity> searchAuditLogs(final AuditLogQuery query) {
     return SearchQueryResult.empty();
+  }
+
+  @Override
+  public List<AuditLogEntity> searchLatestSuccessfulByEntityKeys(
+      final AuditLogEntityType entityType, final List<String> entityKeys) {
+    return List.of();
   }
 
   @Override

--- a/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
+++ b/search/search-client/src/test/java/io/camunda/search/clients/CamundaSearchClientsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
@@ -15,9 +16,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.reader.AuditLogReader;
 import io.camunda.search.clients.reader.ProcessDefinitionInstanceStatisticsReader;
 import io.camunda.search.clients.reader.ProcessInstanceReader;
 import io.camunda.search.clients.reader.SearchClientReaders;
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.exception.TenantAccessDeniedException;
@@ -26,6 +30,7 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.core.auth.SecurityContext;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.security.core.authz.ResourceAccessController;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +43,7 @@ class CamundaSearchClientsTest {
   private final ResourceAccessController resourceAccessController =
       mock(ResourceAccessController.class);
   private final ProcessInstanceReader processInstanceReader = mock(ProcessInstanceReader.class);
+  private final AuditLogReader auditLogReader = mock(AuditLogReader.class);
   private final ProcessDefinitionInstanceStatisticsReader
       processDefinitionInstanceStatisticsReader =
           mock(ProcessDefinitionInstanceStatisticsReader.class);
@@ -59,6 +65,38 @@ class CamundaSearchClientsTest {
               final Function<ResourceAccessChecks, Object> applier = invocation.getArgument(1);
               return applier.apply(ResourceAccessChecks.disabled());
             });
+  }
+
+  @Nested
+  class LatestSuccessfulAuditLogs {
+
+    @Test
+    void shouldPreserveResourceAccessChecks() {
+      final var expected = mock(AuditLogEntity.class);
+      when(readers.auditLogReader()).thenReturn(auditLogReader);
+      when(auditLogReader.searchLatestSuccessfulByEntityKeys(
+              AuditLogEntityType.USER_TASK, List.of("1", "2"), ResourceAccessChecks.disabled()))
+          .thenReturn(List.of(expected));
+
+      final var result =
+          camundaSearchClients.searchLatestSuccessfulByEntityKeys(
+              AuditLogEntityType.USER_TASK, List.of("1", "2", "1"));
+
+      assertThat(result).containsExactly(expected);
+      verify(auditLogReader)
+          .searchLatestSuccessfulByEntityKeys(
+              AuditLogEntityType.USER_TASK, List.of("1", "2"), ResourceAccessChecks.disabled());
+    }
+
+    @Test
+    void shouldReturnEmptyWithoutAccessControllerInteraction() {
+      assertThat(
+              camundaSearchClients.searchLatestSuccessfulByEntityKeys(
+                  AuditLogEntityType.USER_TASK, List.of()))
+          .isEmpty();
+      verifyNoInteractions(auditLogReader);
+      verifyNoInteractions(resourceAccessController);
+    }
   }
 
   @Nested

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/AuditLogLatestSuccessfulAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/AuditLogLatestSuccessfulAggregation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.AuditLogFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+
+public record AuditLogLatestSuccessfulAggregation(AuditLogFilter filter, SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  public static final String AGGREGATION_NAME_BY_ENTITY_KEY = "by-entity-key";
+  public static final String AGGREGATION_SOURCE_NAME_ENTITY_KEY = "entityKey";
+  public static final String AGGREGATION_NAME_LATEST_AUDIT_LOG = "latest-audit-log";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/AuditLogLatestSuccessfulAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/AuditLogLatestSuccessfulAggregationResult.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import io.camunda.search.entities.AuditLogEntity;
+import java.util.List;
+
+public record AuditLogLatestSuccessfulAggregationResult(List<AuditLogEntity> items)
+    implements AggregationResultBase {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionDefinitionEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionDefinitionEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
@@ -21,7 +22,9 @@ public record DecisionDefinitionEntity(
     Long decisionRequirementsKey,
     @Nullable String decisionRequirementsName,
     Integer decisionRequirementsVersion,
-    String tenantId)
+    String tenantId,
+    @Nullable String updatedBy,
+    @Nullable OffsetDateTime updatedAt)
     implements TenantOwnedEntity {
 
   public DecisionDefinitionEntity {
@@ -33,5 +36,45 @@ public record DecisionDefinitionEntity(
     Objects.requireNonNull(decisionRequirementsKey, "decisionRequirementsKey");
     Objects.requireNonNull(decisionRequirementsVersion, "decisionRequirementsVersion");
     Objects.requireNonNull(tenantId, "tenantId");
+  }
+
+  public DecisionDefinitionEntity(
+      final Long decisionDefinitionKey,
+      final String decisionDefinitionId,
+      final String name,
+      final Integer version,
+      final String decisionRequirementsId,
+      final Long decisionRequirementsKey,
+      final @Nullable String decisionRequirementsName,
+      final Integer decisionRequirementsVersion,
+      final String tenantId) {
+    this(
+        decisionDefinitionKey,
+        decisionDefinitionId,
+        name,
+        version,
+        decisionRequirementsId,
+        decisionRequirementsKey,
+        decisionRequirementsName,
+        decisionRequirementsVersion,
+        tenantId,
+        null,
+        null);
+  }
+
+  public DecisionDefinitionEntity withUpdateMetadata(
+      final @Nullable String newUpdatedBy, final @Nullable OffsetDateTime newUpdatedAt) {
+    return new DecisionDefinitionEntity(
+        decisionDefinitionKey,
+        decisionDefinitionId,
+        name,
+        version,
+        decisionRequirementsId,
+        decisionRequirementsKey,
+        decisionRequirementsName,
+        decisionRequirementsVersion,
+        tenantId,
+        newUpdatedBy,
+        newUpdatedAt);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/IncidentEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/IncidentEntity.java
@@ -26,7 +26,9 @@ public record IncidentEntity(
     OffsetDateTime creationTime,
     @Nullable IncidentState state,
     @Nullable Long jobKey,
-    String tenantId)
+    String tenantId,
+    @Nullable String updatedBy,
+    @Nullable OffsetDateTime updatedAt)
     implements TenantOwnedEntity {
 
   public IncidentEntity {
@@ -39,6 +41,58 @@ public record IncidentEntity(
     Objects.requireNonNull(flowNodeInstanceKey, "flowNodeInstanceKey");
     Objects.requireNonNull(creationTime, "creationTime");
     Objects.requireNonNull(tenantId, "tenantId");
+  }
+
+  public IncidentEntity(
+      final Long incidentKey,
+      final Long processDefinitionKey,
+      final String processDefinitionId,
+      final Long processInstanceKey,
+      final @Nullable Long rootProcessInstanceKey,
+      final @Nullable ErrorType errorType,
+      final String errorMessage,
+      final String flowNodeId,
+      final Long flowNodeInstanceKey,
+      final OffsetDateTime creationTime,
+      final @Nullable IncidentState state,
+      final @Nullable Long jobKey,
+      final String tenantId) {
+    this(
+        incidentKey,
+        processDefinitionKey,
+        processDefinitionId,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        errorType,
+        errorMessage,
+        flowNodeId,
+        flowNodeInstanceKey,
+        creationTime,
+        state,
+        jobKey,
+        tenantId,
+        null,
+        null);
+  }
+
+  public IncidentEntity withUpdateMetadata(
+      final @Nullable String newUpdatedBy, final @Nullable OffsetDateTime newUpdatedAt) {
+    return new IncidentEntity(
+        incidentKey,
+        processDefinitionKey,
+        processDefinitionId,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        errorType,
+        errorMessage,
+        flowNodeId,
+        flowNodeInstanceKey,
+        creationTime,
+        state,
+        jobKey,
+        tenantId,
+        newUpdatedBy,
+        newUpdatedAt);
   }
 
   public enum IncidentState {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/ProcessInstanceEntity.java
@@ -45,7 +45,9 @@ public record ProcessInstanceEntity(
     Set<String> tags,
     @Nullable String businessId,
     // not set by the primary handler; populated once the exporter/appliers for SUSPEND/RESUME land.
-    @Nullable OffsetDateTime suspendedDate)
+    @Nullable OffsetDateTime suspendedDate,
+    @Nullable String updatedBy,
+    @Nullable OffsetDateTime updatedAt)
     implements TenantOwnedEntity {
 
   public ProcessInstanceEntity {
@@ -55,6 +57,48 @@ public record ProcessInstanceEntity(
     // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
     // Immutable defaults (e.g. Set.of()) would cause UnsupportedOperationException at runtime.
     tags = tags != null ? tags : new HashSet<>();
+  }
+
+  public ProcessInstanceEntity(
+      final Long processInstanceKey,
+      final @Nullable Long rootProcessInstanceKey,
+      final @Nullable String processDefinitionId,
+      final @Nullable String processDefinitionName,
+      final @Nullable Integer processDefinitionVersion,
+      final @Nullable String processDefinitionVersionTag,
+      final @Nullable Long processDefinitionKey,
+      final @Nullable Long parentProcessInstanceKey,
+      final @Nullable Long parentFlowNodeInstanceKey,
+      final @Nullable OffsetDateTime startDate,
+      final @Nullable OffsetDateTime endDate,
+      final @Nullable ProcessInstanceState state,
+      final @Nullable Boolean hasIncident,
+      final String tenantId,
+      final @Nullable String treePath,
+      final Set<String> tags,
+      final @Nullable String businessId,
+      final @Nullable OffsetDateTime suspendedDate) {
+    this(
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        processDefinitionName,
+        processDefinitionVersion,
+        processDefinitionVersionTag,
+        processDefinitionKey,
+        parentProcessInstanceKey,
+        parentFlowNodeInstanceKey,
+        startDate,
+        endDate,
+        state,
+        hasIncident,
+        tenantId,
+        treePath,
+        tags,
+        businessId,
+        suspendedDate,
+        null,
+        null);
   }
 
   public ProcessInstanceEntity(
@@ -93,7 +137,34 @@ public record ProcessInstanceEntity(
         treePath,
         new HashSet<>(),
         businessId,
+        null,
+        null,
         null);
+  }
+
+  public ProcessInstanceEntity withUpdateMetadata(
+      final @Nullable String newUpdatedBy, final @Nullable OffsetDateTime newUpdatedAt) {
+    return new ProcessInstanceEntity(
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        processDefinitionName,
+        processDefinitionVersion,
+        processDefinitionVersionTag,
+        processDefinitionKey,
+        parentProcessInstanceKey,
+        parentFlowNodeInstanceKey,
+        startDate,
+        endDate,
+        state,
+        hasIncident,
+        tenantId,
+        treePath,
+        tags,
+        businessId,
+        suspendedDate,
+        newUpdatedBy,
+        newUpdatedAt);
   }
 
   public enum ProcessInstanceState {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UserTaskEntity.java
@@ -45,7 +45,9 @@ public record UserTaskEntity(
     Integer processDefinitionVersion,
     Map<String, String> customHeaders,
     @Nullable Integer priority,
-    Set<String> tags)
+    Set<String> tags,
+    @Nullable String updatedBy,
+    @Nullable OffsetDateTime updatedAt)
     implements TenantOwnedEntity {
 
   public UserTaskEntity {
@@ -66,6 +68,62 @@ public record UserTaskEntity(
     candidateUsers = candidateUsers != null ? candidateUsers : new ArrayList<>();
     customHeaders = customHeaders != null ? customHeaders : new HashMap<>();
     tags = tags != null ? tags : new HashSet<>();
+  }
+
+  public UserTaskEntity(
+      final Long userTaskKey,
+      final String elementId,
+      final @Nullable String name,
+      final String processDefinitionId,
+      final @Nullable String processName,
+      final OffsetDateTime creationDate,
+      final @Nullable OffsetDateTime completionDate,
+      final @Nullable String assignee,
+      final UserTaskState state,
+      final @Nullable Long formKey,
+      final Long processDefinitionKey,
+      final Long processInstanceKey,
+      final @Nullable Long rootProcessInstanceKey,
+      final @Nullable String businessId,
+      final Long elementInstanceKey,
+      final String tenantId,
+      final @Nullable OffsetDateTime dueDate,
+      final @Nullable OffsetDateTime followUpDate,
+      final List<String> candidateGroups,
+      final List<String> candidateUsers,
+      final @Nullable String externalFormReference,
+      final Integer processDefinitionVersion,
+      final Map<String, String> customHeaders,
+      final @Nullable Integer priority,
+      final Set<String> tags) {
+    this(
+        userTaskKey,
+        elementId,
+        name,
+        processDefinitionId,
+        processName,
+        creationDate,
+        completionDate,
+        assignee,
+        state,
+        formKey,
+        processDefinitionKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        businessId,
+        elementInstanceKey,
+        tenantId,
+        dueDate,
+        followUpDate,
+        candidateGroups,
+        candidateUsers,
+        externalFormReference,
+        processDefinitionVersion,
+        customHeaders,
+        priority,
+        tags,
+        null,
+        null);
   }
 
   public UserTaskEntity withName(final String newName) {
@@ -94,7 +152,9 @@ public record UserTaskEntity(
         processDefinitionVersion,
         customHeaders,
         priority,
-        tags);
+        tags,
+        updatedBy,
+        updatedAt);
   }
 
   public UserTaskEntity withProcessName(final String newProcessName) {
@@ -123,7 +183,41 @@ public record UserTaskEntity(
         processDefinitionVersion,
         customHeaders,
         priority,
-        tags);
+        tags,
+        updatedBy,
+        updatedAt);
+  }
+
+  public UserTaskEntity withUpdateMetadata(
+      final @Nullable String newUpdatedBy, final @Nullable OffsetDateTime newUpdatedAt) {
+    return new UserTaskEntity(
+        userTaskKey,
+        elementId,
+        name,
+        processDefinitionId,
+        processName,
+        creationDate,
+        completionDate,
+        assignee,
+        state,
+        formKey,
+        processDefinitionKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        businessId,
+        elementInstanceKey,
+        tenantId,
+        dueDate,
+        followUpDate,
+        candidateGroups,
+        candidateUsers,
+        externalFormReference,
+        processDefinitionVersion,
+        customHeaders,
+        priority,
+        tags,
+        newUpdatedBy,
+        newUpdatedAt);
   }
 
   public boolean hasName() {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/VariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/VariableEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
@@ -24,7 +25,9 @@ public record VariableEntity(
     // ES/OS handler only writes when rootProcessInstanceKey > 0 (absent for top-level instances).
     @Nullable Long rootProcessInstanceKey,
     String processDefinitionId,
-    String tenantId)
+    String tenantId,
+    @Nullable String updatedBy,
+    @Nullable OffsetDateTime updatedAt)
     implements TenantOwnedEntity {
 
   public VariableEntity {
@@ -36,5 +39,48 @@ public record VariableEntity(
     Objects.requireNonNull(processInstanceKey, "processInstanceKey");
     Objects.requireNonNull(processDefinitionId, "processDefinitionId");
     Objects.requireNonNull(tenantId, "tenantId");
+  }
+
+  public VariableEntity(
+      final Long variableKey,
+      final String name,
+      final String value,
+      final @Nullable String fullValue,
+      final Boolean isPreview,
+      final Long scopeKey,
+      final Long processInstanceKey,
+      final @Nullable Long rootProcessInstanceKey,
+      final String processDefinitionId,
+      final String tenantId) {
+    this(
+        variableKey,
+        name,
+        value,
+        fullValue,
+        isPreview,
+        scopeKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        tenantId,
+        null,
+        null);
+  }
+
+  public VariableEntity withUpdateMetadata(
+      final @Nullable String newUpdatedBy, final @Nullable OffsetDateTime newUpdatedAt) {
+    return new VariableEntity(
+        variableKey,
+        name,
+        value,
+        fullValue,
+        isPreview,
+        scopeKey,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionId,
+        tenantId,
+        newUpdatedBy,
+        newUpdatedAt);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/AuditLogLatestSuccessfulQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AuditLogLatestSuccessfulQuery.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.AuditLogLatestSuccessfulAggregation;
+import io.camunda.search.filter.AuditLogFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
+
+public record AuditLogLatestSuccessfulQuery(AuditLogFilter filter, SearchQueryPage page)
+    implements TypedSearchAggregationQuery<
+        AuditLogFilter, SortOption, AuditLogLatestSuccessfulAggregation> {
+
+  @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public AuditLogLatestSuccessfulAggregation aggregation() {
+    return new AuditLogLatestSuccessfulAggregation(filter, page);
+  }
+}

--- a/service/src/main/java/io/camunda/service/AuditLogServices.java
+++ b/service/src/main/java/io/camunda/service/AuditLogServices.java
@@ -13,6 +13,7 @@ import static io.camunda.service.authorization.Authorizations.AUDIT_LOG_READ_USE
 
 import io.camunda.search.clients.AuditLogSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory;
 import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -20,12 +21,22 @@ import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.core.auth.condition.AuthorizationCondition;
 import io.camunda.security.core.auth.condition.AuthorizationConditions;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AuditLogServices
     extends SearchQueryService<AuditLogServices, AuditLogQuery, AuditLogEntity> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogServices.class);
 
   private static final AuthorizationCondition AUDIT_LOG_AUTHORIZATIONS =
       AuthorizationConditions.anyOf(
@@ -79,5 +90,37 @@ public class AuditLogServices
                     securityContextProvider.provideSecurityContext(
                         authentication, AUDIT_LOG_AUTHORIZATIONS))
                 .getAuditLog(auditLogKey));
+  }
+
+  public Map<String, AuditLogEntity> latestSuccessfulByEntityKeys(
+      final AuditLogEntityType entityType,
+      final Collection<String> entityKeys,
+      final CamundaAuthentication authentication) {
+    final var distinctEntityKeys = entityKeys.stream().distinct().toList();
+    if (distinctEntityKeys.isEmpty()) {
+      return Map.of();
+    }
+
+    final List<AuditLogEntity> result;
+    try {
+      result =
+          executeSearchRequest(
+              () ->
+                  auditLogSearchClient
+                      .withSecurityContext(
+                          securityContextProvider.provideSecurityContext(
+                              authentication, AUDIT_LOG_AUTHORIZATIONS))
+                      .searchLatestSuccessfulByEntityKeys(entityType, distinctEntityKeys));
+    } catch (final ServiceException e) {
+      if (e.getStatus() == Status.FORBIDDEN) {
+        return Map.of();
+      }
+      LOGGER.warn("Unable to retrieve supplemental update metadata; returning empty metadata");
+      return Map.of();
+    }
+
+    final var latestByEntityKey = new LinkedHashMap<String, AuditLogEntity>();
+    result.forEach(auditLog -> latestByEntityKey.put(auditLog.entityKey(), auditLog));
+    return Map.copyOf(latestByEntityKey);
   }
 }

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -12,6 +12,7 @@ import static io.camunda.security.core.auth.RequiredAuthorization.withRequiredAu
 import static io.camunda.service.authorization.Authorizations.DECISION_DEFINITION_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -37,6 +38,7 @@ public final class DecisionDefinitionServices
 
   private final DecisionDefinitionSearchClient decisionDefinitionSearchClient;
   private final DecisionRequirementsServices decisionRequirementServices;
+  private final UpdateMetadataEnricher updateMetadataEnricher;
 
   public DecisionDefinitionServices(
       final String physicalTenantId,
@@ -44,6 +46,26 @@ public final class DecisionDefinitionServices
       final SecurityContextProvider securityContextProvider,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
       final DecisionRequirementsServices decisionRequirementServices,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    this(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        decisionDefinitionSearchClient,
+        decisionRequirementServices,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public DecisionDefinitionServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
+      final DecisionRequirementsServices decisionRequirementServices,
+      final AuditLogServices auditLogServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
@@ -54,18 +76,26 @@ public final class DecisionDefinitionServices
         brokerRequestAuthorizationConverter);
     this.decisionDefinitionSearchClient = decisionDefinitionSearchClient;
     this.decisionRequirementServices = decisionRequirementServices;
+    updateMetadataEnricher = new UpdateMetadataEnricher(auditLogServices);
   }
 
   @Override
   public SearchQueryResult<DecisionDefinitionEntity> search(
       final DecisionDefinitionQuery query, final CamundaAuthentication authentication) {
-    return executeSearchRequest(
-        () ->
-            decisionDefinitionSearchClient
-                .withSecurityContext(
-                    securityContextProvider.provideSecurityContext(
-                        authentication, DECISION_DEFINITION_READ_AUTHORIZATION))
-                .searchDecisionDefinitions(query));
+    final var result =
+        executeSearchRequest(
+            () ->
+                decisionDefinitionSearchClient
+                    .withSecurityContext(
+                        securityContextProvider.provideSecurityContext(
+                            authentication, DECISION_DEFINITION_READ_AUTHORIZATION))
+                    .searchDecisionDefinitions(query));
+    return updateMetadataEnricher.enrichPage(
+        result,
+        AuditLogEntityType.DECISION,
+        item -> item.decisionDefinitionKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
   }
 
   public SearchQueryResult<DecisionDefinitionEntity> search(
@@ -76,7 +106,7 @@ public final class DecisionDefinitionServices
 
   public String getDecisionDefinitionXml(
       final long decisionKey, final CamundaAuthentication authentication) {
-    return Optional.ofNullable(getByKey(decisionKey, authentication))
+    return Optional.ofNullable(getByKeyRaw(decisionKey, authentication))
         .map(DecisionDefinitionEntity::decisionRequirementsKey)
         .map(
             k ->
@@ -91,16 +121,28 @@ public final class DecisionDefinitionServices
 
   public DecisionDefinitionEntity getByKey(
       final long decisionKey, final CamundaAuthentication authentication) {
-    return executeSearchRequest(
-        () ->
-            decisionDefinitionSearchClient
-                .withSecurityContext(
-                    securityContextProvider.provideSecurityContext(
-                        authentication,
-                        withRequiredAuthorization(
-                            DECISION_DEFINITION_READ_AUTHORIZATION,
-                            DecisionDefinitionEntity::decisionDefinitionId)))
-                .getDecisionDefinition(decisionKey));
+    return updateMetadataEnricher.enrichItem(
+        getByKeyRaw(decisionKey, authentication),
+        AuditLogEntityType.DECISION,
+        item -> item.decisionDefinitionKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
+  }
+
+  private DecisionDefinitionEntity getByKeyRaw(
+      final long decisionKey, final CamundaAuthentication authentication) {
+    final var result =
+        executeSearchRequest(
+            () ->
+                decisionDefinitionSearchClient
+                    .withSecurityContext(
+                        securityContextProvider.provideSecurityContext(
+                            authentication,
+                            withRequiredAuthorization(
+                                DECISION_DEFINITION_READ_AUTHORIZATION,
+                                DecisionDefinitionEntity::decisionDefinitionId)))
+                    .getDecisionDefinition(decisionKey));
+    return result;
   }
 
   public CompletableFuture<BrokerResponse<DecisionEvaluationRecord>> evaluateDecision(

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -12,6 +12,7 @@ import static io.camunda.security.core.auth.RequiredAuthorization.withRequiredAu
 import static io.camunda.service.authorization.Authorizations.INCIDENT_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.IncidentSearchClient;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.IncidentProcessInstanceStatisticsByDefinitionEntity;
@@ -36,12 +37,31 @@ public class IncidentServices
     extends SearchQueryService<IncidentServices, IncidentQuery, IncidentEntity> {
 
   private final IncidentSearchClient incidentSearchClient;
+  private final UpdateMetadataEnricher updateMetadataEnricher;
 
   public IncidentServices(
       final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final IncidentSearchClient incidentSearchClient,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    this(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        incidentSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public IncidentServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final IncidentSearchClient incidentSearchClient,
+      final AuditLogServices auditLogServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
@@ -51,6 +71,7 @@ public class IncidentServices
         executorProvider,
         brokerRequestAuthorizationConverter);
     this.incidentSearchClient = incidentSearchClient;
+    updateMetadataEnricher = new UpdateMetadataEnricher(auditLogServices);
   }
 
   public SearchQueryResult<IncidentEntity> search(
@@ -62,25 +83,39 @@ public class IncidentServices
   @Override
   public SearchQueryResult<IncidentEntity> search(
       final IncidentQuery query, final CamundaAuthentication authentication) {
-    return executeSearchRequest(
-        () ->
-            incidentSearchClient
-                .withSecurityContext(
-                    securityContextProvider.provideSecurityContext(
-                        authentication, INCIDENT_READ_AUTHORIZATION))
-                .searchIncidents(query));
+    final var result =
+        executeSearchRequest(
+            () ->
+                incidentSearchClient
+                    .withSecurityContext(
+                        securityContextProvider.provideSecurityContext(
+                            authentication, INCIDENT_READ_AUTHORIZATION))
+                    .searchIncidents(query));
+    return updateMetadataEnricher.enrichPage(
+        result,
+        AuditLogEntityType.INCIDENT,
+        item -> item.incidentKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
   }
 
   public IncidentEntity getByKey(final Long key, final CamundaAuthentication authentication) {
-    return executeSearchRequest(
-        () ->
-            incidentSearchClient
-                .withSecurityContext(
-                    securityContextProvider.provideSecurityContext(
-                        authentication,
-                        withRequiredAuthorization(
-                            INCIDENT_READ_AUTHORIZATION, IncidentEntity::processDefinitionId)))
-                .getIncident(key));
+    final var result =
+        executeSearchRequest(
+            () ->
+                incidentSearchClient
+                    .withSecurityContext(
+                        securityContextProvider.provideSecurityContext(
+                            authentication,
+                            withRequiredAuthorization(
+                                INCIDENT_READ_AUTHORIZATION, IncidentEntity::processDefinitionId)))
+                    .getIncident(key));
+    return updateMetadataEnricher.enrichItem(
+        result,
+        AuditLogEntityType.INCIDENT,
+        item -> item.incidentKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
   }
 
   public CompletableFuture<IncidentRecord> resolveIncident(

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -17,6 +17,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
 import io.camunda.search.clients.WaitStateSearchClient;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -93,6 +94,7 @@ public final class ProcessInstanceServices
   private final RequestRetryHandler requestRetryHandler;
   private final ExecutorService executor;
   private final int maxVariableNameLength;
+  private final UpdateMetadataEnricher updateMetadataEnricher;
   private final Cache<ProcessDefinitionIdentifier, RequestRetryHandler>
       definitionKeyToRetryHandler =
           Caffeine.newBuilder().maximumSize(MAX_CACHED_DEFINITIONS).build();
@@ -179,6 +181,61 @@ public final class ProcessInstanceServices
       final SequenceFlowSearchClient sequenceFlowSearchClient,
       final WaitStateSearchClient waitStateSearchClient,
       final IncidentServices incidentServices,
+      final AuditLogServices auditLogServices,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final int maxVariableNameLength) {
+    this(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        processInstanceSearchClient,
+        sequenceFlowSearchClient,
+        waitStateSearchClient,
+        incidentServices,
+        auditLogServices,
+        executorProvider,
+        brokerRequestAuthorizationConverter,
+        new RequestRetryHandler(brokerClient, brokerClient.getTopologyManager()),
+        maxVariableNameLength);
+  }
+
+  public ProcessInstanceServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessInstanceSearchClient processInstanceSearchClient,
+      final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
+      final IncidentServices incidentServices,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
+      final RequestRetryHandler requestRetryHandler,
+      final int maxVariableNameLength) {
+    this(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        processInstanceSearchClient,
+        sequenceFlowSearchClient,
+        waitStateSearchClient,
+        incidentServices,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter,
+        requestRetryHandler,
+        maxVariableNameLength);
+  }
+
+  public ProcessInstanceServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessInstanceSearchClient processInstanceSearchClient,
+      final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
+      final IncidentServices incidentServices,
+      final AuditLogServices auditLogServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
       final RequestRetryHandler requestRetryHandler,
@@ -193,6 +250,7 @@ public final class ProcessInstanceServices
     this.sequenceFlowSearchClient = sequenceFlowSearchClient;
     this.waitStateSearchClient = waitStateSearchClient;
     this.incidentServices = incidentServices;
+    updateMetadataEnricher = new UpdateMetadataEnricher(auditLogServices);
     this.requestRetryHandler = requestRetryHandler;
     executor = executorProvider.getExecutor();
     this.maxVariableNameLength = maxVariableNameLength;
@@ -201,13 +259,20 @@ public final class ProcessInstanceServices
   @Override
   public SearchQueryResult<ProcessInstanceEntity> search(
       final ProcessInstanceQuery query, final CamundaAuthentication authentication) {
-    return executeSearchRequest(
-        () ->
-            processInstanceSearchClient
-                .withSecurityContext(
-                    securityContextProvider.provideSecurityContext(
-                        authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
-                .searchProcessInstances(query));
+    final var result =
+        executeSearchRequest(
+            () ->
+                processInstanceSearchClient
+                    .withSecurityContext(
+                        securityContextProvider.provideSecurityContext(
+                            authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                    .searchProcessInstances(query));
+    return updateMetadataEnricher.enrichPage(
+        result,
+        AuditLogEntityType.PROCESS_INSTANCE,
+        item -> item.processInstanceKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
   }
 
   public SearchQueryResult<ProcessInstanceEntity> search(
@@ -231,7 +296,7 @@ public final class ProcessInstanceServices
       final long processInstanceKey, final CamundaAuthentication authentication) {
     // Existence + authorization check: throws ServiceException(NOT_FOUND) / (FORBIDDEN) before
     // aggregating, since the aggregation alone cannot distinguish "not found" from "no results".
-    getByKey(processInstanceKey, authentication);
+    getByKeyRaw(processInstanceKey, authentication);
     return executeSearchRequest(
         () ->
             waitStateSearchClient
@@ -243,7 +308,7 @@ public final class ProcessInstanceServices
 
   public List<ProcessInstanceEntity> callHierarchy(
       final long processInstanceKey, final CamundaAuthentication authentication) {
-    final var rootInstance = getByKey(processInstanceKey, authentication);
+    final var rootInstance = getByKeyRaw(processInstanceKey, authentication);
 
     final var treePath = rootInstance.treePath();
     if (treePath == null || treePath.isBlank()) {
@@ -297,6 +362,16 @@ public final class ProcessInstanceServices
   }
 
   public ProcessInstanceEntity getByKey(
+      final Long processInstanceKey, final CamundaAuthentication authentication) {
+    return updateMetadataEnricher.enrichItem(
+        getByKeyRaw(processInstanceKey, authentication),
+        AuditLogEntityType.PROCESS_INSTANCE,
+        item -> item.processInstanceKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
+  }
+
+  private ProcessInstanceEntity getByKeyRaw(
       final Long processInstanceKey, final CamundaAuthentication authentication) {
     return getByKey(
         processInstanceKey,
@@ -601,7 +676,7 @@ public final class ProcessInstanceServices
       final long processInstanceKey,
       final IncidentQuery query,
       final CamundaAuthentication authentication) {
-    final var processInstance = getByKey(processInstanceKey, authentication);
+    final var processInstance = getByKeyRaw(processInstanceKey, authentication);
     final var treePath = processInstance.treePath();
 
     return incidentServices.search(

--- a/service/src/main/java/io/camunda/service/UpdateMetadataEnricher.java
+++ b/service/src/main/java/io/camunda/service/UpdateMetadataEnricher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.exception.ServiceException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class UpdateMetadataEnricher {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpdateMetadataEnricher.class);
+
+  private final @Nullable AuditLogServices auditLogServices;
+
+  public UpdateMetadataEnricher(final @Nullable AuditLogServices auditLogServices) {
+    this.auditLogServices = auditLogServices;
+  }
+
+  public <T> T enrichItem(
+      final T item,
+      final AuditLogEntityType entityType,
+      final Function<T, String> entityKey,
+      final BiFunction<T, UpdateMetadata, T> withUpdateMetadata,
+      final CamundaAuthentication authentication) {
+    return enrichPage(
+            new SearchQueryResult<>(1, false, List.of(item), null, null),
+            entityType,
+            entityKey,
+            withUpdateMetadata,
+            authentication)
+        .items()
+        .getFirst();
+  }
+
+  public <T> SearchQueryResult<T> enrichPage(
+      final SearchQueryResult<T> result,
+      final AuditLogEntityType entityType,
+      final Function<T, String> entityKey,
+      final BiFunction<T, UpdateMetadata, T> withUpdateMetadata,
+      final CamundaAuthentication authentication) {
+    if (auditLogServices == null || result.items().isEmpty()) {
+      return result;
+    }
+
+    final List<String> entityKeys = result.items().stream().map(entityKey).distinct().toList();
+    final Map<String, AuditLogEntity> auditLogs;
+    try {
+      auditLogs =
+          auditLogServices.latestSuccessfulByEntityKeys(entityType, entityKeys, authentication);
+    } catch (final ServiceException ignored) {
+      LOGGER.warn("Unable to retrieve supplemental update metadata; returning entities without it");
+      return result.withItems(
+          result.items().stream()
+              .map(item -> withUpdateMetadata.apply(item, UpdateMetadata.EMPTY))
+              .toList());
+    }
+
+    return result.withItems(
+        result.items().stream()
+            .map(
+                item -> {
+                  final var auditLog = auditLogs.get(entityKey.apply(item));
+                  return withUpdateMetadata.apply(
+                      item,
+                      auditLog == null
+                          ? UpdateMetadata.EMPTY
+                          : new UpdateMetadata(auditLog.actorId(), auditLog.timestamp()));
+                })
+            .toList());
+  }
+
+  public record UpdateMetadata(@Nullable String updatedBy, @Nullable OffsetDateTime updatedAt) {
+    private static final UpdateMetadata EMPTY = new UpdateMetadata(null, null);
+  }
+}

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -16,6 +16,7 @@ import static io.camunda.service.authorization.Authorizations.USER_TASK_READ_BY_
 
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -75,6 +76,7 @@ public final class UserTaskServices
   private final VariableServices variableServices;
   private final ProcessCache processCache;
   private final AuditLogServices auditLogServices;
+  private final UpdateMetadataEnricher updateMetadataEnricher;
   private final int maxVariableNameLength;
 
   public UserTaskServices(
@@ -128,6 +130,7 @@ public final class UserTaskServices
     this.elementInstanceServices = elementInstanceServices;
     this.variableServices = variableServices;
     this.auditLogServices = auditLogServices;
+    updateMetadataEnricher = new UpdateMetadataEnricher(auditLogServices);
     this.processCache = processCache;
     this.maxVariableNameLength = maxVariableNameLength;
   }
@@ -135,9 +138,15 @@ public final class UserTaskServices
   @Override
   public SearchQueryResult<UserTaskEntity> search(
       final UserTaskQuery query, final CamundaAuthentication authentication) {
-    return search(
-        query,
-        securityContextProvider.provideSecurityContext(authentication, USER_TASK_AUTHORIZATIONS));
+    return updateMetadataEnricher.enrichPage(
+        search(
+            query,
+            securityContextProvider.provideSecurityContext(
+                authentication, USER_TASK_AUTHORIZATIONS)),
+        AuditLogEntityType.USER_TASK,
+        item -> item.userTaskKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
   }
 
   private SearchQueryResult<UserTaskEntity> search(
@@ -236,6 +245,16 @@ public final class UserTaskServices
 
   public UserTaskEntity getByKey(
       final long userTaskKey, final CamundaAuthentication authentication) {
+    return updateMetadataEnricher.enrichItem(
+        getByKeyRaw(userTaskKey, authentication),
+        AuditLogEntityType.USER_TASK,
+        item -> item.userTaskKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
+  }
+
+  private UserTaskEntity getByKeyRaw(
+      final long userTaskKey, final CamundaAuthentication authentication) {
     final var result =
         executeSearchRequest(
             () ->
@@ -251,7 +270,7 @@ public final class UserTaskServices
 
   public Optional<FormEntity> getUserTaskForm(
       final long userTaskKey, final CamundaAuthentication authentication) {
-    return Optional.ofNullable(getByKey(userTaskKey, authentication))
+    return Optional.ofNullable(getByKeyRaw(userTaskKey, authentication))
         .map(UserTaskEntity::formKey)
         .map(formKey -> formServices.getByKey(formKey, CamundaAuthentication.anonymous()));
   }
@@ -262,7 +281,7 @@ public final class UserTaskServices
       final CamundaAuthentication authentication) {
 
     // Fetch the user task by key
-    final var userTask = getByKey(userTaskKey, authentication);
+    final var userTask = getByKeyRaw(userTaskKey, authentication);
 
     // Retrieve the tree path for the flow node instance associated to the user task
     final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey());
@@ -282,10 +301,12 @@ public final class UserTaskServices
                     .page(variableQuery.page()));
 
     // Execute the search
-    return executeSearchRequest(
-        () ->
-            variableServices.search(
-                variableQueryWithTreePathFilter, CamundaAuthentication.anonymous()));
+    final var result =
+        executeSearchRequest(
+            () ->
+                variableServices.searchRaw(
+                    variableQueryWithTreePathFilter, CamundaAuthentication.anonymous()));
+    return enrichVariables(result, authentication);
   }
 
   public SearchQueryResult<VariableEntity> searchUserTaskEffectiveVariables(
@@ -293,7 +314,7 @@ public final class UserTaskServices
       final VariableQuery variableQuery,
       final CamundaAuthentication authentication) {
 
-    final var userTask = getByKey(userTaskKey, authentication);
+    final var userTask = getByKeyRaw(userTaskKey, authentication);
 
     final String treePath = fetchFlowNodeTreePath(userTask.elementInstanceKey());
 
@@ -321,7 +342,7 @@ public final class UserTaskServices
 
     final var allVariables =
         executeSearchRequest(
-            () -> variableServices.search(unlimitedQuery, CamundaAuthentication.anonymous()));
+            () -> variableServices.searchRaw(unlimitedQuery, CamundaAuthentication.anonymous()));
 
     // Deduplicate variables by name, keeping the one from the innermost scope.
     // Since this is a sorted result set by the user's criteria, we iterate through
@@ -340,7 +361,18 @@ public final class UserTaskServices
     final List<VariableEntity> pageItems =
         from < total ? new ArrayList<>(dedupedVariables.subList(from, end)) : List.of();
 
-    return new SearchQueryResult<>(total, false, pageItems, null, null);
+    return enrichVariables(
+        new SearchQueryResult<>(total, false, pageItems, null, null), authentication);
+  }
+
+  private SearchQueryResult<VariableEntity> enrichVariables(
+      final SearchQueryResult<VariableEntity> result, final CamundaAuthentication authentication) {
+    return updateMetadataEnricher.enrichPage(
+        result,
+        AuditLogEntityType.VARIABLE,
+        item -> item.variableKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
   }
 
   /**
@@ -390,7 +422,7 @@ public final class UserTaskServices
       final long userTaskKey,
       final AuditLogQuery auditLogQuery,
       final CamundaAuthentication authentication) {
-    getByKey(userTaskKey, authentication); // Ensure user task exists and is accessible
+    getByKeyRaw(userTaskKey, authentication); // Ensure user task exists and is accessible
 
     // Create an audit log query with user task key filter
     final var auditLogWithUserTaskKeyFilter =

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -11,6 +11,7 @@ import static io.camunda.security.core.auth.RequiredAuthorization.withRequiredAu
 import static io.camunda.service.authorization.Authorizations.VARIABLE_READ_AUTHORIZATION;
 
 import io.camunda.search.clients.VariableSearchClient;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.VariableNameQuery;
@@ -26,12 +27,31 @@ public final class VariableServices
     extends SearchQueryService<VariableServices, VariableQuery, VariableEntity> {
 
   private final VariableSearchClient variableSearchClient;
+  private final UpdateMetadataEnricher updateMetadataEnricher;
 
   public VariableServices(
       final String physicalTenantId,
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final VariableSearchClient variableSearchClient,
+      final ApiServicesExecutorProvider executorProvider,
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    this(
+        physicalTenantId,
+        brokerClient,
+        securityContextProvider,
+        variableSearchClient,
+        null,
+        executorProvider,
+        brokerRequestAuthorizationConverter);
+  }
+
+  public VariableServices(
+      final String physicalTenantId,
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final VariableSearchClient variableSearchClient,
+      final AuditLogServices auditLogServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
     super(
@@ -41,10 +61,21 @@ public final class VariableServices
         executorProvider,
         brokerRequestAuthorizationConverter);
     this.variableSearchClient = variableSearchClient;
+    updateMetadataEnricher = new UpdateMetadataEnricher(auditLogServices);
   }
 
   @Override
   public SearchQueryResult<VariableEntity> search(
+      final VariableQuery query, final CamundaAuthentication authentication) {
+    return updateMetadataEnricher.enrichPage(
+        searchRaw(query, authentication),
+        AuditLogEntityType.VARIABLE,
+        item -> item.variableKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
+  }
+
+  SearchQueryResult<VariableEntity> searchRaw(
       final VariableQuery query, final CamundaAuthentication authentication) {
     return executeSearchRequest(
         () ->
@@ -67,6 +98,15 @@ public final class VariableServices
   }
 
   public VariableEntity getByKey(final Long key, final CamundaAuthentication authentication) {
+    return updateMetadataEnricher.enrichItem(
+        getByKeyRaw(key, authentication),
+        AuditLogEntityType.VARIABLE,
+        item -> item.variableKey().toString(),
+        (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+        authentication);
+  }
+
+  VariableEntity getByKeyRaw(final Long key, final CamundaAuthentication authentication) {
     return executeSearchRequest(
         () ->
             variableSearchClient

--- a/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AuditLogServicesTest.java
@@ -15,7 +15,10 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.AuditLogSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.BatchOperationType;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.query.AuditLogQuery;
@@ -28,6 +31,7 @@ import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -164,5 +168,59 @@ class AuditLogServicesTest {
     assertThat(exception.getMessage())
         .isEqualTo("Unauthorized to perform operation 'READ' on resource 'AUDIT_LOG'");
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
+  }
+
+  @Test
+  void shouldMapLatestSuccessfulAuditLogsByEntityKey() {
+    final var latestLog = auditLog("latest", "1", "2026-07-21T11:00:00Z");
+    final var otherLog = auditLog("other", "2", "2026-07-21T10:30:00Z");
+    when(auditLogSearchClient.searchLatestSuccessfulByEntityKeys(any(), any()))
+        .thenReturn(List.of(latestLog, otherLog));
+
+    final var result =
+        auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.VARIABLE, List.of("1", "2", "1"), authentication);
+
+    assertThat(result).containsEntry("1", latestLog).containsEntry("2", otherLog).hasSize(2);
+    verify(auditLogSearchClient)
+        .searchLatestSuccessfulByEntityKeys(AuditLogEntityType.VARIABLE, List.of("1", "2"));
+  }
+
+  @Test
+  void shouldReturnEmptyMetadataWhenAuditLogAccessIsDenied() {
+    when(auditLogSearchClient.searchLatestSuccessfulByEntityKeys(any(), any()))
+        .thenThrow(new ResourceAccessDeniedException(Authorizations.AUDIT_LOG_READ_AUTHORIZATION));
+
+    final var result =
+        auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.INCIDENT, List.of("1"), authentication);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyMetadataWhenAuditLogSearchFails() {
+    when(auditLogSearchClient.searchLatestSuccessfulByEntityKeys(any(), any()))
+        .thenThrow(new CamundaSearchException("sensitive failure", Reason.SEARCH_SERVER_FAILED));
+
+    final var result =
+        auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.INCIDENT, List.of("1"), authentication);
+
+    assertThat(result).isEmpty();
+  }
+
+  private AuditLogEntity auditLog(
+      final String auditLogKey, final String entityKey, final String timestamp) {
+    return new AuditLogEntity.Builder()
+        .auditLogKey(auditLogKey)
+        .entityKey(entityKey)
+        .entityType(AuditLogEntityType.VARIABLE)
+        .operationType(AuditLogEntity.AuditLogOperationType.UPDATE)
+        .timestamp(OffsetDateTime.parse(timestamp))
+        .actorId("demo")
+        .result(AuditLogEntity.AuditLogOperationResult.SUCCESS)
+        .category(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES)
+        .build();
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -85,11 +85,24 @@ public final class DecisionDefinitionServiceTest {
     when(decisionRequirementServices.getDecisionRequirementsXml(any(Long.class), any()))
         .thenReturn("<foo>bar</foo>");
 
+    final var auditLogServices = mock(AuditLogServices.class);
+    final var enrichedServices =
+        new DecisionDefinitionServices(
+            PHYSICAL_TENANT_ID,
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            client,
+            decisionRequirementServices,
+            auditLogServices,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+
     // when
-    final var xml = services.getDecisionDefinitionXml(42L, authentication);
+    final var xml = enrichedServices.getDecisionDefinitionXml(42L, authentication);
 
     // then
     assertThat(xml).isEqualTo("<foo>bar</foo>");
+    verify(auditLogServices, never()).latestSuccessfulByEntityKeys(any(), any(), any());
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -60,6 +60,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateBatchOperationRe
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteHistoryRequest;
+import io.camunda.zeebe.gateway.validation.VariableNameLengthValidator;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
@@ -97,6 +98,7 @@ public final class ProcessInstanceServiceTest {
   private SequenceFlowSearchClient sequenceFlowSearchClient;
   private WaitStateSearchClient waitStateSearchClient;
   private IncidentServices incidentServices;
+  private AuditLogServices auditLogServices;
   private SecurityContextProvider securityContextProvider;
   private CamundaAuthentication authentication;
   private RequiredAuthorization<BatchOperationCreationRecord> authorizationCheck;
@@ -115,6 +117,7 @@ public final class ProcessInstanceServiceTest {
             RequiredAuthorization.of(a -> a.processDefinition().updateProcessInstance()),
             "myProcess");
     incidentServices = mock(IncidentServices.class);
+    auditLogServices = mock(AuditLogServices.class);
     when(processInstanceSearchClient.withSecurityContext(any()))
         .thenReturn(processInstanceSearchClient);
     when(sequenceFlowSearchClient.withSecurityContext(any())).thenReturn(sequenceFlowSearchClient);
@@ -228,11 +231,13 @@ public final class ProcessInstanceServiceTest {
         .thenReturn(List.of(new WaitStateStatisticsEntity("task-a", 3L)));
 
     // when
-    final var result = services.waitStateStatistics(processInstanceKey, authentication);
+    final var result =
+        servicesWithUpdateMetadata().waitStateStatistics(processInstanceKey, authentication);
 
     // then
     assertThat(result).containsExactly(new WaitStateStatisticsEntity("task-a", 3L));
     verify(waitStateSearchClient).waitStateStatistics(processInstanceKey);
+    verifyNoInteractions(auditLogServices);
   }
 
   @Test
@@ -415,12 +420,15 @@ public final class ProcessInstanceServiceTest {
             new SearchQueryResult<>(1, false, List.of(childProcess, parentProcess), null, null));
 
     // when
-    final var result = services.callHierarchy(childProcess.processInstanceKey(), authentication);
+    final var result =
+        servicesWithUpdateMetadata()
+            .callHierarchy(childProcess.processInstanceKey(), authentication);
 
     // then
     assertThat(result).hasSize(2);
     assertThat(result.get(0).processInstanceKey()).isEqualTo(123L); // Parent comes first
     assertThat(result.get(1).processInstanceKey()).isEqualTo(789L); // Child comes next
+    verifyNoInteractions(auditLogServices);
   }
 
   @Test
@@ -611,7 +619,8 @@ public final class ProcessInstanceServiceTest {
     when(incidentServices.search(any(IncidentQuery.class), any())).thenReturn(queryResult);
 
     // when
-    final var result = services.searchIncidents(processInstanceKey, query, authentication);
+    final var result =
+        servicesWithUpdateMetadata().searchIncidents(processInstanceKey, query, authentication);
 
     // then
     assertThat(result).isEqualTo(queryResult);
@@ -623,6 +632,22 @@ public final class ProcessInstanceServiceTest {
         .containsExactly(Operation.like(processInstance.treePath() + "*"));
     assertThat(incidentQuery.page()).isEqualTo(query.page());
     assertThat(incidentQuery.sort()).isEqualTo(query.sort());
+    verifyNoInteractions(auditLogServices);
+  }
+
+  private ProcessInstanceServices servicesWithUpdateMetadata() {
+    return new ProcessInstanceServices(
+        PHYSICAL_TENANT_ID,
+        brokerClient,
+        securityContextProvider,
+        processInstanceSearchClient,
+        sequenceFlowSearchClient,
+        waitStateSearchClient,
+        incidentServices,
+        auditLogServices,
+        executorProvider,
+        brokerRequestAuthorizationConverter,
+        VariableNameLengthValidator.DEFAULT_MAX_NAME_FIELD_LENGTH);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UpdateMetadataEnricherTest.java
+++ b/service/src/test/java/io/camunda/service/UpdateMetadataEnricherTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class UpdateMetadataEnricherTest {
+
+  private final AuditLogServices auditLogServices = mock(AuditLogServices.class);
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+  private final UpdateMetadataEnricher enricher = new UpdateMetadataEnricher(auditLogServices);
+
+  @Test
+  void shouldMapMetadataAndLeaveMissingResultNullWithOneBulkLookup() {
+    final var timestamp = OffsetDateTime.parse("2026-07-21T12:34:56Z");
+    final var auditLog = mock(AuditLogEntity.class);
+    when(auditLog.actorId()).thenReturn("demo");
+    when(auditLog.timestamp()).thenReturn(timestamp);
+    when(auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.VARIABLE, List.of("1", "2"), authentication))
+        .thenReturn(Map.of("1", auditLog));
+
+    final var result =
+        enricher.enrichPage(
+            SearchQueryResult.of(
+                new Item("1", null, null), new Item("2", "stale", OffsetDateTime.MIN)),
+            AuditLogEntityType.VARIABLE,
+            Item::key,
+            (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+            authentication);
+
+    assertThat(result.items())
+        .containsExactly(new Item("1", "demo", timestamp), new Item("2", null, null));
+    verify(auditLogServices)
+        .latestSuccessfulByEntityKeys(
+            AuditLogEntityType.VARIABLE, List.of("1", "2"), authentication);
+  }
+
+  @Test
+  void shouldEnrichSingleItem() {
+    final var timestamp = OffsetDateTime.parse("2026-07-21T12:34:56Z");
+    final var auditLog = mock(AuditLogEntity.class);
+    when(auditLog.actorId()).thenReturn("demo");
+    when(auditLog.timestamp()).thenReturn(timestamp);
+    when(auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.INCIDENT, List.of("3"), authentication))
+        .thenReturn(Map.of("3", auditLog));
+
+    final var result =
+        enricher.enrichItem(
+            new Item("3", null, null),
+            AuditLogEntityType.INCIDENT,
+            Item::key,
+            (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+            authentication);
+
+    assertThat(result).isEqualTo(new Item("3", "demo", timestamp));
+  }
+
+  @Test
+  void shouldReturnItemsWithNullMetadataWhenAuditSearchFails() {
+    when(auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.VARIABLE, List.of("1"), authentication))
+        .thenThrow(new ServiceException("audit search failed", Status.INTERNAL));
+
+    final var result =
+        enricher.enrichPage(
+            SearchQueryResult.of(new Item("1", "stale", OffsetDateTime.MIN)),
+            AuditLogEntityType.VARIABLE,
+            Item::key,
+            (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+            authentication);
+
+    assertThat(result.items()).containsExactly(new Item("1", null, null));
+  }
+
+  @Test
+  void shouldReturnItemWithNullMetadataWhenNoAuditEntryExists() {
+    when(auditLogServices.latestSuccessfulByEntityKeys(
+            AuditLogEntityType.INCIDENT, List.of("4"), authentication))
+        .thenReturn(Map.of());
+
+    final var result =
+        enricher.enrichItem(
+            new Item("4", "stale", OffsetDateTime.MIN),
+            AuditLogEntityType.INCIDENT,
+            Item::key,
+            (item, metadata) -> item.withUpdateMetadata(metadata.updatedBy(), metadata.updatedAt()),
+            authentication);
+
+    assertThat(result).isEqualTo(new Item("4", null, null));
+  }
+
+  private record Item(String key, String updatedBy, OffsetDateTime updatedAt) {
+    Item withUpdateMetadata(final String newUpdatedBy, final OffsetDateTime newUpdatedAt) {
+      return new Item(key, newUpdatedBy, newUpdatedAt);
+    }
+  }
+}

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.UserTaskEntity;
@@ -87,6 +88,14 @@ public class UserTaskServiceTest {
             null);
 
     when(processCache.getCacheItems(any())).thenReturn(ProcessCacheResult.EMPTY);
+    when(auditLogServices.latestSuccessfulByEntityKeys(any(), any(), any())).thenReturn(Map.of());
+  }
+
+  private UserTaskEntity userTaskWithoutUpdateMetadata() {
+    return Instancio.of(UserTaskEntity.class)
+        .set(field(UserTaskEntity::updatedBy), null)
+        .set(field(UserTaskEntity::updatedAt), null)
+        .create();
   }
 
   @Nested
@@ -130,7 +139,7 @@ public class UserTaskServiceTest {
       when(elementInstanceServices.getByKey(
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any())).thenReturn(SearchQueryResult.of(variable));
+      when(variableServices.searchRaw(any(), any())).thenReturn(SearchQueryResult.of(variable));
 
       // when
       final SearchQueryResult<VariableEntity> searchQueryResult =
@@ -140,6 +149,41 @@ public class UserTaskServiceTest {
       // then
       assertThat(searchQueryResult.total()).isEqualTo(1);
       assertThat(searchQueryResult.items()).containsExactly(variable);
+    }
+
+    @Test
+    void shouldEnrichVariablesWithCallerAuthentication() {
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1")
+              .create();
+      final var variable =
+          new VariableEntity(100L, "city", "Berlin", "Berlin", false, 1L, 1L, 1L, "proc", "t1");
+      final var auditLog = Instancio.create(AuditLogEntity.class);
+
+      when(client.getUserTask(entity.userTaskKey())).thenReturn(entity);
+      when(elementInstanceServices.getByKey(
+              entity.elementInstanceKey(), CamundaAuthentication.anonymous()))
+          .thenReturn(flowNodeInstanceEntity);
+      when(variableServices.searchRaw(any(), eq(CamundaAuthentication.anonymous())))
+          .thenReturn(SearchQueryResult.of(variable));
+      when(auditLogServices.latestSuccessfulByEntityKeys(
+              AuditLogEntityType.VARIABLE, List.of("100"), authentication))
+          .thenReturn(Map.of("100", auditLog));
+
+      final var result =
+          services.searchUserTaskVariables(
+              entity.userTaskKey(), variableSearchQuery().build(), authentication);
+
+      assertThat(result.items().getFirst().updatedBy()).isEqualTo(auditLog.actorId());
+      assertThat(result.items().getFirst().updatedAt()).isEqualTo(auditLog.timestamp());
+      verify(auditLogServices)
+          .latestSuccessfulByEntityKeys(
+              AuditLogEntityType.VARIABLE, List.of("100"), authentication);
+      verify(auditLogServices, never())
+          .latestSuccessfulByEntityKeys(eq(AuditLogEntityType.USER_TASK), any(), any());
     }
   }
 
@@ -164,7 +208,7 @@ public class UserTaskServiceTest {
       when(elementInstanceServices.getByKey(
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(SearchQueryResult.of(outerVar, innerVar));
 
       // when
@@ -197,7 +241,7 @@ public class UserTaskServiceTest {
       when(elementInstanceServices.getByKey(
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(SearchQueryResult.of(rootVar, midVar, leafVar));
 
       // when
@@ -232,7 +276,7 @@ public class UserTaskServiceTest {
       when(elementInstanceServices.getByKey(
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when
@@ -272,7 +316,7 @@ public class UserTaskServiceTest {
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
       // Mock returns variables sorted by name ASC (like data layer would)
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when — sort by name ASC after deduplication
@@ -311,7 +355,7 @@ public class UserTaskServiceTest {
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
       // Mock returns variables sorted by value DESC (like data layer would)
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when — sort by value DESC after deduplication
@@ -351,7 +395,7 @@ public class UserTaskServiceTest {
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
       // Mock returns variables sorted by name ASC (like data layer would)
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(SearchQueryResult.of(b -> b.total(vars.size()).items(vars)));
 
       // when — sort by name ASC, then paginate from=1, size=2
@@ -369,6 +413,37 @@ public class UserTaskServiceTest {
       assertThat(result.items())
           .extracting(VariableEntity::name, VariableEntity::value)
           .containsExactly(tuple("b", "2-inner"), tuple("c", "3"));
+    }
+
+    @Test
+    void shouldEnrichOnlyFinalEffectiveVariablePage() {
+      final var entity = Instancio.create(UserTaskEntity.class);
+      final var flowNodeInstanceEntity =
+          Instancio.of(FlowNodeInstanceEntity.class)
+              .set(field(FlowNodeInstanceEntity::flowNodeInstanceKey), entity.elementInstanceKey())
+              .set(field(FlowNodeInstanceEntity::treePath), "1/2")
+              .create();
+      final var outer = new VariableEntity(1L, "a", "outer", "outer", false, 1L, 1L, 1L, "p", "t");
+      final var inner = new VariableEntity(2L, "a", "inner", "inner", false, 2L, 1L, 1L, "p", "t");
+      final var second =
+          new VariableEntity(3L, "b", "second", "second", false, 2L, 1L, 1L, "p", "t");
+
+      when(client.getUserTask(entity.userTaskKey())).thenReturn(entity);
+      when(elementInstanceServices.getByKey(
+              entity.elementInstanceKey(), CamundaAuthentication.anonymous()))
+          .thenReturn(flowNodeInstanceEntity);
+      when(variableServices.searchRaw(any(), eq(CamundaAuthentication.anonymous())))
+          .thenReturn(SearchQueryResult.of(outer, inner, second));
+
+      final var result =
+          services.searchUserTaskEffectiveVariables(
+              entity.userTaskKey(),
+              VariableQuery.of(q -> q.page(p -> p.from(0).size(1))),
+              authentication);
+
+      assertThat(result.items()).containsExactly(inner);
+      verify(auditLogServices)
+          .latestSuccessfulByEntityKeys(AuditLogEntityType.VARIABLE, List.of("2"), authentication);
     }
 
     @Test
@@ -392,7 +467,7 @@ public class UserTaskServiceTest {
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
       // The search backend returns cursors, but the early-exit must strip them
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(new SearchQueryResult<>(2, false, vars, "start-cursor", "end-cursor"));
 
       // when
@@ -427,7 +502,7 @@ public class UserTaskServiceTest {
               eq(flowNodeInstanceEntity.flowNodeInstanceKey()), any()))
           .thenReturn(flowNodeInstanceEntity);
       // The search backend returns cursors, but the service should strip them
-      when(variableServices.search(any(), any()))
+      when(variableServices.searchRaw(any(), any()))
           .thenReturn(new SearchQueryResult<>(2, false, vars, "start-cursor", "end-cursor"));
 
       // when
@@ -486,6 +561,7 @@ public class UserTaskServiceTest {
 
       // then
       assertThat(searchQueryResult.items()).containsOnly(outputEntity);
+      verify(auditLogServices, never()).latestSuccessfulByEntityKeys(any(), any(), any());
     }
   }
 
@@ -507,6 +583,7 @@ public class UserTaskServiceTest {
       // then
       assertThat(result).isPresent();
       assertThat(result.get()).isEqualTo(form);
+      verify(auditLogServices, never()).latestSuccessfulByEntityKeys(any(), any(), any());
     }
 
     @Test
@@ -530,7 +607,7 @@ public class UserTaskServiceTest {
 
     @Test
     void shouldReturnUserTask() {
-      final var entity = Instancio.create(UserTaskEntity.class);
+      final var entity = userTaskWithoutUpdateMetadata();
 
       when(client.getUserTask(any(Long.class))).thenReturn(entity);
 
@@ -612,7 +689,7 @@ public class UserTaskServiceTest {
 
     @Test
     void shouldReturnUserTask() {
-      final var entity = Instancio.create(UserTaskEntity.class);
+      final var entity = userTaskWithoutUpdateMetadata();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
 
       final var searchQueryResult = services.search(UserTaskQuery.of(q -> q), authentication);
@@ -623,7 +700,11 @@ public class UserTaskServiceTest {
     @Test
     void shouldReturnUserTaskWithCachedName() {
       final var entity =
-          Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
+          Instancio.of(UserTaskEntity.class)
+              .set(field(UserTaskEntity::name), null)
+              .set(field(UserTaskEntity::updatedBy), null)
+              .set(field(UserTaskEntity::updatedAt), null)
+              .create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
       when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
           .thenReturn(
@@ -638,7 +719,11 @@ public class UserTaskServiceTest {
     @Test
     void shouldReturnUserTaskWithProcessName() {
       final var entity =
-          Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::processName), null).create();
+          Instancio.of(UserTaskEntity.class)
+              .set(field(UserTaskEntity::processName), null)
+              .set(field(UserTaskEntity::updatedBy), null)
+              .set(field(UserTaskEntity::updatedAt), null)
+              .create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
       when(processCache.getCacheItems(Set.of(entity.processDefinitionKey())))
           .thenReturn(
@@ -653,7 +738,11 @@ public class UserTaskServiceTest {
     @Test
     void shouldReturnUserTaskWithElementIdAsDefaultName() {
       final var entity =
-          Instancio.of(UserTaskEntity.class).set(field(UserTaskEntity::name), null).create();
+          Instancio.of(UserTaskEntity.class)
+              .set(field(UserTaskEntity::name), null)
+              .set(field(UserTaskEntity::updatedBy), null)
+              .set(field(UserTaskEntity::updatedAt), null)
+              .create();
       when(client.searchUserTasks(any())).thenReturn(SearchQueryResult.of(entity));
 
       final var searchQueryResult = services.search(UserTaskQuery.of(q -> q), authentication);

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -11,10 +11,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.exception.ResourceAccessDeniedException;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableFilter.Builder;
@@ -111,5 +114,28 @@ public class VariableServiceTest {
         .isEqualTo(
             "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
+  }
+
+  @Test
+  void shouldPropagatePrimaryEntityLookupFailureWithoutAuditLookup() {
+    final var auditLogServices = mock(AuditLogServices.class);
+    services =
+        new VariableServices(
+            PHYSICAL_TENANT_ID,
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            client,
+            auditLogServices,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+    when(client.getVariable(1L))
+        .thenThrow(
+            new CamundaSearchException("primary search failed", Reason.SEARCH_SERVER_FAILED));
+
+    assertThatThrownBy(() -> services.getByKey(1L, authentication))
+        .isInstanceOfSatisfying(
+            ServiceException.class,
+            exception -> assertThat(exception.getStatus()).isEqualTo(Status.INTERNAL));
+    verifyNoInteractions(auditLogServices);
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -301,6 +301,8 @@ components:
         - name
         - tenantId
         - version
+        - updatedBy
+        - updatedAt
       properties:
         decisionDefinitionId:
           allOf:
@@ -333,6 +335,20 @@ components:
         version:
           description: The assigned version of the decision definition.
           type: integer
+        updatedBy:
+          description: |
+            The actor ID from an accessible successful audit-log entry with the latest timestamp.
+            If multiple entries have that timestamp, which actor is returned is unspecified. This
+            is `null` if no such entry exists.
+          nullable: true
+          type: string
+        updatedAt:
+          description: |
+            The latest timestamp among accessible successful audit-log entries. This is `null` if
+            none exists.
+          nullable: true
+          type: string
+          format: date-time
       x-properties-added-in-version:
         - propertyName: decisionDefinitionId
           addedInVersion: "8.6"
@@ -352,6 +368,10 @@ components:
           addedInVersion: "8.6"
         - propertyName: version
           addedInVersion: "8.6"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     DecisionEvaluationInstruction:
       x-polymorphic-schema: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -492,6 +492,8 @@ components:
         - rootProcessInstanceKey
         - jobKey
         - tenantId
+        - updatedBy
+        - updatedAt
       properties:
         processDefinitionId:
           allOf:
@@ -549,6 +551,20 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
+        updatedBy:
+          description: |
+            The actor ID from an accessible successful audit-log entry with the latest timestamp.
+            If multiple entries have that timestamp, which actor is returned is unspecified. This
+            is `null` if no such entry exists.
+          nullable: true
+          type: string
+        updatedAt:
+          description: |
+            The latest timestamp among accessible successful audit-log entries. This is `null` if
+            none exists.
+          nullable: true
+          type: string
+          format: date-time
       x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.6"
@@ -576,6 +592,10 @@ components:
           addedInVersion: "8.8"
         - propertyName: jobKey
           addedInVersion: "8.6"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     IncidentResolutionRequest:
       type: object
@@ -739,5 +759,3 @@ components:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
         - field
-
-

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1736,6 +1736,8 @@ components:
         - rootProcessInstanceKey
         - tags
         - businessId
+        - updatedBy
+        - updatedAt
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
@@ -1800,6 +1802,20 @@ components:
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+        updatedBy:
+          description: |
+            The actor ID from an accessible successful audit-log entry with the latest timestamp.
+            If multiple entries have that timestamp, which actor is returned is unspecified. This
+            is `null` if no such entry exists.
+          nullable: true
+          type: string
+        updatedAt:
+          description: |
+            The latest timestamp among accessible successful audit-log entries. This is `null` if
+            none exists.
+          nullable: true
+          type: string
+          format: date-time
       x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.8"
@@ -1833,6 +1849,10 @@ components:
           addedInVersion: "8.8"
         - propertyName: businessId
           addedInVersion: "8.9"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     CancelProcessInstanceRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -714,6 +714,8 @@ components:
         - followUpDate
         - processDefinitionVersion
         - formKey
+        - updatedBy
+        - updatedAt
       properties:
         name:
           nullable: true
@@ -828,6 +830,20 @@ components:
             - $ref: 'keys.yaml#/components/schemas/FormKey'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        updatedBy:
+          description: |
+            The actor ID from an accessible successful audit-log entry with the latest timestamp.
+            If multiple entries have that timestamp, which actor is returned is unspecified. This
+            is `null` if no such entry exists.
+          nullable: true
+          type: string
+        updatedAt:
+          description: |
+            The latest timestamp among accessible successful audit-log entries. This is `null` if
+            none exists.
+          nullable: true
+          type: string
+          format: date-time
       x-properties-added-in-version:
         - propertyName: name
           addedInVersion: "8.8"
@@ -879,6 +895,10 @@ components:
           addedInVersion: "8.6"
         - propertyName: tags
           addedInVersion: "8.9"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     UserTaskCompletionRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -234,6 +234,8 @@ components:
         - variableKey
         - scopeKey
         - rootProcessInstanceKey
+        - updatedBy
+        - updatedAt
       properties:
         name:
           description: Name of this variable.
@@ -266,9 +268,27 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+        updatedBy:
+          description: |
+            The actor ID from an accessible successful audit-log entry with the latest timestamp.
+            If multiple entries have that timestamp, which actor is returned is unspecified. This
+            is `null` if no such entry exists.
+          nullable: true
+          type: string
+        updatedAt:
+          description: |
+            The latest timestamp among accessible successful audit-log entries. This is `null` if
+            none exists.
+          nullable: true
+          type: string
+          format: date-time
       x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     VariableValueFilterProperty:
       type: object


### PR DESCRIPTION
## Summary

Expose nullable `updatedBy` and `updatedAt` fields on search and detail responses for:

- user tasks
- process instances
- variables
- incidents
- decision definitions

The values come from the latest successful audit-log entry visible to the caller. If no matching entry exists, audit access is denied, or supplemental lookup fails, both fields are returned as `null` without failing the primary entity request.

## Implementation

- Adds backend-neutral bulk audit lookup contracts.
- Uses a composite aggregation with top hits for Elasticsearch and OpenSearch.
- Uses ranked RDBMS queries with key chunking for supported relational databases.
- Applies audit-log resource and tenant authorization before selecting the latest entry.
- Enriches only public response paths; internal/preflight reads do not perform supplemental lookups.
- Exposes the fields through the Java client.
- Updates OpenAPI and generated API response assertions.

## Verification

- 113-module dependency reactor compile: passed.
- RDBMS H2 multi-database acceptance: 28/28 passed.
- Elasticsearch 8.19.16 multi-database acceptance: 28/28 passed.
- OpenSearch 2.19.5: process/audit 22/22 and user-task 6/6 reports passed; local Maven teardown hung after execution.
- Focused search transformer, RDBMS mapper/reader, service, gateway mapper, and Java client tests passed.

The acceptance tests cover all five entities through exporter, secondary storage, REST API, and Java client, for both search and detail responses. They also cover nullable metadata when no audit event exists.

## Performance and rollout

This draft intentionally starts with always-on enrichment so CI can exercise the full API and database matrix. Each search page adds one document-store aggregation; RDBMS uses one ranked query per chunk of up to 900 keys. Local small-page timings were acceptable, but this is not a production-scale benchmark.

Before marking ready for review, we should decide from CI and representative benchmarks whether search requests should instead require `includeUpdateMetadata: true`. Detail responses can remain always-on.

## Known limitations

- Audit-log coverage is intentionally partial, so `null` does not imply that the entity was never changed.
- Equal latest timestamps have unspecified actor selection because no backend-neutral global causal ordering exists.
- Very large tenant/authorization ID lists can exceed vendor bind limits; supplemental enrichment fails open to `null` rather than failing the entity API.
- No schema or underlying entity-table changes are introduced.