### PR TITLE
fix: route post-importer-queue writes by partition id (backport of #56526)

### DIFF
--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessor.java
@@ -96,7 +96,12 @@ public class IncidentZeebeRecordProcessor {
             .setPartitionId(record.getPartitionId())
             .setProcessInstanceKey(recordValue.getProcessInstanceKey());
 
-    batchRequest.add(postImporterQueueTemplate.getFullQualifiedName(), postImporterQueueEntity);
+    // Route each entry to a single shard by partition id so that, within a partition, a search can
+    // never observe a higher position without also seeing all lower positions (see #56117)
+    batchRequest.addWithRouting(
+        postImporterQueueTemplate.getFullQualifiedName(),
+        postImporterQueueEntity,
+        String.valueOf(record.getPartitionId()));
   }
 
   private void persistIncident(

--- a/operate/importer-8_7/src/test/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/IncidentZeebeRecordProcessorTest.java
+++ b/operate/importer-8_7/src/test/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/IncidentZeebeRecordProcessorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebeimport.v8_7.processors.processors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.entities.post.PostImporterQueueEntity;
+import io.camunda.operate.exceptions.PersistenceException;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.templates.IncidentTemplate;
+import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
+import io.camunda.operate.store.BatchRequest;
+import io.camunda.operate.util.OperationsManager;
+import io.camunda.operate.zeebeimport.IncidentNotifier;
+import io.camunda.operate.zeebeimport.processors.IncidentZeebeRecordProcessor;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IncidentZeebeRecordProcessorTest {
+
+  private static final String INCIDENT_INDEX = "incident-index";
+  private static final String POST_IMPORTER_QUEUE_INDEX = "post-importer-queue-index";
+
+  @Mock private OperateProperties operateProperties;
+  @Mock private IncidentTemplate incidentTemplate;
+  @Mock private PostImporterQueueTemplate postImporterQueueTemplate;
+  @Mock private OperationsManager operationsManager;
+  @Mock private IncidentNotifier incidentNotifier;
+  @InjectMocks private IncidentZeebeRecordProcessor incidentZeebeRecordProcessor;
+
+  @Test
+  void shouldRoutePostImporterQueueEntryByPartitionId() throws PersistenceException {
+    // given - an incident record on a specific partition
+    final long incidentKey = 42L;
+    final int partitionId = 3;
+    final long position = 7L;
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+    when(incidentTemplate.getFullQualifiedName()).thenReturn(INCIDENT_INDEX);
+    when(postImporterQueueTemplate.getFullQualifiedName()).thenReturn(POST_IMPORTER_QUEUE_INDEX);
+
+    final Record<IncidentRecordValue> record =
+        incidentRecord(IncidentIntent.CREATED, incidentKey, partitionId, position);
+
+    // when
+    incidentZeebeRecordProcessor.processIncidentRecord(record, batchRequest, incident -> {});
+
+    // then - the post-importer-queue entry is written with routing == partition id (see #56117)
+    // so that a partition's entries co-locate on a single shard and cannot exhibit refresh skew
+    final ArgumentCaptor<PostImporterQueueEntity> captor =
+        ArgumentCaptor.forClass(PostImporterQueueEntity.class);
+    verify(batchRequest)
+        .addWithRouting(
+            eq(POST_IMPORTER_QUEUE_INDEX), captor.capture(), eq(String.valueOf(partitionId)));
+    // ...and never with an unrouted add, which was the source of the bug
+    verify(batchRequest, never()).add(eq(POST_IMPORTER_QUEUE_INDEX), any());
+
+    final PostImporterQueueEntity queueEntity = captor.getValue();
+    assertThat(queueEntity.getKey()).isEqualTo(incidentKey);
+    assertThat(queueEntity.getPartitionId()).isEqualTo(partitionId);
+    assertThat(queueEntity.getPosition()).isEqualTo(position);
+    assertThat(queueEntity.getIntent()).isEqualTo(IncidentIntent.CREATED.name());
+  }
+
+  private Record<IncidentRecordValue> incidentRecord(
+      final IncidentIntent intent, final long key, final int partitionId, final long position) {
+    final IncidentRecordValue recordValue =
+        ImmutableIncidentRecordValue.builder()
+            .withProcessInstanceKey(key)
+            .withErrorType(ErrorType.UNKNOWN)
+            .withErrorMessage("boom")
+            .build();
+    return ImmutableRecord.<IncidentRecordValue>builder()
+        .withKey(key)
+        .withPartitionId(partitionId)
+        .withPosition(position)
+        .withIntent(intent)
+        .withTimestamp(1000L)
+        .withValueType(ValueType.INCIDENT)
+        .withValue(recordValue)
+        .build();
+  }
+}

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -106,12 +106,16 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
     final Map<Long, IncidentState> incidents2Process;
 
     // Force a refresh of the post-importer-queue write index before reading the batch so that all
-    // of its shards expose their acknowledged writes. The queue is written without routing, so a
-    // single partition's entries are scattered across all shards, which refresh on independent
-    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
-    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
-    // would then advance past the lower entry and, because the lower bound is strict, never revisit
-    // it. See https://github.com/camunda/camunda/issues/56117.
+    // of its shards expose their acknowledged writes. New entries are written with routing by
+    // partition id, so a single partition's entries co-locate on one shard and cannot exhibit
+    // refresh skew. This refresh remains load-bearing for the unrouted tail — legacy documents
+    // predating this change, restored backups, and entries written by older brokers during a
+    // rolling upgrade — which are still scattered across shards that refresh on independent timers.
+    // Without it, for those unrouted entries a higher-position entry on an already-refreshed shard
+    // could be returned while a lower-position entry on a not-yet-refreshed shard is still
+    // invisible; the cursor would then advance past the lower entry and, because the lower bound is
+    // strict, never revisit it. See https://github.com/camunda/camunda/issues/56117. Expected to
+    // become removable once routed writes are the norm.
     refreshPostImporterQueueIndex();
 
     // query post importer queue

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
@@ -96,12 +96,16 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
     final Map<Long, IncidentState> incidents2Process;
 
     // Force a refresh of the post-importer-queue write index before reading the batch so that all
-    // of its shards expose their acknowledged writes. The queue is written without routing, so a
-    // single partition's entries are scattered across all shards, which refresh on independent
-    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
-    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
-    // would then advance past the lower entry and, because the lower bound is strict, never revisit
-    // it. See https://github.com/camunda/camunda/issues/56117.
+    // of its shards expose their acknowledged writes. New entries are written with routing by
+    // partition id, so a single partition's entries co-locate on one shard and cannot exhibit
+    // refresh skew. This refresh remains load-bearing for the unrouted tail — legacy documents
+    // predating this change, restored backups, and entries written by older brokers during a
+    // rolling upgrade — which are still scattered across shards that refresh on independent timers.
+    // Without it, for those unrouted entries a higher-position entry on an already-refreshed shard
+    // could be returned while a lower-position entry on a not-yet-refreshed shard is still
+    // invisible; the cursor would then advance past the lower entry and, because the lower bound is
+    // strict, never revisit it. See https://github.com/camunda/camunda/issues/56117. Expected to
+    // become removable once routed writes are the norm.
     refreshPostImporterQueueIndex();
 
     record Result(Long key, Long position, String intent) {}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessorIT.java
@@ -13,8 +13,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.entities.IncidentEntity;
+import io.camunda.operate.entities.post.PostImporterQueueEntity;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.schema.templates.IncidentTemplate;
+import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.zeebe.PartitionHolder;
@@ -33,6 +35,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 public class IncidentZeebeRecordProcessorIT extends OperateSearchAbstractIT {
 
   @Autowired private IncidentTemplate incidentTemplate;
+  @Autowired private PostImporterQueueTemplate postImporterQueueTemplate;
   @Autowired private IncidentZeebeRecordProcessor incidentZeebeRecordProcessor;
   @Autowired private BeanFactory beanFactory;
   @MockBean private PartitionHolder partitionHolder;
@@ -64,6 +67,64 @@ public class IncidentZeebeRecordProcessorIT extends OperateSearchAbstractIT {
         .isEqualTo(io.camunda.operate.entities.ErrorType.EXECUTION_LISTENER_NO_RETRIES);
   }
 
+  /**
+   * Regression test for https://github.com/camunda/camunda/issues/56117. The processor must write
+   * every post-importer-queue entry with {@code routing == partitionId} so that a partition's
+   * entries co-locate on a single shard; without this the entries scatter across shards that
+   * refresh independently and the strict, forward-only position cursor of the incident post-import
+   * can skip a lower-position entry, leaving its incident stuck {@code PENDING} forever. This is
+   * asserted end-to-end against the real store (Elasticsearch and OpenSearch): entries are queried
+   * back by the {@code _routing} metadata field, which only matches documents that were actually
+   * indexed with that routing value.
+   */
+  @Test
+  public void shouldRoutePostImporterQueueEntriesByPartitionId()
+      throws PersistenceException, IOException {
+    // given - CREATED incidents on two different partitions
+    final int partitionA = 3;
+    final int partitionB = 5;
+    final List<Record<IncidentRecordValue>> records =
+        List.of(
+            createdIncidentOnPartition(31L, partitionA, 1L),
+            createdIncidentOnPartition(32L, partitionA, 2L),
+            createdIncidentOnPartition(33L, partitionA, 3L),
+            createdIncidentOnPartition(51L, partitionB, 1L));
+
+    // when
+    importIncidentZeebeRecords(records);
+
+    // then - a partition's entries are all queryable by _routing == partitionId (proving they were
+    // indexed with that routing) and by nothing else
+    assertThat(findQueueEntriesByRouting(partitionA))
+        .hasSize(3)
+        .allSatisfy(entry -> assertThat(entry.getPartitionId()).isEqualTo(partitionA))
+        .extracting(PostImporterQueueEntity::getKey)
+        .containsExactlyInAnyOrder(31L, 32L, 33L);
+    assertThat(findQueueEntriesByRouting(partitionB))
+        .hasSize(1)
+        .allSatisfy(entry -> assertThat(entry.getPartitionId()).isEqualTo(partitionB))
+        .extracting(PostImporterQueueEntity::getKey)
+        .containsExactly(51L);
+  }
+
+  private List<PostImporterQueueEntity> findQueueEntriesByRouting(final int partitionId)
+      throws IOException {
+    return testSearchRepository.searchTerm(
+        postImporterQueueTemplate.getFullQualifiedName(),
+        "_routing",
+        String.valueOf(partitionId),
+        PostImporterQueueEntity.class,
+        10);
+  }
+
+  @NotNull
+  private Record<IncidentRecordValue> createdIncidentOnPartition(
+      final long key, final int partitionId, final long position) {
+    return createIncidentZeebeRecord(
+        b -> b.withIntent(CREATED).withKey(key).withPartitionId(partitionId).withPosition(position),
+        b -> b.withErrorType(ErrorType.UNKNOWN).withErrorMessage("boom"));
+  }
+
   @NotNull
   private IncidentEntity findIncidentByKey(final long key) throws IOException {
     final List<IncidentEntity> entities =
@@ -80,5 +141,16 @@ public class IncidentZeebeRecordProcessorIT extends OperateSearchAbstractIT {
     incidentZeebeRecordProcessor.processIncidentRecord(List.of(zeebeRecord), batchRequest);
     batchRequest.execute();
     searchContainerManager.refreshIndices(incidentTemplate.getFullQualifiedName());
+  }
+
+  private void importIncidentZeebeRecords(final List<Record<IncidentRecordValue>> zeebeRecords)
+      throws PersistenceException {
+    final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
+    for (final Record<IncidentRecordValue> zeebeRecord : zeebeRecords) {
+      incidentZeebeRecordProcessor.processIncidentRecord(zeebeRecord, batchRequest, incident -> {});
+    }
+    batchRequest.execute();
+    searchContainerManager.refreshIndices(incidentTemplate.getFullQualifiedName());
+    searchContainerManager.refreshIndices(postImporterQueueTemplate.getFullQualifiedName());
   }
 }


### PR DESCRIPTION
backports #56526 
relates to https://github.com/camunda/camunda/issues/56117