### PR TITLE
test: unskip retry and cancel multiple instances (bug #42448 fixed)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -197,9 +197,10 @@ test.describe('Operations', () => {
     });
   });
 
-  // Skipped due to bug 42448: https://github.com/camunda/camunda/issues/42448
-  // !Note: assert the code after the bug is fixed as it was dicoverd during the test implementation
-  test.skip('Retry and cancel multiple instances', async ({
+  // Regression coverage for bug 42448 (fixed by #48419): batch cancellation with
+  // an operationId filter no longer returns 400.
+  // https://github.com/camunda/camunda/issues/42448
+  test('Retry and cancel multiple instances', async ({
     operateProcessesPage,
     operateFiltersPanelPage,
     operateOperationPanelPage,


### PR DESCRIPTION
## Summary

Unskips the `Retry and cancel multiple instances` E2E test in `qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts`.

Bug [#42448](https://github.com/camunda/camunda/issues/42448) (batch cancellation of instances returning **400 Bad Request** when an operationId filter is applied) was **fixed by #48419** and no longer reproduces on 8.8 — see the [closing comment](https://github.com/camunda/camunda/issues/42448#issuecomment). The auto-unskip run that produced #55649 was opened on 2026-06-22, before #42448 was closed (2026-07-21), so this test was left skipped. This unskips it as regression coverage and refreshes the stale note.

This is the follow-up to #55649, which handled the other closed-bug tests in the same file.

## Test plan

- Batch retry + cancel over 5 instances; the test asserts the retry and cancel operation entries appear in the operations panel and all instances end canceled. Batch operations legitimately create operation entries (unlike a single-instance cancel, per #42375).
- Validated via the on-demand E2E workflow on this branch (link added below once triggered).