### PR TITLE
test: wait for completion toast to clear between sequential task completions

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-details.spec.ts
@@ -472,6 +472,13 @@ test.describe('task details page', () => {
     await taskDetailsPage.fillTextInput('Department', 'Rome');
     await taskDetailsPage.clickCompleteTaskButton();
     await expect(taskDetailsPage.taskCompletedBanner).toBeVisible();
+    // Wait for the completion toast to auto-dismiss before completing the
+    // second task. taskCompletedBanner is an unscoped getByText('Task
+    // completed') and the toasts stack, so a lingering first toast makes the
+    // second assertion match two elements (strict-mode violation).
+    await expect(taskDetailsPage.taskCompletedBanner).toBeHidden({
+      timeout: 15000,
+    });
 
     await taskPanelPage.filterBy('Unassigned');
     // The next task can take a moment to be indexed/rendered right after


### PR DESCRIPTION
## Description

Fixes the only failing test in the [8.8 orchestration-cluster nightly E2E run (Tasklist v2 mode)](https://github.com/camunda/camunda/actions/runs/29903836218):

`qa/c8-orchestration-cluster-e2e-test-suite` › `tests/tasklist/task-details.spec.ts` › **"variables are passed along the forms if no output variables are defined"**

### Root cause (from the run's json-report artifact)

The test completes two tasks back-to-back and asserts `taskCompletedBanner` after each. `taskCompletedBanner` is an **unscoped** `getByText('Task completed')` (`pages/TaskDetailsPage.ts`), and Tasklist's completion toasts stack. The first toast could still be on screen when the second appears, so the second assertion matched two elements:

- **attempt 0** → failed at line 474 (`toBeVisible` after 1st completion): toast not found within 10s
- **retry 1** → failed at line 496 (`toBeVisible` after 2nd completion): `strict mode violation: getByText('Task completed') resolved to 2 elements`

This is the only test in the suite that completes two tasks in a single test, which is why it is the only one affected. It was added recently in `69c630`.

### Fix

Gate the first completion by waiting for its toast to auto-dismiss before opening the next task, so only one "Task completed" toast exists at a time. This mirrors the existing `TaskDetailsPage.unassignReassignToMeAndComplete` pattern (visible → hidden). No assertion is weakened and no `.first()` shortcut is used (which could match a stale toast and pass spuriously).

### Validation

Reproduced locally against `camunda/camunda:8.8-SNAPSHOT` in Docker (Elasticsearch, Tasklist v2 mode), running only this spec on a fresh cluster:
Run: https://github.com/camunda/camunda/actions/runs/29906970526 
⚠️ will check aPI tests later
```
✓  tests/tasklist/task-details.spec.ts › task details page › variables are passed along the forms if no output variables are defined (13.3s)
1 passed
```

Test-only change; touches a single spec on `stable/8.8` (the test does not exist on other versions).