### PR TITLE
deps: bump camunda-security-library to 0.1.0-alpha56

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
@@ -93,6 +93,7 @@ final class PhysicalTenantOverridePolicyValidation {
               // camunda.security.* — identity-security settings that must apply uniformly
               "security.authentication.method",
               "security.authentication.unprotected-api",
+              "security.authentication.webapp-enabled",
               "security.csrf",
               "security.http-headers",
               // forward declaration — property lands with #54898

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -71,6 +71,7 @@ data.secondary-storage.rdbms.max-varchar-field-length
 license.key
 security.authentication.method
 security.authentication.unprotected-api
+security.authentication.webapp-enabled
 security.cluster-admin.basic.users
 security.cluster-admin.oidc.claims
 security.cluster-admin.oidc.clients

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha54</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha56</version.camunda-security-library>
     <version.checkstyle>13.8.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Summary
- Bumps `camunda-security-library` from `0.1.0-alpha53` to `0.1.0-alpha56` in `parent/pom.xml`.
- Picks up the fix in camunda/camunda-security-library#560, which restores the `{baseUrl}/sso-callback` default `redirect-uri` when it is unset — fixing an OIDC login regression for configs that relied on the implicit default (a regression against Orchestration Cluster 8.9).

## Test plan
- [x] `./mvnw license:format spotless:apply -pl parent`
- [x] `./mvnw install -pl parent -Dquickly` builds green with the new version