### PR TITLE
feat: long polling, physical tenant aware job available notifications

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/job/HttpJobHandlerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/job/HttpJobHandlerConfiguration.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.gateway.impl.configuration.LongPollingCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
 import io.camunda.zeebe.gateway.rest.controller.ResponseObserverProvider;
 import io.camunda.zeebe.scheduler.Actor;
@@ -96,8 +96,9 @@ public class HttpJobHandlerConfiguration {
                 GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(
                 GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(
-                new LongPollingMetrics(meterRegistry, LongPollingMetricsDoc.GatewayProtocol.REST))
+            .setMetricsFactory(
+                new LongPollingMetricsFactory(
+                    meterRegistry, LongPollingMetricsDoc.GatewayProtocol.REST))
             .build();
     // Register for purge notifications so pending long-poll requests are cancelled on cluster purge
     brokerClient

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClient.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClient.java
@@ -94,5 +94,13 @@ public interface BrokerClient extends AutoCloseable {
 
   BrokerTopologyManager getTopologyManager();
 
-  void subscribeJobAvailableNotification(String topic, Consumer<String> handler);
+  /**
+   * Subscribes to job-available notifications on the given topic.
+   *
+   * @param topic the topic to subscribe to
+   * @param subscriber identifies the caller; deduped per (topic, subscriber) pair using identity
+   *     equality, so pass {@code this}, not a {@code String}
+   * @param handler invoked with the topic's payload on each notification
+   */
+  void subscribeJobAvailableNotification(String topic, Object subscriber, Consumer<String> handler);
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ public final class BrokerClientImpl implements BrokerClient {
   private final BrokerRequestManager requestManager;
 
   private boolean isClosed;
-  private Subscription jobAvailableSubscription;
+  private final List<Subscription> jobAvailableSubscriptions = new CopyOnWriteArrayList<>();
   private final ClusterEventService eventService;
   private final ActorSchedulingService schedulingService;
   private final AtomixClientTransportAdapter atomixTransportAdapter;
@@ -82,9 +83,7 @@ public final class BrokerClientImpl implements BrokerClient {
     doAndLogException(atomixTransportAdapter::close);
     LOG.debug("transport client closed");
 
-    if (jobAvailableSubscription != null) {
-      jobAvailableSubscription.close();
-    }
+    jobAvailableSubscriptions.forEach(Subscription::close);
 
     LOG.debug("Gateway broker client closed.");
   }
@@ -139,7 +138,7 @@ public final class BrokerClientImpl implements BrokerClient {
   @Override
   public void subscribeJobAvailableNotification(
       final String topic, final Consumer<String> handler) {
-    jobAvailableSubscription =
+    final var subscription =
         eventService
             .subscribe(
                 topic,
@@ -148,6 +147,7 @@ public final class BrokerClientImpl implements BrokerClient {
                   return CompletableFuture.completedFuture(null);
                 })
             .join();
+    jobAvailableSubscriptions.add(subscription);
   }
 
   private void doAndLogException(final Runnable r) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -22,8 +22,9 @@ import io.camunda.zeebe.transport.impl.AtomixClientTransportAdapter;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,10 @@ public final class BrokerClientImpl implements BrokerClient {
   private final BrokerRequestManager requestManager;
 
   private boolean isClosed;
-  private final List<Subscription> jobAvailableSubscriptions = new CopyOnWriteArrayList<>();
+  // Keyed by topic so a repeated subscribe for the same topic is a no-op: ActivateJobsHandler#
+  // activateJobs can be called concurrently and lazily subscribes per physical tenant on every
+  // call, so the dedup here must be atomic (computeIfAbsent) rather than left to the caller.
+  private final Map<String, Subscription> jobAvailableSubscriptions = new ConcurrentHashMap<>();
   private final ClusterEventService eventService;
   private final ActorSchedulingService schedulingService;
   private final AtomixClientTransportAdapter atomixTransportAdapter;
@@ -83,7 +87,7 @@ public final class BrokerClientImpl implements BrokerClient {
     doAndLogException(atomixTransportAdapter::close);
     LOG.debug("transport client closed");
 
-    jobAvailableSubscriptions.forEach(Subscription::close);
+    jobAvailableSubscriptions.values().forEach(Subscription::close);
 
     LOG.debug("Gateway broker client closed.");
   }
@@ -138,16 +142,17 @@ public final class BrokerClientImpl implements BrokerClient {
   @Override
   public void subscribeJobAvailableNotification(
       final String topic, final Consumer<String> handler) {
-    final var subscription =
-        eventService
-            .subscribe(
-                topic,
-                msg -> {
-                  handler.accept((String) msg);
-                  return CompletableFuture.completedFuture(null);
-                })
-            .join();
-    jobAvailableSubscriptions.add(subscription);
+    jobAvailableSubscriptions.computeIfAbsent(
+        topic,
+        t ->
+            eventService
+                .subscribe(
+                    t,
+                    msg -> {
+                      handler.accept((String) msg);
+                      return CompletableFuture.completedFuture(null);
+                    })
+                .join());
   }
 
   private void doAndLogException(final Runnable r) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientImpl.java
@@ -36,10 +36,10 @@ public final class BrokerClientImpl implements BrokerClient {
   private final BrokerRequestManager requestManager;
 
   private boolean isClosed;
-  // Keyed by topic so a repeated subscribe for the same topic is a no-op: ActivateJobsHandler#
-  // activateJobs can be called concurrently and lazily subscribes per physical tenant on every
-  // call, so the dedup here must be atomic (computeIfAbsent) rather than left to the caller.
-  private final Map<String, Subscription> jobAvailableSubscriptions = new ConcurrentHashMap<>();
+  // Keyed by (topic, subscriber), not topic alone: topic-only would collapse distinct callers
+  // (e.g. gRPC and REST gateways) onto one subscription, dropping every subscriber but the first.
+  private final Map<TopicSubscriber, Subscription> jobAvailableSubscriptions =
+      new ConcurrentHashMap<>();
   private final ClusterEventService eventService;
   private final ActorSchedulingService schedulingService;
   private final AtomixClientTransportAdapter atomixTransportAdapter;
@@ -141,13 +141,13 @@ public final class BrokerClientImpl implements BrokerClient {
 
   @Override
   public void subscribeJobAvailableNotification(
-      final String topic, final Consumer<String> handler) {
+      final String topic, final Object subscriber, final Consumer<String> handler) {
     jobAvailableSubscriptions.computeIfAbsent(
-        topic,
-        t ->
+        new TopicSubscriber(topic, subscriber),
+        k ->
             eventService
                 .subscribe(
-                    t,
+                    topic,
                     msg -> {
                       handler.accept((String) msg);
                       return CompletableFuture.completedFuture(null);
@@ -162,4 +162,8 @@ public final class BrokerClientImpl implements BrokerClient {
       LOG.error("Exception when closing client. Ignoring", e);
     }
   }
+
+  // Relies on subscriber's default (identity-based) equals/hashCode; a caller-side override to
+  // content-based equality would silently collapse distinct subscribers again.
+  private record TopicSubscriber(String topic, Object subscriber) {}
 }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -400,6 +400,30 @@ public final class BrokerClientTest {
   }
 
   @Test
+  void shouldCloseAllJobAvailableSubscriptionsOnClose() {
+    // given
+    client.subscribeJobAvailableNotification("foo", ignored -> {});
+    client.subscribeJobAvailableNotification("bar", ignored -> {});
+    Awaitility.await("both subscriptions are registered")
+        .untilAsserted(
+            () -> {
+              assertThat(atomixCluster.getEventService().getSubscriptions("foo")).isNotEmpty();
+              assertThat(atomixCluster.getEventService().getSubscriptions("bar")).isNotEmpty();
+            });
+
+    // when
+    client.close();
+
+    // then — every subscription is closed, not just the most recently registered one
+    Awaitility.await("both subscriptions are unregistered")
+        .untilAsserted(
+            () -> {
+              assertThat(atomixCluster.getEventService().getSubscriptions("foo")).isEmpty();
+              assertThat(atomixCluster.getEventService().getSubscriptions("bar")).isEmpty();
+            });
+  }
+
+  @Test
   public void shouldThrowCorrectErrorForInactivePartitionAndNoLeaderRequest() {
     // given
     final var partitionId = 1;

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -400,6 +400,19 @@ public final class BrokerClientTest {
   }
 
   @Test
+  void shouldSubscribeToJobAvailableTopicOnlyOnceOnRepeatedCalls() {
+    // given — a repeated subscribe for the same topic, as happens when a physical-tenant-aware
+    // caller lazily (re-)subscribes on every request rather than tracking subscriptions itself
+    client.subscribeJobAvailableNotification("foo", ignored -> {});
+    client.subscribeJobAvailableNotification("foo", ignored -> {});
+
+    // then — only one subscription was registered with the event service, not two
+    Awaitility.await("subscription is registered")
+        .untilAsserted(
+            () -> assertThat(atomixCluster.getEventService().getSubscriptions("foo")).hasSize(1));
+  }
+
+  @Test
   void shouldCloseAllJobAvailableSubscriptionsOnClose() {
     // given
     client.subscribeJobAvailableNotification("foo", ignored -> {});

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -389,7 +389,7 @@ public final class BrokerClientTest {
   void shouldReceiveJobAvailableNotification() {
     // given
     final AtomicReference<String> messageRef = new AtomicReference<>();
-    client.subscribeJobAvailableNotification("foo", messageRef::set);
+    client.subscribeJobAvailableNotification("foo", new Object(), messageRef::set);
 
     // when
     atomixCluster.getEventService().broadcast("foo", "bar");
@@ -400,11 +400,13 @@ public final class BrokerClientTest {
   }
 
   @Test
-  void shouldSubscribeToJobAvailableTopicOnlyOnceOnRepeatedCalls() {
-    // given — a repeated subscribe for the same topic, as happens when a physical-tenant-aware
-    // caller lazily (re-)subscribes on every request rather than tracking subscriptions itself
-    client.subscribeJobAvailableNotification("foo", ignored -> {});
-    client.subscribeJobAvailableNotification("foo", ignored -> {});
+  void shouldSubscribeToJobAvailableTopicOnlyOnceOnRepeatedCallsFromSameSubscriber() {
+    // given — a repeated subscribe for the same topic from the same subscriber, as happens when a
+    // physical-tenant-aware caller lazily (re-)subscribes on every request rather than tracking
+    // subscriptions itself
+    final var subscriber = new Object();
+    client.subscribeJobAvailableNotification("foo", subscriber, ignored -> {});
+    client.subscribeJobAvailableNotification("foo", subscriber, ignored -> {});
 
     // then — only one subscription was registered with the event service, not two
     Awaitility.await("subscription is registered")
@@ -413,10 +415,32 @@ public final class BrokerClientTest {
   }
 
   @Test
+  void shouldSubscribeIndependentlyPerSubscriberForTheSameTopic() {
+    // given — two distinct callers (e.g. the gRPC and REST gateways) subscribing to the same
+    // topic; neither should silently drop the other's handler
+    final AtomicReference<String> firstMessage = new AtomicReference<>();
+    final AtomicReference<String> secondMessage = new AtomicReference<>();
+    client.subscribeJobAvailableNotification("foo", new Object(), firstMessage::set);
+    client.subscribeJobAvailableNotification("foo", new Object(), secondMessage::set);
+
+    // when
+    atomixCluster.getEventService().broadcast("foo", "bar");
+
+    // then — both subscribers were registered and both were notified
+    Awaitility.await("both subscriptions are registered")
+        .untilAsserted(
+            () -> assertThat(atomixCluster.getEventService().getSubscriptions("foo")).hasSize(2));
+    Awaitility.await("first subscriber received notification")
+        .untilAtomic(firstMessage, Matchers.equalTo("bar"));
+    Awaitility.await("second subscriber received notification")
+        .untilAtomic(secondMessage, Matchers.equalTo("bar"));
+  }
+
+  @Test
   void shouldCloseAllJobAvailableSubscriptionsOnClose() {
     // given
-    client.subscribeJobAvailableNotification("foo", ignored -> {});
-    client.subscribeJobAvailableNotification("bar", ignored -> {});
+    client.subscribeJobAvailableNotification("foo", new Object(), ignored -> {});
+    client.subscribeJobAvailableNotification("bar", new Object(), ignored -> {});
     Awaitility.await("both subscriptions are registered")
         .untilAsserted(
             () -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -150,7 +150,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                     final var jobStreamService =
                         new JobStreamService(
                             remoteStreamService,
-                            new RemoteJobStreamer(streamer, clusterServices.getEventService()),
+                            new RemoteJobStreamer(
+                                streamer, clusterServices.getEventService(), physicalTenantId),
                             errorHandlerService);
                     clusterServices.getMembershipService().addListener(remoteStreamService);
                     brokerStartupContext.addJobStreamService(physicalTenantId, jobStreamService);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.jobstream;
 
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -19,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class JobStreamMetrics implements RemoteStreamMetrics {
 
-  private static final String PHYSICAL_TENANT_ID_TAG = "physicalTenantId";
+  private static final String PHYSICAL_TENANT_ID_TAG = PartitionKeyNames.PHYSICAL_TENANT.asString();
   private final AtomicInteger streamCount = new AtomicInteger(0);
   private final Map<ErrorCode, Counter> pushTryFailedCount = new EnumMap<>(ErrorCode.class);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamer.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.jobstream;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
@@ -21,17 +23,32 @@ public final class RemoteJobStreamer implements JobStreamer {
 
   private final RemoteStreamer<JobActivationProperties, ActivatedJob> delegate;
   private final ClusterEventService eventService;
+  private final String physicalTenantId;
 
   public RemoteJobStreamer(
       final RemoteStreamer<JobActivationProperties, ActivatedJob> delegate,
-      final ClusterEventService eventService) {
+      final ClusterEventService eventService,
+      final String physicalTenantId) {
     this.delegate = delegate;
     this.eventService = eventService;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
   public void notifyWorkAvailable(final String jobType) {
-    eventService.broadcast(JOBS_AVAILABLE_TOPIC, jobType);
+    eventService.broadcast(topic(physicalTenantId), jobType);
+    legacyBroadcastIfDefaultTenant(jobType);
+  }
+
+  private static String topic(final String physicalTenantId) {
+    return physicalTenantId + "-" + JOBS_AVAILABLE_TOPIC;
+  }
+
+  /** Rolling-upgrade compat; remove alongside the legacy topic in 8.11. */
+  private void legacyBroadcastIfDefaultTenant(final String jobType) {
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      eventService.broadcast(JOBS_AVAILABLE_TOPIC, jobType);
+    }
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.jobstream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import io.atomix.cluster.messaging.ClusterEventService;
+import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
+import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
+import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
+import org.junit.jupiter.api.Test;
+
+final class RemoteJobStreamerTest {
+
+  private static final String JOB_TYPE = "foo";
+
+  private final ClusterEventService eventService = mock(ClusterEventService.class);
+  private final RemoteStreamer<JobActivationProperties, ActivatedJob> delegate =
+      mock(RemoteStreamer.class);
+
+  @Test
+  void shouldBroadcastOnlyOnTenantScopedTopicForNonDefaultTenant() {
+    // given
+    final var streamer = new RemoteJobStreamer(delegate, eventService, "tenanta");
+
+    // when
+    streamer.notifyWorkAvailable(JOB_TYPE);
+
+    // then
+    verify(eventService).broadcast(eq("tenanta-jobsAvailable"), eq(JOB_TYPE));
+    verify(eventService, never()).broadcast(eq("jobsAvailable"), any());
+  }
+
+  @Test
+  void shouldDualBroadcastOnLegacyAndScopedTopicForDefaultTenant() {
+    // given
+    final var streamer = new RemoteJobStreamer(delegate, eventService, "default");
+
+    // when
+    streamer.notifyWorkAvailable(JOB_TYPE);
+
+    // then
+    verify(eventService).broadcast(eq("default-jobsAvailable"), eq(JOB_TYPE));
+    verify(eventService).broadcast(eq("jobsAvailable"), eq(JOB_TYPE));
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -34,8 +34,8 @@ import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.InterceptorRepository;
 import io.camunda.zeebe.gateway.interceptors.impl.PhysicalTenantHandlerFactory;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.query.impl.QueryApiImpl;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
@@ -395,8 +395,9 @@ public final class Gateway implements CloseableSilently {
         .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
         .setResourceExhaustedExceptionProvider(RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
         .setRequestCanceledExceptionProvider(REQUEST_CANCELED_EXCEPTION_PROVIDER)
-        .setMetrics(
-            new LongPollingMetrics(meterRegistry, LongPollingMetricsDoc.GatewayProtocol.GRPC))
+        .setMetricsFactory(
+            new LongPollingMetricsFactory(
+                meterRegistry, LongPollingMetricsDoc.GatewayProtocol.GRPC))
         .build();
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.gateway.impl.stream.JobClientStreamMetricsDoc.PushResult
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -21,7 +22,7 @@ import java.util.Map;
 
 final class JobClientStreamMetrics implements ClientStreamMetrics {
 
-  private static final String PHYSICAL_TENANT_ID_TAG = "physicalTenantId";
+  private static final String PHYSICAL_TENANT_ID_TAG = PartitionKeyNames.PHYSICAL_TENANT.asString();
 
   private final Map<ErrorCode, Counter> pushAttempts = new EnumMap<>(ErrorCode.class);
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -28,7 +28,7 @@ import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationHandler.Oidc;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationMetrics;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
@@ -196,7 +196,7 @@ public final class StubbedGateway {
         .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
         .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
         .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-        .setMetrics(LongPollingMetrics.noop())
+        .setMetricsFactory(LongPollingMetricsFactory.noop())
         .build();
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPriorityTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPriorityTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.gateway.ResponseMapper;
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.scheduler.Actor;
@@ -53,7 +53,7 @@ final class LongPollingActivateJobsPriorityTest {
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
             .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitHandlerActor(handler);
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -44,7 +44,7 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestHandler;
 import io.camunda.zeebe.gateway.grpc.ServerStreamObserver;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -108,7 +108,7 @@ public final class LongPollingActivateJobsTest {
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
             .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(handler);
 
@@ -328,7 +328,7 @@ public final class LongPollingActivateJobsTest {
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
             .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(handler);
 
@@ -358,7 +358,7 @@ public final class LongPollingActivateJobsTest {
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
             .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(handler);
 
@@ -1033,7 +1033,7 @@ public final class LongPollingActivateJobsTest {
             .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
             .setResourceExhaustedExceptionProvider(Gateway.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(Gateway.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(customHandler);
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.job;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -1050,7 +1051,10 @@ public final class LongPollingActivateJobsTest {
 
     // probe fires: re-activates request against broker (2nd call: response pending)
     actorClock.addTime(Duration.ofMillis(probeTimeout + 1));
-    Awaitility.await().until(() -> customHandler.activeRequestsCountForJobType(TYPE) > 0);
+    Awaitility.await()
+        .until(
+            () ->
+                customHandler.activeRequestsCountForJobType(DEFAULT_PHYSICAL_TENANT_ID, TYPE) > 0);
 
     // when
     // long-poll timeout fires: request closes while broker call is still in-flight
@@ -1066,7 +1070,10 @@ public final class LongPollingActivateJobsTest {
 
     // then
     // request must be removed from activeRequests
-    Awaitility.await().until(() -> customHandler.activeRequestsCountForJobType(TYPE) == 0);
+    Awaitility.await()
+        .until(
+            () ->
+                customHandler.activeRequestsCountForJobType(DEFAULT_PHYSICAL_TENANT_ID, TYPE) == 0);
   }
 
   @Test
@@ -1077,7 +1084,8 @@ public final class LongPollingActivateJobsTest {
     // given
     activateJobsAndWaitUntilBlocked(FAILED_RESPONSE_THRESHOLD);
     actorClock.addTime(Duration.ofMillis(LONG_POLLING_TIMEOUT));
-    Awaitility.await().until(() -> handler.pendingRequestsCountForJobType(TYPE) == 0);
+    Awaitility.await()
+        .until(() -> handler.pendingRequestsCountForJobType(DEFAULT_PHYSICAL_TENANT_ID, TYPE) == 0);
 
     activateJobsStub.addAvailableJobs(TYPE, 1);
     final var newRequest = getLongPollingActivateJobsRequest();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -41,7 +41,7 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient.RequestHandler;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.ErrorCode;
@@ -114,7 +114,7 @@ public class LongPollingActivateJobsRestTest {
                 GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(
                 GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(handler);
 
@@ -361,7 +361,7 @@ public class LongPollingActivateJobsRestTest {
                 GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(
                 GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(handler);
 
@@ -393,7 +393,7 @@ public class LongPollingActivateJobsRestTest {
                 GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
             .setRequestCanceledExceptionProvider(
                 GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitActorToActivateJobs(handler);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -31,7 +31,7 @@ import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.config.PhysicalTenantRestConfigProvider;
@@ -425,7 +425,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
                   GatewayErrorMapper.RESOURCE_EXHAUSTED_EXCEPTION_PROVIDER)
               .setRequestCanceledExceptionProvider(
                   GatewayErrorMapper.REQUEST_CANCELED_EXCEPTION_PROVIDER)
-              .setMetrics(LongPollingMetrics.noop())
+              .setMetricsFactory(LongPollingMetricsFactory.noop())
               .build();
       final var future = new CompletableFuture<>();
       final var actor =

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -105,7 +105,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-cluster</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import java.time.Duration;
@@ -50,7 +51,8 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   private final long probeTimeoutMillis;
   private final int failedAttemptThreshold;
 
-  private final LongPollingMetrics metrics;
+  private final LongPollingMetricsFactory metricsFactory;
+  private final Map<String, LongPollingMetrics> metricsByPhysicalTenant = new ConcurrentHashMap<>();
 
   private ActorControl actor;
 
@@ -65,7 +67,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
       final Function<JobActivationResponse, JobActivationResult<T>> activationResultMapper,
       final Function<String, Exception> resourceExhaustedExceptionProvider,
       final Function<String, Throwable> requestCanceledExceptionProvider,
-      final LongPollingMetrics metrics) {
+      final LongPollingMetricsFactory metricsFactory) {
     this.brokerClient = brokerClient;
     activateJobsHandler =
         new RoundRobinActivateJobsHandler<>(
@@ -74,7 +76,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     this.longPollingTimeout = Duration.ofMillis(longPollingTimeout);
     this.probeTimeoutMillis = probeTimeoutMillis;
     this.failedAttemptThreshold = failedAttemptThreshold;
-    this.metrics = metrics;
+    this.metricsFactory = metricsFactory;
   }
 
   @Override
@@ -112,6 +114,12 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   /** The physicalTenantId-scoped topic name, used for every physical tenant, including default. */
   private static String topic(final String physicalTenantId) {
     return physicalTenantId + "-" + JOBS_AVAILABLE_TOPIC;
+  }
+
+  /** Returns the {@link LongPollingMetrics} tagged for the given physical tenant. */
+  private LongPollingMetrics metricsFor(final String physicalTenantId) {
+    return metricsByPhysicalTenant.computeIfAbsent(
+        physicalTenantId, metricsFactory::forPhysicalTenant);
   }
 
   /**
@@ -210,7 +218,10 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
           subscribeIfNeeded(physicalTenantId);
           final InFlightLongPollingActivateJobsRequestsState<T> state =
               jobTypeState.computeIfAbsent(
-                  key, k -> new InFlightLongPollingActivateJobsRequestsState<>(jobType, metrics));
+                  key,
+                  k ->
+                      new InFlightLongPollingActivateJobsRequestsState<>(
+                          jobType, metricsFor(physicalTenantId)));
 
           tryToActivateJobsOnAllPartitions(state, longPollingRequest);
         });
@@ -310,10 +321,13 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
       return;
     }
 
+    final var key = keyOf(request);
     final var state =
         jobTypeState.computeIfAbsent(
-            keyOf(request),
-            k -> new InFlightLongPollingActivateJobsRequestsState<>(request.getType(), metrics));
+            key,
+            k ->
+                new InFlightLongPollingActivateJobsRequestsState<>(
+                    request.getType(), metricsFor(key.physicalTenantId())));
 
     if (!request.hasScheduledTimer()) {
       scheduleLongPollingTimeout(state, request);
@@ -335,12 +349,13 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
             return;
           }
 
+          final var key = keyOf(request);
           final InFlightLongPollingActivateJobsRequestsState<T> state =
               jobTypeState.computeIfAbsent(
-                  keyOf(request),
+                  key,
                   k ->
                       new InFlightLongPollingActivateJobsRequestsState<>(
-                          request.getType(), metrics));
+                          request.getType(), metricsFor(key.physicalTenantId())));
 
           if (state.shouldAttempt(failedAttemptThreshold)) {
             tryToActivateJobsOnAllPartitions(state, request);
@@ -475,7 +490,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     private Function<JobActivationResponse, JobActivationResult<T>> activationResultMapper;
     private Function<String, Exception> resourceExhaustedExceptionProvider;
     private Function<String, Throwable> requestCanceledExceptionProvider;
-    private LongPollingMetrics metrics;
+    private LongPollingMetricsFactory metricsFactory;
 
     public Builder<T> setBrokerClient(final BrokerClient brokerClient) {
       this.brokerClient = brokerClient;
@@ -520,8 +535,8 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
       return this;
     }
 
-    public Builder<T> setMetrics(final LongPollingMetrics metrics) {
-      this.metrics = metrics;
+    public Builder<T> setMetricsFactory(final LongPollingMetricsFactory metricsFactory) {
+      this.metricsFactory = metricsFactory;
       return this;
     }
 
@@ -536,7 +551,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
           activationResultMapper,
           resourceExhaustedExceptionProvider,
           requestCanceledExceptionProvider,
-          metrics);
+          metricsFactory);
     }
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.scheduler.ScheduledTimer;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -47,7 +46,6 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
 
   private final Map<JobTypeKey, InFlightLongPollingActivateJobsRequestsState<T>> jobTypeState =
       new ConcurrentHashMap<>();
-  private final Set<String> subscribedPhysicalTenants = ConcurrentHashMap.newKeySet();
   private final Duration longPollingTimeout;
   private final long probeTimeoutMillis;
   private final int failedAttemptThreshold;
@@ -95,15 +93,14 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   }
 
   /**
-   * Subscribes to the job-available notifications of a physical tenant the first time it is seen,
-   * so a notification only wakes long-poll requests of its own tenant. The default tenant also
-   * listens on the legacy, prefix-less topic for rolling-upgrade compat with 8.9 brokers; remove
-   * alongside the legacy topic in 8.11.
+   * Subscribes to the job-available notifications of a physical tenant, so a notification only
+   * wakes long-poll requests of its own tenant. Safe to call on every request for a tenant: {@link
+   * BrokerClient#subscribeJobAvailableNotification} dedups by topic, so a repeat call for an
+   * already-subscribed tenant is a no-op. The default tenant also listens on the legacy,
+   * prefix-less topic for rolling-upgrade compat with 8.9 brokers; remove alongside the legacy
+   * topic in 8.11.
    */
   private void subscribeIfNeeded(final String physicalTenantId) {
-    if (!subscribedPhysicalTenants.add(physicalTenantId)) {
-      return;
-    }
     brokerClient.subscribeJobAvailableNotification(
         topic(physicalTenantId), jobType -> onJobAvailableNotification(physicalTenantId, jobType));
     if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.impl.job;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_LONG_POLLING_EMPTY_RESPONSE_THRESHOLD;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_LONG_POLLING_TIMEOUT;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PROBE_TIMEOUT;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.scheduler.ScheduledTimer;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -43,8 +45,9 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   private final RoundRobinActivateJobsHandler<T> activateJobsHandler;
   private final BrokerClient brokerClient;
 
-  private final Map<String, InFlightLongPollingActivateJobsRequestsState<T>> jobTypeState =
+  private final Map<JobTypeKey, InFlightLongPollingActivateJobsRequestsState<T>> jobTypeState =
       new ConcurrentHashMap<>();
+  private final Set<String> subscribedPhysicalTenants = ConcurrentHashMap.newKeySet();
   private final Duration longPollingTimeout;
   private final long probeTimeoutMillis;
   private final int failedAttemptThreshold;
@@ -86,10 +89,32 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   void onActorStarted() {
     actor.run(
         () -> {
-          brokerClient.subscribeJobAvailableNotification(
-              JOBS_AVAILABLE_TOPIC, this::onJobAvailableNotification);
+          subscribeIfNeeded(DEFAULT_PHYSICAL_TENANT_ID);
           actor.runAtFixedRate(Duration.ofMillis(probeTimeoutMillis), this::probe);
         });
+  }
+
+  /**
+   * Subscribes to the job-available notifications of a physical tenant the first time it is seen,
+   * so a notification only wakes long-poll requests of its own tenant. The default tenant also
+   * listens on the legacy, prefix-less topic for rolling-upgrade compat with 8.9 brokers; remove
+   * alongside the legacy topic in 8.11.
+   */
+  private void subscribeIfNeeded(final String physicalTenantId) {
+    if (!subscribedPhysicalTenants.add(physicalTenantId)) {
+      return;
+    }
+    brokerClient.subscribeJobAvailableNotification(
+        topic(physicalTenantId), jobType -> onJobAvailableNotification(physicalTenantId, jobType));
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
+      brokerClient.subscribeJobAvailableNotification(
+          JOBS_AVAILABLE_TOPIC, jobType -> onJobAvailableNotification(physicalTenantId, jobType));
+    }
+  }
+
+  /** The physicalTenantId-scoped topic name, used for every physical tenant, including default. */
+  private static String topic(final String physicalTenantId) {
+    return physicalTenantId + "-" + JOBS_AVAILABLE_TOPIC;
   }
 
   /**
@@ -173,34 +198,36 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
             responseObserver,
             requestTimeout);
     final String jobType = longPollingRequest.getType();
+    final String physicalTenantId = request.getPartitionGroup();
+    final var key = new JobTypeKey(physicalTenantId, jobType);
     // Eagerly removing the request on cancellation may free up some resources
     // We are not allowed to change the responseObserver after we completed this call
     // this means we can't do it async in the following actor call.
-    setCancelHandler.accept(() -> onRequestCancel(jobType, longPollingRequest));
+    setCancelHandler.accept(() -> onRequestCancel(key, longPollingRequest));
     actor.run(
         () -> {
           if (!longPollingRequest.isOpen()) {
             return;
           }
 
+          subscribeIfNeeded(physicalTenantId);
           final InFlightLongPollingActivateJobsRequestsState<T> state =
               jobTypeState.computeIfAbsent(
-                  jobType,
-                  type -> new InFlightLongPollingActivateJobsRequestsState<>(type, metrics));
+                  key, k -> new InFlightLongPollingActivateJobsRequestsState<>(jobType, metrics));
 
           tryToActivateJobsOnAllPartitions(state, longPollingRequest);
         });
   }
 
   private void onRequestCancel(
-      final String type, final InflightActivateJobsRequest<T> longPollingRequest) {
+      final JobTypeKey key, final InflightActivateJobsRequest<T> longPollingRequest) {
     actor.run(
         () -> {
-          final var state = jobTypeState.get(type);
+          final var state = jobTypeState.get(key);
           if (state != null) {
             state.removeRequest(longPollingRequest);
             state.removeActiveRequest(longPollingRequest);
-            tryCleanupJobTypeState(type);
+            tryCleanupJobTypeState(key);
           }
         });
   }
@@ -235,7 +262,7 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
                     request.complete();
                     state.removeActiveRequest(request);
                     state.resetFailedAttempts();
-                    handlePendingRequests(state, request.getType());
+                    handlePendingRequests(state, keyOf(request));
                   });
             }
           });
@@ -288,8 +315,8 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
 
     final var state =
         jobTypeState.computeIfAbsent(
-            request.getType(),
-            type1 -> new InFlightLongPollingActivateJobsRequestsState<>(type1, metrics));
+            keyOf(request),
+            k -> new InFlightLongPollingActivateJobsRequestsState<>(request.getType(), metrics));
 
     if (!request.hasScheduledTimer()) {
       scheduleLongPollingTimeout(state, request);
@@ -311,11 +338,12 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
             return;
           }
 
-          final String jobType = request.getType();
           final InFlightLongPollingActivateJobsRequestsState<T> state =
               jobTypeState.computeIfAbsent(
-                  jobType,
-                  type -> new InFlightLongPollingActivateJobsRequestsState<>(type, metrics));
+                  keyOf(request),
+                  k ->
+                      new InFlightLongPollingActivateJobsRequestsState<>(
+                          request.getType(), metrics));
 
           if (state.shouldAttempt(failedAttemptThreshold)) {
             tryToActivateJobsOnAllPartitions(state, request);
@@ -325,31 +353,35 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
         });
   }
 
-  private void onJobAvailableNotification(final String jobType) {
-    LOG.trace("Received jobs available notification for type {}.", jobType);
+  private void onJobAvailableNotification(final String physicalTenantId, final String jobType) {
+    LOG.trace(
+        "Received jobs available notification for type {} of physical tenant {}.",
+        jobType,
+        physicalTenantId);
 
+    final var key = new JobTypeKey(physicalTenantId, jobType);
     // instead of calling #getJobTypeState(), do only a
     // get to avoid the creation of a state instance.
-    final var state = jobTypeState.get(jobType);
+    final var state = jobTypeState.get(key);
 
     if (state != null) {
       LOG.trace("Handle jobs available notification for type {}.", jobType);
       actor.run(
           () -> {
             state.resetFailedAttempts();
-            handlePendingRequests(state, jobType);
+            handlePendingRequests(state, key);
           });
     }
   }
 
   private void handlePendingRequests(
-      final InFlightLongPollingActivateJobsRequestsState<T> state, final String jobType) {
+      final InFlightLongPollingActivateJobsRequestsState<T> state, final JobTypeKey key) {
     final var nextPending = getNextOpenPendingRequest(state);
     if (nextPending != null) {
       LOG.trace("Unblocking ActivateJobsRequest {}", nextPending.getRequest());
       internalActivateJobsRetry(nextPending);
     } else if (!state.hasActiveRequests()) {
-      jobTypeState.remove(jobType);
+      jobTypeState.remove(key);
     }
   }
 
@@ -376,14 +408,18 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
             () -> {
               request.timeout();
               state.removeRequest(request);
-              tryCleanupJobTypeState(request.getType());
+              tryCleanupJobTypeState(keyOf(request));
             });
     request.setScheduledTimer(timeout);
   }
 
-  private void tryCleanupJobTypeState(final String jobType) {
+  private void tryCleanupJobTypeState(final JobTypeKey key) {
     jobTypeState.computeIfPresent(
-        jobType, (k, s) -> s.hasActiveRequests() || s.hasPendingRequests() ? s : null);
+        key, (k, s) -> s.hasActiveRequests() || s.hasPendingRequests() ? s : null);
+  }
+
+  private static JobTypeKey keyOf(final InflightActivateJobsRequest<?> request) {
+    return new JobTypeKey(request.getRequest().getPartitionGroup(), request.getType());
   }
 
   private void probe() {
@@ -415,19 +451,21 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
     return null;
   }
 
-  int activeRequestsCountForJobType(final String jobType) {
-    final var state = jobTypeState.get(jobType);
+  int activeRequestsCountForJobType(final String physicalTenantId, final String jobType) {
+    final var state = jobTypeState.get(new JobTypeKey(physicalTenantId, jobType));
     return state == null ? 0 : state.activeRequestsCount();
   }
 
-  int pendingRequestsCountForJobType(final String jobType) {
-    final var state = jobTypeState.get(jobType);
+  int pendingRequestsCountForJobType(final String physicalTenantId, final String jobType) {
+    final var state = jobTypeState.get(new JobTypeKey(physicalTenantId, jobType));
     return state == null ? 0 : state.pendingRequestsCount();
   }
 
   public static <T> Builder<T> newBuilder() {
     return new Builder<>();
   }
+
+  private record JobTypeKey(String physicalTenantId, String jobType) {}
 
   public static class Builder<T> {
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -95,19 +95,21 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
   }
 
   /**
-   * Subscribes to the job-available notifications of a physical tenant, so a notification only
-   * wakes long-poll requests of its own tenant. Safe to call on every request for a tenant: {@link
-   * BrokerClient#subscribeJobAvailableNotification} dedups by topic, so a repeat call for an
-   * already-subscribed tenant is a no-op. The default tenant also listens on the legacy,
-   * prefix-less topic for rolling-upgrade compat with 8.9 brokers; remove alongside the legacy
-   * topic in 8.11.
+   * Safe to call on every request: {@link BrokerClient#subscribeJobAvailableNotification} dedups by
+   * (topic, subscriber), using {@code this} as the subscriber. The default tenant also listens on
+   * the legacy, prefix-less topic for rolling-upgrade compat with 8.9 brokers; remove alongside the
+   * legacy topic in 8.11.
    */
   private void subscribeIfNeeded(final String physicalTenantId) {
     brokerClient.subscribeJobAvailableNotification(
-        topic(physicalTenantId), jobType -> onJobAvailableNotification(physicalTenantId, jobType));
+        topic(physicalTenantId),
+        this,
+        jobType -> onJobAvailableNotification(physicalTenantId, jobType));
     if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       brokerClient.subscribeJobAvailableNotification(
-          JOBS_AVAILABLE_TOPIC, jobType -> onJobAvailableNotification(physicalTenantId, jobType));
+          JOBS_AVAILABLE_TOPIC,
+          this,
+          jobType -> onJobAvailableNotification(physicalTenantId, jobType));
     }
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetrics.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetrics.java
@@ -15,17 +15,29 @@ import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.GatewayProtocol;
 import io.camunda.zeebe.util.micrometer.BoundedMeterCache;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Objects;
 
-/** Metrics to monitor the health of the long polling requests per protocol. */
+/**
+ * Records the number of long polling requests blocked per job type, for one physical tenant. Every
+ * instance is tagged with its physical tenant; use {@link LongPollingMetricsFactory} to obtain one
+ * rather than constructing it directly.
+ */
 public sealed class LongPollingMetrics {
 
   private final BoundedMeterCache<StatefulGauge> requestsQueued;
 
-  public LongPollingMetrics(final MeterRegistry registry, final GatewayProtocol gatewayProtocol) {
+  LongPollingMetrics(
+      final MeterRegistry registry,
+      final GatewayProtocol gatewayProtocol,
+      final String physicalTenantId) {
     final var provider =
         StatefulGauge.builder(REQUESTS_QUEUED_CURRENT.getName())
             .description(REQUESTS_QUEUED_CURRENT.getDescription())
             .tag(GatewayKeyNames.GATEWAY_PROTOCOL.asString(), gatewayProtocol.value())
+            .tag(
+                GatewayKeyNames.PHYSICAL_TENANT_ID.asString(),
+                Objects.requireNonNull(
+                    physicalTenantId, GatewayKeyNames.PHYSICAL_TENANT_ID.asString()))
             .withRegistry(registry);
 
     requestsQueued = BoundedMeterCache.of(registry, provider, TYPE);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetrics.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetrics.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.RequestsQue
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.GatewayKeyNames;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.GatewayProtocol;
 import io.camunda.zeebe.util.micrometer.BoundedMeterCache;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
@@ -35,9 +36,9 @@ public sealed class LongPollingMetrics {
             .description(REQUESTS_QUEUED_CURRENT.getDescription())
             .tag(GatewayKeyNames.GATEWAY_PROTOCOL.asString(), gatewayProtocol.value())
             .tag(
-                GatewayKeyNames.PHYSICAL_TENANT_ID.asString(),
+                PartitionKeyNames.PHYSICAL_TENANT.asString(),
                 Objects.requireNonNull(
-                    physicalTenantId, GatewayKeyNames.PHYSICAL_TENANT_ID.asString()))
+                    physicalTenantId, PartitionKeyNames.PHYSICAL_TENANT.asString()))
             .withRegistry(registry);
 
     requestsQueued = BoundedMeterCache.of(registry, provider, TYPE);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsDoc.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsDoc.java
@@ -60,6 +60,13 @@ public enum LongPollingMetricsDoc implements ExtendedMeterDocumentation {
       public String asString() {
         return "protocol";
       }
+    },
+    /** The physical tenant the blocked request belongs to */
+    PHYSICAL_TENANT_ID {
+      @Override
+      public String asString() {
+        return "physicalTenantId";
+      }
     }
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsDoc.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsDoc.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
@@ -37,7 +38,7 @@ public enum LongPollingMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getAdditionalKeyNames() {
-      return GatewayKeyNames.values();
+      return KeyName.merge(GatewayKeyNames.values(), PartitionKeyNames.values());
     }
   };
 
@@ -59,13 +60,6 @@ public enum LongPollingMetricsDoc implements ExtendedMeterDocumentation {
       @Override
       public String asString() {
         return "protocol";
-      }
-    },
-    /** The physical tenant the blocked request belongs to */
-    PHYSICAL_TENANT_ID {
-      @Override
-      public String asString() {
-        return "physicalTenantId";
       }
     }
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsFactory.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.metrics;
+
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.GatewayProtocol;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Builds {@link LongPollingMetrics} instances for a given gateway protocol, one per physical
+ * tenant. Created once at gateway startup, before any physical tenant is known; records no metrics
+ * itself.
+ */
+public sealed class LongPollingMetricsFactory {
+
+  private final MeterRegistry registry;
+  private final GatewayProtocol gatewayProtocol;
+
+  public LongPollingMetricsFactory(
+      final MeterRegistry registry, final GatewayProtocol gatewayProtocol) {
+    this.registry = registry;
+    this.gatewayProtocol = gatewayProtocol;
+  }
+
+  /** Returns a factory whose instances do nothing. Mostly useful for testing. */
+  public static LongPollingMetricsFactory noop() {
+    return new Noop();
+  }
+
+  /** Returns a {@link LongPollingMetrics} instance tagged for the given physical tenant. */
+  public LongPollingMetrics forPhysicalTenant(final String physicalTenantId) {
+    return new LongPollingMetrics(registry, gatewayProtocol, physicalTenantId);
+  }
+
+  private static final class Noop extends LongPollingMetricsFactory {
+
+    private Noop() {
+      super(null, null);
+    }
+
+    @Override
+    public LongPollingMetrics forPhysicalTenant(final String physicalTenantId) {
+      return LongPollingMetrics.noop();
+    }
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -31,7 +31,6 @@ public final class StubbedBrokerClient implements BrokerClient {
 
   final BrokerTopologyManager topologyManager = new StubbedTopologyManager();
   private final Map<String, Consumer<String>> jobsAvailableHandlers = new HashMap<>();
-  private final List<String> jobAvailableSubscriptionTopics = new ArrayList<>();
 
   private final Map<Class<?>, RequestHandler<?, ?>> requestHandlers = new HashMap<>();
 
@@ -117,13 +116,7 @@ public final class StubbedBrokerClient implements BrokerClient {
   @Override
   public void subscribeJobAvailableNotification(
       final String topic, final Consumer<String> handler) {
-    jobAvailableSubscriptionTopics.add(topic);
     jobsAvailableHandlers.put(topic, handler);
-  }
-
-  /** Every topic passed to {@link #subscribeJobAvailableNotification}, including duplicates. */
-  public List<String> getJobAvailableSubscriptionTopics() {
-    return jobAvailableSubscriptionTopics;
   }
 
   public <RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -30,7 +30,8 @@ import java.util.function.Consumer;
 public final class StubbedBrokerClient implements BrokerClient {
 
   final BrokerTopologyManager topologyManager = new StubbedTopologyManager();
-  private Consumer<String> jobsAvailableHandler;
+  private final Map<String, Consumer<String>> jobsAvailableHandlers = new HashMap<>();
+  private final List<String> jobAvailableSubscriptionTopics = new ArrayList<>();
 
   private final Map<Class<?>, RequestHandler<?, ?>> requestHandlers = new HashMap<>();
 
@@ -116,7 +117,13 @@ public final class StubbedBrokerClient implements BrokerClient {
   @Override
   public void subscribeJobAvailableNotification(
       final String topic, final Consumer<String> handler) {
-    jobsAvailableHandler = handler;
+    jobAvailableSubscriptionTopics.add(topic);
+    jobsAvailableHandlers.put(topic, handler);
+  }
+
+  /** Every topic passed to {@link #subscribeJobAvailableNotification}, including duplicates. */
+  public List<String> getJobAvailableSubscriptionTopics() {
+    return jobAvailableSubscriptionTopics;
   }
 
   public <RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>
@@ -125,8 +132,16 @@ public final class StubbedBrokerClient implements BrokerClient {
     requestHandlers.put(requestType, requestHandler);
   }
 
+  /** Notifies on the legacy, prefix-less topic, as if raised by the default physical tenant. */
   public void notifyJobsAvailable(final String type) {
-    jobsAvailableHandler.accept(type);
+    notifyJobsAvailable("jobsAvailable", type);
+  }
+
+  public void notifyJobsAvailable(final String topic, final String type) {
+    final var handler = jobsAvailableHandlers.get(topic);
+    if (handler != null) {
+      handler.accept(type);
+    }
   }
 
   public <T extends BrokerRequest<?>> T getSingleBrokerRequest() {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedBrokerClient.java
@@ -115,7 +115,7 @@ public final class StubbedBrokerClient implements BrokerClient {
 
   @Override
   public void subscribeJobAvailableNotification(
-      final String topic, final Consumer<String> handler) {
+      final String topic, final Object subscriber, final Consumer<String> handler) {
     jobsAvailableHandlers.put(topic, handler);
   }
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/RequestRetryHandlerTest.java
@@ -313,7 +313,7 @@ final class RequestRetryHandlerTest {
 
     @Override
     public void subscribeJobAvailableNotification(
-        final String topic, final Consumer<String> handler) {}
+        final String topic, final Object subscriber, final Consumer<String> handler) {}
   }
 
   private static class TestBrokerRequest extends BrokerExecuteCommand<String> {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandlerMetricsTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandlerMetricsTest.java
@@ -7,42 +7,44 @@
  */
 package io.camunda.zeebe.gateway.impl.job;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.GatewayProtocol;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.util.unit.DataSize;
 
-final class LongPollingActivateJobsHandlerPurgeTest {
+/**
+ * Covers the full wiring from {@link LongPollingActivateJobsHandler} through {@link
+ * io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory} down to the actual metrics registry —
+ * not just the individual metrics classes in isolation.
+ */
+final class LongPollingActivateJobsHandlerMetricsTest {
 
   private static final String TYPE = "testJob";
   private static final long LONG_POLLING_TIMEOUT = 5000;
   private static final long PROBE_TIMEOUT = 20000;
-  // threshold of 3: after 3 failed attempts the next request goes pending immediately
   private static final int FAILED_RESPONSE_THRESHOLD = 3;
   private static final int MAX_JOBS_TO_ACTIVATE = 2;
   private static final long MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4).toBytes();
+  private static final String GAUGE_NAME = "zeebe.long.polling.queued.current";
 
   @RegisterExtension
   final ControlledActorSchedulerExtension actorScheduler = new ControlledActorSchedulerExtension();
 
   private final StubbedBrokerClient brokerClient = new StubbedBrokerClient();
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private LongPollingActivateJobsHandler<Object> handler;
   private ActivateJobsStub activateJobsStub;
 
@@ -60,11 +62,11 @@ final class LongPollingActivateJobsHandlerPurgeTest {
                     new JobActivationResult<>() {
                       @Override
                       public int getJobsCount() {
-                        return 0;
+                        return response.brokerResponse().getJobKeys().size();
                       }
 
                       @Override
-                      public List<ActivatedJob> getJobs() {
+                      public List<JobActivationResult.ActivatedJob> getJobs() {
                         return Collections.emptyList();
                       }
 
@@ -74,83 +76,71 @@ final class LongPollingActivateJobsHandlerPurgeTest {
                       }
 
                       @Override
-                      public List<ActivatedJob> getJobsToDefer() {
+                      public List<JobActivationResult.ActivatedJob> getJobsToDefer() {
                         return Collections.emptyList();
                       }
                     })
             .setResourceExhaustedExceptionProvider(RuntimeException::new)
             .setRequestCanceledExceptionProvider(RuntimeException::new)
-            .setMetricsFactory(LongPollingMetricsFactory.noop())
+            .setMetricsFactory(new LongPollingMetricsFactory(meterRegistry, GatewayProtocol.GRPC))
             .build();
+    submitHandlerActor(handler);
 
     activateJobsStub = new ActivateJobsStub();
     activateJobsStub.registerWith(brokerClient);
-    // no jobs available — all activate attempts return empty responses
     activateJobsStub.addAvailableJobs(TYPE, 0);
   }
 
   @Test
-  void shouldBeNoOpWhenActorNotStarted() {
-    // handler.actor is null because we never submitted it to the scheduler
-    assertThatCode(handler::onClusterIncarnationChanged).doesNotThrowAnyException();
+  void shouldTagBlockedRequestsGaugePerPhysicalTenantIndependently() {
+    // given — a different number of pending requests per tenant, for the same job type
+    submitPendingRequest("tenanta");
+    submitPendingRequest("tenanta");
+    submitPendingRequest("tenantb");
+
+    // then — each tenant has its own gauge, correctly tagged, with its own count.
+    // Different counts prove the tenants aren't sharing a counter under the hood.
+    assertThat(blockedRequestsGauge("tenanta")).isEqualTo(2);
+    assertThat(blockedRequestsGauge("tenantb")).isEqualTo(1);
   }
 
   @Test
-  void shouldFailPendingRequestsOnPurge() throws Exception {
-    // Start the handler actor
-    submitHandlerActor(handler);
+  void shouldDropBlockedRequestsGaugeBackToZeroOnceUnblocked() {
+    // given
+    submitPendingRequest("tenanta");
+    assertThat(blockedRequestsGauge("tenanta")).isEqualTo(1);
 
-    // Build a request and put it in pending state.
-    // We exhaust the failure threshold first so the next internalActivateJobsRetry
-    // enqueues the request as pending rather than trying the broker again.
-    final var errorRef = new AtomicReference<Throwable>();
-    final InflightActivateJobsRequest<Object> pendingRequest = buildRequest(errorRef);
-
-    // Exhaust the threshold via internalActivateJobsRetry calls
-    // (each call triggers tryToActivateJobsOnAllPartitions which returns 0 jobs and
-    //  increments the failed attempt counter)
-    for (int i = 0; i < FAILED_RESPONSE_THRESHOLD; i++) {
-      handler.internalActivateJobsRetry(pendingRequest);
-      actorScheduler.workUntilDone();
-    }
-
-    // After threshold is reached the next retry marks the request as pending
-    handler.internalActivateJobsRetry(pendingRequest);
+    // when — a job becomes available and the pending request is unblocked
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    brokerClient.notifyJobsAvailable("tenanta-jobsAvailable", TYPE);
     actorScheduler.workUntilDone();
 
-    // Trigger purge
-    handler.onClusterIncarnationChanged();
-    actorScheduler.workUntilDone();
-
-    // The response observer should have received an error mentioning "purge"
-    assertThat(errorRef.get()).isNotNull();
-    assertThat(errorRef.get().getMessage()).containsIgnoringCase("purge");
+    // then
+    assertThat(blockedRequestsGauge("tenanta")).isEqualTo(0);
   }
 
   // -- helpers --
 
-  private void submitHandlerActor(final LongPollingActivateJobsHandler<Object> handlerToSubmit) {
-    final var ready = new CompletableFuture<Void>();
-    final var actor =
-        Actor.newActor()
-            .name("TestHandler")
-            .actorStartedHandler(handlerToSubmit.andThen(ignored -> ready.complete(null)))
-            .build();
-    actorScheduler.submitActor(actor);
-    actorScheduler.workUntilDone();
-    ready.join();
+  private Double blockedRequestsGauge(final String physicalTenantId) {
+    final var gauge =
+        meterRegistry
+            .find(GAUGE_NAME)
+            .tag("physicalTenantId", physicalTenantId)
+            .tag("type", TYPE)
+            .gauge();
+    assertThat(gauge).describedAs("gauge for tenant %s", physicalTenantId).isNotNull();
+    return gauge.value();
   }
 
-  private InflightActivateJobsRequest<Object> buildRequest(
-      final AtomicReference<Throwable> errorRef) {
-    final var brokerRequest = mock(BrokerActivateJobsRequest.class);
-    final var requestWriter = new JobBatchRecord();
-    requestWriter.setType(TYPE);
-    requestWriter.setWorker("test-worker");
-    requestWriter.setMaxJobsToActivate(MAX_JOBS_TO_ACTIVATE);
-    when(brokerRequest.getRequestWriter()).thenReturn(requestWriter);
-    when(brokerRequest.getPartitionId()).thenReturn(1);
-    when(brokerRequest.getPartitionGroup()).thenReturn(DEFAULT_PHYSICAL_TENANT_ID);
+  private void submitPendingRequest(final String physicalTenantId) {
+    final var brokerRequest =
+        new BrokerActivateJobsRequest(TYPE)
+            .setMaxJobsToActivate(MAX_JOBS_TO_ACTIVATE)
+            .setTimeout(LONG_POLLING_TIMEOUT)
+            .setTenantIds(Collections.emptyList())
+            .setVariables(Collections.emptyList())
+            .setWorker("test-worker");
+    brokerRequest.setPartitionGroup(physicalTenantId);
 
     final ResponseObserver<Object> observer =
         new ResponseObserver<>() {
@@ -166,11 +156,22 @@ final class LongPollingActivateJobsHandlerPurgeTest {
           }
 
           @Override
-          public void onError(final Throwable throwable) {
-            errorRef.set(throwable);
-          }
+          public void onError(final Throwable throwable) {}
         };
 
-    return new InflightActivateJobsRequest<>(1L, brokerRequest, observer, LONG_POLLING_TIMEOUT);
+    handler.activateJobs(brokerRequest, observer, cancelHandler -> {}, LONG_POLLING_TIMEOUT);
+    actorScheduler.workUntilDone();
+  }
+
+  private void submitHandlerActor(final LongPollingActivateJobsHandler<Object> handlerToSubmit) {
+    final var ready = new CompletableFuture<Void>();
+    final var actor =
+        Actor.newActor()
+            .name("TestHandler")
+            .actorStartedHandler(handlerToSubmit.andThen(ignored -> ready.complete(null)))
+            .build();
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
+    ready.join();
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandlerMetricsTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandlerMetricsTest.java
@@ -125,7 +125,7 @@ final class LongPollingActivateJobsHandlerMetricsTest {
     final var gauge =
         meterRegistry
             .find(GAUGE_NAME)
-            .tag("physicalTenantId", physicalTenantId)
+            .tag("physicalTenant", physicalTenantId)
             .tag("type", TYPE)
             .gauge();
     assertThat(gauge).describedAs("gauge for tenant %s", physicalTenantId).isNotNull();

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPhysicalTenantTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPhysicalTenantTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
-import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsFactory;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import java.util.Collections;
@@ -76,7 +76,7 @@ final class LongPollingActivateJobsPhysicalTenantTest {
                     })
             .setResourceExhaustedExceptionProvider(RuntimeException::new)
             .setRequestCanceledExceptionProvider(RuntimeException::new)
-            .setMetrics(LongPollingMetrics.noop())
+            .setMetricsFactory(LongPollingMetricsFactory.noop())
             .build();
     submitHandlerActor(handler);
 

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPhysicalTenantTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPhysicalTenantTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.job;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.util.unit.DataSize;
+
+/** Covers physical-tenant scoping of job-available notifications (issue #56224). */
+final class LongPollingActivateJobsPhysicalTenantTest {
+
+  private static final String TYPE = "testJob";
+  private static final long LONG_POLLING_TIMEOUT = 5000;
+  private static final long PROBE_TIMEOUT = 20000;
+  private static final int FAILED_RESPONSE_THRESHOLD = 3;
+  private static final int MAX_JOBS_TO_ACTIVATE = 2;
+  private static final long MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4).toBytes();
+
+  @RegisterExtension
+  final ControlledActorSchedulerExtension actorScheduler = new ControlledActorSchedulerExtension();
+
+  private final StubbedBrokerClient brokerClient = new StubbedBrokerClient();
+  private LongPollingActivateJobsHandler<Object> handler;
+  private ActivateJobsStub activateJobsStub;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        LongPollingActivateJobsHandler.<Object>newBuilder()
+            .setBrokerClient(brokerClient)
+            .setMaxMessageSize(MAX_MESSAGE_SIZE)
+            .setLongPollingTimeout(LONG_POLLING_TIMEOUT)
+            .setProbeTimeoutMillis(PROBE_TIMEOUT)
+            .setMinEmptyResponses(FAILED_RESPONSE_THRESHOLD)
+            .setActivationResultMapper(
+                response ->
+                    new JobActivationResult<>() {
+                      @Override
+                      public int getJobsCount() {
+                        return response.brokerResponse().getJobKeys().size();
+                      }
+
+                      @Override
+                      public List<JobActivationResult.ActivatedJob> getJobs() {
+                        return Collections.emptyList();
+                      }
+
+                      @Override
+                      public Object getActivateJobsResponse() {
+                        return response;
+                      }
+
+                      @Override
+                      public List<JobActivationResult.ActivatedJob> getJobsToDefer() {
+                        return Collections.emptyList();
+                      }
+                    })
+            .setResourceExhaustedExceptionProvider(RuntimeException::new)
+            .setRequestCanceledExceptionProvider(RuntimeException::new)
+            .setMetrics(LongPollingMetrics.noop())
+            .build();
+    submitHandlerActor(handler);
+
+    activateJobsStub = new ActivateJobsStub();
+    activateJobsStub.registerWith(brokerClient);
+    activateJobsStub.addAvailableJobs(TYPE, 0);
+  }
+
+  @Test
+  void shouldNotWakeRequestOfAnotherPhysicalTenant() {
+    // given — one pending request per tenant, for the same job type
+    final var tenantACompletions = new AtomicInteger();
+    final var tenantBCompletions = new AtomicInteger();
+    submitPendingRequest("tenanta", tenantACompletions);
+    submitPendingRequest("tenantb", tenantBCompletions);
+
+    // when — a job becomes available and only tenanta's topic is notified
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    brokerClient.notifyJobsAvailable("tenanta-jobsAvailable", TYPE);
+    actorScheduler.workUntilDone();
+
+    // then — only the matching tenant's request is unblocked
+    assertThat(tenantACompletions.get()).isEqualTo(1);
+    assertThat(tenantBCompletions.get()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldWakeDefaultTenantRequestViaLegacyTopic() {
+    // given — default tenant listens on both the scoped and the legacy prefix-less topic
+    final var completions = new AtomicInteger();
+    submitPendingRequest(DEFAULT_PHYSICAL_TENANT_ID, completions);
+
+    // when
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    brokerClient.notifyJobsAvailable(TYPE);
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(completions.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldWakeDefaultTenantRequestViaScopedTopic() {
+    // given — default tenant also listens on its own new, prefixed topic, not only the legacy one
+    final var completions = new AtomicInteger();
+    submitPendingRequest(DEFAULT_PHYSICAL_TENANT_ID, completions);
+
+    // when
+    activateJobsStub.addAvailableJobs(TYPE, 1);
+    brokerClient.notifyJobsAvailable("default-jobsAvailable", TYPE);
+    actorScheduler.workUntilDone();
+
+    // then
+    assertThat(completions.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldSubscribeOncePerPhysicalTenantAcrossMultipleRequests() {
+    // given — two separate long-poll requests for the same non-default tenant
+    submitPendingRequest("tenanta", new AtomicInteger());
+    submitPendingRequest("tenanta", new AtomicInteger());
+
+    // then — the tenant's topic was subscribed to exactly once, not once per request
+    assertThat(brokerClient.getJobAvailableSubscriptionTopics())
+        .filteredOn("tenanta-jobsAvailable"::equals)
+        .hasSize(1);
+  }
+
+  // -- helpers --
+
+  private void submitPendingRequest(
+      final String physicalTenantId, final AtomicInteger completions) {
+    final var brokerRequest =
+        new BrokerActivateJobsRequest(TYPE)
+            .setMaxJobsToActivate(MAX_JOBS_TO_ACTIVATE)
+            .setTimeout(LONG_POLLING_TIMEOUT)
+            .setTenantIds(Collections.emptyList())
+            .setVariables(Collections.emptyList())
+            .setWorker("test-worker");
+    brokerRequest.setPartitionGroup(physicalTenantId);
+
+    final ResponseObserver<Object> observer =
+        new ResponseObserver<>() {
+          @Override
+          public void onCompleted() {
+            completions.incrementAndGet();
+          }
+
+          @Override
+          public void onNext(final Object element) {}
+
+          @Override
+          public boolean isCancelled() {
+            return false;
+          }
+
+          @Override
+          public void onError(final Throwable throwable) {}
+        };
+
+    handler.activateJobs(brokerRequest, observer, cancelHandler -> {}, LONG_POLLING_TIMEOUT);
+    actorScheduler.workUntilDone();
+  }
+
+  private void submitHandlerActor(final LongPollingActivateJobsHandler<Object> handlerToSubmit) {
+    final var ready = new CompletableFuture<Void>();
+    final var actor =
+        Actor.newActor()
+            .name("TestHandler")
+            .actorStartedHandler(handlerToSubmit.andThen(ignored -> ready.complete(null)))
+            .build();
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
+    ready.join();
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPhysicalTenantTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsPhysicalTenantTest.java
@@ -133,18 +133,6 @@ final class LongPollingActivateJobsPhysicalTenantTest {
     assertThat(completions.get()).isEqualTo(1);
   }
 
-  @Test
-  void shouldSubscribeOncePerPhysicalTenantAcrossMultipleRequests() {
-    // given — two separate long-poll requests for the same non-default tenant
-    submitPendingRequest("tenanta", new AtomicInteger());
-    submitPendingRequest("tenanta", new AtomicInteger());
-
-    // then — the tenant's topic was subscribed to exactly once, not once per request
-    assertThat(brokerClient.getJobAvailableSubscriptionTopics())
-        .filteredOn("tenanta-jobsAvailable"::equals)
-        .hasSize(1);
-  }
-
   // -- helpers --
 
   private void submitPendingRequest(

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.metrics.LongPollingMetricsDoc.GatewayProtocol;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+final class LongPollingMetricsTest {
+
+  @Test
+  void shouldTagAndValueGaugesPerPhysicalTenantIndependently() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var factory = new LongPollingMetricsFactory(registry, GatewayProtocol.GRPC);
+    final var tenantAMetrics = factory.forPhysicalTenant("tenantA");
+    final var tenantBMetrics = factory.forPhysicalTenant("tenantB");
+
+    // when
+    tenantAMetrics.setBlockedRequestsCount("jobTypeX", 3);
+    tenantBMetrics.setBlockedRequestsCount("jobTypeX", 7);
+
+    // then
+    final var tenantAGauge =
+        registry
+            .find("zeebe.long.polling.queued.current")
+            .tag("physicalTenantId", "tenantA")
+            .tag("type", "jobTypeX")
+            .gauge();
+    final var tenantBGauge =
+        registry
+            .find("zeebe.long.polling.queued.current")
+            .tag("physicalTenantId", "tenantB")
+            .tag("type", "jobTypeX")
+            .gauge();
+
+    assertThat(tenantAGauge).isNotNull();
+    assertThat(tenantBGauge).isNotNull();
+    assertThat(tenantAGauge.value()).isEqualTo(3);
+    assertThat(tenantBGauge.value()).isEqualTo(7);
+  }
+}

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/metrics/LongPollingMetricsTest.java
@@ -31,13 +31,13 @@ final class LongPollingMetricsTest {
     final var tenantAGauge =
         registry
             .find("zeebe.long.polling.queued.current")
-            .tag("physicalTenantId", "tenantA")
+            .tag("physicalTenant", "tenantA")
             .tag("type", "jobTypeX")
             .gauge();
     final var tenantBGauge =
         registry
             .find("zeebe.long.polling.queued.current")
-            .tag("physicalTenantId", "tenantB")
+            .tag("physicalTenant", "tenantB")
             .tag("type", "jobTypeX")
             .gauge();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobAvailableNotificationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobAvailableNotificationIT.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end proof that the broker's tenant-scoped {@code jobsAvailable} notification
+ * (physical-tenant-aware long polling, issue #56224) actually reaches the gateway's {@code
+ * LongPollingActivateJobsHandler} on the wire: the broker formats the topic as {@code
+ * <physicalTenantId>-jobsAvailable} and the gateway subscribes to that same string independently on
+ * its own side, so nothing but a matching literal proves the two sides agree.
+ *
+ * <p>The probe timeout is set far longer than the assertion window, so a blocked long-poll request
+ * can only complete in time via the notification path; if the topic strings ever drifted apart,
+ * this test would time out waiting on the (empty) probe cycle instead.
+ */
+@ZeebeIntegration
+final class PhysicalTenantJobAvailableNotificationIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String JOB_TYPE = "task";
+  private static final String PROCESS_ID = "notification-process";
+
+  // far longer than the assertion window below, so only the job-available notification -- not the
+  // periodic probe -- can plausibly unblock the long-poll request in time
+  private static final Duration PROBE_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration NOTIFICATION_ASSERTION_WINDOW = Duration.ofSeconds(10);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withUnifiedConfig(
+                  camunda ->
+                      camunda.getApi().getLongPolling().setProbeTimeout(PROBE_TIMEOUT.toMillis())));
+
+  @AutoClose private CamundaClient tenantAClient;
+
+  @BeforeEach
+  void beforeEach() {
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+  }
+
+  @Test
+  void shouldUnblockLongPollRequestViaTenantScopedNotificationFasterThanTheProbe() {
+    // given - a process deployed to tenant A, and a long-poll ActivateJobs request already
+    // blocked (no job exists yet) before the process instance is created
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+
+    await("deployment to tenant A succeeds")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        tenantAClient
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, PROCESS_ID + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+
+    final var jobs =
+        tenantAClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(1)
+            .requestTimeout(PROBE_TIMEOUT.plusSeconds(30))
+            .send();
+
+    // when - a job becomes available in tenant A only after the request is already blocked
+    final long processInstanceKey =
+        tenantAClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    // then - the request completes well before the probe would ever fire, so it can only have been
+    // unblocked by the tenant-scoped notification reaching the gateway
+    assertThat((CompletionStage<ActivateJobsResponse>) jobs)
+        .succeedsWithin(NOTIFICATION_ASSERTION_WINDOW.toSeconds(), TimeUnit.SECONDS)
+        .satisfies(
+            response -> {
+              assertThat(response.getJobs()).hasSize(1);
+              assertThat(response.getJobs().getFirst().getProcessInstanceKey())
+                  .isEqualTo(processInstanceKey);
+            });
+  }
+}


### PR DESCRIPTION
## Description

  Implements physical-tenant-aware job-available notifications (long-polling), mirroring the topic-naming/dual-publish pattern from the physical-tenant job-streaming ADR `zeebe/docs/adr/0004-810-physical-tenant-job-streaming.md`, which explicitly deferred this exact optimization.

  - Broker `RemoteJobStreamer` now broadcasts `notifyWorkAvailable` on a `<physicalTenantId>-jobsAvailable` topic instead of the single global `jobsAvailable` topic. The default tenant additionally dual-broadcasts on the legacy, prefix-less topic for rolling-upgrade compatibility with 8.9 gateways        
  (removable in 8.11, same as the job-streaming control topics).
  - Gateway `LongPollingActivateJobsHandler` now keys pending/active long-poll requests by `(physicalTenantId, jobType)` instead of just `jobType`, and lazily subscribes to a tenant's notification topic the first time a request for that tenant is seen. A notification only unblocks requests for its own
  tenant, eliminating the spurious cross-tenant wakeups called out as accepted-but-optimizable in the ADR.
  - `BrokerClientImpl.subscribeJobAvailableNotification` fixed to track a list of subscriptions instead of overwriting a single field (latent leak once a caller subscribes to more than one topic, which the tenant-aware handler now does).
  - `camunda-cluster` widened from test-scope to compile-scope dependency in `zeebe/gateway` so the gateway can reference the canonical `PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID` constant directly instead of a locally duplicated string.

  No correctness change: as noted in the ADR, no job ever crossed tenants before this change either (the notification carries no job, only a job-type signal). This is a noisy-neighbour / efficiency optimization only.

  ## Testing

  - `RemoteJobStreamerTest` (new) — tenant-scoped-only broadcast for non-default tenants; dual broadcast (scoped + legacy) for the default tenant.
  - `LongPollingActivateJobsPhysicalTenantTest` (new) — cross-tenant notifications don't wake another tenant's pending request; same-tenant notifications do; default tenant wakes via both the legacy and the new scoped topic; a tenant's topic is subscribed to exactly once across multiple requests (no        
  duplicate subscriptions).
  - `BrokerClientTest#shouldCloseAllJobAvailableSubscriptionsOnClose` (new) — regression guard: `close()` closes every accumulated subscription, not just the most recent one.
  - `PhysicalTenantJobAvailableNotificationIT` (new, `zeebe/qa/integration-tests`) — end-to-end proof with a real embedded broker + gateway across two physical tenants: probe timeout set far longer than the assertion window, so a blocked long-poll request can only complete in time via the tenant-scoped     
  notification actually reaching the gateway on the wire (not the slow probe fallback).
  - All existing long-polling regression suites (gateway, gateway-grpc, gateway-rest) pass unchanged.


## Related issues

closes #56224
