### PR TITLE
fix: revert remove C8SM preview /console, add /modeler for to webModeler.restapi service

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/httproute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/httproute.yml
@@ -45,7 +45,7 @@ spec:
   hostnames:
   - {{ include "ingress.domain" $ | quote }}
   rules:
-  # app-root: redirect "/" to Web Modeler.
+  # app-root: redirect "/" to Console.
   - matches:
     - path:
         type: Exact
@@ -56,12 +56,12 @@ spec:
         statusCode: 302
         path:
           type: ReplaceFullPath
-          replaceFullPath: {{ .Values.camundaPlatform.webModeler.contextPath | quote }}
-  # Orchestration (REST gateway)
+          replaceFullPath: {{ .Values.camundaPlatform.console.contextPath | quote }}
+  # Console
   - matches:
     - path:
         type: PathPrefix
-        value: {{ .Values.camundaPlatform.orchestration.contextPath | quote }}
+        value: {{ .Values.camundaPlatform.console.contextPath | quote }}
     # Vouch + error-pages filter set, anchored here and reused by every other
     # authenticated rule below via the *authFilters alias.
     filters: &authFilters
@@ -77,6 +77,15 @@ spec:
         kind: Middleware
         name: {{ $errorsMiddleware }}
     {{- end }}
+    backendRefs:
+    - name: {{ template "console.fullname" $camundaPlatform }}
+      port: {{ .Values.camundaPlatform.console.service.port }}
+  # Orchestration (REST gateway)
+  - matches:
+    - path:
+        type: PathPrefix
+        value: {{ .Values.camundaPlatform.orchestration.contextPath | quote }}
+    filters: *authFilters
     backendRefs:
     - name: {{ template "orchestration.fullname" $camundaPlatform }}-gateway
       port: {{ .Values.camundaPlatform.orchestration.service.httpPort }}

--- a/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
@@ -23,6 +23,7 @@
 {{- $clientIP := printf "ClientIP(`%s`)" (join "`, `" $sourceRanges) -}}
 {{- $host := include "ingress.domain" $ -}}
 {{- $backends := list
+    (dict "path" .Values.camundaPlatform.console.contextPath "name" (include "console.fullname" $camundaPlatform) "port" .Values.camundaPlatform.console.service.port)
     (dict "path" .Values.camundaPlatform.orchestration.contextPath "name" (printf "%s-gateway" (include "orchestration.fullname" $camundaPlatform)) "port" .Values.camundaPlatform.orchestration.service.httpPort)
     (dict "path" (include "identity.keycloak.contextPath" $camundaPlatform) "name" (include "identity.keycloak.service" $camundaPlatform) "port" (include "identity.keycloak.port" $camundaPlatform | int))
     (dict "path" .Values.camundaPlatform.identity.contextPath "name" (include "identity.fullname" $camundaPlatform) "port" .Values.camundaPlatform.identity.service.port)


### PR DESCRIPTION
## Description

This reverts commit 17be3acf66b1d16fc07436b25ab383a9a11f422a from https://github.com/camunda/camunda/pull/58381. 8.9 still has Console.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
