### PR TITLE
feat: physical-tenant exporter assignment via exporters-assigned

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterAssignedValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterAssignedValidation.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Exporter;
+import io.camunda.configuration.UnifiedConfigurationException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Validates the {@code data.exporters-assigned} manifest per physical tenant (ADR-0008 D1/D2/D5).
+ * {@code exporters-assigned} is read from the environment via {@link Binder} — it is never a field
+ * on the config POJO — and is the complete manifest of the generic exporters that run for a tenant
+ * (catalog entries it inherits plus exporters it declares itself). The autoconfigured {@code
+ * camundaexporter}/{@code rdbms} exporters are outside the catalog and must never be listed.
+ *
+ * <p>Per tenant, this rejects at boot (as a {@link UnifiedConfigurationException}):
+ *
+ * <ul>
+ *   <li><b>mandatory-explicit:</b> an absent manifest whenever a generic exporter could apply (a
+ *       non-empty root catalog, or a generic exporter declared by the tenant) — an empty list is
+ *       valid and means "no generic exporters";
+ *   <li><b>blank entry:</b> a blank id in the list;
+ *   <li><b>exempt id:</b> an autoconfigured id ({@code camundaexporter}/{@code rdbms}) in the list;
+ *   <li><b>unknown id:</b> an assigned id that is neither in the root catalog nor declared by the
+ *       tenant;
+ *   <li><b>configured-but-unassigned:</b> a generic exporter id the tenant declares under {@code
+ *       data.exporters} but omits from {@code exporters-assigned} — configuring an exporter is not
+ *       a way to activate it, and unassigning one is not a way to deactivate it.
+ * </ul>
+ *
+ * <p>The {@code className}/{@code jarPath}-divergence boot error (assigning a root id but giving it
+ * a different class) is enforced upstream in {@link PhysicalTenantExporterConfigurations#apply}.
+ * This mirrors {@link PhysicalTenantDocumentAssignedValidation}; the synthesized {@code default}
+ * tenant is exempt, an explicitly declared {@code default} is validated like any other tenant.
+ *
+ * <p><b>Dormant:</b> not yet called from {@link PhysicalTenantResolver} — wiring it in is gated on
+ * <a href="https://github.com/camunda/camunda/issues/56652">#56652</a>; see {@link
+ * PhysicalTenantExporterConfigurations} for the activation recipe and the reason for the gate.
+ */
+@NullMarked
+final class PhysicalTenantExporterAssignedValidation {
+
+  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
+  private static final String ROOT_ASSIGNED_KEY = Camunda.PREFIX + ".data.exporters-assigned";
+
+  private PhysicalTenantExporterAssignedValidation() {}
+
+  /**
+   * Rejects {@code camunda.data.exporters-assigned} at the root level. Assignment is a per-tenant
+   * isolation decision read only from the tenant prefix; a root-level key would be silently
+   * ignored.
+   */
+  static void validateRootAssignedAbsent(final Environment environment) {
+    final boolean rootAssignedPresent =
+        Binder.get(environment).bind(ROOT_ASSIGNED_KEY, Bindable.listOf(String.class)).isBound();
+    if (rootAssignedPresent) {
+      throw new UnifiedConfigurationException(
+          "'"
+              + ROOT_ASSIGNED_KEY
+              + "' must not be set at the root level. Declare it per physical tenant under "
+              + "'camunda.physical-tenants.<id>.data.exporters-assigned'.");
+    }
+  }
+
+  static void validate(
+      final Environment environment,
+      final Map<String, Camunda> resolvedByTenant,
+      final Set<String> explicitlyDeclared) {
+    final Binder binder = Binder.get(environment);
+    final List<String> errors = new ArrayList<>();
+
+    resolvedByTenant.forEach(
+        (tenantId, camunda) -> {
+          if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)
+              && !explicitlyDeclared.contains(tenantId)) {
+            // synthesized default is exempt; explicitly declared default is validated like any
+            // other
+            return;
+          }
+          validateTenant(binder, tenantId, camunda, errors);
+        });
+
+    if (!errors.isEmpty()) {
+      throw new UnifiedConfigurationException(
+          "Invalid physical-tenant exporter assignment: " + String.join("; ", errors));
+    }
+  }
+
+  private static void validateTenant(
+      final Binder binder,
+      final String tenantId,
+      final Camunda camunda,
+      final List<String> errors) {
+    // The generic-exporter universe (post-apply, pre-narrow): every resolved exporter id except the
+    // autoconfigured ones — i.e. catalog entries the tenant inherits plus entries it declares.
+    final Set<String> genericUniverse = new LinkedHashSet<>();
+    camunda.getData().getExporters().keySet().stream()
+        .filter(id -> !isAutoconfigured(id))
+        .forEach(genericUniverse::add);
+
+    // Ids the tenant declares itself (configures), from a targeted re-bind of the tenant prefix.
+    final Set<String> tenantConfigured = new LinkedHashSet<>();
+    bindTenantDeclared(binder, tenantId).keySet().stream()
+        .filter(id -> !isAutoconfigured(id))
+        .forEach(tenantConfigured::add);
+
+    final List<String> assigned = bindAssigned(binder, tenantId);
+
+    if (assigned == null) {
+      if (!genericUniverse.isEmpty()) {
+        errors.add(
+            String.format(
+                "physical tenant '%s' must declare "
+                    + "'camunda.physical-tenants.%s.data.exporters-assigned' listing which generic "
+                    + "exporters run for it (an empty list is valid and means \"no generic "
+                    + "exporters\"); it is mandatory because a generic exporter could apply to this "
+                    + "tenant — one is declared in the root catalog or by the tenant itself",
+                tenantId, tenantId));
+      }
+      return;
+    }
+
+    // blank entries would otherwise fall through and render confusingly in the unknown-id message
+    if (assigned.stream().anyMatch(String::isBlank)) {
+      errors.add(
+          String.format(
+              "physical tenant '%s' declares a blank entry in "
+                  + "'camunda.physical-tenants.%s.data.exporters-assigned'; every id must be a "
+                  + "non-blank exporter id",
+              tenantId, tenantId));
+      return;
+    }
+
+    final List<String> exemptListed =
+        assigned.stream()
+            .filter(PhysicalTenantExporterAssignedValidation::isAutoconfigured)
+            .distinct()
+            .toList();
+    if (!exemptListed.isEmpty()) {
+      errors.add(
+          String.format(
+              "physical tenant '%s' lists autoconfigured exporter id(s) %s in "
+                  + "'camunda.physical-tenants.%s.data.exporters-assigned'; the autoconfigured %s "
+                  + "exporters are always present when their secondary storage is configured and "
+                  + "must not be assigned",
+              tenantId,
+              exemptListed,
+              tenantId,
+              PhysicalTenantExporterConfigurations.AUTOCONFIGURED_EXPORTER_IDS));
+    }
+
+    final Set<String> assignedIds = new LinkedHashSet<>(assigned);
+
+    final List<String> unknown =
+        assignedIds.stream()
+            .filter(id -> !isAutoconfigured(id))
+            .filter(id -> !genericUniverse.contains(id))
+            .distinct()
+            .toList();
+    if (!unknown.isEmpty()) {
+      errors.add(
+          String.format(
+              "physical tenant '%s' assigns unknown exporter id(s) %s in "
+                  + "'camunda.physical-tenants.%s.data.exporters-assigned'; an assigned id must be "
+                  + "declared either in the root catalog or by the tenant itself. Known generic "
+                  + "exporter ids are %s",
+              tenantId, unknown, tenantId, genericUniverse));
+    }
+
+    final List<String> configuredNotAssigned =
+        tenantConfigured.stream().filter(id -> !assignedIds.contains(id)).distinct().toList();
+    if (!configuredNotAssigned.isEmpty()) {
+      errors.add(
+          String.format(
+              "physical tenant '%s' configures exporter id(s) %s under "
+                  + "'camunda.physical-tenants.%s.data.exporters' but does not assign them in "
+                  + "'exporters-assigned'; configuring an exporter is not a way to activate it, and "
+                  + "unassigning one is not a way to deactivate it (runtime deactivation is the job "
+                  + "of the exporter-disable management endpoint)",
+              tenantId, configuredNotAssigned, tenantId));
+    }
+  }
+
+  private static boolean isAutoconfigured(final String id) {
+    // exporter ids are case-sensitive (#36444), so match the autoconfigured ids verbatim
+    return PhysicalTenantExporterConfigurations.AUTOCONFIGURED_EXPORTER_IDS.contains(id);
+  }
+
+  private static Map<String, Exporter> bindTenantDeclared(
+      final Binder binder, final String tenantId) {
+    return binder
+        .bind(
+            PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".data.exporters",
+            Bindable.mapOf(String.class, Exporter.class))
+        .orElseGet(Map::of);
+  }
+
+  private static @Nullable List<String> bindAssigned(final Binder binder, final String tenantId) {
+    return binder
+        .bind(
+            PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".data.exporters-assigned",
+            Bindable.listOf(String.class))
+        .orElse(null);
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,29 +52,36 @@ import org.springframework.core.env.Environment;
  * is derived downstream from the tenant's secondary-storage properties, and args-tuning declared
  * for them is taken as-is.
  *
- * <p><b>Deliberately not implemented yet (ADR-0008 §6 step 2, gated on <a
- * href="https://github.com/camunda/camunda/issues/56652">#56652</a>):</b> the {@code
- * data.exporters-assigned} manifest — mandatory-explicit validation, narrowing unassigned catalog
- * entries out of the tenant's resolved map, and the configured-but-unassigned boot error. As long
- * as the initial dynamic cluster configuration derives the per-partition exporter <em>enable</em>
- * state from the root {@code BrokerCfg} only, a narrowed-away id would remain enabled on the
- * tenant's partitions and be instantiated as a {@code BlockingExporter}, stalling exporting and log
- * compaction. This step therefore changes only entry <em>contents</em>, never which ids exist for a
+ * <p><b>The {@code data.exporters-assigned} manifest (ADR-0008 D1/D2/D5) is implemented but not yet
+ * wired into {@link PhysicalTenantResolver}, gated on <a
+ * href="https://github.com/camunda/camunda/issues/56652">#56652</a>:</b> its mandatory-explicit
+ * validation, the exempt/unknown/configured-but-unassigned boot errors, and the root-level
+ * placement check live in {@link PhysicalTenantExporterAssignedValidation}; the narrowing of
+ * unassigned catalog entries out of the tenant's resolved map lives in {@link #narrowToAssigned}.
+ * Both are dormant on purpose: as long as the initial dynamic cluster configuration derives the
+ * per-partition exporter <em>enable</em> state from the root {@code BrokerCfg} only, a
+ * narrowed-away id would remain enabled on the tenant's partitions and be instantiated as a {@code
+ * BlockingExporter}, stalling exporting and log compaction — so the interim inherit-all behavior
+ * stands until #56652 flips the wire-in. To activate (from {@link PhysicalTenantResolver#of}): call
+ * {@link PhysicalTenantExporterAssignedValidation#validateRootAssignedAbsent} before the tenant
+ * loop, then — after the loop and once every tenant's {@link #apply} has run — {@link
+ * PhysicalTenantExporterAssignedValidation#validate} for the whole resolved-by-tenant map, and only
+ * then {@link #narrowToAssigned} for each tenant. Validation must precede narrowing: narrowing
+ * removes ids, and validation checks assigned ids against the full pre-narrow universe. {@link
+ * #apply} itself therefore changes only entry <em>contents</em>, never which ids exist for a
  * tenant.
  */
 @NullMarked
 final class PhysicalTenantExporterConfigurations {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(PhysicalTenantExporterConfigurations.class);
-
-  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
-
-  /** Autoconfigured exporter ids, always outside the generic-exporter catalog (ADR-0008 §1). */
-  private static final Set<String> AUTOCONFIGURED_EXPORTER_IDS =
+  static final Set<String> AUTOCONFIGURED_EXPORTER_IDS =
       Set.of(
           BrokerBasedPropertiesOverride.CAMUNDA_EXPORTER_NAME,
           BrokerBasedPropertiesOverride.RDBMS_EXPORTER_NAME);
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PhysicalTenantExporterConfigurations.class);
+  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
 
   private PhysicalTenantExporterConfigurations() {}
 
@@ -228,5 +236,36 @@ final class PhysicalTenantExporterConfigurations {
 
   private static Map<String, Object> immutableCopy(final @Nullable Map<String, Object> args) {
     return args == null ? Map.of() : Collections.unmodifiableMap(new LinkedHashMap<>(args));
+  }
+
+  /**
+   * Narrows {@code physicalTenant}'s resolved {@code data.exporters} to exactly the assigned
+   * generic exporters plus the always-present autoconfigured entries (ADR-0008 D1/D2): every
+   * catalog entry the tenant inherited but did not assign is removed, so the resolved map becomes
+   * the tenant's complete generic-exporter manifest. The {@code exporters-assigned} list is read
+   * from the environment — it is never a field on the config POJO. An absent manifest is a no-op
+   * here ({@link PhysicalTenantExporterAssignedValidation} already rejects it at boot whenever a
+   * generic exporter could apply); an explicit empty manifest keeps only the autoconfigured
+   * entries.
+   *
+   * <p><b>Dormant:</b> not yet called from {@link PhysicalTenantResolver} — wiring it in is gated
+   * on <a href="https://github.com/camunda/camunda/issues/56652">#56652</a>; see the class javadoc.
+   */
+  static void narrowToAssigned(
+      final Camunda physicalTenant, final String tenantId, final Environment environment) {
+    final List<String> assigned =
+        Binder.get(environment)
+            .bind(
+                PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".data.exporters-assigned",
+                Bindable.listOf(String.class))
+            .orElse(null);
+    if (assigned == null) {
+      return;
+    }
+    final Set<String> keep = new LinkedHashSet<>(AUTOCONFIGURED_EXPORTER_IDS);
+    assigned.stream().filter(id -> !id.isBlank()).forEach(keep::add);
+    // exporter ids are matched verbatim: they are case-sensitive (#36444), and no other id match in
+    // this resolver (e.g. apply's catalog lookup) trims or normalizes, so neither does this one
+    physicalTenant.getData().getExporters().keySet().removeIf(id -> !keep.contains(id));
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterAssignedValidationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterAssignedValidationTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Exporter;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit-tests the dormant {@code exporters-assigned} validation (ADR-0008 D1/D2/D5). Exercises the
+ * validation class directly with a constructed resolved-by-tenant map (the class is not yet wired
+ * into {@link PhysicalTenantResolver} — gated on #56652), mirroring {@link
+ * PhysicalTenantDocumentAssignedValidationTest}.
+ */
+class PhysicalTenantExporterAssignedValidationTest {
+
+  private static final String TENANT = "tenanta";
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldPassWhenSynthesizedDefaultOmitsAssigned() {
+    // synthesized default (absent from explicitlyDeclared) is exempt even with a catalog
+    final Map<String, Camunda> resolved =
+        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithExporters("es"));
+    assertThatCode(() -> validate(resolved, Set.of())).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFailWhenNonDefaultTenantOmitsAssignedButCatalogHasGenericExporters() {
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .withMessageContaining(TENANT)
+        .withMessageContaining("must declare");
+  }
+
+  @Test
+  void shouldRequireAssignedWhenTenantDeclaresGenericExporterEvenWithEmptyRootCatalog() {
+    // the mandatory rule fires from the tenant's own generic declaration too (empty root catalog):
+    // the resolved map here holds only a tenant-declared exporter, and the manifest is absent
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("custom")), Set.of()))
+        .withMessageContaining(TENANT)
+        .withMessageContaining("must declare");
+  }
+
+  @Test
+  void shouldPassWhenNoGenericExportersAndAssignedAbsent() {
+    // only the autoconfigured exporter is present — no generic exporter could apply, key optional
+    assertThatCode(
+            () -> validate(tenants(TENANT, camundaWithExporters("camundaexporter")), Set.of()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenAssignedIsEmptyAndTenantDeclaresNoGenericExporter() {
+    // an explicit empty manifest is valid ("no generic exporters"); the inherited catalog entry is
+    // narrowed away downstream, not a validation error
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned", "");
+    assertThatCode(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldPassWhenAssignedMatchesCatalog() {
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "es");
+    assertThatCode(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldTreatDifferentlyCasedAssignedIdAsUnknown() {
+    // exporter ids are case-sensitive (#36444): "Es" does not match the catalog id "es"
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "Es");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .withMessageContaining("unknown exporter id(s) [Es]");
+  }
+
+  @Test
+  void shouldFailWhenAssignedListsAutoconfiguredId() {
+    environment.setProperty(
+        "camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "camundaexporter");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .withMessageContaining(TENANT)
+        .withMessageContaining("autoconfigured")
+        .withMessageContaining("camundaexporter");
+  }
+
+  @Test
+  void shouldFailWhenAssignedIdIsUnknown() {
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "ghost");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .withMessageContaining(TENANT)
+        .withMessageContaining("unknown exporter id(s) [ghost]");
+  }
+
+  @Test
+  void shouldFailOnBlankAssignedEntry() {
+    // blank entries must be caught before the unknown-id check; otherwise they render as `[]`
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("es")), Set.of()))
+        .withMessageContaining(TENANT)
+        .withMessageContaining("blank entry");
+  }
+
+  @Test
+  void shouldFailWhenTenantConfiguresGenericExporterButDoesNotAssignIt() {
+    // tenant declares "custom" under data.exporters (yes/no/yes) but assigns only "es"
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "es");
+    environment.setProperty(
+        "camunda.physical-tenants.tenanta.data.exporters.custom.class-name", "com.acme.Custom");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("es", "custom")), Set.of()))
+        .withMessageContaining(TENANT)
+        .withMessageContaining("configures exporter id(s) [custom]");
+  }
+
+  @Test
+  void shouldFailWhenAssignedEmptyButTenantConfiguresGenericExporter() {
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned", "");
+    environment.setProperty(
+        "camunda.physical-tenants.tenanta.data.exporters.custom.class-name", "com.acme.Custom");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(tenants(TENANT, camundaWithExporters("custom")), Set.of()))
+        .withMessageContaining("configures exporter id(s) [custom]");
+  }
+
+  @Test
+  void shouldPassForTenantPrivateExporterThatIsAssignedAndConfigured() {
+    // no root entry, tenant assigns + configures it (no/yes/yes) — a tenant-private exporter
+    environment.setProperty(
+        "camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "private");
+    environment.setProperty(
+        "camunda.physical-tenants.tenanta.data.exporters.private.class-name", "com.acme.Private");
+    assertThatCode(() -> validate(tenants(TENANT, camundaWithExporters("private")), Set.of()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldValidateExplicitlyDeclaredDefaultLikeAnyOtherTenant() {
+    final Map<String, Camunda> resolved =
+        tenants(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, camundaWithExporters("es"));
+    final Set<String> explicitlyDeclared = Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(() -> validate(resolved, explicitlyDeclared))
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .withMessageContaining("must declare");
+  }
+
+  @Test
+  void shouldRejectRootLevelExportersAssigned() {
+    environment.setProperty("camunda.data.exporters-assigned[0]", "es");
+    assertThatExceptionOfType(UnifiedConfigurationException.class)
+        .isThrownBy(
+            () -> PhysicalTenantExporterAssignedValidation.validateRootAssignedAbsent(environment))
+        .withMessageContaining("must not be set at the root level");
+  }
+
+  @Test
+  void shouldAcceptAbsentRootLevelExportersAssigned() {
+    assertThatCode(
+            () -> PhysicalTenantExporterAssignedValidation.validateRootAssignedAbsent(environment))
+        .doesNotThrowAnyException();
+  }
+
+  // --- helpers -----------------------------------------------------------------------------------
+
+  private void validate(final Map<String, Camunda> resolved, final Set<String> explicitlyDeclared) {
+    PhysicalTenantExporterAssignedValidation.validate(environment, resolved, explicitlyDeclared);
+  }
+
+  private static Camunda camundaWithExporters(final String... exporterIds) {
+    final Camunda camunda = new Camunda();
+    final Map<String, Exporter> exporters = new LinkedHashMap<>();
+    for (final String id : exporterIds) {
+      final Exporter exporter = new Exporter();
+      exporter.setClassName("com.acme." + id);
+      exporters.put(id, exporter);
+    }
+    camunda.getData().setExporters(exporters);
+    return camunda;
+  }
+
+  private static Map<String, Camunda> tenants(final Object... idThenCamunda) {
+    final Map<String, Camunda> map = new LinkedHashMap<>();
+    for (int i = 0; i < idThenCamunda.length; i += 2) {
+      map.put((String) idThenCamunda[i], (Camunda) idThenCamunda[i + 1]);
+    }
+    return map;
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
@@ -25,11 +25,14 @@ import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
- * Covers the step-1 rows of the ADR-0008 §2 decision table against the test-only mergers registered
- * via {@code src/test/resources/META-INF/services} (real-merger end-to-end coverage lives in {@code
- * PhysicalTenantExporterConfigIT}). The step-2 rows — the {@code exporters-assigned} manifest,
- * narrowing, and the configured-but-unassigned error — are gated on #56652 and deliberately absent
- * here; see {@link PhysicalTenantExporterConfigurations}.
+ * Covers the step-1 rows of the ADR-0008 §2 decision table (args merge, class-divergence, and
+ * autoconfigured tuning) against the test-only mergers registered via {@code
+ * src/test/resources/META-INF/services} (real-merger end-to-end coverage lives in {@code
+ * PhysicalTenantExporterConfigIT}), plus the dormant step-2 {@link
+ * PhysicalTenantExporterConfigurations#narrowToAssigned}. The step-2 mandatory-explicit and
+ * boot-error validations live in {@link PhysicalTenantExporterAssignedValidationTest}. Both step-2
+ * halves are dormant (not wired into {@link PhysicalTenantResolver}) pending #56652; see {@link
+ * PhysicalTenantExporterConfigurations}.
  */
 class PhysicalTenantExporterConfigurationsTest {
 
@@ -273,5 +276,83 @@ class PhysicalTenantExporterConfigurationsTest {
     assertThat(boundEmpty.isBound()).isTrue();
     assertThat(boundEmpty.get()).isEmpty();
     assertThat(absent.isBound()).isFalse();
+  }
+
+  // --- step-2 narrowing (dormant; gated on #56652) ---------------------------------------------
+
+  @Test
+  void shouldNarrowAwayUnassignedCatalogEntries() {
+    // given — a tenant resolved with two catalog entries; only one is assigned
+    final Camunda tenant = camundaWithExporters("es", "other");
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "es");
+
+    // when
+    PhysicalTenantExporterConfigurations.narrowToAssigned(tenant, TENANT, environment);
+
+    // then — the unassigned catalog entry is removed
+    assertThat(tenant.getData().getExporters()).containsOnlyKeys("es");
+  }
+
+  @Test
+  void shouldAlwaysKeepAutoconfiguredEntriesEvenWhenUnassigned() {
+    // given — autoconfigured ids are never listed in exporters-assigned but must survive narrowing
+    final Camunda tenant = camundaWithExporters("es", "camundaexporter", "rdbms");
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "es");
+
+    // when
+    PhysicalTenantExporterConfigurations.narrowToAssigned(tenant, TENANT, environment);
+
+    // then
+    assertThat(tenant.getData().getExporters()).containsOnlyKeys("es", "camundaexporter", "rdbms");
+  }
+
+  @Test
+  void shouldRemoveAllGenericExportersWhenAssignedIsEmpty() {
+    // given — an explicit empty manifest means "no generic exporters"
+    final Camunda tenant = camundaWithExporters("es", "other", "camundaexporter");
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned", "");
+
+    // when
+    PhysicalTenantExporterConfigurations.narrowToAssigned(tenant, TENANT, environment);
+
+    // then — only the autoconfigured entry survives
+    assertThat(tenant.getData().getExporters()).containsOnlyKeys("camundaexporter");
+  }
+
+  @Test
+  void shouldNotNarrowWhenAssignedIsAbsent() {
+    // given — no manifest at all: narrowing is a no-op (validation rejects this at boot upstream)
+    final Camunda tenant = camundaWithExporters("es", "other");
+
+    // when
+    PhysicalTenantExporterConfigurations.narrowToAssigned(tenant, TENANT, environment);
+
+    // then — the resolved map is left untouched
+    assertThat(tenant.getData().getExporters()).containsOnlyKeys("es", "other");
+  }
+
+  @Test
+  void shouldMatchAssignedIdsCaseSensitivelyWhenNarrowing() {
+    // given — exporter ids are case-sensitive (#36444): "ES" does not match the catalog key "es"
+    final Camunda tenant = camundaWithExporters("es");
+    environment.setProperty("camunda.physical-tenants.tenanta.data.exporters-assigned[0]", "ES");
+
+    // when
+    PhysicalTenantExporterConfigurations.narrowToAssigned(tenant, TENANT, environment);
+
+    // then — the differently-cased id matches nothing, so the catalog entry is narrowed away
+    assertThat(tenant.getData().getExporters()).isEmpty();
+  }
+
+  private static Camunda camundaWithExporters(final String... exporterIds) {
+    final Camunda camunda = new Camunda();
+    final Map<String, Exporter> exporters = new HashMap<>();
+    for (final String id : exporterIds) {
+      final Exporter exporter = new Exporter();
+      exporter.setClassName("com.acme." + id);
+      exporters.put(id, exporter);
+    }
+    camunda.getData().setExporters(exporters);
+    return camunda;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
 import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -33,6 +34,7 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,11 +57,15 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
  * 1). Each tenant's partition group then runs the exporter with that tenant's resolved
  * configuration.
  *
- * <p>Not yet supported: declaring an exporter <b>only</b> for a physical tenant (absent from the
- * root config). The initial cluster configuration — which decides which exporter ids are enabled on
- * a partition — is still generated from the root {@code BrokerCfg} only, so a tenant-only exporter
- * is never enabled. See the disabled test below; this will be addressed once the
- * cluster-configuration layer supports per-physical-tenant exporters.
+ * <p>Not yet supported (both gated on <a
+ * href="https://github.com/camunda/camunda/issues/56652">#56652</a>, see the disabled tests below):
+ * declaring an exporter <b>only</b> for a physical tenant (absent from the root config), and
+ * <b>narrowing</b> a root-declared exporter out of a tenant via its {@code exporters-assigned}
+ * manifest. The initial cluster configuration — which decides which exporter ids are enabled on a
+ * partition — is still generated from the root {@code BrokerCfg} only, so a tenant-only exporter is
+ * never enabled, and a narrowed-away exporter would stay enabled (and turn into a {@code
+ * BlockingExporter}). Until the cluster-configuration layer derives that state per tenant, the
+ * assignment step stays dormant and the interim inherit-all behavior stands.
  */
 @Timeout(120)
 @ZeebeIntegration
@@ -76,6 +82,12 @@ final class PhysicalTenantExporterConfigIT {
   private static final String ES_MERGE_EXPORTER_ID = "esmerge";
   private static final String ROOT_INDEX_PREFIX = "rootmergeprefix";
   private static final String TENANT_A_INDEX_PREFIX = "tenantamergeprefix";
+
+  // A root-declared exporter that tenantA's exporters-assigned manifest deliberately omits, used by
+  // the disabled narrowing test only.
+  private static final String NARROWED_EXPORTER_ID = "narrowed-exporter";
+  private static final String DEFAULT_NARROW_PROCESS = "default-narrow-process";
+  private static final String TENANT_A_NARROW_PROCESS = "tenanta-narrow-process";
 
   @SuppressWarnings("resource")
   private static final ElasticsearchContainer ES =
@@ -102,7 +114,9 @@ final class PhysicalTenantExporterConfigIT {
   // whole-entry-replace path for a class without a merger), and overrides ONLY the index prefix
   // of the Elasticsearch exporter (the deep-merge path: its class ships an ExporterConfigMerger,
   // so url and bulk tuning are inherited from the root entry). The tenantA-only exporter
-  // exercises the not-yet-supported case and is used by the disabled test only.
+  // exercises the not-yet-supported case and is used by the disabled test only. The narrowed
+  // exporter is root-declared but omitted from tenantA's exporters-assigned manifest, so once
+  // narrowing is wired in (#56652) it must stop running on tenantA's partition group.
   @TestZeebe
   private final TestStandaloneBroker broker =
       TENANTS
@@ -123,6 +137,9 @@ final class PhysicalTenantExporterConfigIT {
                         "bulk", Map.of("size", 1, "delay", 1),
                         "index", Map.of("prefix", ROOT_INDEX_PREFIX)));
               })
+          .withExporter(
+              NARROWED_EXPORTER_ID,
+              cfg -> cfg.setClassName(ProcessIdRecordingExporter.class.getName()))
           .withPtConfig(
               TENANT_A,
               camunda -> {
@@ -139,7 +156,19 @@ final class PhysicalTenantExporterConfigIT {
                 final var tenantOnlyExporter = new io.camunda.configuration.Exporter();
                 tenantOnlyExporter.setClassName(TenantAExporter.class.getName());
                 camunda.getData().getExporters().put(TENANT_A_ONLY_EXPORTER_ID, tenantOnlyExporter);
-              });
+              })
+          // tenantA's complete generic-exporter manifest (ADR-0008 D1): it assigns every id it
+          // touches — the redeclared location exporter, the partially-overridden ES exporter, and
+          // its tenant-private exporter — but deliberately omits NARROWED_EXPORTER_ID. Bound via
+          // the
+          // Binder (never a POJO field); ignored until the assignment step is wired in (#56652).
+          .withProperty(
+              "camunda.physical-tenants.tenanta.data.exporters-assigned[0]", LOCATION_EXPORTER_ID)
+          .withProperty(
+              "camunda.physical-tenants.tenanta.data.exporters-assigned[1]", ES_MERGE_EXPORTER_ID)
+          .withProperty(
+              "camunda.physical-tenants.tenanta.data.exporters-assigned[2]",
+              TENANT_A_ONLY_EXPORTER_ID);
 
   @AutoClose private CamundaClient tenantAClient;
   @AutoClose private CamundaClient defaultClient;
@@ -148,6 +177,7 @@ final class PhysicalTenantExporterConfigIT {
   void setUp() {
     LocationRecordingExporter.reset();
     TenantAExporter.reset();
+    ProcessIdRecordingExporter.reset();
     tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
     defaultClient =
         TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
@@ -210,6 +240,54 @@ final class PhysicalTenantExporterConfigIT {
     await("tenant-only exporter is opened and receives records from tenantA's partition")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(() -> assertThat(TenantAExporter.RECORDS).isNotEmpty());
+  }
+
+  /**
+   * Asserts the ADR-0008 D1 narrowing effect: a root-declared exporter that tenantA's {@code
+   * exporters-assigned} manifest omits ({@link #NARROWED_EXPORTER_ID}) must run on the default
+   * tenant's partition group but not on tenantA's — tenantA's records must never reach it.
+   *
+   * <p>Disabled: assignment is not wired into {@code PhysicalTenantResolver}, and even if it were,
+   * narrowing an exporter out of a tenant's resolved config while the initial {@code
+   * DynamicPartitionConfig} still enables it from the root {@code BrokerCfg}
+   * (StaticConfigurationGenerator) would leave it enabled-but-config-less on tenantA's partitions
+   * and turn it into a {@code BlockingExporter}. Until then the interim inherit-all behavior stands
+   * (the exporter runs on both groups). To be re-enabled once the cluster-configuration layer
+   * derives per-partition exporter enable state per tenant.
+   */
+  @Disabled(
+      "Narrowing a root-declared exporter out of a physical tenant requires per-physical-tenant"
+          + " exporter support in the cluster-configuration layer (initial DynamicPartitionConfig"
+          + " is generated from the root BrokerCfg only), and the assignment step is not yet wired"
+          + " into PhysicalTenantResolver; tracked in"
+          + " https://github.com/camunda/camunda/issues/56652")
+  @Test
+  void shouldNarrowAwayUnassignedRootExporterForTenant() {
+    // given — records flow through both tenants' partition groups under distinct process ids
+    deployAndCreateInstance(defaultClient, DEFAULT_NARROW_PROCESS);
+    deployAndCreateInstance(tenantAClient, TENANT_A_NARROW_PROCESS);
+
+    // then — the narrowed exporter (still assigned implicitly on the exempt default tenant)
+    // received
+    // the default tenant's process
+    await("narrowed exporter receives the default tenant's process")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(ProcessIdRecordingExporter.SEEN_PROCESS_IDS)
+                    .contains(DEFAULT_NARROW_PROCESS));
+
+    // and tenantA's process never reaches it, because the exporter was narrowed away for tenantA.
+    // Await the absence for a window rather than asserting it once: the exporter thread is async,
+    // so
+    // an immediate check could pass before tenantA's records would otherwise have arrived.
+    await("tenantA's process never reaches the narrowed exporter")
+        .during(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () ->
+                assertThat(ProcessIdRecordingExporter.SEEN_PROCESS_IDS)
+                    .doesNotContain(TENANT_A_NARROW_PROCESS));
   }
 
   /**
@@ -343,6 +421,38 @@ final class PhysicalTenantExporterConfigIT {
     @Override
     public void export(final Record<?> record) {
       RECORDS.add(record.getPosition());
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+
+  /**
+   * A minimal {@link Exporter} used by the disabled narrowing test. Records the {@code
+   * bpmnProcessId} of every process-instance record it sees, so a test can assert which tenants'
+   * partition groups it ran on.
+   */
+  public static final class ProcessIdRecordingExporter implements Exporter {
+
+    static final Set<String> SEEN_PROCESS_IDS = ConcurrentHashMap.newKeySet();
+
+    private Controller controller;
+
+    static void reset() {
+      SEEN_PROCESS_IDS.clear();
+    }
+
+    @Override
+    public void configure(final Context context) {}
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      if (record.getValue() instanceof final ProcessInstanceRecordValue processInstance) {
+        SEEN_PROCESS_IDS.add(processInstance.getBpmnProcessId());
+      }
       controller.updateLastExportedRecordPosition(record.getPosition());
     }
   }


### PR DESCRIPTION
## What

Implements the **assignment** half of [ADR-0008](https://github.com/camunda/camunda/blob/main/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0008-physical-tenant-exporter-assignment-and-args-merge.md) (D1/D2/D5): which root-declared generic exporters run for a physical tenant, selected explicitly via `camunda.physical-tenants.<id>.data.exporters-assigned`. This closes the generic-exporter isolation gap at the same place as document stores and OIDC providers — nothing root-declared runs for a tenant implicitly, and a tenant's export surface is readable off one key.

## How

- **`PhysicalTenantExporterAssignedValidation`** (new) enforces the boot-time rules, mirroring `PhysicalTenantDocumentAssignedValidation`: a root-level `exporters-assigned` is rejected; the manifest is mandatory-explicit whenever a generic exporter could apply (an empty list is valid = "no generic exporters"); blank ids, autoconfigured ids (`camundaexporter`/`rdbms`), and unknown ids are rejected; and configuring a generic exporter without assigning it is a boot error.
- **`PhysicalTenantExporterConfigurations.narrowToAssigned`** narrows a tenant's resolved `data.exporters` to the always-present autoconfigured entries plus exactly the assigned ids. Exporter ids are matched **verbatim** — they are case-sensitive (#36444), consistent with the existing catalog lookup in `apply`.
- The `className`/`jarPath`-divergence boot error is already enforced in `apply` (the merge half, #57590).

## Dormant — gated on #56652

The validation and narrowing are **not yet wired into `PhysicalTenantResolver.of`**. Narrowing an exporter out of a tenant while the initial `DynamicPartitionConfig` still derives per-partition exporter enable-state from the root `BrokerCfg` (`StaticConfigurationGenerator`) would leave it enabled-but-config-less on the tenant's partitions and turn it into a `BlockingExporter`, stalling exporting and log compaction. Until then the interim inherit-all behavior stands. The activation recipe (`validateRootAssignedAbsent` before the loop → `validate` after it → `narrowToAssigned` per tenant; validate must precede narrow) is documented on the resolver step, so #56652 becomes a small wire-in plus re-enabling the disabled runtime IT.

## Tests

- `PhysicalTenantExporterAssignedValidationTest` — the full boot-error matrix + case-sensitivity, run directly against the validation entry point.
- Narrowing cases in `PhysicalTenantExporterConfigurationsTest`.
- A `@Disabled` narrowing scenario in `PhysicalTenantExporterConfigIT`, next to the existing tenant-only case, to be re-enabled by #56652.

Configuration module unit tests green; `zeebe/qa/integration-tests` test-compiles.

## Related

Part of #57591. Gated on #56652. Builds on the merge half (#57590 / #57339).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
