### PR TITLE
56997 introduce exporter target index

### DIFF
--- a/debug-cli/src/main/java/io/camunda/debug/cli/recover/ProcessDefinitionRecovery.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/recover/ProcessDefinitionRecovery.java
@@ -12,6 +12,7 @@ import static io.camunda.debug.cli.util.ErrorMessageUtil.rootMessage;
 import io.camunda.exporter.handlers.EmbeddedFormHandler;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
@@ -86,7 +87,8 @@ final class ProcessDefinitionRecovery {
       final T entity = handler.createNewEntity(id);
       handler.updateEntity(record, entity);
       if (batch != null) {
-        handler.flush(entity, batch);
+        final var index = TargetIndex.mainIndex(handler.getIndexName());
+        handler.flush(index, entity, batch);
       }
     }
   }

--- a/debug-cli/src/test/java/io/camunda/debug/cli/recover/FakeBatchRequest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/recover/FakeBatchRequest.java
@@ -9,6 +9,7 @@ package io.camunda.debug.cli.recover;
 
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -38,7 +39,7 @@ final class FakeBatchRequest implements BatchRequest {
   }
 
   List<Added> addedTo(final String index) {
-    return added.stream().filter(a -> a.index().equals(index)).toList();
+    return added.stream().filter(a -> a.index().name().equals(index)).toList();
   }
 
   @Override
@@ -52,7 +53,7 @@ final class FakeBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest add(final String index, final ExporterEntity entity) {
+  public BatchRequest add(final TargetIndex index, final ExporterEntity entity) {
     added.add(new Added(index, entity));
     return this;
   }
@@ -60,19 +61,20 @@ final class FakeBatchRequest implements BatchRequest {
   // --- Unused operations ---------------------------------------------------
 
   @Override
-  public BatchRequest addWithId(final String index, final String id, final ExporterEntity entity) {
+  public BatchRequest addWithId(
+      final TargetIndex index, final String id, final ExporterEntity entity) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public BatchRequest addWithRouting(
-      final String index, final ExporterEntity entity, final String routing) {
+      final TargetIndex index, final ExporterEntity entity, final String routing) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public BatchRequest upsert(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final Map<String, Object> updateFields) {
@@ -81,7 +83,7 @@ final class FakeBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithRouting(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final Map<String, Object> updateFields,
@@ -91,7 +93,7 @@ final class FakeBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithScript(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final String script,
@@ -101,7 +103,7 @@ final class FakeBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithScriptAndRouting(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final String script,
@@ -112,18 +114,19 @@ final class FakeBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest update(
-      final String index, final String id, final Map<String, Object> updateFields) {
+      final TargetIndex index, final String id, final Map<String, Object> updateFields) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public BatchRequest update(final String index, final String id, final ExporterEntity entity) {
+  public BatchRequest update(
+      final TargetIndex index, final String id, final ExporterEntity entity) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public BatchRequest updateWithScript(
-      final String index,
+      final TargetIndex index,
       final String id,
       final String script,
       final Map<String, Object> parameters) {
@@ -131,12 +134,13 @@ final class FakeBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest delete(final String index, final String id) {
+  public BatchRequest delete(final TargetIndex index, final String id) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public BatchRequest deleteWithRouting(final String index, final String id, final String routing) {
+  public BatchRequest deleteWithRouting(
+      final TargetIndex index, final String id, final String routing) {
     throw new UnsupportedOperationException();
   }
 
@@ -154,5 +158,5 @@ final class FakeBatchRequest implements BatchRequest {
     execute();
   }
 
-  record Added(String index, ExporterEntity entity) {}
+  record Added(TargetIndex index, ExporterEntity entity) {}
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/recover/RecoverProcessDefinitionsMultiDbIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/recover/RecoverProcessDefinitionsMultiDbIT.java
@@ -15,6 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.configuration.beans.SearchEngineConnectProperties;
 import io.camunda.debug.cli.Main;
 import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
@@ -158,7 +159,7 @@ public class RecoverProcessDefinitionsMultiDbIT {
       throws Exception {
     try (final ClientAdapter adapter = ClientAdapter.of(connectConfiguration)) {
       final var batchRequest = adapter.createBatchRequest();
-      batchRequest.delete(indexName, String.valueOf(key));
+      batchRequest.delete(TargetIndex.mainIndex(indexName), String.valueOf(key));
       batchRequest.executeWithRefresh();
     }
   }

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/TargetIndexArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/TargetIndexArchTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass.Predicates;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import io.camunda.exporter.index.TargetIndex;
+import io.camunda.exporter.store.ExporterBatchWriter;
+
+@AnalyzeClasses(packages = "io.camunda.exporter", importOptions = DoNotIncludeTestsOrTestJars.class)
+public class TargetIndexArchTest {
+  @ArchTest
+  static final ArchRule TARGET_INDEXES_SHOULD_ONLY_BE_CREATED_BY_BATCH_WRITER =
+      ArchRuleDefinition.methods()
+          .that()
+          .areDeclaredInClassesThat()
+          .resideInAPackage("io.camunda.exporter.index..")
+          .and()
+          .haveNameNotMatching("^(name).*")
+          .should()
+          .onlyBeCalled()
+          .byClassesThat()
+          .areAssignableTo(
+              DescribedPredicate.or(
+                  Predicates.assignableTo(TargetIndex.class),
+                  Predicates.assignableTo(ExporterBatchWriter.class)))
+          .because(
+              "TargetIndex instances should only be created by the ExporterBatchWriter to ensure that all writes are sent to the correct index.");
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractCorrelatedMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractCorrelatedMessageSubscriptionHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.toOffsetDateTime;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.CorrelatedMessageSubscriptionEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -56,7 +57,9 @@ public abstract class AbstractCorrelatedMessageSubscriptionHandler<T extends Rec
 
   @Override
   public void flush(
-      final CorrelatedMessageSubscriptionEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(getIndexName(), entity);
+      final TargetIndex index,
+      final CorrelatedMessageSubscriptionEntity entity,
+      final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -32,6 +32,7 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_NAME;
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.TOOL_PROPERTIES;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -87,6 +88,7 @@ public abstract class AbstractEventHandler<R extends RecordValue>
   }
 
   protected void persistEvent(
+      final TargetIndex index,
       final MessageSubscriptionEntity entity,
       final String positionFieldName,
       final long positionFieldValue,
@@ -132,7 +134,7 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     }
 
     // write event
-    batchRequest.upsert(indexName, entity.getId(), entity, jsonMap);
+    batchRequest.upsert(index, entity.getId(), entity, jsonMap);
   }
 
   protected void extractDefinitionData(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.COMMIT_STATUS;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
@@ -123,11 +124,12 @@ public class AgentHistoryHandler
   }
 
   @Override
-  public void flush(final AgentHistoryEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final AgentHistoryEntity entity, final BatchRequest batchRequest) {
     // Only commitStatus changes after CREATED. Pass it as the sole update-fields entry so
     // partial updates on COMMITTED/DISCARDED never overwrite other fields in the document.
     batchRequest.upsert(
-        indexName, entity.getId(), entity, Map.of(COMMIT_STATUS, entity.getCommitStatus()));
+        index, entity.getId(), entity, Map.of(COMMIT_STATUS, entity.getCommitStatus()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -17,6 +17,7 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
@@ -120,7 +121,8 @@ public class AgentInstanceHandler
   }
 
   @Override
-  public void flush(final AgentInstanceEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final AgentInstanceEntity entity, final BatchRequest batchRequest) {
     // `creationDate` is intentionally excluded: it is handler-derived from
     // `record.getTimestamp()` and only populated by `updateEntity()` on the CREATED
     // intent. Including it here would overwrite the existing index value with null on
@@ -135,7 +137,7 @@ public class AgentInstanceHandler
     updateFields.put(ELEMENT_INSTANCE_KEYS, entity.getElementInstanceKeys());
     updateFields.put(LAST_UPDATED_DATE, entity.getLastUpdatedDate());
     updateFields.put(COMPLETION_DATE, entity.getCompletionDate());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -72,9 +73,10 @@ public class AuthorizationCreatedUpdatedHandler
   }
 
   @Override
-  public void flush(final AuthorizationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final AuthorizationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -68,9 +69,10 @@ public class AuthorizationDeletedHandler
   }
 
   @Override
-  public void flush(final AuthorizationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final AuthorizationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(getIndexName(), entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
@@ -102,14 +103,15 @@ public class ClusterVariableCreatedUpdatedHandler
                     new MetadataEntry(
                         e.getKey(),
                         String.valueOf(e.getValue()),
-                        e.getValue() instanceof Number n ? n.doubleValue() : null))
+                        e.getValue() instanceof final Number n ? n.doubleValue() : null))
             .toList());
   }
 
   @Override
-  public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final ClusterVariableEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
@@ -66,9 +67,10 @@ public class ClusterVariableDeletedHandler
   }
 
   @Override
-  public void flush(final ClusterVariableEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final ClusterVariableEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
@@ -131,8 +132,11 @@ public class DecisionEvaluationHandler
   }
 
   @Override
-  public void flush(final DecisionInstanceEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index,
+      final DecisionInstanceEntity entity,
+      final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
@@ -80,8 +81,11 @@ public class DecisionHandler
   }
 
   @Override
-  public void flush(final DecisionDefinitionEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index,
+      final DecisionDefinitionEntity entity,
+      final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionRequirementsHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionRequirementsHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
@@ -88,8 +89,11 @@ public class DecisionRequirementsHandler
   }
 
   @Override
-  public void flush(final DecisionRequirementsEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index,
+      final DecisionRequirementsEntity entity,
+      final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EmbeddedFormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EmbeddedFormHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.form.EmbeddedFormBatch;
 import io.camunda.webapps.schema.entities.form.FormEntity;
@@ -65,9 +66,10 @@ public class EmbeddedFormHandler implements ExportHandler<EmbeddedFormBatch, Pro
   }
 
   @Override
-  public void flush(final EmbeddedFormBatch entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final EmbeddedFormBatch entity, final BatchRequest batchRequest) {
     final var forms = entity.getForms();
-    Optional.ofNullable(forms).ifPresent(l -> l.forEach(f -> batchRequest.add(indexName, f)));
+    Optional.ofNullable(forms).ifPresent(l -> l.forEach(f -> batchRequest.add(index, f)));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -70,11 +71,13 @@ public interface ExportHandler<T extends ExporterEntity<T>, R extends RecordValu
   /**
    * Adds the entity or update to the entity to the batch request.
    *
+   * @param index the index to write the entity to
    * @param entity the entity to write to ElasticSearch or OpenSearch
    * @param batchRequest the batch request to add the entity to
    * @throws PersistenceException if the handler fails to flush the entity to the batch request
    */
-  void flush(T entity, BatchRequest batchRequest) throws PersistenceException;
+  void flush(final TargetIndex index, T entity, BatchRequest batchRequest)
+      throws PersistenceException;
 
   /**
    * @return the index name that the handler entities are flushed to.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -74,10 +75,13 @@ public class FlowNodeInstanceFromIncidentHandler
   }
 
   @Override
-  public void flush(final FlowNodeInstanceEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final FlowNodeInstanceEntity entity,
+      final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(FlowNodeInstanceTemplate.INCIDENT_KEY, entity.getIncidentKey());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_MIGRATED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -151,7 +152,10 @@ public class FlowNodeInstanceFromProcessInstanceHandler
   }
 
   @Override
-  public void flush(final FlowNodeInstanceEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final FlowNodeInstanceEntity entity,
+      final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(FlowNodeInstanceTemplate.ID, entity.getId());
     updateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, entity.getPartitionId());
@@ -187,7 +191,7 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     if (entity.getPosition() != null) {
       updateFields.put(FlowNodeInstanceTemplate.POSITION, entity.getPosition());
     }
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -106,13 +107,16 @@ public class FlowNodeInstanceNameFromAdHocActivityHandler
   }
 
   @Override
-  public void flush(final FlowNodeInstanceEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final FlowNodeInstanceEntity entity,
+      final BatchRequest batchRequest) {
     // Only sets the name. The inner-instance document (with its identifying fields) is normally
     // inserted first by FlowNodeInstanceFromProcessInstanceHandler, since the engine writes the
     // inner instance's own ELEMENT_ACTIVATING before the entry child's. The upsert here is a
     // defensive fallback: it lets ES/OS create the document rather than fail if it is missing.
     batchRequest.upsertWithScript(
-        indexName,
+        index,
         entity.getId(),
         entity,
         SET_IF_NULL_NAME_SCRIPT,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.form.FormEntity;
 import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
@@ -78,8 +79,9 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
   }
 
   @Override
-  public void flush(final FormEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index, final FormEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.GlobalListenerUtil;
 import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
@@ -77,9 +78,10 @@ public class GlobalListenerCreatedUpdatedHandler
   }
 
   @Override
-  public void flush(final GlobalListenerEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final GlobalListenerEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.GlobalListenerUtil;
 import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
@@ -62,9 +63,10 @@ public class GlobalListenerDeletedHandler
   }
 
   @Override
-  public void flush(final GlobalListenerEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final GlobalListenerEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
@@ -68,9 +69,10 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   }
 
   @Override
-  public void flush(final GroupEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
@@ -64,9 +65,10 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   }
 
   @Override
-  public void flush(final GroupEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity;
@@ -68,9 +69,10 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupMemberEntity,
   }
 
   @Override
-  public void flush(final GroupMemberEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final GroupMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().parent()));
+    batchRequest.addWithRouting(index, entity, String.valueOf(entity.getJoin().parent()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity;
@@ -66,10 +67,11 @@ public class GroupEntityRemovedHandler
   }
 
   @Override
-  public void flush(final GroupMemberEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final GroupMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.deleteWithRouting(
-        indexName, entity.getId(), String.valueOf(entity.getJoin().parent()));
+        index, entity.getId(), String.valueOf(entity.getJoin().parent()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -64,9 +65,10 @@ public class HistoryDeletionDeletedHandler
   }
 
   @Override
-  public void flush(final HistoryDeletionEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final HistoryDeletionEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.webapps.schema.descriptors.template.IncidentTemplate.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.operate.TreePath;
@@ -117,7 +118,8 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
   }
 
   @Override
-  public void flush(final IncidentEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final IncidentEntity entity, final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(BPMN_PROCESS_ID, entity.getBpmnProcessId());
     updateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
@@ -125,7 +127,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     updateFields.put(POSITION, entity.getPosition());
     updateFields.put(TREE_PATH, entity.getTreePath());
     updateFields.put(STATE, entity.getState());
-    batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
+    batchRequest.upsert(index, String.valueOf(entity.getKey()), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.jobmetricsbatch.JobMetricsBatchEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -116,9 +117,10 @@ public class JobBatchMetricsExportedHandler
   }
 
   @Override
-  public void flush(final JobMetricsBatchEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final JobMetricsBatchEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -24,6 +24,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.JobEntity;
@@ -162,7 +163,8 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
   }
 
   @Override
-  public void flush(final JobEntity jobEntity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final JobEntity jobEntity, final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
     if (jobEntity.getFlowNodeId() != null) {
       updateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());
@@ -188,7 +190,7 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     if (FAILED_JOB_EVENTS.stream().anyMatch(i -> jobEntity.getState().equals(i.name()))) {
       updateFields.put(JOB_FAILED_WITH_RETRIES_LEFT, jobEntity.isJobFailedWithRetriesLeft());
     }
-    batchRequest.upsert(indexName, jobEntity.getId(), jobEntity, updateFields);
+    batchRequest.upsert(index, jobEntity.getId(), jobEntity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT_POSITION;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -99,7 +100,9 @@ public class ListViewFlowNodeFromIncidentHandler
 
   @Override
   public void flush(
-      final FlowNodeInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+      final TargetIndex index,
+      final FlowNodeInstanceForListViewEntity entity,
+      final BatchRequest batchRequest) {
 
     LOGGER.debug("Flow node instance for list view: id {}", entity.getId());
     final Map<String, Object> updateFields = new LinkedHashMap<>();
@@ -109,7 +112,7 @@ public class ListViewFlowNodeFromIncidentHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
+        index, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JOB_POSITION;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -104,7 +105,9 @@ public class ListViewFlowNodeFromJobHandler
 
   @Override
   public void flush(
-      final FlowNodeInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+      final TargetIndex index,
+      final FlowNodeInstanceForListViewEntity entity,
+      final BatchRequest batchRequest) {
 
     LOGGER.debug(
         "Update job state for flow node instance: id {} JobFailedWithRetriesLeft {}",
@@ -117,7 +120,7 @@ public class ListViewFlowNodeFromJobHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
+        index, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
@@ -15,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.AC
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeType;
@@ -123,7 +124,9 @@ public class ListViewFlowNodeFromProcessInstanceHandler
 
   @Override
   public void flush(
-      final FlowNodeInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+      final TargetIndex index,
+      final FlowNodeInstanceForListViewEntity entity,
+      final BatchRequest batchRequest) {
 
     LOGGER.debug("Flow node instance for list view: id {}", entity.getId());
 
@@ -136,7 +139,7 @@ public class ListViewFlowNodeFromProcessInstanceHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, processInstanceKey.toString());
+        index, entity.getId(), entity, updateFields, processInstanceKey.toString());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.emptyToNull;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -80,10 +81,12 @@ public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandl
 
   @Override
   public void flush(
-      final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+      final TargetIndex index,
+      final ProcessInstanceForListViewEntity entity,
+      final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(ListViewTemplate.BUSINESS_ID, emptyToNull(entity.getBusinessId()));
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.update(index, entity.getId(), updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.*;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -160,7 +161,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
 
   @Override
   public void flush(
-      final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+      final TargetIndex index,
+      final ProcessInstanceForListViewEntity entity,
+      final BatchRequest batchRequest) {
 
     final Map<String, Object> updateFields = new HashMap<>();
     if (entity.getStartDate() != null) {
@@ -192,7 +195,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       updateFields.put(ListViewTemplate.BUSINESS_ID, entity.getBusinessId());
     }
 
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSI
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VAR_NAME;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.VAR_VALUE;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -99,7 +100,10 @@ public class ListViewVariableFromVariableHandler
   }
 
   @Override
-  public void flush(final VariableForListViewEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final VariableForListViewEntity entity,
+      final BatchRequest batchRequest) {
 
     LOGGER.debug("Variable for list view: id {}", entity.getId());
     final Map<String, Object> updateFields = new HashMap<>();
@@ -110,7 +114,7 @@ public class ListViewVariableFromVariableHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
+        index, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.MappingRuleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -68,9 +69,10 @@ public class MappingRuleCreatedUpdatedHandler
   }
 
   @Override
-  public void flush(final MappingRuleEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final MappingRuleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingRuleDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.MappingRuleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -62,9 +63,10 @@ public class MappingRuleDeletedHandler
   }
 
   @Override
-  public void flush(final MappingRuleEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final MappingRuleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -88,8 +89,12 @@ public class MessageSubscriptionFromMessageStartEventSubscriptionHandler
   }
 
   @Override
-  public void flush(final MessageSubscriptionEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final MessageSubscriptionEntity entity,
+      final BatchRequest batchRequest) {
     persistEvent(
+        index,
         entity,
         MessageSubscriptionTemplate.POSITION_MESSAGE,
         entity.getPositionProcessMessageSubscription(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.MessageSubscriptionEntity;
@@ -113,8 +114,12 @@ public class MessageSubscriptionFromProcessMessageSubscriptionHandler
   }
 
   @Override
-  public void flush(final MessageSubscriptionEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final MessageSubscriptionEntity entity,
+      final BatchRequest batchRequest) {
     persistEvent(
+        index,
         entity,
         MessageSubscriptionTemplate.POSITION_MESSAGE,
         entity.getPositionProcessMessageSubscription(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
@@ -72,14 +73,15 @@ public class MigratedVariableHandler implements ExportHandler<VariableEntity, Va
   }
 
   @Override
-  public void flush(final VariableEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final VariableEntity entity, final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
 
     updateFields.put(VariableTemplate.PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     updateFields.put(VariableTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
     updateFields.put(VariableTemplate.POSITION, entity.getPosition());
 
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
 import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
@@ -84,10 +85,13 @@ public class PostImporterQueueFromIncidentHandler
   }
 
   @Override
-  public void flush(final PostImporterQueueEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final PostImporterQueueEntity entity,
+      final BatchRequest batchRequest) {
     // Route each entry to a single shard by partition id so that, within a partition, a search can
     // never observe a higher position without also seeing all lower positions (see #56117)
-    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getPartitionId()));
+    batchRequest.addWithRouting(index, entity, String.valueOf(entity.getPartitionId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.entities.ProcessDefinitionState;
@@ -58,10 +59,11 @@ public class ProcessDeletedHandler implements ExportHandler<ProcessEntity, Proce
   }
 
   @Override
-  public void flush(final ProcessEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final ProcessEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.update(
-        indexName, entity.getId(), Map.of(ProcessIndex.STATE, ProcessDefinitionState.DELETED));
+        index, entity.getId(), Map.of(ProcessIndex.STATE, ProcessDefinitionState.DELETED));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.ProcessEntity;
@@ -111,8 +112,9 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
   }
 
   @Override
-  public void flush(final ProcessEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index, final ProcessEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceCreatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.util.ResourceUtils;
 import io.camunda.webapps.schema.entities.resource.DeployedResourceEntity;
@@ -69,9 +70,10 @@ public class ResourceCreatedHandler implements ExportHandler<DeployedResourceEnt
   }
 
   @Override
-  public void flush(final DeployedResourceEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final DeployedResourceEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ResourceDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.resource.DeployedResourceEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -57,9 +58,10 @@ public class ResourceDeletedHandler implements ExportHandler<DeployedResourceEnt
   }
 
   @Override
-  public void flush(final DeployedResourceEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final DeployedResourceEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
@@ -63,9 +64,10 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
   }
 
   @Override
-  public void flush(final RoleEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final RoleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
@@ -64,9 +65,10 @@ public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordV
   }
 
   @Override
-  public void flush(final RoleEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final RoleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
@@ -67,9 +68,10 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleMemberEntity, R
   }
 
   @Override
-  public void flush(final RoleMemberEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final RoleMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent());
+    batchRequest.addWithRouting(index, entity, entity.getJoin().parent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
@@ -65,9 +66,10 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleMemberEntity,
   }
 
   @Override
-  public void flush(final RoleMemberEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final RoleMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.deleteWithRouting(indexName, entity.getId(), entity.getJoin().parent());
+    batchRequest.deleteWithRouting(index, entity.getId(), entity.getJoin().parent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
@@ -71,9 +72,10 @@ public class SequenceFlowDeletedHandler
   }
 
   @Override
-  public void flush(final SequenceFlowEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final SequenceFlowEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
@@ -70,8 +71,9 @@ public class SequenceFlowHandler
   }
 
   @Override
-  public void flush(final SequenceFlowEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index, final SequenceFlowEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
@@ -68,9 +69,10 @@ public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, Te
   }
 
   @Override
-  public void flush(final TenantEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
@@ -65,9 +66,10 @@ public class TenantDeletedHandler implements ExportHandler<TenantEntity, TenantR
   }
 
   @Override
-  public void flush(final TenantEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
@@ -68,9 +69,10 @@ public class TenantEntityAddedHandler
   }
 
   @Override
-  public void flush(final TenantMemberEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final TenantMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent());
+    batchRequest.addWithRouting(index, entity, entity.getJoin().parent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
@@ -67,10 +68,11 @@ public class TenantEntityRemovedHandler
   }
 
   @Override
-  public void flush(final TenantMemberEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final TenantMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.deleteWithRouting(
-        indexName, entity.getId(), String.valueOf(entity.getJoin().parent()));
+        index, entity.getId(), String.valueOf(entity.getJoin().parent()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -65,9 +66,10 @@ public class UserCreatedUpdatedHandler implements ExportHandler<UserEntity, User
   }
 
   @Override
-  public void flush(final UserEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final UserEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -64,9 +65,10 @@ public class UserDeletedHandler implements ExportHandler<UserEntity, UserRecordV
   }
 
   @Override
-  public void flush(final UserEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final UserEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -12,6 +12,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -84,8 +85,11 @@ public class UserTaskCompletionVariableHandler
   }
 
   @Override
-  public void flush(final SnapshotTaskVariableBatch entity, final BatchRequest batchRequest) {
-    entity.variables().forEach(v -> flushSnapshotTaskVariableEntity(v, batchRequest));
+  public void flush(
+      final TargetIndex index,
+      final SnapshotTaskVariableBatch entity,
+      final BatchRequest batchRequest) {
+    entity.variables().forEach(v -> flushSnapshotTaskVariableEntity(index, v, batchRequest));
   }
 
   @Override
@@ -94,12 +98,14 @@ public class UserTaskCompletionVariableHandler
   }
 
   private void flushSnapshotTaskVariableEntity(
-      final SnapshotTaskVariableEntity entity, final BatchRequest batchRequest) {
+      final TargetIndex index,
+      final SnapshotTaskVariableEntity entity,
+      final BatchRequest batchRequest) {
     final var updateFields = new HashMap<String, Object>();
     updateFields.put(SnapshotTaskVariableTemplate.VALUE, entity.getValue());
     updateFields.put(SnapshotTaskVariableTemplate.FULL_VALUE, entity.getFullValue());
     updateFields.put(SnapshotTaskVariableTemplate.IS_PREVIEW, entity.getIsPreview());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   private SnapshotTaskVariableEntity createSnapshotVariableEntity(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCreatingHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity;
@@ -84,11 +85,12 @@ public class UserTaskCreatingHandler implements ExportHandler<TaskEntity, UserTa
   }
 
   @Override
-  public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final TaskEntity entity, final BatchRequest batchRequest) {
     final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
     batchRequest.addWithRouting(
-        indexName,
+        index,
         entity,
         previousVersionRecord ? String.valueOf(entity.getKey()) : entity.getProcessInstanceId());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
@@ -129,14 +130,15 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   }
 
   @Override
-  public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final TaskEntity entity, final BatchRequest batchRequest) {
 
     final Map<String, Object> updateFields = getUpdatedFields(entity);
 
     final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
     batchRequest.upsertWithRouting(
-        indexName,
+        index,
         previousVersionRecord ? String.valueOf(entity.getKey()) : entity.getId(),
         entity,
         updateFields,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
@@ -172,12 +173,13 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
   }
 
   @Override
-  public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index, final TaskEntity entity, final BatchRequest batchRequest) {
     final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
     if (entity.isMarkedForDeletion() && previousVersionRecord) {
       final var jobKey = String.valueOf(entity.getKey());
-      batchRequest.deleteWithRouting(indexName, jobKey, jobKey);
+      batchRequest.deleteWithRouting(index, jobKey, jobKey);
       return;
     }
 
@@ -186,7 +188,7 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
     final var processInstanceKey = entity.getProcessInstanceId();
 
     batchRequest.upsertWithRouting(
-        indexName,
+        index,
         previousVersionRecord ? String.valueOf(entity.getKey()) : taskEntityId,
         entity,
         updateFields,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
@@ -71,8 +72,11 @@ public class UserTaskProcessInstanceHandler
   }
 
   @Override
-  public void flush(final TaskProcessInstanceEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index,
+      final TaskProcessInstanceEntity entity,
+      final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
@@ -121,7 +122,10 @@ public class UserTaskVariableHandler
   }
 
   @Override
-  public void flush(final UserTaskVariableBatch entity, final BatchRequest batchRequest) {
+  public void flush(
+      final TargetIndex index,
+      final UserTaskVariableBatch entity,
+      final BatchRequest batchRequest) {
     entity
         .getVariables()
         .forEach(
@@ -130,7 +134,7 @@ public class UserTaskVariableHandler
               updateFields.put(TaskTemplate.VARIABLE_VALUE, v.getValue());
               updateFields.put(TaskTemplate.IS_TRUNCATED, v.getIsTruncated());
               batchRequest.upsertWithRouting(
-                  indexName, v.getId(), v, updateFields, String.valueOf(v.getProcessInstanceId()));
+                  index, v.getId(), v, updateFields, String.valueOf(v.getProcessInstanceId()));
             });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
@@ -88,8 +89,9 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
   }
 
   @Override
-  public void flush(final VariableEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+  public void flush(
+      final TargetIndex index, final VariableEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AbstractAuditLogHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/auditlog/AbstractAuditLogHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.auditlog;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
@@ -56,8 +57,9 @@ abstract class AbstractAuditLogHandler<T extends ExporterEntity<T>, R extends Re
   }
 
   @Override
-  public void flush(final T entity, final BatchRequest batchRequest) throws PersistenceException {
-    batchRequest.add(indexName, entity);
+  public void flush(final TargetIndex index, final T entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/AbstractOperationStatusHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.batchoperation;
 import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperationReferenceNullValue;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -107,7 +108,8 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
   }
 
   @Override
-  public void flush(final OperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final OperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(OperationTemplate.BATCH_OPERATION_ID, entity.getBatchOperationId());
@@ -118,7 +120,7 @@ public abstract class AbstractOperationStatusHandler<R extends RecordValue>
     updateFields.put(OperationTemplate.COMPLETED_DATE, entity.getCompletedDate());
     updateFields.put(OperationTemplate.ERROR_MSG, entity.getErrorMessage());
 
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
     LOGGER.trace("Updated operation {} with fields {}", entity.getId(), updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.batchoperation;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
@@ -81,14 +82,15 @@ public class BatchOperationChunkCreatedHandler
   }
 
   @Override
-  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     // Atomically increment the total and reset endDate so the BatchOperationUpdateTask
     // re-processes the counts. Extract the batchKey from the composite cache ID (batchKey:chunk).
     final String batchOperationKey = entity.getId().split(":")[0];
 
     batchRequest.updateWithScript(
-        indexName,
+        index,
         batchOperationKey,
         """
             ctx._source.operationsTotalCount = ctx._source.operationsTotalCount + params.operationsTotalCount;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.batchoperation;
 import com.google.common.base.Splitter;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
@@ -119,9 +120,10 @@ public class BatchOperationChunkCreatedItemHandler
   }
 
   @Override
-  public void flush(final OperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final OperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.map;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
@@ -93,7 +94,8 @@ public class BatchOperationCreatedHandler
   }
 
   @Override
-  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     // Use upsert instead of add (index) to prevent cross-partition document overwrites.
     // The CREATED event is distributed to all partitions, so each partition's exporter writes to
@@ -116,7 +118,7 @@ public class BatchOperationCreatedHandler
     if (actorId != null) {
       updateFields.put(BatchOperationTemplate.ACTOR_ID, actorId);
     }
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.batchoperation;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
@@ -75,7 +76,8 @@ public class BatchOperationInitializedHandler
   }
 
   @Override
-  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     // Use upsertWithScript to be resilient against cross-partition ordering. Each partition
     // independently produces an INITIALIZED event, so multiple exporters write state=ACTIVE to
@@ -84,7 +86,7 @@ public class BatchOperationInitializedHandler
     // current state is CREATED or null, preventing state regression.
     // If the document does not yet exist, the upsert creates it from the entity.
     batchRequest.upsertWithScript(
-        indexName,
+        index,
         entity.getId(),
         entity,
         CONDITIONAL_UPDATE_SCRIPT,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.intent.BatchOperationIntent.*;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
@@ -133,7 +134,8 @@ public class BatchOperationLifecycleManagementHandler
   }
 
   @Override
-  public void flush(final BatchOperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final BatchOperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     // Use upsertWithScript to be resilient against cross-partition ordering.
     // CANCELED, SUSPENDED, and RESUMED events are distributed to all partitions, so each
@@ -148,7 +150,7 @@ public class BatchOperationLifecycleManagementHandler
       scriptParams.put(BatchOperationTemplate.ERRORS, entity.getErrors());
     }
     batchRequest.upsertWithScript(
-        indexName, entity.getId(), entity, CONDITIONAL_STATE_UPDATE_SCRIPT, scriptParams);
+        index, entity.getId(), entity, CONDITIONAL_STATE_UPDATE_SCRIPT, scriptParams);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.batchoperation.AbstractOperationHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -66,7 +67,10 @@ public abstract class AbstractProcessInstanceFromOperationItemHandler<
   }
 
   @Override
-  public void flush(final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index,
+      final ProcessInstanceForListViewEntity entity,
+      final BatchRequest batchRequest)
       throws PersistenceException {
     // Extract just the processInstanceKey from the composite cache ID
     // (processInstanceKey:batchOperationReference).
@@ -78,7 +82,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandler<
             + "ctx._source.batchOperationIds.add(params.batchOperationId);"
             + "}";
     batchRequest.updateWithScript(
-        indexName,
+        index,
         processInstanceKey,
         script,
         Map.of("batchOperationId", entity.getBatchOperationIds().getFirst()));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.batchoperation.listview;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -65,7 +66,10 @@ public class ListViewFromChunkItemHandler
   }
 
   @Override
-  public void flush(final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index,
+      final ProcessInstanceForListViewEntity entity,
+      final BatchRequest batchRequest)
       throws PersistenceException {
     // Extract just the processInstanceKey from the composite cache ID
     // (processInstanceKey:batchOperationKey).
@@ -77,7 +81,7 @@ public class ListViewFromChunkItemHandler
             + "ctx._source.batchOperationIds.add(params.batchOperationId);"
             + "}";
     batchRequest.updateWithScript(
-        indexName,
+        index,
         processInstanceKey,
         script,
         Map.of("batchOperationId", entity.getBatchOperationIds().getFirst()));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.operation;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -58,7 +59,8 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
   }
 
   @Override
-  public void flush(final OperationEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final OperationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(OperationTemplate.STATE, entity.getState());
@@ -66,7 +68,7 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
     updateFields.put(OperationTemplate.LOCK_OWNER, entity.getLockOwner());
     updateFields.put(OperationTemplate.LOCK_EXPIRATION_TIME, entity.getLockExpirationTime());
 
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.update(index, entity.getId(), updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/usage/AbstractUsageMetricExportedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/usage/AbstractUsageMetricExportedHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType.T
 
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.usage.AbstractUsageMetricExportedHandler.Batch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType;
@@ -70,8 +71,8 @@ abstract class AbstractUsageMetricExportedHandler<
   }
 
   @Override
-  public void flush(final B batch, final BatchRequest batchRequest) {
-    batch.getMetrics().forEach(e -> batchRequest.add(indexName, e));
+  public void flush(final TargetIndex index, final B batch, final BatchRequest batchRequest) {
+    batch.getMetrics().forEach(e -> batchRequest.add(index, e));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateAddHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.waitstate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
@@ -40,8 +41,9 @@ public class WaitStateAddHandler<R extends RecordValue & WaitStateRelated>
   }
 
   @Override
-  public void flush(final WaitStateEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final WaitStateEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index, entity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateRemoveHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.waitstate;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
 import io.camunda.zeebe.exporter.common.waitstate.WaitStateTransformer;
@@ -68,9 +69,10 @@ public class WaitStateRemoveHandler<R extends RecordValue & WaitStateRelated>
   }
 
   @Override
-  public void flush(final WaitStateEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final WaitStateEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index, entity.getId());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/waitstate/WaitStateUpdateHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers.waitstate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
@@ -44,7 +45,8 @@ public class WaitStateUpdateHandler<R extends RecordValue & WaitStateRelated>
   }
 
   @Override
-  public void flush(final WaitStateEntity entity, final BatchRequest batchRequest)
+  public void flush(
+      final TargetIndex index, final WaitStateEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     final Map<String, Object> updateFields = new HashMap<>();
     // elementId and bpmnProcessId are null when the transformer called
@@ -57,6 +59,6 @@ public class WaitStateUpdateHandler<R extends RecordValue & WaitStateRelated>
       updateFields.put(WaitStateTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
     }
     updateFields.put(WaitStateTemplate.DETAILS, entity.getDetails());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index, entity.getId(), entity, updateFields);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/MainIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/MainIndex.java
@@ -7,4 +7,10 @@
  */
 package io.camunda.exporter.index;
 
-record MainIndex(String name) implements TargetIndex {}
+record MainIndex(String name) implements TargetIndex {
+  MainIndex {
+    if (name == null || name.isBlank()) {
+      throw new IllegalArgumentException("Main index name must not be null or blank");
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/MainIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/MainIndex.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.index;
+
+record MainIndex(String name) implements TargetIndex {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.index;
+
+public interface TargetIndex {
+  String name();
+
+  static TargetIndex mainIndex(final String name) {
+    return new MainIndex(name);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/index/TargetIndex.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.index;
 
-public interface TargetIndex {
+public sealed interface TargetIndex permits MainIndex {
   String name();
 
   static TargetIndex mainIndex(final String name) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.store;
 
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
@@ -22,47 +23,48 @@ public interface BatchRequest {
 
   BatchRequest withMaxBytes(long maxBulkBytes);
 
-  BatchRequest add(String index, ExporterEntity entity);
+  BatchRequest add(TargetIndex index, ExporterEntity entity);
 
-  BatchRequest addWithId(String index, String id, ExporterEntity entity);
+  BatchRequest addWithId(TargetIndex index, String id, ExporterEntity entity);
 
-  BatchRequest addWithRouting(String index, ExporterEntity entity, String routing);
+  BatchRequest addWithRouting(TargetIndex index, ExporterEntity entity, String routing);
 
   BatchRequest upsert(
-      String index, String id, ExporterEntity entity, Map<String, Object> updateFields);
+      TargetIndex index, String id, ExporterEntity entity, Map<String, Object> updateFields);
 
   BatchRequest upsertWithRouting(
-      String index,
+      TargetIndex index,
       String id,
       ExporterEntity entity,
       Map<String, Object> updateFields,
       String routing);
 
   BatchRequest upsertWithScript(
-      String index,
+      TargetIndex index,
       String id,
       ExporterEntity entity,
       String script,
       Map<String, Object> parameters);
 
   BatchRequest upsertWithScriptAndRouting(
-      String index,
+      TargetIndex index,
       String id,
       ExporterEntity entity,
       String script,
       Map<String, Object> parameters,
       String routing);
 
-  BatchRequest update(String index, String id, Map<String, Object> updateFields);
+  BatchRequest update(TargetIndex index, String id, Map<String, Object> updateFields);
 
-  BatchRequest update(String index, String id, ExporterEntity entity) throws PersistenceException;
+  BatchRequest update(TargetIndex index, String id, ExporterEntity entity)
+      throws PersistenceException;
 
   BatchRequest updateWithScript(
-      String index, String id, String script, Map<String, Object> parameters);
+      TargetIndex index, String id, String script, Map<String, Object> parameters);
 
-  BatchRequest delete(String index, String id);
+  BatchRequest delete(TargetIndex index, String id);
 
-  BatchRequest deleteWithRouting(String index, String id, String routing);
+  BatchRequest deleteWithRouting(TargetIndex index, String id, String routing);
 
   /**
    * Applies all updates in this batch.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -22,6 +22,7 @@ import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.util.BinaryData;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import io.camunda.exporter.utils.NdJsonSizeUtil;
@@ -69,12 +70,13 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest add(final String index, final ExporterEntity entity) {
+  public BatchRequest add(final TargetIndex index, final ExporterEntity entity) {
     return addWithId(index, entity.getId(), entity);
   }
 
   @Override
-  public BatchRequest addWithId(final String index, final String id, final ExporterEntity entity) {
+  public BatchRequest addWithId(
+      final TargetIndex index, final String id, final ExporterEntity entity) {
     LOGGER.debug("Add index request for index {} id {} and entity {} ", index, id, entity);
     addIndexOp(index, id, null, entity);
     return this;
@@ -82,7 +84,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest addWithRouting(
-      final String index, final ExporterEntity entity, final String routing) {
+      final TargetIndex index, final ExporterEntity entity, final String routing) {
     LOGGER.debug(
         "Add index request with routing {} for index {} and entity {} ", routing, index, entity);
     addIndexOp(index, entity.getId(), routing, entity);
@@ -91,7 +93,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsert(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final Map<String, Object> updateFields) {
@@ -100,7 +102,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithRouting(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final Map<String, Object> updateFields,
@@ -118,7 +120,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithScript(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final String script,
@@ -128,7 +130,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithScriptAndRouting(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final String script,
@@ -152,7 +154,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest update(
-      final String index, final String id, final Map<String, Object> updateFields) {
+      final TargetIndex index, final String id, final Map<String, Object> updateFields) {
     LOGGER.debug(
         "Add update request for index {} id {} and update fields {}", index, id, updateFields);
     addUpdateOp(index, id, null, a -> a.doc(updateFields));
@@ -160,7 +162,8 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest update(final String index, final String id, final ExporterEntity entity) {
+  public BatchRequest update(
+      final TargetIndex index, final String id, final ExporterEntity entity) {
     LOGGER.debug("Add update request for index {} id {} and entity {}", index, id, entity);
     addUpdateOp(index, id, null, a -> a.doc(entity));
     return this;
@@ -168,7 +171,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest updateWithScript(
-      final String index,
+      final TargetIndex index,
       final String id,
       final String script,
       final Map<String, Object> parameters) {
@@ -184,14 +187,15 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest delete(final String index, final String id) {
+  public BatchRequest delete(final TargetIndex index, final String id) {
     LOGGER.debug("Add delete request for index {} and id {}", index, id);
     addDeleteOp(index, id, null);
     return this;
   }
 
   @Override
-  public BatchRequest deleteWithRouting(final String index, final String id, final String routing) {
+  public BatchRequest deleteWithRouting(
+      final TargetIndex index, final String id, final String routing) {
     LOGGER.debug(
         "Add delete index request with routing {} for index {} and entity {} ", routing, index, id);
     addDeleteOp(index, id, routing);
@@ -210,15 +214,15 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   private void addIndexOp(
-      final String index, final String id, final String routing, final ExporterEntity entity) {
+      final TargetIndex index, final String id, final String routing, final ExporterEntity entity) {
     final BinaryData binaryDoc = BinaryData.of(entity, jsonpMapper);
     final IndexOperation<Object> indexOp =
-        IndexOperation.of(i -> i.index(index).id(id).routing(routing).document(binaryDoc));
+        IndexOperation.of(i -> i.index(index.name()).id(id).routing(routing).document(binaryDoc));
     addOperation(BulkOperation.of(b -> b.index(indexOp)), binaryDoc.size());
   }
 
   private void addUpdateOp(
-      final String index,
+      final TargetIndex index,
       final String id,
       final String routing,
       final Function<Builder<Object, Object>, ?> actionBuilder) {
@@ -234,7 +238,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
             b ->
                 b.update(
                     u ->
-                        u.index(index)
+                        u.index(index.name())
                             .id(id)
                             .routing(routing)
                             .retryOnConflict(UPDATE_RETRY_COUNT)
@@ -242,9 +246,9 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     addOperation(op, binaryAction.size());
   }
 
-  private void addDeleteOp(final String index, final String id, final String routing) {
+  private void addDeleteOp(final TargetIndex index, final String id, final String routing) {
     final BulkOperation op =
-        BulkOperation.of(b -> b.delete(d -> d.index(index).id(id).routing(routing)));
+        BulkOperation.of(b -> b.delete(d -> d.index(index.name()).id(id).routing(routing)));
     addOperation(op, 0L);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.store;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -124,7 +125,8 @@ public final class ExporterBatchWriter {
       final var key = entry.getKey();
       final var handler = key.handler();
       final var entity = entry.getValue();
-      handler.flush(entity, batchRequest);
+      final var index = TargetIndex.mainIndex(handler.getIndexName());
+      handler.flush(index, entity, batchRequest);
     }
 
     batchRequest.execute(customErrorHandler);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.store;
 
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -67,12 +68,13 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest add(final String index, final ExporterEntity entity) {
+  public BatchRequest add(final TargetIndex index, final ExporterEntity entity) {
     return addWithId(index, entity.getId(), entity);
   }
 
   @Override
-  public BatchRequest addWithId(final String index, final String id, final ExporterEntity entity) {
+  public BatchRequest addWithId(
+      final TargetIndex index, final String id, final ExporterEntity entity) {
     LOGGER.debug("Add index request for index {} id {} and entity {} ", index, id, entity);
     addIndexOp(index, id, null, entity);
     return this;
@@ -80,7 +82,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest addWithRouting(
-      final String index, final ExporterEntity entity, final String routing) {
+      final TargetIndex index, final ExporterEntity entity, final String routing) {
     LOGGER.debug(
         "Add index request with routing {} for index {} and entity {} ", routing, index, entity);
     addIndexOp(index, entity.getId(), routing, entity);
@@ -89,7 +91,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsert(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final Map<String, Object> updateFields) {
@@ -98,7 +100,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithRouting(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final Map<String, Object> updateFields,
@@ -116,7 +118,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithScript(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final String script,
@@ -126,7 +128,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest upsertWithScriptAndRouting(
-      final String index,
+      final TargetIndex index,
       final String id,
       final ExporterEntity entity,
       final String script,
@@ -153,7 +155,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest update(
-      final String index, final String id, final Map<String, Object> updateFields) {
+      final TargetIndex index, final String id, final Map<String, Object> updateFields) {
     LOGGER.debug(
         "Add update request for index {} id {} and update fields {}", index, id, updateFields);
     addUpdateOp(index, id, null, wrapper -> wrapper.document(updateFields));
@@ -161,7 +163,8 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest update(final String index, final String id, final ExporterEntity entity) {
+  public BatchRequest update(
+      final TargetIndex index, final String id, final ExporterEntity entity) {
     LOGGER.debug("Add update request for index {} id {} and entity {}", index, id, entity);
     addUpdateOp(index, id, null, wrapper -> wrapper.document(entity));
     return this;
@@ -169,7 +172,7 @@ public class OpensearchBatchRequest implements BatchRequest {
 
   @Override
   public BatchRequest updateWithScript(
-      final String index,
+      final TargetIndex index,
       final String id,
       final String script,
       final Map<String, Object> parameters) {
@@ -188,14 +191,15 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public BatchRequest delete(final String index, final String id) {
+  public BatchRequest delete(final TargetIndex index, final String id) {
     LOGGER.debug("Add delete request for index {} and id {}", index, id);
     addDeleteOp(index, id, null);
     return this;
   }
 
   @Override
-  public BatchRequest deleteWithRouting(final String index, final String id, final String routing) {
+  public BatchRequest deleteWithRouting(
+      final TargetIndex index, final String id, final String routing) {
     LOGGER.debug(
         "Add delete index request with routing {} for index {} and entity {} ", routing, index, id);
     addDeleteOp(index, id, routing);
@@ -214,28 +218,28 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   private void addIndexOp(
-      final String index, final String id, final String routing, final ExporterEntity entity) {
+      final TargetIndex index, final String id, final String routing, final ExporterEntity entity) {
     final BinaryData binaryDoc = BinaryData.of(entity, jsonpMapper);
     final IndexOperation<BinaryData> indexOp =
-        IndexOperation.of(i -> i.index(index).id(id).routing(routing).document(binaryDoc));
+        IndexOperation.of(i -> i.index(index.name()).id(id).routing(routing).document(binaryDoc));
     addOperation(BulkOperation.of(b -> b.index(indexOp)), binaryDoc.size());
   }
 
   private void addUpdateOp(
-      final String index,
+      final TargetIndex index,
       final String id,
       final String routing,
       final Consumer<BinaryUpdateOperationWrapper> wrapperConfigurer) {
     final BinaryUpdateOperationWrapper wrapper = new BinaryUpdateOperationWrapper(jsonpMapper);
     wrapperConfigurer.accept(wrapper);
     final UpdateOperation<BinaryData> updateOp =
-        wrapper.build(index, id, routing, UPDATE_RETRY_COUNT);
+        wrapper.build(index.name(), id, routing, UPDATE_RETRY_COUNT);
     addOperation(BulkOperation.of(b -> b.update(updateOp)), wrapper.payloadBytes());
   }
 
-  private void addDeleteOp(final String index, final String id, final String routing) {
+  private void addDeleteOp(final TargetIndex index, final String id, final String routing) {
     final BulkOperation op =
-        BulkOperation.of(b -> b.delete(d -> d.index(index).id(id).routing(routing)));
+        BulkOperation.of(b -> b.delete(d -> d.index(index.name()).id(id).routing(routing)));
     addOperation(op, 0L);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -11,8 +11,10 @@ import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate;
 import io.camunda.webapps.schema.entities.agenthistory.AgentHistoryCommitStatus;
@@ -43,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.mockito.Mockito;
 
 final class AgentHistoryHandlerTest {
 
@@ -328,14 +329,15 @@ final class AgentHistoryHandlerTest {
     final var entity = new AgentHistoryEntity().setId("1");
     underTest.updateEntity(record, entity);
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then — only commitStatus is included in the upsert updateFields map
     verify(mockRequest)
-        .upsert(indexName, entity.getId(), entity, Map.of(COMMIT_STATUS, entity.getCommitStatus()));
+        .upsert(index, entity.getId(), entity, Map.of(COMMIT_STATUS, entity.getCommitStatus()));
   }
 
   @ParameterizedTest(name = "[{index}] Should map protocol role ''{0}'' to entity role")

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -329,7 +329,7 @@ final class AgentHistoryHandlerTest {
     final var entity = new AgentHistoryEntity().setId("1");
     underTest.updateEntity(record, entity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -17,7 +17,6 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -355,7 +354,7 @@ final class AgentInstanceHandlerTest {
     final var entity = new AgentInstanceEntity().setId("1");
     underTest.updateEntity(record, entity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 
     // when
@@ -390,7 +389,7 @@ final class AgentInstanceHandlerTest {
             .setCompletionDate(completionDate)
             .setLastUpdatedDate(completionDate);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -17,9 +17,11 @@ import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTempla
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate;
 import io.camunda.webapps.schema.entities.agentinstance.AgentInstanceEntity;
@@ -353,10 +355,11 @@ final class AgentInstanceHandlerTest {
     final var entity = new AgentInstanceEntity().setId("1");
     underTest.updateEntity(record, entity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then — updateFields keys match template constants; values come from entity (not hardcoded)
     final var expectedUpdateFields = new LinkedHashMap<String, Object>();
@@ -372,7 +375,7 @@ final class AgentInstanceHandlerTest {
     // payload is identical across intents (no-op when null overwrites null in the index).
     expectedUpdateFields.put(COMPLETION_DATE, null);
 
-    verify(mockRequest, times(1)).upsert(indexName, entity.getId(), entity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, entity.getId(), entity, expectedUpdateFields);
   }
 
   @Test
@@ -387,15 +390,16 @@ final class AgentInstanceHandlerTest {
             .setCompletionDate(completionDate)
             .setLastUpdatedDate(completionDate);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsert(
-            Mockito.eq(indexName),
+            Mockito.eq(index),
             Mockito.eq(entityId),
             Mockito.eq(entity),
             Mockito.argThat(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -146,12 +147,13 @@ public class AuthorizationCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final var inputEntity = new AuthorizationEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -147,7 +147,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final var inputEntity = new AuthorizationEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationDeletedHandlerTest.java
@@ -76,7 +76,7 @@ public class AuthorizationDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final AuthorizationEntity inputEntity = new AuthorizationEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -75,12 +76,13 @@ public class AuthorizationDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final AuthorizationEntity inputEntity = new AuthorizationEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -8,15 +8,12 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
@@ -157,14 +154,16 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             .setScope(
                 io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT)
             .setKind(ClusterVariableKind.SECRET_REFERENCE);
+
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(eq(indexName), eq(inputEntity));
-    verify(mockRequest, never()).upsert(anyString(), anyString(), any(), anyMap());
+    verify(mockRequest).add(eq(index), eq(inputEntity));
+    verifyNoMoreInteractions(mockRequest);
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -155,7 +155,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
                 io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT)
             .setKind(ClusterVariableKind.SECRET_REFERENCE);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
@@ -113,7 +113,7 @@ public class ClusterVariableDeletedHandlerTest {
             .setTenantId("tenantId")
             .setScope(
                 io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
     underTest.flush(index, inputEntity, mockRequest);
     verify(mockRequest, times(1)).delete(index, inputEntity.getId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableDeletedHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -112,8 +113,9 @@ public class ClusterVariableDeletedHandlerTest {
             .setTenantId("tenantId")
             .setScope(
                 io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope.TENANT);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
-    underTest.flush(inputEntity, mockRequest);
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    underTest.flush(index, inputEntity, mockRequest);
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -8,9 +8,11 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -29,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.mockito.Mockito;
 
 final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -256,12 +257,13 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     final CorrelatedMessageSubscriptionEntity entity =
         underTest.createNewEntity(underTest.generateIds(record).getFirst());
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(expectedIndexName, entity);
+    verify(mockRequest, times(1)).add(index, entity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -257,7 +257,7 @@ final class CorrelatedMessageSubscriptionFromMessageStartEventSubscriptionHandle
     final CorrelatedMessageSubscriptionEntity entity =
         underTest.createNewEntity(underTest.generateIds(record).getFirst());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -8,9 +8,11 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.template.CorrelatedMessageSubscriptionTemplate;
@@ -29,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.mockito.Mockito;
 
 final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -276,12 +277,13 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     final CorrelatedMessageSubscriptionEntity entity =
         underTest.createNewEntity(underTest.generateIds(record).getFirst());
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(expectedIndexName, entity);
+    verify(mockRequest, times(1)).add(index, entity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -277,7 +277,7 @@ final class CorrelatedMessageSubscriptionFromProcessMessageSubscriptionHandlerTe
     final CorrelatedMessageSubscriptionEntity entity =
         underTest.createNewEntity(underTest.generateIds(record).getFirst());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
@@ -107,7 +107,7 @@ public class DecisionEvaluationHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final DecisionInstanceEntity inputEntity = new DecisionInstanceEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceState;
@@ -106,13 +107,14 @@ public class DecisionEvaluationHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final DecisionInstanceEntity inputEntity = new DecisionInstanceEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -111,7 +111,7 @@ final class DecisionHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final DecisionDefinitionEntity inputEntity = new DecisionDefinitionEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.cache.TestDecisionRequirementsCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
@@ -110,13 +111,14 @@ final class DecisionHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final DecisionDefinitionEntity inputEntity = new DecisionDefinitionEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
@@ -144,7 +144,7 @@ final class DecisionRequirementsHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final DecisionRequirementsEntity inputEntity = new DecisionRequirementsEntity();
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestDecisionRequirementsCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.entities.dmn.definition.DecisionRequirementsEntity;
@@ -143,13 +144,14 @@ final class DecisionRequirementsHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final DecisionRequirementsEntity inputEntity = new DecisionRequirementsEntity();
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.form.EmbeddedFormBatch;
 import io.camunda.webapps.schema.entities.form.FormEntity;
@@ -99,13 +100,14 @@ public class EmbeddedFormHandlerTest {
     final var batch = new EmbeddedFormBatch().setId("111");
     batch.setForms(Collections.singletonList(inputEntity));
 
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(batch, mockRequest);
+    underTest.flush(index, batch, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test
@@ -116,14 +118,15 @@ public class EmbeddedFormHandlerTest {
     final var batch = new EmbeddedFormBatch().setId("111");
     batch.setForms(Arrays.asList(firstInputEntity, secondInputEntity));
 
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(batch, mockRequest);
+    underTest.flush(index, batch, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, firstInputEntity);
-    verify(mockRequest, times(1)).add(indexName, secondInputEntity);
+    verify(mockRequest, times(1)).add(index, firstInputEntity);
+    verify(mockRequest, times(1)).add(index, secondInputEntity);
   }
 
   @Test
@@ -131,10 +134,11 @@ public class EmbeddedFormHandlerTest {
     // given
     final var inputEntity = new EmbeddedFormBatch().setId("111");
 
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verifyNoInteractions(mockRequest);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
@@ -100,7 +100,7 @@ public class EmbeddedFormHandlerTest {
     final var batch = new EmbeddedFormBatch().setId("111");
     batch.setForms(Collections.singletonList(inputEntity));
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when
@@ -118,7 +118,7 @@ public class EmbeddedFormHandlerTest {
     final var batch = new EmbeddedFormBatch().setId("111");
     batch.setForms(Arrays.asList(firstInputEntity, secondInputEntity));
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when
@@ -134,7 +134,7 @@ public class EmbeddedFormHandlerTest {
     // given
     final var inputEntity = new EmbeddedFormBatch().setId("111");
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -86,7 +86,7 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
             .setTenantId("tenantId")
             .setIncidentKey(987L);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -85,17 +86,18 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
             .setTenantId("tenantId")
             .setIncidentKey(987L);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(FlowNodeInstanceTemplate.INCIDENT_KEY, inputEntity.getIncidentKey());
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -178,6 +179,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setTreePath("444/356/111")
             .setLevel(1)
             .setPosition(333L);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new HashMap<>();
@@ -199,10 +201,10 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(FlowNodeInstanceTemplate.POSITION, inputEntity.getPosition());
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
     // then
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test
@@ -219,6 +221,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setFlowNodeName(null)
             .setProcessDefinitionKey(222L)
             .setBpmnProcessId("bpmnId");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new HashMap<>();
@@ -235,10 +238,10 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
         FlowNodeInstanceTemplate.BPMN_PROCESS_ID, inputEntity.getBpmnProcessId());
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
     // then
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -179,7 +179,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setTreePath("444/356/111")
             .setLevel(1)
             .setPosition(333L);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new HashMap<>();
@@ -221,7 +221,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setFlowNodeName(null)
             .setProcessDefinitionKey(222L)
             .setBpmnProcessId("bpmnId");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new HashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -258,6 +258,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             .setFlowNodeName(null)
             .setProcessDefinitionKey(222L)
             .setBpmnProcessId("bpmnId");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new HashMap<>();
@@ -271,10 +272,10 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(
         FlowNodeInstanceTemplate.BPMN_PROCESS_ID, inputEntity.getBpmnProcessId());
 
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceNameFromAdHocActivityHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeInstanceEntity;
@@ -142,15 +143,16 @@ public class FlowNodeInstanceNameFromAdHocActivityHandlerTest {
     // given
     final FlowNodeInstanceEntity entity =
         new FlowNodeInstanceEntity().setId("111").setFlowNodeName("List users");
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsertWithScript(
-            eq(indexName),
+            eq(index),
             eq("111"),
             eq(entity),
             eq(FlowNodeInstanceNameFromAdHocActivityHandler.SET_IF_NULL_NAME_SCRIPT),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.form.FormEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -91,26 +92,28 @@ public class FormHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final FormEntity inputEntity = new FormEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test
   void shouldAddEntityOnFlushForDeletion() {
     // given
     final FormEntity inputEntity = new FormEntity().setId("111").setKey(123L).setIsDeleted(true);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -92,7 +92,7 @@ public class FormHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final FormEntity inputEntity = new FormEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -106,7 +106,7 @@ public class FormHandlerTest {
   void shouldAddEntityOnFlushForDeletion() {
     // given
     final FormEntity inputEntity = new FormEntity().setId("111").setKey(123L).setIsDeleted(true);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
 import io.camunda.webapps.schema.entities.globallistener.GlobalListenerSource;
@@ -121,13 +122,14 @@ public class GlobalListenerCreatedUpdatedHandlerTest {
             .setPriority(50)
             .setSource(GlobalListenerSource.API)
             .setListenerType(GlobalListenerType.USER_TASK);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerCreatedUpdatedHandlerTest.java
@@ -122,7 +122,7 @@ public class GlobalListenerCreatedUpdatedHandlerTest {
             .setPriority(50)
             .setSource(GlobalListenerSource.API)
             .setListenerType(GlobalListenerType.USER_TASK);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.globallistener.GlobalListenerEntity;
 import io.camunda.webapps.schema.entities.globallistener.GlobalListenerSource;
@@ -109,13 +110,14 @@ public class GlobalListenerDeletedHandlerTest {
             .setPriority(50)
             .setSource(GlobalListenerSource.API)
             .setListenerType(GlobalListenerType.USER_TASK);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GlobalListenerDeletedHandlerTest.java
@@ -110,7 +110,7 @@ public class GlobalListenerDeletedHandlerTest {
             .setPriority(50)
             .setSource(GlobalListenerSource.API)
             .setListenerType(GlobalListenerType.USER_TASK);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
@@ -121,7 +121,7 @@ public class GroupCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final GroupEntity inputEntity = new GroupEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
@@ -120,12 +121,13 @@ public class GroupCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final GroupEntity inputEntity = new GroupEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
@@ -78,12 +79,13 @@ public class GroupDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final GroupEntity inputEntity = new GroupEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
@@ -79,7 +79,7 @@ public class GroupDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final GroupEntity inputEntity = new GroupEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -88,7 +88,7 @@ public class GroupEntityAddedHandlerTest {
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new GroupMemberEntity().setId("111").setMemberId(memberId).setJoin(joinRelation);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity;
@@ -87,13 +88,14 @@ public class GroupEntityAddedHandlerTest {
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new GroupMemberEntity().setId("111").setMemberId(memberId).setJoin(joinRelation);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
+        .addWithRouting(index, inputEntity, String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupMemberEntity;
@@ -87,13 +88,14 @@ public class GroupEntityRemovedHandlerTest {
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new GroupMemberEntity().setId("111").setMemberId(memberId).setJoin(joinRelation);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, inputEntity.getId(), String.valueOf(joinRelation.parent()));
+        .deleteWithRouting(index, inputEntity.getId(), String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -88,7 +88,7 @@ public class GroupEntityRemovedHandlerTest {
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new GroupMemberEntity().setId("111").setMemberId(memberId).setJoin(joinRelation);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandlerTest.java
@@ -133,7 +133,7 @@ class HistoryDeletionDeletedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final var historyDeletionEntity = new HistoryDeletionEntity();
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/HistoryDeletionDeletedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.HistoryDeletionEntity;
 import io.camunda.zeebe.protocol.record.ImmutableRecord.Builder;
@@ -132,13 +133,14 @@ class HistoryDeletionDeletedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final var historyDeletionEntity = new HistoryDeletionEntity();
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(historyDeletionEntity, mockRequest);
+    underTest.flush(index, historyDeletionEntity, mockRequest);
 
     // then
-    verify(mockRequest).add(indexName, historyDeletionEntity);
+    verify(mockRequest).add(index, historyDeletionEntity);
     verifyNoMoreInteractions(mockRequest);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -134,7 +134,7 @@ public class IncidentHandlerTest {
     final IncidentEntity incidentEntity = new IncidentEntity();
     underTest.updateEntity(incidentRecord, incidentEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
@@ -133,15 +134,16 @@ public class IncidentHandlerTest {
     final IncidentEntity incidentEntity = new IncidentEntity();
     underTest.updateEntity(incidentRecord, incidentEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(incidentEntity, mockRequest);
+    underTest.flush(index, incidentEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             String.valueOf(recordKey),
             incidentEntity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandlerTest.java
@@ -184,7 +184,7 @@ public class JobBatchMetricsExportedHandlerTest {
             .setTenantId("tenant1")
             .setJobType("jobType1")
             .setWorker("worker1");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobBatchMetricsExportedHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.jobmetricsbatch.JobMetricsBatchEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -183,13 +184,14 @@ public class JobBatchMetricsExportedHandlerTest {
             .setTenantId("tenant1")
             .setJobType("jobType1")
             .setWorker("worker1");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -578,7 +578,7 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
     expectedUpdateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -645,7 +645,7 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
     expectedUpdateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -24,9 +24,11 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.PROCESS
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.JobTemplate;
 import io.camunda.webapps.schema.entities.JobEntity;
@@ -50,7 +52,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
-import org.mockito.Mockito;
 
 final class JobHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -577,14 +578,14 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
     expectedUpdateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(jobEntity, mockRequest);
+    underTest.flush(index, jobEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1))
-        .upsert(expectedIndexName, jobEntity.getId(), jobEntity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, jobEntity.getId(), jobEntity, expectedUpdateFields);
   }
 
   @Test
@@ -644,14 +645,14 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
     expectedUpdateFields.put(LAST_UPDATE_TIME, jobEntity.getLastUpdateTime());
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(jobEntity, mockRequest);
+    underTest.flush(index, jobEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1))
-        .upsert(expectedIndexName, jobEntity.getId(), jobEntity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, jobEntity.getId(), jobEntity, expectedUpdateFields);
   }
 
   private Record<JobRecordValue> generateRecord(final JobIntent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
@@ -76,7 +76,7 @@ public class ListViewFlowNodeFromIncidentHandlerTest {
             .setPositionIncident(123L);
     inputEntity.getJoinRelation().setParent(66L);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.IN
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -75,17 +76,18 @@ public class ListViewFlowNodeFromIncidentHandlerTest {
             .setPositionIncident(123L);
     inputEntity.getJoinRelation().setParent(66L);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(ERROR_MESSAGE, inputEntity.getErrorMessage());
     expectedUpdateFields.put(INCIDENT_POSITION, inputEntity.getPositionIncident());
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JO
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.FlowNodeInstanceForListViewEntity;
@@ -134,6 +135,7 @@ public class ListViewFlowNodeFromJobHandlerTest {
             .setJobFailedWithRetriesLeft(true);
     inputEntity.getJoinRelation().setParent(66L);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -141,12 +143,12 @@ public class ListViewFlowNodeFromJobHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.JOB_FAILED_WITH_RETRIES_LEFT, true);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
@@ -135,7 +135,7 @@ public class ListViewFlowNodeFromJobHandlerTest {
             .setJobFailedWithRetriesLeft(true);
     inputEntity.getJoinRelation().setParent(66L);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
@@ -188,7 +188,7 @@ public class ListViewFlowNodeFromProcessInstanceHandlerTest {
             .setActivityId("A")
             .setActivityType(FlowNodeType.CALL_ACTIVITY)
             .setActivityState(FlowNodeState.ACTIVE);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandlerTest.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSI
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.flownode.FlowNodeState;
@@ -187,6 +188,7 @@ public class ListViewFlowNodeFromProcessInstanceHandlerTest {
             .setActivityId("A")
             .setActivityType(FlowNodeType.CALL_ACTIVITY)
             .setActivityState(FlowNodeState.ACTIVE);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -196,12 +198,12 @@ public class ListViewFlowNodeFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.ACTIVE);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
@@ -98,7 +98,7 @@ public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandl
     // given
     final ProcessInstanceForListViewEntity inputEntity =
         new ProcessInstanceForListViewEntity().setId("111").setBusinessId("my-business-id");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -116,7 +116,7 @@ public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandl
     // given
     final ProcessInstanceForListViewEntity inputEntity =
         new ProcessInstanceForListViewEntity().setId("111").setBusinessId("");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -97,16 +98,17 @@ public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandl
     // given
     final ProcessInstanceForListViewEntity inputEntity =
         new ProcessInstanceForListViewEntity().setId("111").setBusinessId("my-business-id");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(ListViewTemplate.BUSINESS_ID, "my-business-id");
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).update(indexName, "111", expectedUpdateFields);
+    verify(mockRequest, times(1)).update(index, "111", expectedUpdateFields);
   }
 
   @Test
@@ -114,16 +116,17 @@ public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandl
     // given
     final ProcessInstanceForListViewEntity inputEntity =
         new ProcessInstanceForListViewEntity().setId("111").setBusinessId("");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(ListViewTemplate.BUSINESS_ID, null);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).update(indexName, "111", expectedUpdateFields);
+    verify(mockRequest, times(1)).update(index, "111", expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
@@ -176,6 +177,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setTreePath("PI_111")
             .setTags(Set.of("businessKey:123", "priority:high"))
             .setBusinessId("my-business-id");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -195,10 +197,10 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(POSITION, 123L);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, "111", inputEntity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, "111", inputEntity, expectedUpdateFields);
   }
 
   @Test
@@ -214,6 +216,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setPartitionId(12)
             .setPosition(123L)
             .setState(ProcessInstanceState.ACTIVE);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -227,10 +230,10 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     expectedUpdateFields.put(POSITION, 123L);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, "111", inputEntity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, "111", inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -177,7 +177,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setTreePath("PI_111")
             .setTags(Set.of("businessKey:123", "priority:high"))
             .setBusinessId("my-business-id");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
@@ -216,7 +216,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setPartitionId(12)
             .setPosition(123L)
             .setState(ProcessInstanceState.ACTIVE);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -116,7 +116,7 @@ public class ListViewVariableFromVariableHandlerTest {
     expectedUpdateFields.put(VAR_NAME, inputEntity.getVarName());
     expectedUpdateFields.put(VAR_VALUE, inputEntity.getVarValue());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -115,15 +116,16 @@ public class ListViewVariableFromVariableHandlerTest {
     expectedUpdateFields.put(VAR_NAME, inputEntity.getVarName());
     expectedUpdateFields.put(VAR_VALUE, inputEntity.getVarValue());
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandlerTest.java
@@ -122,7 +122,7 @@ public class MappingRuleCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final MappingRuleEntity inputEntity = new MappingRuleEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleCreatedUpdatedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.MappingRuleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -121,12 +122,13 @@ public class MappingRuleCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final MappingRuleEntity inputEntity = new MappingRuleEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.MappingRuleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -74,12 +75,13 @@ public class MappingRuleDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final MappingRuleEntity inputEntity = new MappingRuleEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingRuleDeletedHandlerTest.java
@@ -75,7 +75,7 @@ public class MappingRuleDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final MappingRuleEntity inputEntity = new MappingRuleEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -11,9 +11,11 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
 import io.camunda.webapps.schema.entities.messagesubscription.EventSourceType;
@@ -48,7 +50,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
 
   @SuppressWarnings("unchecked")
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
-      Mockito.mock(ExporterEntityCache.class);
+      mock(ExporterEntityCache.class);
 
   private final MessageSubscriptionFromMessageStartEventSubscriptionHandler underTest =
       new MessageSubscriptionFromMessageStartEventSubscriptionHandler(
@@ -346,13 +348,14 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(expectedIndexName, id, inputEntity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, id, inputEntity, expectedUpdateFields);
   }
 
   private Record<MessageStartEventSubscriptionRecordValue> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest.java
@@ -348,7 +348,7 @@ final class MessageSubscriptionFromMessageStartEventSubscriptionHandlerTest {
     expectedUpdateFields.put("inboundConnectorType", null);
     expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -12,10 +12,12 @@ import static io.camunda.webapps.schema.descriptors.template.MessageSubscription
 import static io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate.MESSAGE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.MessageSubscriptionTemplate;
@@ -52,7 +54,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
 
   @SuppressWarnings("unchecked")
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
-      Mockito.mock(ExporterEntityCache.class);
+      mock(ExporterEntityCache.class);
 
   private final MessageSubscriptionFromProcessMessageSubscriptionHandler underTest =
       new MessageSubscriptionFromProcessMessageSubscriptionHandler(
@@ -448,13 +450,14 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
 
-    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+    final TargetIndex index = mock(TargetIndex.class);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(expectedIndexName, id, inputEntity, expectedUpdateFields);
+    verify(mockRequest, times(1)).upsert(index, id, inputEntity, expectedUpdateFields);
   }
 
   private Record<ProcessMessageSubscriptionRecordValue> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MessageSubscriptionFromProcessMessageSubscriptionHandlerTest.java
@@ -450,7 +450,7 @@ final class MessageSubscriptionFromProcessMessageSubscriptionHandlerTest {
     expectedUpdateFields.put("toolProperties", null);
     expectedUpdateFields.put("metadata", metadataMap);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.VariableEntity;
@@ -108,10 +109,11 @@ public class MigratedVariableHandlerTest {
             .setBpmnProcessId("procId")
             .setProcessDefinitionKey(123L)
             .setPosition(456L);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(VariableTemplate.BPMN_PROCESS_ID, inputEntity.getBpmnProcessId());
     updateFields.put(
@@ -119,7 +121,7 @@ public class MigratedVariableHandlerTest {
     updateFields.put(VariableTemplate.POSITION, inputEntity.getPosition());
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, inputEntity.getId(), inputEntity, updateFields);
+    verify(mockRequest, times(1)).upsert(index, inputEntity.getId(), inputEntity, updateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
@@ -109,7 +109,7 @@ public class MigratedVariableHandlerTest {
             .setBpmnProcessId("procId")
             .setProcessDefinitionKey(123L)
             .setPosition(456L);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
 import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
@@ -129,14 +130,14 @@ public class PostImporterQueueFromIncidentHandlerTest {
     final int partitionId = 3;
     final PostImporterQueueEntity inputEntity =
         new PostImporterQueueEntity().setId("111").setPartitionId(partitionId);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(partitionId));
+    verify(mockRequest, times(1)).addWithRouting(index, inputEntity, String.valueOf(partitionId));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -130,7 +130,7 @@ public class PostImporterQueueFromIncidentHandlerTest {
     final int partitionId = 3;
     final PostImporterQueueEntity inputEntity =
         new PostImporterQueueEntity().setId("111").setPartitionId(partitionId);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessDeletedHandlerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
 import io.camunda.webapps.schema.entities.ProcessDefinitionState;
@@ -120,13 +121,14 @@ class ProcessDeletedHandlerTest {
   void shouldFlushPartialUpdateWithStateDeleted() throws Exception {
     // given
     final ProcessEntity entity = new ProcessEntity().setId("789");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
     verify(mockRequest)
-        .update(indexName, "789", Map.of(ProcessIndex.STATE, ProcessDefinitionState.DELETED));
+        .update(index, "789", Map.of(ProcessIndex.STATE, ProcessDefinitionState.DELETED));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessDeletedHandlerTest.java
@@ -121,7 +121,7 @@ class ProcessDeletedHandlerTest {
   void shouldFlushPartialUpdateWithStateDeleted() throws Exception {
     // given
     final ProcessEntity entity = new ProcessEntity().setId("789");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -96,7 +96,7 @@ public class ProcessHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final ProcessEntity inputEntity = new ProcessEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.ProcessEntity;
 import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
@@ -95,13 +96,14 @@ public class ProcessHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final ProcessEntity inputEntity = new ProcessEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceCreatedHandlerTest.java
@@ -129,7 +129,7 @@ public class ResourceCreatedHandlerTest {
             .setVersionTag("v1")
             .setDeploymentKey(100L)
             .setTenantId("<default>");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceCreatedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.resource.DeployedResourceEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -128,13 +129,14 @@ public class ResourceCreatedHandlerTest {
             .setVersionTag("v1")
             .setDeploymentKey(100L)
             .setTenantId("<default>");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, entity);
+    verify(mockRequest, times(1)).add(index, entity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.resource.DeployedResourceEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -101,13 +102,14 @@ public class ResourceDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final DeployedResourceEntity entity = new DeployedResourceEntity().setId("42");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, "42");
+    verify(mockRequest, times(1)).delete(index, "42");
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ResourceDeletedHandlerTest.java
@@ -102,7 +102,7 @@ public class ResourceDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final DeployedResourceEntity entity = new DeployedResourceEntity().setId("42");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
@@ -107,13 +108,14 @@ public class RoleCreateUpdateHandlerTest {
   @Test
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
+    final TargetIndex index = mock(TargetIndex.class);
     final RoleEntity inputEntity = new RoleEntity().setId("111");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleCreateUpdateHandlerTest.java
@@ -108,7 +108,7 @@ public class RoleCreateUpdateHandlerTest {
   @Test
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final RoleEntity inputEntity = new RoleEntity().setId("111");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
@@ -78,7 +78,7 @@ public class RoleDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final RoleEntity inputEntity = new RoleEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
@@ -77,12 +78,13 @@ public class RoleDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final RoleEntity inputEntity = new RoleEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
@@ -85,7 +85,7 @@ public class RoleMemberAddedHandlerTest {
     final var joinRelation = RoleIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new RoleMemberEntity().setId("111").setMemberId("member-id-2").setJoin(joinRelation);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberAddedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
@@ -84,13 +85,14 @@ public class RoleMemberAddedHandlerTest {
     final var joinRelation = RoleIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new RoleMemberEntity().setId("111").setMemberId("member-id-2").setJoin(joinRelation);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
+        .addWithRouting(index, inputEntity, String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberRemovedHandlerTest.java
@@ -85,7 +85,7 @@ public class RoleMemberRemovedHandlerTest {
     final var joinRelation = RoleIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new RoleMemberEntity().setId("111").setMemberId("member-id-1").setJoin(joinRelation);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleMemberRemovedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleMemberEntity;
@@ -84,13 +85,14 @@ public class RoleMemberRemovedHandlerTest {
     final var joinRelation = RoleIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new RoleMemberEntity().setId("111").setMemberId("member-id-1").setJoin(joinRelation);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, inputEntity.getId(), String.valueOf(joinRelation.parent()));
+        .deleteWithRouting(index, inputEntity.getId(), String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -106,13 +107,14 @@ public class SequenceFlowDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() {
     // given
     final SequenceFlowEntity inputEntity = new SequenceFlowEntity();
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowDeletedHandlerTest.java
@@ -107,7 +107,7 @@ public class SequenceFlowDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() {
     // given
     final SequenceFlowEntity inputEntity = new SequenceFlowEntity();
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
@@ -105,7 +105,7 @@ public class SequenceFlowHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final SequenceFlowEntity inputEntity = new SequenceFlowEntity();
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -104,13 +105,14 @@ public class SequenceFlowHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final SequenceFlowEntity inputEntity = new SequenceFlowEntity();
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
@@ -110,7 +110,7 @@ public class TenantCreateUpdateHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final TenantEntity inputEntity = new TenantEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
@@ -109,12 +110,13 @@ public class TenantCreateUpdateHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final TenantEntity inputEntity = new TenantEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
@@ -78,7 +78,7 @@ public class TenantDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final TenantEntity inputEntity = new TenantEntity().setId("test-tenant");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
@@ -77,12 +78,13 @@ public class TenantDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final TenantEntity inputEntity = new TenantEntity().setId("test-tenant");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -84,7 +84,7 @@ public class TenantEntityAddedHandlerTest {
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new TenantMemberEntity().setId("111").setMemberId("member-id-2").setJoin(joinRelation);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
@@ -83,13 +84,14 @@ public class TenantEntityAddedHandlerTest {
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new TenantMemberEntity().setId("111").setMemberId("member-id-2").setJoin(joinRelation);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
+        .addWithRouting(index, inputEntity, String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -86,7 +86,7 @@ public class TenantEntityRemovedHandlerTest {
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new TenantMemberEntity().setId("111").setMemberId("member-id-1").setJoin(joinRelation);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
@@ -85,13 +86,14 @@ public class TenantEntityRemovedHandlerTest {
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
     final var inputEntity =
         new TenantMemberEntity().setId("111").setMemberId("member-id-1").setJoin(joinRelation);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, inputEntity.getId(), String.valueOf(joinRelation.parent()));
+        .deleteWithRouting(index, inputEntity.getId(), String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
@@ -111,7 +111,7 @@ public class UserCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final UserEntity inputEntity = new UserEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -110,12 +111,13 @@ public class UserCreatedUpdatedHandlerTest {
   void shouldAddEntityOnFlush() throws PersistenceException {
     // given
     final UserEntity inputEntity = new UserEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
@@ -75,7 +75,7 @@ public class UserDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final UserEntity inputEntity = new UserEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -74,12 +75,13 @@ public class UserDeletedHandlerTest {
   void shouldDeleteEntityOnFlush() throws PersistenceException {
     // given
     final UserEntity inputEntity = new UserEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index, inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -135,7 +135,7 @@ public class UserTaskCompletionVariableHandlerTest {
     // given
     final SnapshotTaskVariableEntity inputEntity =
         new SnapshotTaskVariableEntity().setId("111").setValue("value").setIsPreview(false);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.template.SnapshotTaskVariableTemplate;
@@ -134,10 +135,11 @@ public class UserTaskCompletionVariableHandlerTest {
     // given
     final SnapshotTaskVariableEntity inputEntity =
         new SnapshotTaskVariableEntity().setId("111").setValue("value").setIsPreview(false);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(new SnapshotTaskVariableBatch("123", List.of(inputEntity)), mockRequest);
+    underTest.flush(index, new SnapshotTaskVariableBatch("123", List.of(inputEntity)), mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
@@ -145,8 +147,7 @@ public class UserTaskCompletionVariableHandlerTest {
     updateFieldsMap.put(SnapshotTaskVariableTemplate.FULL_VALUE, inputEntity.getFullValue());
     updateFieldsMap.put(SnapshotTaskVariableTemplate.IS_PREVIEW, inputEntity.getIsPreview());
 
-    verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, updateFieldsMap);
+    verify(mockRequest, times(1)).upsert(index, inputEntity.getId(), inputEntity, updateFieldsMap);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
@@ -163,7 +163,7 @@ public class UserTaskCreatingHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -191,7 +191,7 @@ public class UserTaskCreatingHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCreatingHandlerTest.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -162,16 +163,17 @@ public class UserTaskCreatingHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
 
     verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(processInstanceKey));
+        .addWithRouting(index, inputEntity, String.valueOf(processInstanceKey));
   }
 
   @Test
@@ -189,15 +191,16 @@ public class UserTaskCreatingHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
 
-    verify(mockRequest, times(1)).addWithRouting(indexName, inputEntity, String.valueOf(recordKey));
+    verify(mockRequest, times(1)).addWithRouting(index, inputEntity, String.valueOf(recordKey));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.TestProcessCache;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -206,17 +207,18 @@ public class UserTaskHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             String.valueOf(flowNodeInstanceKey),
             inputEntity,
             updateFieldsMap,
@@ -238,17 +240,18 @@ public class UserTaskHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             String.valueOf(recordKey),
             inputEntity,
             updateFieldsMap,
@@ -699,10 +702,11 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(111L));
     underTest.updateEntity(taskRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.PROCESS_DEFINITION_ID, taskEntity.getProcessDefinitionId());
     expectedUpdates.put(TaskTemplate.BPMN_PROCESS_ID, taskEntity.getBpmnProcessId());
@@ -717,7 +721,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getBpmnProcessId()).isEqualTo(taskRecordValue.getBpmnProcessId());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @Test
@@ -743,9 +747,10 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = underTest.createNewEntity(String.valueOf(123));
     underTest.updateEntity(taskRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
@@ -755,7 +760,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getAssignee()).isEqualTo(taskRecordValue.getAssignee());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -786,9 +791,10 @@ public class UserTaskHandlerTest {
         underTest.createNewEntity(String.valueOf(123)).setAssignee("test-assignee");
     underTest.updateEntity(taskRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.ASSIGNEE, null);
     expectedUpdates.put(TaskTemplate.CHANGED_ATTRIBUTES, List.of("assignee"));
@@ -798,7 +804,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getAssignee()).isEqualTo(null);
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -825,17 +831,18 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(123));
     underTest.updateEntity(taskRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.STATE, TaskState.COMPLETED);
     expectedUpdates.put(TaskTemplate.COMPLETION_TIME, taskEntity.getCompletionTime());
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -881,9 +888,10 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = underTest.createNewEntity(String.valueOf(recordKey));
     underTest.updateEntity(taskRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
     expectedUpdates.put(TaskTemplate.FOLLOW_UP_DATE, taskEntity.getFollowUpDate());
@@ -906,7 +914,7 @@ public class UserTaskHandlerTest {
         .isEqualTo(taskRecordValue.getCandidateUsersList());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             String.valueOf(recordKey),
             taskEntity,
             expectedUpdates,
@@ -953,9 +961,10 @@ public class UserTaskHandlerTest {
     underTest.updateEntity(taskRecord, taskEntity);
     underTest.updateEntity(assignTaskRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.PRIORITY, taskEntity.getPriority());
     expectedUpdates.put(TaskTemplate.ASSIGNEE, taskEntity.getAssignee());
@@ -967,7 +976,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getAssignee()).isEqualTo(assignTaskRecordValue.getAssignee());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @ParameterizedTest
@@ -991,13 +1000,14 @@ public class UserTaskHandlerTest {
     underTest.updateEntity(taskRecord, taskEntity);
 
     // when
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
 
     // then
     verify(mockRequest)
         .upsertWithRouting(
-            eq(indexName),
+            eq(index),
             eq(taskEntity.getId()),
             eq(taskEntity),
             updateFieldsCaptor.capture(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -207,7 +207,7 @@ public class UserTaskHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -240,7 +240,7 @@ public class UserTaskHandlerTest {
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setKey(recordKey)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -702,7 +702,7 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(111L));
     underTest.updateEntity(taskRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -747,7 +747,7 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = underTest.createNewEntity(String.valueOf(123));
     underTest.updateEntity(taskRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     underTest.flush(index, taskEntity, mockRequest);
@@ -791,7 +791,7 @@ public class UserTaskHandlerTest {
         underTest.createNewEntity(String.valueOf(123)).setAssignee("test-assignee");
     underTest.updateEntity(taskRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     underTest.flush(index, taskEntity, mockRequest);
@@ -831,7 +831,7 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(123));
     underTest.updateEntity(taskRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -888,7 +888,7 @@ public class UserTaskHandlerTest {
     final TaskEntity taskEntity = underTest.createNewEntity(String.valueOf(recordKey));
     underTest.updateEntity(taskRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     underTest.flush(index, taskEntity, mockRequest);
@@ -961,7 +961,7 @@ public class UserTaskHandlerTest {
     underTest.updateEntity(taskRecord, taskEntity);
     underTest.updateEntity(assignTaskRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     underTest.flush(index, taskEntity, mockRequest);
@@ -1000,7 +1000,7 @@ public class UserTaskHandlerTest {
     underTest.updateEntity(taskRecord, taskEntity);
 
     // when
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
     underTest.flush(index, taskEntity, mockRequest);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.search.test.utils.TestObjectMapper;
@@ -300,17 +301,18 @@ public class UserTaskJobBasedHandlerTest {
             .setKey(recordKey)
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             String.valueOf(flowNodeInstanceKey),
             inputEntity,
             updateFieldsMap,
@@ -333,10 +335,11 @@ public class UserTaskJobBasedHandlerTest {
             .setState(TaskState.CREATED)
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
@@ -344,7 +347,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index,
             String.valueOf(recordKey),
             inputEntity,
             updateFieldsMap,
@@ -608,10 +611,11 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.PROCESS_DEFINITION_ID, taskEntity.getProcessDefinitionId());
     expectedUpdates.put(TaskTemplate.BPMN_PROCESS_ID, taskEntity.getBpmnProcessId());
@@ -625,7 +629,7 @@ public class UserTaskJobBasedHandlerTest {
     assertThat(taskEntity.getBpmnProcessId()).isEqualTo(jobRecordValue.getBpmnProcessId());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @Test
@@ -648,17 +652,18 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.STATE, TaskState.COMPLETED);
     expectedUpdates.put(TaskTemplate.COMPLETION_TIME, taskEntity.getCompletionTime());
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @Test
@@ -710,16 +715,17 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.STATE, TaskState.FAILED);
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @Test
@@ -773,16 +779,17 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.STATE, TaskState.FAILED);
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @Test
@@ -836,16 +843,17 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 
   @Test
@@ -893,6 +901,7 @@ public class UserTaskJobBasedHandlerTest {
                     .withKey(legacyJobKey)
                     .withValue(migrationCancelValue));
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when: process the migration cancel through the handler
@@ -902,15 +911,15 @@ public class UserTaskJobBasedHandlerTest {
         id -> {
           final var entity = underTest.createNewEntity(id);
           underTest.updateEntity(migrationCancelRecord, entity);
-          underTest.flush(entity, mockRequest);
+          underTest.flush(index, entity, mockRequest);
         });
 
     // then — the stale legacy task doc (keyed by jobKey) must be deleted; no upsert should occur
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
+        .deleteWithRouting(index, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
     verify(mockRequest, never())
         .upsertWithRouting(
-            org.mockito.ArgumentMatchers.eq(indexName),
+            org.mockito.ArgumentMatchers.eq(index),
             org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)),
             org.mockito.ArgumentMatchers.any(),
             org.mockito.ArgumentMatchers.any(),
@@ -952,21 +961,22 @@ public class UserTaskJobBasedHandlerTest {
                     .withKey(legacyJobKey)
                     .withValue(migrationCancelValue));
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
     final TaskEntity sharedEntity = underTest.createNewEntity(String.valueOf(legacyJobKey));
 
     // simulate same-batch processing: CREATED first, then CANCELED+migration on the same entity
     underTest.updateEntity(createdRecord, sharedEntity);
     underTest.updateEntity(migrationCancelRecord, sharedEntity);
-    underTest.flush(sharedEntity, mockRequest);
+    underTest.flush(index, sharedEntity, mockRequest);
 
     // then — the migration-cancel must mark the entity for deletion so the delete path is taken
     assertThat(sharedEntity.isMarkedForDeletion()).isTrue();
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
+        .deleteWithRouting(index, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
     verify(mockRequest, never())
         .upsertWithRouting(
-            org.mockito.ArgumentMatchers.eq(indexName),
+            org.mockito.ArgumentMatchers.eq(index),
             org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)),
             org.mockito.ArgumentMatchers.any(),
             org.mockito.ArgumentMatchers.any(),
@@ -1024,6 +1034,7 @@ public class UserTaskJobBasedHandlerTest {
                     .withKey(legacyJobKey)
                     .withValue(normalCancelValue));
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when: non-migration cancel is handled normally (state update, not delete)
@@ -1033,7 +1044,7 @@ public class UserTaskJobBasedHandlerTest {
         id -> {
           final var entity = underTest.createNewEntity(id);
           underTest.updateEntity(normalCancelRecord, entity);
-          underTest.flush(entity, mockRequest);
+          underTest.flush(index, entity, mockRequest);
         });
 
     // then — normal cancel issues an upsert (state update), never a delete
@@ -1044,7 +1055,7 @@ public class UserTaskJobBasedHandlerTest {
             org.mockito.ArgumentMatchers.any());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            org.mockito.ArgumentMatchers.eq(indexName),
+            org.mockito.ArgumentMatchers.eq(index),
             org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)),
             org.mockito.ArgumentMatchers.any(),
             org.mockito.ArgumentMatchers.any(),
@@ -1071,15 +1082,16 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(taskEntity, mockRequest);
+    underTest.flush(index, taskEntity, mockRequest);
     final Map<String, Object> expectedUpdates = new HashMap<>();
     expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
+            index, taskEntity.getId(), taskEntity, expectedUpdates, taskEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -301,7 +301,7 @@ public class UserTaskJobBasedHandlerTest {
             .setKey(recordKey)
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -335,7 +335,7 @@ public class UserTaskJobBasedHandlerTest {
             .setState(TaskState.CREATED)
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -611,7 +611,7 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -652,7 +652,7 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -715,7 +715,7 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -779,7 +779,7 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -843,7 +843,7 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -901,7 +901,7 @@ public class UserTaskJobBasedHandlerTest {
                     .withKey(legacyJobKey)
                     .withValue(migrationCancelValue));
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when: process the migration cancel through the handler
@@ -961,7 +961,7 @@ public class UserTaskJobBasedHandlerTest {
                     .withKey(legacyJobKey)
                     .withValue(migrationCancelValue));
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
     final TaskEntity sharedEntity = underTest.createNewEntity(String.valueOf(legacyJobKey));
 
@@ -1034,7 +1034,7 @@ public class UserTaskJobBasedHandlerTest {
                     .withKey(legacyJobKey)
                     .withValue(normalCancelValue));
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when: non-migration cancel is handled normally (state update, not delete)
@@ -1082,7 +1082,7 @@ public class UserTaskJobBasedHandlerTest {
     final TaskEntity taskEntity = new TaskEntity().setId("111");
     underTest.updateEntity(jobRecord, taskEntity);
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.usertask.TaskProcessInstanceEntity;
@@ -119,13 +120,14 @@ public class UserTaskProcessInstanceHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final TaskProcessInstanceEntity inputEntity = new TaskProcessInstanceEntity().setId("111");
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
@@ -120,7 +120,7 @@ public class UserTaskProcessInstanceHandlerTest {
   void shouldAddEntityOnFlush() {
     // given
     final TaskProcessInstanceEntity inputEntity = new TaskProcessInstanceEntity().setId("111");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.usertask.TaskJoinRelationship.TaskJoinRelationshipType;
@@ -206,6 +207,7 @@ public class UserTaskVariableHandlerTest {
             .setScopeKey(456L);
 
     variableBatch.getVariables().addAll(List.of(processVariableEntity, taskVariableEntity));
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
@@ -216,13 +218,13 @@ public class UserTaskVariableHandlerTest {
     final ArgumentCaptor<String> routingCaptor = ArgumentCaptor.forClass(String.class);
 
     // when
-    underTest.flush(variableBatch, mockRequest);
+    underTest.flush(index, variableBatch, mockRequest);
 
     // then
     assertThat(variableBatch.getVariables()).hasSize(2);
     verify(mockRequest, times(2))
         .upsertWithRouting(
-            eq(indexName),
+            eq(index),
             idCaptor.capture(),
             entityCaptor.capture(),
             updateFieldsCaptor.capture(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -207,7 +207,7 @@ public class UserTaskVariableHandlerTest {
             .setScopeKey(456L);
 
     variableBatch.getVariables().addAll(List.of(processVariableEntity, taskVariableEntity));
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     final ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
@@ -106,7 +106,7 @@ public class VariableHandlerTest {
             .setValue("value")
             .setBpmnProcessId("procId")
             .setProcessDefinitionKey(123L);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
@@ -125,7 +125,7 @@ public class VariableHandlerTest {
             .setValue("null")
             .setBpmnProcessId("procId")
             .setProcessDefinitionKey(123L);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.VariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -105,13 +106,14 @@ public class VariableHandlerTest {
             .setValue("value")
             .setBpmnProcessId("procId")
             .setProcessDefinitionKey(123L);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test
@@ -123,13 +125,14 @@ public class VariableHandlerTest {
             .setValue("null")
             .setBpmnProcessId("procId")
             .setProcessDefinitionKey(123L);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(index, inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
@@ -147,7 +147,7 @@ public class AuditLogCleanupHandlerTest {
   @Test
   void shouldAddEntityOnFlush() throws PersistenceException {
     final var entity = new AuditLogCleanupEntity().setId(ENTITY_ID);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     handler.flush(index, entity, batchRequest);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogCleanupHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.AuditLogTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
@@ -146,11 +147,12 @@ public class AuditLogCleanupHandlerTest {
   @Test
   void shouldAddEntityOnFlush() throws PersistenceException {
     final var entity = new AuditLogCleanupEntity().setId(ENTITY_ID);
+    final TargetIndex index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
-    handler.flush(entity, batchRequest);
+    handler.flush(index, entity, batchRequest);
 
-    verify(batchRequest).add(INDEX_NAME, entity);
+    verify(batchRequest).add(index, entity);
     verifyNoMoreInteractions(batchRequest);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
@@ -124,7 +124,7 @@ class AuditLogHandlerTest {
   @Test
   void shouldAddEntityOnFlush() throws PersistenceException {
     final var entity = new AuditLogEntity().setId(ENTITY_ID);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     handler.flush(index, entity, batchRequest);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/auditlog/AuditLogHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
@@ -123,11 +124,12 @@ class AuditLogHandlerTest {
   @Test
   void shouldAddEntityOnFlush() throws PersistenceException {
     final var entity = new AuditLogEntity().setId(ENTITY_ID);
+    final TargetIndex index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
-    handler.flush(entity, batchRequest);
+    handler.flush(index, entity, batchRequest);
 
-    verify(batchRequest).add(INDEX_NAME, entity);
+    verify(batchRequest).add(index, entity);
     verifyNoMoreInteractions(batchRequest);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -122,7 +122,7 @@ class BatchOperationChunkCreatedHandlerTest {
     final var entity = new BatchOperationEntity().setId("123:chunk").setEndDate(null);
     final Record<BatchOperationChunkRecordValue> record = createRecord(1L, 11L);
     underTest.updateEntity(record, entity);
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
@@ -121,10 +122,11 @@ class BatchOperationChunkCreatedHandlerTest {
     final var entity = new BatchOperationEntity().setId("123:chunk").setEndDate(null);
     final Record<BatchOperationChunkRecordValue> record = createRecord(1L, 11L);
     underTest.updateEntity(record, entity);
+    final var index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     final Map<String, Object> expectedParams = new HashMap<>();
     expectedParams.put(BatchOperationTemplate.OPERATIONS_TOTAL_COUNT, 1);
@@ -132,7 +134,7 @@ class BatchOperationChunkCreatedHandlerTest {
     // then - the ES document ID is just the batchKey extracted from the composite ID
     final var scriptCaptor = ArgumentCaptor.forClass(String.class);
     verify(mockRequest, times(1))
-        .updateWithScript(eq(indexName), eq("123"), scriptCaptor.capture(), eq(expectedParams));
+        .updateWithScript(eq(index), eq("123"), scriptCaptor.capture(), eq(expectedParams));
 
     final var script = scriptCaptor.getValue();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -169,7 +169,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
     underTest.updateEntity(record, entity);
 
     // when
-    underTest.flush(index, entity, mockRequest); // Assuming null is acceptable for this test
+    underTest.flush(index, entity, mockRequest);
 
     // then
     final var entityCaptor = ArgumentCaptor.forClass(OperationEntity.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.entities.BatchOperationType;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
@@ -156,6 +157,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
   @Test
   void shouldFlushEntity() {
     // given
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
     final Record<BatchOperationChunkRecordValue> record =
         factory.generateRecordWithIntent(
@@ -167,11 +169,11 @@ class BatchOperationChunkCreatedItemHandlerTest {
     underTest.updateEntity(record, entity);
 
     // when
-    underTest.flush(entity, mockRequest); // Assuming null is acceptable for this test
+    underTest.flush(index, entity, mockRequest); // Assuming null is acceptable for this test
 
     // then
     final var entityCaptor = ArgumentCaptor.forClass(OperationEntity.class);
-    verify(mockRequest).add(eq(indexName), entityCaptor.capture());
+    verify(mockRequest).add(eq(index), entityCaptor.capture());
     final var capturedEntity = entityCaptor.getValue();
     assertThat(capturedEntity).isEqualTo(entity);
   }
@@ -181,6 +183,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
     // given
     when(batchOperationCache.get("42")).thenReturn(Optional.empty());
 
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
     final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(42L, 1);
     final var item = record.getValue().getItems().getFirst();
@@ -190,12 +193,12 @@ class BatchOperationChunkCreatedItemHandlerTest {
     underTest.updateEntity(record, entity);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
     verify(batchOperationCache).get("42"); // verify cache was consulted
     final var entityCaptor = ArgumentCaptor.forClass(OperationEntity.class);
-    verify(mockRequest).add(eq(indexName), entityCaptor.capture());
+    verify(mockRequest).add(eq(index), entityCaptor.capture());
     final var capturedEntity = entityCaptor.getValue();
     assertThat(capturedEntity.getType()).isNull();
     assertThat(capturedEntity.getState()).isEqualTo(OperationState.SCHEDULED);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationChunkCreatedItemHandlerTest.java
@@ -157,7 +157,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
   @Test
   void shouldFlushEntity() {
     // given
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     final Record<BatchOperationChunkRecordValue> record =
         factory.generateRecordWithIntent(
@@ -183,7 +183,7 @@ class BatchOperationChunkCreatedItemHandlerTest {
     // given
     when(batchOperationCache.get("42")).thenReturn(Optional.empty());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     final Record<BatchOperationChunkRecordValue> record = aChunkRecordWithMultipleItems(42L, 1);
     final var item = record.getValue().getItems().getFirst();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogActorType;
@@ -246,15 +247,16 @@ class BatchOperationCreatedHandlerTest {
             .setType(OperationType.RESOLVE_INCIDENT)
             .setActorType(AuditLogActorType.USER)
             .setActorId("username");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsert(
-            eq(indexName),
+            eq(index),
             eq("123"),
             eq(entity),
             eq(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationCreatedHandlerTest.java
@@ -247,7 +247,7 @@ class BatchOperationCreatedHandlerTest {
             .setType(OperationType.RESOLVE_INCIDENT)
             .setActorType(AuditLogActorType.USER)
             .setActorId("username");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
@@ -107,15 +108,16 @@ class BatchOperationInitializedHandlerTest {
             .setId("123")
             .setState(BatchOperationState.ACTIVE)
             .setStartDate(startDate);
+    final var index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
     verify(mockRequest, times(1))
         .upsertWithScript(
-            eq(indexName),
+            eq(index),
             eq(entity.getId()),
             eq(entity),
             eq(BatchOperationInitializedHandler.CONDITIONAL_UPDATE_SCRIPT),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationInitializedHandlerTest.java
@@ -108,7 +108,7 @@ class BatchOperationInitializedHandlerTest {
             .setId("123")
             .setState(BatchOperationState.ACTIVE)
             .setStartDate(startDate);
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
@@ -272,7 +272,7 @@ class BatchOperationLifecycleManagementHandlerTest {
   @Test
   void shouldFlushEntityWithConditionalScript() throws Exception {
     // given
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest batchRequest = mock(BatchRequest.class);
     final BatchOperationEntity entity =
         new BatchOperationEntity()
@@ -301,7 +301,7 @@ class BatchOperationLifecycleManagementHandlerTest {
   @Test
   void shouldFlushEntityWithErrorsInScript() throws Exception {
     // given
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest batchRequest = mock(BatchRequest.class);
     final var errorEntity =
         new io.camunda.webapps.schema.entities.operation.BatchOperationErrorEntity()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/BatchOperationLifecycleManagementHandlerTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.batchoperation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
@@ -271,6 +272,7 @@ class BatchOperationLifecycleManagementHandlerTest {
   @Test
   void shouldFlushEntityWithConditionalScript() throws Exception {
     // given
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest batchRequest = mock(BatchRequest.class);
     final BatchOperationEntity entity =
         new BatchOperationEntity()
@@ -279,13 +281,13 @@ class BatchOperationLifecycleManagementHandlerTest {
             .setEndDate(DateUtil.toOffsetDateTime(Instant.now().toEpochMilli()));
 
     // when
-    handler.flush(entity, batchRequest);
+    handler.flush(index, entity, batchRequest);
 
     // then
     final var paramsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(batchRequest)
         .upsertWithScript(
-            eq(indexName),
+            eq(index),
             eq("12345"),
             eq(entity),
             eq(BatchOperationLifecycleManagementHandler.CONDITIONAL_STATE_UPDATE_SCRIPT),
@@ -299,6 +301,7 @@ class BatchOperationLifecycleManagementHandlerTest {
   @Test
   void shouldFlushEntityWithErrorsInScript() throws Exception {
     // given
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest batchRequest = mock(BatchRequest.class);
     final var errorEntity =
         new io.camunda.webapps.schema.entities.operation.BatchOperationErrorEntity()
@@ -313,13 +316,13 @@ class BatchOperationLifecycleManagementHandlerTest {
             .setErrors(List.of(errorEntity));
 
     // when
-    handler.flush(entity, batchRequest);
+    handler.flush(index, entity, batchRequest);
 
     // then - errors should be included in script params when present
     final var paramsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(batchRequest)
         .upsertWithScript(
-            eq(indexName),
+            eq(index),
             eq("12345"),
             eq(entity),
             eq(BatchOperationLifecycleManagementHandler.CONDITIONAL_STATE_UPDATE_SCRIPT),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/DecisionInstanceHistoryDeletionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/DecisionInstanceHistoryDeletionOperationHandlerTest.java
@@ -199,7 +199,7 @@ class DecisionInstanceHistoryDeletionOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/DecisionInstanceHistoryDeletionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/DecisionInstanceHistoryDeletionOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -198,11 +199,12 @@ class DecisionInstanceHistoryDeletionOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
-    handler.flush(entity, mockRequest);
+    handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             entity.getId(),
             entity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -225,11 +226,12 @@ class ProcessInstanceCancellationOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
-    handler.flush(entity, mockRequest);
+    handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             entity.getId(),
             entity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceCancellationOperationHandlerTest.java
@@ -226,7 +226,7 @@ class ProcessInstanceCancellationOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceHistoryDeletionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceHistoryDeletionOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -198,11 +199,12 @@ class ProcessInstanceHistoryDeletionOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
-    handler.flush(entity, mockRequest);
+    handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             entity.getId(),
             entity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceHistoryDeletionOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceHistoryDeletionOperationHandlerTest.java
@@ -199,7 +199,7 @@ class ProcessInstanceHistoryDeletionOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandlerTest.java
@@ -197,7 +197,7 @@ class ProcessInstanceMigrationOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceMigrationOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -196,11 +197,12 @@ class ProcessInstanceMigrationOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
-    handler.flush(entity, mockRequest);
+    handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             entity.getId(),
             entity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -196,11 +197,12 @@ class ProcessInstanceModificationOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
-    handler.flush(entity, mockRequest);
+    handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             entity.getId(),
             entity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ProcessInstanceModificationOperationHandlerTest.java
@@ -197,7 +197,7 @@ class ProcessInstanceModificationOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandlerTest.java
@@ -195,7 +195,7 @@ class ResolveIncidentOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final var mockRequest = mock(BatchRequest.class);
     handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/ResolveIncidentOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.batchOperat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -194,11 +195,12 @@ class ResolveIncidentOperationHandlerTest {
     entity.setProcessInstanceKey(456L);
     entity.setCompletedDate(OffsetDateTime.now());
     entity.setErrorMessage("error message");
+    final TargetIndex index = mock(TargetIndex.class);
     final var mockRequest = mock(BatchRequest.class);
-    handler.flush(entity, mockRequest);
+    handler.flush(index, entity, mockRequest);
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
+            index,
             entity.getId(),
             entity,
             Map.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -185,15 +186,16 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
     final String batchOperationKey = "batch-op-1";
     final var entity = underTest.createNewEntity(processInstanceKey + ":" + batchOperationKey);
     entity.setBatchOperationIds(List.of(batchOperationKey));
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // When
-    underTest.flush(entity, batchRequest);
+    underTest.flush(index, entity, batchRequest);
 
     // Then - the ES document ID is just the processInstanceKey, extracted from the composite ID
     Mockito.verify(batchRequest)
         .updateWithScript(
-            eq(underTest.getIndexName()),
+            eq(index),
             eq(processInstanceKey),
             anyString(),
             eq(Map.of("batchOperationId", batchOperationKey)));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/AbstractProcessInstanceFromOperationItemHandlerTest.java
@@ -186,7 +186,7 @@ public abstract class AbstractProcessInstanceFromOperationItemHandlerTest<
     final String batchOperationKey = "batch-op-1";
     final var entity = underTest.createNewEntity(processInstanceKey + ":" + batchOperationKey);
     entity.setBatchOperationIds(List.of(batchOperationKey));
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // When

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
@@ -113,7 +113,7 @@ class ListViewFromChunkItemHandlerTest {
     entity.setBatchOperationIds(List.of(batchOperationKey));
 
     // when
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
     underTest.flush(index, entity, batchRequest);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/batchoperation/listview/ListViewFromChunkItemHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -112,13 +113,14 @@ class ListViewFromChunkItemHandlerTest {
     entity.setBatchOperationIds(List.of(batchOperationKey));
 
     // when
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
-    underTest.flush(entity, batchRequest);
+    underTest.flush(index, entity, batchRequest);
 
     // then - the ES document ID is just the processInstanceKey, extracted from the composite ID
     Mockito.verify(batchRequest)
         .updateWithScript(
-            eq(underTest.getIndexName()),
+            eq(index),
             eq(processInstanceKey),
             anyString(),
             eq(Map.of("batchOperationId", batchOperationKey)));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
@@ -108,6 +109,7 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
             .setLockOwner(null)
             .setCompletedDate(OffsetDateTime.now());
 
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(OperationTemplate.STATE, entity.getState());
@@ -117,10 +119,10 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
         OperationTemplate.LOCK_EXPIRATION_TIME, entity.getLockExpirationTime());
 
     // when
-    underTest.flush(entity, mockRequest);
+    underTest.flush(index, entity, mockRequest);
 
     // then
-    verify(mockRequest).update(indexName, entity.getId(), expectedUpdateFields);
+    verify(mockRequest).update(index, entity.getId(), expectedUpdateFields);
   }
 
   protected Record<R> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -109,7 +109,7 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
             .setLockOwner(null)
             .setCompletedDate(OffsetDateTime.now());
 
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(OperationTemplate.STATE, entity.getState());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricExportedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricExportedHandlerTest.java
@@ -95,7 +95,7 @@ class UsageMetricExportedHandlerTest
     final var existingMetrics = composeUsageMetrics(now, 11L, 22L);
     final var usageMetricsBatch = new UsageMetricsBatch(EVENT_KEY);
     existingMetrics.forEach(usageMetricsBatch::addMetric);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricExportedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricExportedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.usage.UsageMetricExportedHandler.UsageMetricsBatch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.metrics.UsageMetricsEntity;
 import io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType;
@@ -94,13 +95,14 @@ class UsageMetricExportedHandlerTest
     final var existingMetrics = composeUsageMetrics(now, 11L, 22L);
     final var usageMetricsBatch = new UsageMetricsBatch(EVENT_KEY);
     existingMetrics.forEach(usageMetricsBatch::addMetric);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(usageMetricsBatch, mockRequest);
+    underTest.flush(index, usageMetricsBatch, mockRequest);
 
     // then
-    usageMetricsBatch.getMetrics().forEach(entity -> verify(mockRequest).add(INDEX_NAME, entity));
+    usageMetricsBatch.getMetrics().forEach(entity -> verify(mockRequest).add(index, entity));
     verifyNoMoreInteractions(mockRequest);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricTUExportedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricTUExportedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.usage.UsageMetricTUExportedHandler.UsageMetricsTUBatch;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.metrics.UsageMetricsTUEntity;
 import io.camunda.zeebe.protocol.record.value.ImmutableUsageMetricRecordValue;
@@ -92,13 +93,14 @@ class UsageMetricTUExportedHandlerTest
     final var now = OffsetDateTime.now().toEpochSecond();
     final var usageMetricsBatch = new UsageMetricsTUBatch(EVENT_KEY);
     composeUsageMetricsTU(now).forEach(usageMetricsBatch::addMetric);
+    final TargetIndex index = mock(TargetIndex.class);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(usageMetricsBatch, mockRequest);
+    underTest.flush(index, usageMetricsBatch, mockRequest);
 
     // then
-    usageMetricsBatch.getMetrics().forEach(entity -> verify(mockRequest).add(INDEX_NAME, entity));
+    usageMetricsBatch.getMetrics().forEach(entity -> verify(mockRequest).add(index, entity));
     verifyNoMoreInteractions(mockRequest);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricTUExportedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/usage/UsageMetricTUExportedHandlerTest.java
@@ -93,7 +93,7 @@ class UsageMetricTUExportedHandlerTest
     final var now = OffsetDateTime.now().toEpochSecond();
     final var usageMetricsBatch = new UsageMetricsTUBatch(EVENT_KEY);
     composeUsageMetricsTU(now).forEach(usageMetricsBatch::addMetric);
-    final TargetIndex index = mock(TargetIndex.class);
+    final TargetIndex index = TargetIndex.mainIndex("test-index");
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
@@ -166,26 +167,28 @@ class JobWaitStateHandlerTest {
   void shouldFlushAddEntityToIndex() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(JOB_KEY));
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    addHandler.flush(entity, batchRequest);
+    addHandler.flush(index, entity, batchRequest);
 
     // then
-    verify(batchRequest).add(eq(INDEX_NAME), eq(entity));
+    verify(batchRequest).add(eq(index), eq(entity));
   }
 
   @Test
   void shouldFlushRemoveDeleteFromIndexBySameId() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(JOB_KEY));
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    removeHandler.flush(entity, batchRequest);
+    removeHandler.flush(index, entity, batchRequest);
 
     // then
-    verify(batchRequest).delete(INDEX_NAME, String.valueOf(JOB_KEY));
+    verify(batchRequest).delete(index, String.valueOf(JOB_KEY));
   }
 
   @Test
@@ -281,15 +284,16 @@ class JobWaitStateHandlerTest {
     // given — FAILED/RETRIES_UPDATED: transformer nulls elementId to avoid overwriting stored value
     final var id = String.valueOf(JOB_KEY);
     final var entity = new WaitStateEntity().setId(id).setDetails("{\"retries\":0}");
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    updateHandler.flush(entity, batchRequest);
+    updateHandler.flush(index, entity, batchRequest);
 
     // then — only DETAILS in the update map; ELEMENT_ID is skipped
     verify(batchRequest)
         .upsert(
-            eq(INDEX_NAME),
+            eq(index),
             eq(id),
             eq(entity),
             argThat(map -> map.containsKey(WaitStateTemplate.DETAILS) && map.size() == 1));
@@ -306,15 +310,16 @@ class JobWaitStateHandlerTest {
             .setElementId("task-after-migration")
             .setBpmnProcessId("target-process")
             .setDetails("{\"retries\":3}");
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    updateHandler.flush(entity, batchRequest);
+    updateHandler.flush(index, entity, batchRequest);
 
     // then — ELEMENT_ID, BPMN_PROCESS_ID and DETAILS are all sent
     verify(batchRequest)
         .upsert(
-            eq(INDEX_NAME),
+            eq(index),
             eq(id),
             eq(entity),
             argThat(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/JobWaitStateHandlerTest.java
@@ -167,7 +167,7 @@ class JobWaitStateHandlerTest {
   void shouldFlushAddEntityToIndex() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(JOB_KEY));
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when
@@ -181,7 +181,7 @@ class JobWaitStateHandlerTest {
   void shouldFlushRemoveDeleteFromIndexBySameId() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(JOB_KEY));
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when
@@ -284,7 +284,7 @@ class JobWaitStateHandlerTest {
     // given — FAILED/RETRIES_UPDATED: transformer nulls elementId to avoid overwriting stored value
     final var id = String.valueOf(JOB_KEY);
     final var entity = new WaitStateEntity().setId(id).setDetails("{\"retries\":0}");
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when
@@ -310,7 +310,7 @@ class JobWaitStateHandlerTest {
             .setElementId("task-after-migration")
             .setBpmnProcessId("target-process")
             .setDetails("{\"retries\":3}");
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.template.WaitStateTemplate;
 import io.camunda.webapps.schema.entities.waitstate.WaitStateEntity;
@@ -172,26 +173,28 @@ class UserTaskWaitStateHandlerTest {
   void shouldFlushAddEntityToIndex() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(USER_TASK_KEY));
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    addHandler.flush(entity, batchRequest);
+    addHandler.flush(index, entity, batchRequest);
 
     // then
-    verify(batchRequest).add(eq(INDEX_NAME), eq(entity));
+    verify(batchRequest).add(eq(index), eq(entity));
   }
 
   @Test
   void shouldFlushRemoveDeleteFromIndexBySameId() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(USER_TASK_KEY));
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    removeHandler.flush(entity, batchRequest);
+    removeHandler.flush(index, entity, batchRequest);
 
     // then
-    verify(batchRequest).delete(INDEX_NAME, String.valueOf(USER_TASK_KEY));
+    verify(batchRequest).delete(index, String.valueOf(USER_TASK_KEY));
   }
 
   @Test
@@ -222,15 +225,16 @@ class UserTaskWaitStateHandlerTest {
     // given — elementId null means no migration, only task metadata changed
     final var id = String.valueOf(USER_TASK_KEY);
     final var entity = new WaitStateEntity().setId(id).setDetails("{\"taskKey\":999}");
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    updateHandler.flush(entity, batchRequest);
+    updateHandler.flush(index, entity, batchRequest);
 
     // then — only DETAILS in the update map; ELEMENT_ID is skipped
     verify(batchRequest)
         .upsert(
-            eq(INDEX_NAME),
+            eq(index),
             eq(id),
             eq(entity),
             argThat(map -> map.containsKey(WaitStateTemplate.DETAILS) && map.size() == 1));
@@ -247,15 +251,16 @@ class UserTaskWaitStateHandlerTest {
             .setElementId("task-after-migration")
             .setBpmnProcessId("target-process")
             .setDetails("{\"taskKey\":999}");
+    final var index = mock(TargetIndex.class);
     final var batchRequest = mock(BatchRequest.class);
 
     // when
-    updateHandler.flush(entity, batchRequest);
+    updateHandler.flush(index, entity, batchRequest);
 
     // then — ELEMENT_ID, BPMN_PROCESS_ID and DETAILS are all sent
     verify(batchRequest)
         .upsert(
-            eq(INDEX_NAME),
+            eq(index),
             eq(id),
             eq(entity),
             argThat(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/waitstate/UserTaskWaitStateHandlerTest.java
@@ -173,7 +173,7 @@ class UserTaskWaitStateHandlerTest {
   void shouldFlushAddEntityToIndex() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(USER_TASK_KEY));
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when
@@ -187,7 +187,7 @@ class UserTaskWaitStateHandlerTest {
   void shouldFlushRemoveDeleteFromIndexBySameId() throws PersistenceException {
     // given
     final var entity = new WaitStateEntity().setId(String.valueOf(USER_TASK_KEY));
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when
@@ -225,7 +225,7 @@ class UserTaskWaitStateHandlerTest {
     // given — elementId null means no migration, only task metadata changed
     final var id = String.valueOf(USER_TASK_KEY);
     final var entity = new WaitStateEntity().setId(id).setDetails("{\"taskKey\":999}");
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when
@@ -251,7 +251,7 @@ class UserTaskWaitStateHandlerTest {
             .setElementId("task-after-migration")
             .setBpmnProcessId("target-process")
             .setDetails("{\"taskKey\":999}");
-    final var index = mock(TargetIndex.class);
+    final var index = TargetIndex.mainIndex("test-index");
     final var batchRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -31,6 +31,7 @@ import co.elastic.clients.util.BinaryData;
 import io.camunda.exporter.entities.TestExporterEntity;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
@@ -48,7 +49,10 @@ class ElasticsearchBatchRequestTest {
 
   private static final String ID = "id";
   private static final String INDEX = "index";
+  private static final TargetIndex TARGET_INDEX = TargetIndex.mainIndex(INDEX);
   private static final String INDEX_WITH_HANDLER = "indexWithHandler";
+  private static final TargetIndex TARGET_INDEX_WITH_HANDLER =
+      TargetIndex.mainIndex(INDEX_WITH_HANDLER);
   private ElasticsearchBatchRequest batchRequest;
   private ElasticsearchClient elasticsearchClient;
   private ElasticsearchScriptBuilder scriptBuilder;
@@ -74,7 +78,7 @@ class ElasticsearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
     // When
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     batchRequest.execute();
 
     // Then
@@ -100,7 +104,7 @@ class ElasticsearchBatchRequestTest {
     final String routing = "routing";
 
     // When
-    batchRequest.addWithRouting(INDEX, entity, routing);
+    batchRequest.addWithRouting(TARGET_INDEX, entity, routing);
 
     batchRequest.execute();
 
@@ -129,7 +133,7 @@ class ElasticsearchBatchRequestTest {
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
     // When
-    batchRequest.upsert(INDEX, ID, entity, updateFields);
+    batchRequest.upsert(TARGET_INDEX, ID, entity, updateFields);
     batchRequest.execute();
 
     // Then
@@ -157,7 +161,7 @@ class ElasticsearchBatchRequestTest {
     final String routing = "routing";
 
     // When
-    batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
+    batchRequest.upsertWithRouting(TARGET_INDEX, ID, entity, updateFields, routing);
     batchRequest.execute();
 
     // Then
@@ -189,7 +193,7 @@ class ElasticsearchBatchRequestTest {
     when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
 
     // When
-    batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
+    batchRequest.upsertWithScript(TARGET_INDEX, ID, entity, script, params);
     batchRequest.execute();
 
     // Then
@@ -221,7 +225,7 @@ class ElasticsearchBatchRequestTest {
     when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
 
     // When
-    batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
+    batchRequest.upsertWithScriptAndRouting(TARGET_INDEX, ID, entity, script, params, routing);
     batchRequest.execute();
 
     // Then
@@ -247,7 +251,7 @@ class ElasticsearchBatchRequestTest {
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
     // When
-    batchRequest.update(INDEX, ID, updateFields);
+    batchRequest.update(TARGET_INDEX, ID, updateFields);
     batchRequest.execute();
 
     // Then
@@ -273,7 +277,7 @@ class ElasticsearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
     // When
-    batchRequest.update(INDEX, ID, entity);
+    batchRequest.update(TARGET_INDEX, ID, entity);
     batchRequest.execute();
 
     // Then
@@ -303,7 +307,7 @@ class ElasticsearchBatchRequestTest {
     when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
 
     // When
-    batchRequest.updateWithScript(INDEX, ID, script, params);
+    batchRequest.updateWithScript(TARGET_INDEX, ID, script, params);
     batchRequest.execute();
 
     // Then
@@ -326,7 +330,7 @@ class ElasticsearchBatchRequestTest {
   @Test
   void shouldDeleteEntity() throws IOException, PersistenceException {
     // When
-    batchRequest.delete(INDEX, ID);
+    batchRequest.delete(TARGET_INDEX, ID);
     batchRequest.execute();
 
     // Then
@@ -351,7 +355,7 @@ class ElasticsearchBatchRequestTest {
     final String routing = "routing";
 
     // when
-    batchRequest.deleteWithRouting(INDEX, ID, routing);
+    batchRequest.deleteWithRouting(TARGET_INDEX, ID, routing);
     batchRequest.execute();
 
     // then
@@ -376,8 +380,8 @@ class ElasticsearchBatchRequestTest {
     // Given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
     // When
-    batchRequest.add(INDEX, entity);
-    batchRequest.update(INDEX, ID, entity);
+    batchRequest.add(TARGET_INDEX, entity);
+    batchRequest.update(TARGET_INDEX, ID, entity);
     batchRequest.execute();
 
     // Then
@@ -398,9 +402,9 @@ class ElasticsearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
     // when
-    tinyCapRequest.add(INDEX, entity);
-    tinyCapRequest.add(INDEX, entity);
-    tinyCapRequest.add(INDEX, entity);
+    tinyCapRequest.add(TARGET_INDEX, entity);
+    tinyCapRequest.add(TARGET_INDEX, entity);
+    tinyCapRequest.add(TARGET_INDEX, entity);
     tinyCapRequest.execute();
 
     // then - three separate bulk calls, one operation each
@@ -415,7 +419,7 @@ class ElasticsearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
     // When
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     batchRequest.executeWithRefresh();
 
     // Then
@@ -433,7 +437,7 @@ class ElasticsearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
     // When
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     when(elasticsearchClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
 
     // When
@@ -458,7 +462,7 @@ class ElasticsearchBatchRequestTest {
     when(elasticsearchClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
 
     // When
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     final ThrowingCallable callable = () -> batchRequest.execute();
 
     // Then
@@ -494,7 +498,7 @@ class ElasticsearchBatchRequestTest {
             item.operationType(), item.index(), item.id(), item.error().reason());
 
     // When
-    batchRequest.add(INDEX_WITH_HANDLER, entity);
+    batchRequest.add(TARGET_INDEX_WITH_HANDLER, entity);
     batchRequest.execute(errorHandler);
 
     // Then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.store.ExporterBatchWriter.Builder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -103,7 +104,10 @@ public class ExporterBatchWriterMultipleHandlersTest {
 
     // then
     verify(batchRequest, times(2))
-        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexA")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     verify(batchRequest).execute(any());
   }
 
@@ -130,9 +134,15 @@ public class ExporterBatchWriterMultipleHandlersTest {
 
     // then
     verify(batchRequest)
-        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexA")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     verify(batchRequest)
-        .update(eq("indexB"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexB")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     verify(batchRequest).execute(any());
   }
 
@@ -164,22 +174,40 @@ public class ExporterBatchWriterMultipleHandlersTest {
     final InOrder inOrder = Mockito.inOrder(batchRequest);
     inOrder
         .verify(batchRequest)
-        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexA")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexB"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexB")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexC"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexC")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexD"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexD")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexE"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexE")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexF"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexF")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder.verify(batchRequest).execute(any());
   }
 
@@ -212,13 +240,22 @@ public class ExporterBatchWriterMultipleHandlersTest {
     final InOrder inOrder = Mockito.inOrder(batchRequest);
     inOrder
         .verify(batchRequest)
-        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(OtherTestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexA")),
+            eq(Long.toString(record.getKey())),
+            any(OtherTestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(DifferentTestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexA")),
+            eq(Long.toString(record.getKey())),
+            any(DifferentTestEntity.class));
     inOrder
         .verify(batchRequest)
-        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+        .update(
+            eq(TargetIndex.mainIndex("indexA")),
+            eq(Long.toString(record.getKey())),
+            any(TestEntity.class));
     inOrder.verify(batchRequest).execute(any());
   }
 
@@ -355,13 +392,14 @@ public class ExporterBatchWriterMultipleHandlersTest {
     }
 
     @Override
-    public void flush(final T entity, final BatchRequest batchRequest) throws PersistenceException {
-      batchRequest.update(indexName, entity.getId(), entity);
+    public void flush(final TargetIndex index, final T entity, final BatchRequest batchRequest)
+        throws PersistenceException {
+      batchRequest.update(index, entity.getId(), entity);
     }
 
     @Override
     public String getIndexName() {
-      return null;
+      return indexName;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -231,6 +231,7 @@ class ExporterBatchWriterTest {
     final TestRecord record = new TestRecord(0, NULL_VAL);
     final String id = "1";
     final TestExporterEntity entity = new TestExporterEntity().setId(id);
+    when(handler.getIndexName()).thenReturn("test-index");
     when(handler.handlesRecord(eq(record))).thenReturn(true);
     when(handler.generateIds(eq(record))).thenReturn(List.of(id));
     when(handler.createNewEntity(eq(id))).thenReturn(entity);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.exporter.entities.TestExporterEntity;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.protocol.TestRecord;
 import io.camunda.protocol.TestValue;
 import java.util.List;
@@ -117,6 +118,7 @@ class ExporterBatchWriterTest {
     final TestRecord record = new TestRecord(0, NULL_VAL);
     final String id = "1";
     final TestExporterEntity entity = new TestExporterEntity().setId(id);
+    when(handler.getIndexName()).thenReturn("test-index");
     when(handler.handlesRecord(eq(record))).thenReturn(true);
     when(handler.generateIds(eq(record))).thenReturn(List.of(id));
     when(handler.createNewEntity(eq(id))).thenReturn(entity);
@@ -131,7 +133,7 @@ class ExporterBatchWriterTest {
 
     // then
 
-    verify(handler).flush(entity, batchRequest);
+    verify(handler).flush(TargetIndex.mainIndex("test-index"), entity, batchRequest);
     verify(batchRequest).execute(any());
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
     assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(0);
@@ -143,6 +145,7 @@ class ExporterBatchWriterTest {
     final TestRecord record = new TestRecord(0, NULL_VAL);
     final String id = "1";
     final TestExporterEntity entity = new TestExporterEntity().setId(id);
+    when(handler.getIndexName()).thenReturn("test-index");
     when(handler.handlesRecord(eq(record))).thenReturn(true);
     when(handler.generateIds(eq(record))).thenReturn(List.of(id));
     when(handler.createNewEntity(eq(id))).thenReturn(entity);
@@ -156,7 +159,7 @@ class ExporterBatchWriterTest {
     batchWriter.flush(batchRequest);
 
     // then
-    verify(handler).flush(entity, batchRequest);
+    verify(handler).flush(TargetIndex.mainIndex("test-index"), entity, batchRequest);
     verify(batchRequest).execute(any());
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
     assertThat(batchWriter.getEntitiesToFlushSize()).isEqualTo(0);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.exporter.entities.TestExporterEntity;
 import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
@@ -47,7 +48,10 @@ class OpensearchBatchRequestTest {
 
   private static final String ID = "id";
   private static final String INDEX = "index";
+  private static final TargetIndex TARGET_INDEX = TargetIndex.mainIndex(INDEX);
   private static final String INDEX_WITH_HANDLER = "indexWithHandler";
+  private static final TargetIndex TARGET_INDEX_WITH_HANDLER =
+      TargetIndex.mainIndex(INDEX_WITH_HANDLER);
   private OpensearchBatchRequest batchRequest;
   private OpenSearchClient osClient;
   private OpensearchScriptBuilder scriptBuilder;
@@ -73,7 +77,7 @@ class OpensearchBatchRequestTest {
     // given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     // when
     batchRequest.execute();
 
@@ -96,7 +100,7 @@ class OpensearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
     final String routing = "routing";
 
-    batchRequest.addWithRouting(INDEX, entity, routing);
+    batchRequest.addWithRouting(TARGET_INDEX, entity, routing);
     // when
     batchRequest.execute();
 
@@ -120,7 +124,7 @@ class OpensearchBatchRequestTest {
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
-    batchRequest.upsert(INDEX, ID, entity, updateFields);
+    batchRequest.upsert(TARGET_INDEX, ID, entity, updateFields);
     // when
     batchRequest.execute();
 
@@ -145,7 +149,7 @@ class OpensearchBatchRequestTest {
     final Map<String, Object> updateFields = Map.of("id", "id2");
     final String routing = "routing";
 
-    batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
+    batchRequest.upsertWithRouting(TARGET_INDEX, ID, entity, updateFields, routing);
     // when
     batchRequest.execute();
 
@@ -172,7 +176,7 @@ class OpensearchBatchRequestTest {
     final Script scriptWithParameters = realScript("ctx._source.id = params.id");
     when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
 
-    batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
+    batchRequest.upsertWithScript(TARGET_INDEX, ID, entity, script, params);
     // when
     batchRequest.execute();
 
@@ -199,7 +203,7 @@ class OpensearchBatchRequestTest {
     final Script scriptWithParameters = realScript("ctx._source.id = params.id");
     when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
 
-    batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
+    batchRequest.upsertWithScriptAndRouting(TARGET_INDEX, ID, entity, script, params, routing);
     // when
     batchRequest.execute();
 
@@ -221,7 +225,7 @@ class OpensearchBatchRequestTest {
     // given
     final Map<String, Object> updateFields = Map.of("id", "id2");
 
-    batchRequest.update(INDEX, ID, updateFields);
+    batchRequest.update(TARGET_INDEX, ID, updateFields);
     // when
     batchRequest.execute();
 
@@ -242,7 +246,7 @@ class OpensearchBatchRequestTest {
     // given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    batchRequest.update(INDEX, ID, entity);
+    batchRequest.update(TARGET_INDEX, ID, entity);
     // when
     batchRequest.execute();
 
@@ -267,7 +271,7 @@ class OpensearchBatchRequestTest {
     final Script scriptWithParameters = realScript("ctx._source.id = params.id");
     when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
 
-    batchRequest.updateWithScript(INDEX, ID, script, params);
+    batchRequest.updateWithScript(TARGET_INDEX, ID, script, params);
     // when
     batchRequest.execute();
 
@@ -286,7 +290,7 @@ class OpensearchBatchRequestTest {
   @Test
   void shouldDeleteEntity() throws IOException, PersistenceException {
     // given
-    batchRequest.delete(INDEX, ID);
+    batchRequest.delete(TARGET_INDEX, ID);
     // when
     batchRequest.execute();
 
@@ -307,7 +311,7 @@ class OpensearchBatchRequestTest {
     // given
     final String routing = "routing";
 
-    batchRequest.deleteWithRouting(INDEX, ID, routing);
+    batchRequest.deleteWithRouting(TARGET_INDEX, ID, routing);
     // when
     batchRequest.execute();
 
@@ -328,8 +332,8 @@ class OpensearchBatchRequestTest {
   void shouldExecuteWithMultipleOperationsInBatch() throws PersistenceException, IOException {
     // given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
-    batchRequest.add(INDEX, entity);
-    batchRequest.update(INDEX, ID, entity);
+    batchRequest.add(TARGET_INDEX, entity);
+    batchRequest.update(TARGET_INDEX, ID, entity);
     // when
     batchRequest.execute();
 
@@ -349,9 +353,9 @@ class OpensearchBatchRequestTest {
         new OpensearchBatchRequest(osClient, scriptBuilder).withMaxBytes(1L);
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    tinyCapRequest.add(INDEX, entity);
-    tinyCapRequest.add(INDEX, entity);
-    tinyCapRequest.add(INDEX, entity);
+    tinyCapRequest.add(TARGET_INDEX, entity);
+    tinyCapRequest.add(TARGET_INDEX, entity);
+    tinyCapRequest.add(TARGET_INDEX, entity);
     // when
     tinyCapRequest.execute();
 
@@ -366,7 +370,7 @@ class OpensearchBatchRequestTest {
     // given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     // when
     batchRequest.executeWithRefresh();
 
@@ -384,7 +388,7 @@ class OpensearchBatchRequestTest {
     // given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     when(osClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
 
     // when
@@ -410,7 +414,7 @@ class OpensearchBatchRequestTest {
 
     when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
 
-    batchRequest.add(INDEX, entity);
+    batchRequest.add(TARGET_INDEX, entity);
     // when
     final ThrowingCallable callable = () -> batchRequest.execute();
 
@@ -446,7 +450,7 @@ class OpensearchBatchRequestTest {
             "%s failed for type [%s] and id [%s]: %s",
             item.operationType(), item.index(), item.id(), item.error().reason());
 
-    batchRequest.add(INDEX_WITH_HANDLER, entity);
+    batchRequest.add(TARGET_INDEX_WITH_HANDLER, entity);
     // when
     batchRequest.execute(errorHandler);
 
@@ -522,7 +526,7 @@ class OpensearchBatchRequestTest {
   }
 
   private static byte[] readAllBytes(final BinaryData data) {
-    try (var in = data.asInputStream()) {
+    try (final var in = data.asInputStream()) {
       return in.readAllBytes();
     } catch (final IOException e) {
       throw new AssertionError("failed to read BinaryData", e);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -16,6 +16,7 @@ import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -90,7 +91,8 @@ abstract class BatchOperationUpdateRepositoryIT {
   protected void indexBatchOperation(final BatchOperationEntity batchOperationEntity)
       throws PersistenceException {
     final var batchRequest = clientAdapter.createBatchRequest();
-    batchRequest.add(batchOperationTemplate.getFullQualifiedName(), batchOperationEntity);
+    batchRequest.add(
+        TargetIndex.mainIndex(batchOperationTemplate.getFullQualifiedName()), batchOperationEntity);
     batchRequest.executeWithRefresh();
   }
 
@@ -121,7 +123,9 @@ abstract class BatchOperationUpdateRepositoryIT {
     protected void indexBatchOperation(final BatchOperationEntity batchOperationEntity)
         throws PersistenceException {
       final var batchRequest = clientAdapter.createBatchRequest();
-      batchRequest.add(batchOperationTemplate.getFullQualifiedName(), batchOperationEntity);
+      batchRequest.add(
+          TargetIndex.mainIndex(batchOperationTemplate.getFullQualifiedName()),
+          batchOperationEntity);
       Awaitility.await()
           .ignoreException(PersistenceException.class)
           .timeout(searchDB.dataAvailabilityTimeout())
@@ -267,7 +271,8 @@ abstract class BatchOperationUpdateRepositoryIT {
 
     private void indexOperation(final OperationEntity operationEntity) throws PersistenceException {
       final var batchRequest = clientAdapter.createBatchRequest();
-      batchRequest.add(operationTemplate.getFullQualifiedName(), operationEntity);
+      batchRequest.add(
+          TargetIndex.mainIndex(operationTemplate.getFullQualifiedName()), operationEntity);
       batchRequest.executeWithRefresh();
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -19,6 +19,7 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
+import io.camunda.exporter.index.TargetIndex;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
@@ -177,7 +178,7 @@ abstract class IncidentUpdateRepositoryIT {
 
   private void indexIncident(final IncidentEntity incident) throws PersistenceException {
     final var batchRequest = clientAdapter.createBatchRequest();
-    batchRequest.add(incidentTemplate.getFullQualifiedName(), incident);
+    batchRequest.add(TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()), incident);
     batchRequest.executeWithRefresh();
   }
 
@@ -414,7 +415,10 @@ abstract class IncidentUpdateRepositoryIT {
               .peek(modifier)
               .toList();
       final var batchRequest = clientAdapter.createBatchRequest();
-      updates.forEach(e -> batchRequest.add(postImporterQueueTemplate.getFullQualifiedName(), e));
+      updates.forEach(
+          e ->
+              batchRequest.add(
+                  TargetIndex.mainIndex(postImporterQueueTemplate.getFullQualifiedName()), e));
       batchRequest.executeWithRefresh();
     }
 
@@ -596,7 +600,8 @@ abstract class IncidentUpdateRepositoryIT {
               .setProcessInstanceKey(key)
               .setPosition(position);
       final var batchRequest = clientAdapter.createBatchRequest();
-      batchRequest.add(postImporterQueueTemplate.getFullQualifiedName(), entry);
+      batchRequest.add(
+          TargetIndex.mainIndex(postImporterQueueTemplate.getFullQualifiedName()), entry);
       if (refresh) {
         batchRequest.executeWithRefresh();
       } else {
@@ -629,15 +634,16 @@ abstract class IncidentUpdateRepositoryIT {
           new PostImporterQueueFromIncidentHandler(
               postImporterQueueTemplate.getFullQualifiedName());
       final var batchRequest = clientAdapter.createBatchRequest();
-
+      final var index = TargetIndex.mainIndex(handler.getIndexName());
       // when - the handler flushes several entries for two partitions across many positions
       // partition 1 (the consumer's partition): positions 1..5, keys 1..5
       for (long position = 1; position <= 5; position++) {
-        handler.flush(newQueueEntry(position, position, PARTITION_ID), batchRequest);
+        handler.flush(index, newQueueEntry(position, position, PARTITION_ID), batchRequest);
       }
       // partition 2: positions 1..3, keys offset so they do not collide with partition 1
       for (long position = 1; position <= 3; position++) {
-        handler.flush(newQueueEntry(100 + position, position, OTHER_PARTITION_ID), batchRequest);
+        handler.flush(
+            index, newQueueEntry(100 + position, position, OTHER_PARTITION_ID), batchRequest);
       }
       batchRequest.executeWithRefresh();
 
@@ -728,14 +734,14 @@ abstract class IncidentUpdateRepositoryIT {
       final var bulk = new IncidentBulkUpdate();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "1",
           new IncidentEntity()
               .setKey(1)
               .setState(IncidentState.PENDING)
               .setErrorMessage("failure"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "2",
           new IncidentEntity().setKey(2).setState(IncidentState.ACTIVE).setErrorMessage("failure"));
       batchRequest.executeWithRefresh();
@@ -779,11 +785,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var bulk = new IncidentBulkUpdate();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "1",
           new ProcessInstanceForListViewEntity().setKey(1).setIncident(false));
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "2",
           new ProcessInstanceForListViewEntity().setKey(2).setIncident(true));
       batchRequest.executeWithRefresh();
@@ -828,11 +834,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var bulk = new IncidentBulkUpdate();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          flowNodeInstanceTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),
           "1",
           new FlowNodeInstanceEntity().setKey(1).setIncident(false));
       batchRequest.addWithId(
-          flowNodeInstanceTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),
           "2",
           new FlowNodeInstanceEntity().setKey(2).setIncident(false));
       batchRequest.executeWithRefresh();
@@ -993,7 +999,7 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.add(
-          operationTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(operationTemplate.getFullQualifiedName()),
           new OperationEntity()
               .setProcessInstanceKey(2L)
               .setType(OperationType.DELETE_PROCESS_INSTANCE)
@@ -1013,7 +1019,7 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.add(
-          operationTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(operationTemplate.getFullQualifiedName()),
           new OperationEntity()
               .setProcessInstanceKey(2L)
               .setType(OperationType.CANCEL_PROCESS_INSTANCE)
@@ -1038,7 +1044,7 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.add(
-          operationTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(operationTemplate.getFullQualifiedName()),
           new OperationEntity()
               .setProcessInstanceKey(1L)
               .setType(OperationType.DELETE_PROCESS_INSTANCE)
@@ -1062,7 +1068,7 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.add(
-          operationTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(operationTemplate.getFullQualifiedName()),
           new OperationEntity()
               .setProcessInstanceKey(1L)
               .setType(OperationType.DELETE_PROCESS_INSTANCE)
@@ -1089,11 +1095,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithRouting(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           createFlowNodeInstance(ListViewTemplate.ACTIVITIES_JOIN_RELATION).setId("1"),
           "0");
       batchRequest.addWithRouting(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           createFlowNodeInstance(ListViewTemplate.ACTIVITIES_JOIN_RELATION).setId("2"),
           "0");
       batchRequest.executeWithRefresh();
@@ -1116,11 +1122,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithRouting(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           createFlowNodeInstance(ListViewTemplate.ACTIVITIES_JOIN_RELATION).setId("1"),
           "0");
       batchRequest.addWithRouting(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           createFlowNodeInstance(ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION).setId("2"),
           "0");
       batchRequest.executeWithRefresh();
@@ -1141,11 +1147,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithRouting(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           createFlowNodeInstance(ListViewTemplate.ACTIVITIES_JOIN_RELATION).setId("1"),
           "0");
       batchRequest.addWithRouting(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           createFlowNodeInstance(ListViewTemplate.ACTIVITIES_JOIN_RELATION).setId("2"),
           "0");
       batchRequest.executeWithRefresh();
@@ -1179,9 +1185,13 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          flowNodeInstanceTemplate.getFullQualifiedName(), "1", new FlowNodeInstanceEntity());
+          TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),
+          "1",
+          new FlowNodeInstanceEntity());
       batchRequest.addWithId(
-          flowNodeInstanceTemplate.getFullQualifiedName(), "2", new FlowNodeInstanceEntity());
+          TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),
+          "2",
+          new FlowNodeInstanceEntity());
       batchRequest.executeWithRefresh();
 
       // when
@@ -1202,9 +1212,13 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          flowNodeInstanceTemplate.getFullQualifiedName(), "1", new FlowNodeInstanceEntity());
+          TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),
+          "1",
+          new FlowNodeInstanceEntity());
       batchRequest.addWithId(
-          flowNodeInstanceTemplate.getFullQualifiedName(), "2", new FlowNodeInstanceEntity());
+          TargetIndex.mainIndex(flowNodeInstanceTemplate.getFullQualifiedName()),
+          "2",
+          new FlowNodeInstanceEntity());
       batchRequest.executeWithRefresh();
 
       // when
@@ -1230,15 +1244,15 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "7",
           newIncident(7).setState(IncidentState.ACTIVE).setTreePath("PI_1/FNI_2"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "8",
           newIncident(8).setState(IncidentState.ACTIVE).setTreePath("PI_1/FNI_2/PI_3/FNI_4"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "9",
           newIncident(9).setState(IncidentState.ACTIVE).setTreePath("PI_5/FNI_6"));
       batchRequest.executeWithRefresh();
@@ -1261,15 +1275,15 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "7",
           newIncident(7).setState(IncidentState.ACTIVE).setTreePath("PI_1/FNI_2"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "8",
           newIncident(8).setState(IncidentState.PENDING).setTreePath("PI_1/FNI_3"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "9",
           newIncident(9).setState(IncidentState.RESOLVED).setTreePath("PI_1/FNI_4"));
       batchRequest.executeWithRefresh();
@@ -1290,15 +1304,15 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "7",
           newIncident(7).setState(IncidentState.ACTIVE).setTreePath("PI_1/FNI_2/PI_7"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "8",
           newIncident(8).setState(IncidentState.ACTIVE).setTreePath("PI_3/FNI_4"));
       batchRequest.addWithId(
-          incidentTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(incidentTemplate.getFullQualifiedName()),
           "9",
           newIncident(9).setState(IncidentState.ACTIVE).setTreePath("PI_5/FNI_6"));
       batchRequest.executeWithRefresh();
@@ -1328,11 +1342,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "1",
           new ProcessInstanceForListViewEntity().setKey(1).setTreePath("PI_1"));
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "2",
           new ProcessInstanceForListViewEntity().setKey(2).setTreePath("PI_2"));
       batchRequest.executeWithRefresh();
@@ -1355,11 +1369,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var repository = createRepository();
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "1",
           new ProcessInstanceForListViewEntity().setKey(1).setTreePath("PI_1"));
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "2",
           new ProcessInstanceForListViewEntity().setKey(2).setTreePath("PI_2"));
       batchRequest.executeWithRefresh();
@@ -1383,10 +1397,11 @@ abstract class IncidentUpdateRepositoryIT {
       final var flowNode = new FlowNodeInstanceForListViewEntity().setKey(2).setId("2");
       flowNode.getJoinRelation().setParent(1L);
       batchRequest.addWithId(
-          listViewTemplate.getFullQualifiedName(),
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()),
           "1",
           new ProcessInstanceForListViewEntity().setKey(1).setTreePath("PI_1"));
-      batchRequest.addWithRouting(listViewTemplate.getFullQualifiedName(), flowNode, "1");
+      batchRequest.addWithRouting(
+          TargetIndex.mainIndex(listViewTemplate.getFullQualifiedName()), flowNode, "1");
       batchRequest.executeWithRefresh();
 
       // when


### PR DESCRIPTION
## Description

This is some initial refactoring related to the archiver-less work.

* Adds a `TargetIndex` object that we use instead of `String` for specifying ES/OS indexes to write to
* Expands `ExporterHandler.flush` to take a `TargetIndex` parameter instead of hard coding the index used (later on handlers will need to write to different ordinal based indexes).

This also adds some arch unit tests to help enforce usage of `TargetIndex`.

It's a lot of lines changed, but it's mostly just the same change applied to lots of different `ExportHandler` implementations (and their tests).

Breaking this out into a separate PR due to the large line count.

## Related issues

refs #56997
