### PR TITLE
test: prevent stale unified-config environment leaking into embedded test apps

### DIFF
--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorFlakeReproIT.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorFlakeReproIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+/**
+ * Reproduces the cross-test config leak behind the DocumentStoreS3CompatibleIT flakes: a previous
+ * test's app pins its Environment (containing legacy 'none' database properties) into the static
+ * field of {@link UnifiedConfigurationHelper}; the next test's MultiDbConfigurator then trips the
+ * legacy-vs-unified validation while merely building its configuration.
+ */
+class MultiDbConfiguratorFlakeReproIT {
+
+  @AfterEach
+  void unpinStaleEnvironment() {
+    new UnifiedConfigurationHelper(new StandardEnvironment());
+  }
+
+  @Test
+  void shouldConfigureWhenPreviousTestPinnedLegacyNoneEnvironment() {
+    // given -- some earlier test in the same JVM booted an app whose Spring Environment
+    // declares a legacy database property. Constructing the helper is exactly what Spring
+    // does when that app's context starts; it pins the environment statically.
+    final var previousTestsEnvironment = new StandardEnvironment();
+    previousTestsEnvironment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource("previous-test-app", Map.of("camunda.database.type", "none")));
+    new UnifiedConfigurationHelper(previousTestsEnvironment);
+
+    // when -- the next test configures a fresh, unrelated app for Elasticsearch
+    final var configurator = new MultiDbConfigurator(new TestCamundaApplication());
+
+    // then -- the stale environment must not leak into this app's configuration
+    assertThatCode(() -> configurator.configureElasticsearchSupport("http://localhost", "repro"))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldConfigureWhenNoStaleEnvironmentIsPinned() {
+    // given -- fresh JVM fork: no previous app ever pinned an environment with legacy values
+    final var configurator = new MultiDbConfigurator(new TestCamundaApplication());
+
+    // then -- the exact same call succeeds, which is why the flake is order-dependent
+    assertThatCode(() -> configurator.configureElasticsearchSupport("http://localhost", "repro"))
+        .doesNotThrowAnyException();
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -14,6 +14,7 @@ import io.camunda.application.Profile;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer;
@@ -40,6 +41,7 @@ import org.springframework.boot.Banner.Mode;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.http.client.ReactorResourceFactory;
 
 public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
@@ -220,6 +222,12 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
    */
   @Override
   public T withUnifiedConfig(final Consumer<Camunda> modifier) {
+    // Unified-config getters such as SecondaryStorage#getType() validate against legacy
+    // properties read from the Environment statically pinned in UnifiedConfigurationHelper.
+    // In the test JVM that static still points at the Environment of whichever embedded test
+    // application booted last, so a previous test's legacy values would leak into this
+    // configuration. Re-pin a clean Environment before evaluating the modifier.
+    new UnifiedConfigurationHelper(new StandardEnvironment());
     modifier.accept(unifiedConfig);
     return self();
   }


### PR DESCRIPTION
## Description

Fixes the `DocumentStoreS3CompatibleIT` flakes (top-5 flakiest, ~168x/day) that appeared after #58217.

`UnifiedConfigurationHelper` pins the Spring `Environment` in a static field that is never cleared when an application context shuts down:
https://github.com/camunda/camunda/blob/5eccaa55dbe6dc6384db9d6ffd211ccef9d9bb8b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationHelper.java#L41-L45

Failsafe forks run many test classes per JVM, and each embedded test application boots an in-process Spring context, so that static always points at the config of whichever app booted **last** — even after it stopped. Since #58217, `MultiDbConfigurator` evaluates unified-config getters at test-setup time; `SecondaryStorage#getType()` validates against the legacy properties (`camunda.database.type`, `camunda.operate.database`, `camunda.tasklist.database`, `zeebe.broker.exporters.camundaexporter.args.connect.type`) read from that stale environment. A previous test whose app declared a legacy `none` database type then fails an unrelated test's Elasticsearch setup with `Ambiguous configuration` — order-dependent, hence flaky.

**Fix:** re-pin a clean `Environment` before evaluating `withUnifiedConfig` modifiers, so test-setup config building never sees another test's properties:
https://github.com/camunda/camunda/blob/5eccaa55dbe6dc6384db9d6ffd211ccef9d9bb8b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java#L223-L231

`MultiDbConfiguratorFlakeReproIT` reproduces the leak (it threw `Ambiguous configuration` before this fix) and now guards against regressions.

This is a tactical fix: the static pinning in `UnifiedConfigurationHelper` remains and should be removed by validating within each context instead — follow-up issue to come.

## Alternatives considered
- Avoiding `getDocumentBasedDatabase()` in `MultiDbConfigurator` only — doesn't cover other test-setup call sites (`IncidentNotifierIT`, `UnhandledBpmnErrorActivityIdIT`).
- Dispatching on the raw field in `SecondaryStorage` — weakens intended production boot-time validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)