### PR TITLE
feat: add SECRET resource type and REVEAL permission to zod schema

### DIFF
--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/authorization.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/authorization.ts
@@ -53,6 +53,7 @@ const permissionTypeSchema = z.enum([
 	'SUSPEND_PROCESS_INSTANCE',
 	'CLAIM_USER_TASK',
 	'COMPLETE_USER_TASK',
+	'REVEAL',
 ]);
 type PermissionType = z.infer<typeof permissionTypeSchema>;
 
@@ -73,6 +74,7 @@ const resourceTypeSchema = z.enum([
 	'PROCESS_DEFINITION',
 	'RESOURCE',
 	'ROLE',
+	'SECRET',
 	'SYSTEM',
 	'TENANT',
 	'USER',


### PR DESCRIPTION
related to #56570

## Description

Adds SECRET resource type and REVEAL permission to zod schema

TODO
Once this branch is reviewed and merged:

1. Publish new @camunda/camunda-api-zod-schemas version
2. Bump identity/client/package.json pin from 0.0.82 to new published version. Separate PR/commit, after step 2 done (new version must exist on registry first).
3. Add e2e test (Playwright, qa/c8-orchestration-cluster-e2e-test-suite) — only after step 3, else test builds identity/client against old published schema (no SECRET) and goes red in CI. Mirror COMPONENT precedent — fixture in constants.ts + test in authorizations.spec.ts.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56570
