### PR TITLE
build: ignore Maven release:perform failures so release job continues

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -252,7 +252,8 @@ jobs:
             -DskipQaBuild=true \
             -P-autoFormat \
             ${PROFILE_FLAGS} \
-            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\""
+            -Darguments="-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_CENTRAL_RELEASE} -Dskip.camunda.release=${SKIP_CAMUNDA_RELEASE} -DwaitMaxTime=${CENTRAL_WAIT_MAX_TIME} ${ARGUMENTS_PROFILE} -Dgpg.passphrase=\"${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}\"" \
+            || echo "::warning::release:perform failed, continuing anyway"
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory


### PR DESCRIPTION
## What

Make the `Maven Perform Release` step in `camunda-platform-release.yml` non-fatal by appending `|| echo "::warning::..."` after `./mvnw release:perform`, so the command exits 0.

## Why

During the recent release incident, transient Sonatype Central server errors caused `release:perform` to fail, aborting the entire release job before the remaining steps could run. This is a deliberate stop-gap so subsequent commands within the step and all downstream steps still execute when the Maven Central publish errors out.

## Reviewer notes

- This intentionally **ignores** the perform result rather than retrying — the failure is surfaced only as a `::warning::` annotation, not a red step.
- Tradeoff: downstream success reporting (deployment-ID extraction, C8 `is_camunda_release_successful: true` message, success Slack) will still fire even if publishing did not actually complete. If we want to avoid that, follow-up would be to guard those steps on `steps.maven-perform-release` output. Left out here to keep this a minimal workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)