### PR TITLE
test: automate analytics-exporter P7/N1 scenarios in isolated env

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -214,6 +214,26 @@ jobs:
           npm run test -- --project=api-tests
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
+      # N1 (analytics exporter disabled by default) and P7 (counter/raw-count
+      # parity) each manage their own standalone, throwaway broker/collector/
+      # Loki/Prometheus via utils/dockerComposeControl.ts — separate from the
+      # shared stack started above, so they run as their own project rather
+      # than under api-tests. Gated to main only: this project doesn't exist
+      # yet on stable/8.7, 8.8, 8.9 until backported.
+      - name: Run analytics-exporter isolated tests
+        if: inputs.branch == 'main'
+        shell: bash
+        run: npm run test -- --project=analytics-exporter-isolated
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+
+      - name: Clean up analytics-exporter isolated environment
+        if: always() && inputs.branch == 'main'
+        shell: bash
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.analytics-isolated.yml \
+            -p analytics-isolated down -v || true
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
       - name: Publish test results to TestRail
         if: always()
         shell: bash

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.analytics-isolated.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.analytics-isolated.yml
@@ -1,0 +1,127 @@
+# Standalone, throwaway environment for analytics-exporter scenarios that
+# can't share the main stack's long-running `camunda` container — either
+# because the test needs to prove something is absent by default (N1) or
+# because comparing exact counts (P7) would get contaminated by every other
+# test's process instances running concurrently against the same broker.
+# Deliberately NOT part of docker-compose.yml — brought up and torn down
+# around a single test via utils/dockerComposeControl.ts, on shared
+# otel-collector-isolated/loki-isolated/prometheus-isolated companions, with
+# two mutually-exclusive camunda variants (only one is ever started at a
+# time, both bind the same host ports):
+#
+#   camunda-analytics-isolated           — N1: no exporter config at all
+#   camunda-analytics-isolated-exporter  — P7: exporter enabled, endpoint
+#                                           points at otel-collector-isolated
+#
+# Usage:
+#   docker compose -f config/docker-compose.yml -f config/docker-compose.analytics-isolated.yml \
+#     -p analytics-isolated up -d --no-deps camunda-analytics-isolated otel-collector-isolated loki-isolated prometheus-isolated
+#   docker compose -f config/docker-compose.yml -f config/docker-compose.analytics-isolated.yml \
+#     -p analytics-isolated down
+
+x-camunda-analytics-isolated-base-env: &camunda-analytics-isolated-base-env
+  JAVA_TOOL_OPTIONS: '-Xms512m -Xmx1g'
+  SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-e2e-test,consolidated-auth,tasklist,broker,operate,admin}
+  CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: 'false'
+  CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: 'true'
+  CAMUNDA_SECURITY_AUTHENTICATION_METHOD: BASIC
+  CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED: 'false'
+  CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME: demo
+  CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD: demo
+  CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME: Demo
+  CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL: demo@example.com
+  CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
+  CAMUNDA_LICENSE_KEY: ${CAMUNDA_LICENSE_KEY:-local-test-license-key}
+  # In-memory H2, matching dist/src/main/resources/application-rdbmsH2.yaml
+  # (the repo's own local-dev H2 reference config) — AUTO_DDL=true is
+  # required so the schema gets created; without it startup fails since
+  # no tables pre-exist for a fresh in-memory database. Confirmed live that
+  # the camunda/camunda:SNAPSHOT image's actual default secondary storage is
+  # elasticsearch, not H2 — omitting this override makes the broker retry
+  # forever trying to reach a nonexistent ES host.
+  CAMUNDA_DATA_SECONDARY_STORAGE_TYPE: rdbms
+  CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL: jdbc:h2:mem:camunda
+  CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_USERNAME: sa
+  CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_PASSWORD: ''
+  CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_AUTO_DDL: 'true'
+
+services:
+  camunda-analytics-isolated:
+    container_name: camunda-analytics-isolated
+    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}
+    environment:
+      <<: *camunda-analytics-isolated-base-env
+      ZEEBE_BROKER_NETWORK_HOST: camunda-analytics-isolated
+      # Deliberately no CAMUNDA_DATA_EXPORTERS_ANALYTICS_* vars — this is the
+      # entire point of the N1 test (exporter absent unless explicitly
+      # configured).
+    ports:
+      - '28080:8080'
+      - '28600:9600'
+      - '28650:26500'
+    networks:
+      - zeebe_network
+    depends_on:
+      - otel-collector-isolated
+
+  camunda-analytics-isolated-exporter:
+    container_name: camunda-analytics-isolated-exporter
+    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}
+    environment:
+      <<: *camunda-analytics-isolated-base-env
+      ZEEBE_BROKER_NETWORK_HOST: camunda-analytics-isolated-exporter
+      # Endpoint uses the docker-network service name, not localhost, since
+      # this and otel-collector-isolated are sibling containers on the same
+      # network — but the exporter's own validation rejects any http://
+      # endpoint whose host isn't literally "localhost" (confirmed live: same
+      # rule N9 documents), so ALLOWINSECURE=true is required; there's no TLS
+      # on this throwaway otel-collector to satisfy https instead.
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_CLASSNAME: io.camunda.exporter.analytics.AnalyticsExporter
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_ENDPOINT: http://otel-collector-isolated:4318
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_ALLOWINSECURE: 'true'
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL: PT30S
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_HEARTBEATINTERVAL: PT30S
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE: '2048'
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE: '512'
+      CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_SAMPLINGRATE: '1.0'
+    ports:
+      - '28080:8080'
+      - '28600:9600'
+      - '28650:26500'
+    networks:
+      - zeebe_network
+    depends_on:
+      - otel-collector-isolated
+
+  otel-collector-isolated:
+    container_name: otel-collector-isolated
+    image: otel/opentelemetry-collector-contrib:latest
+    volumes:
+      - ./otel-collector-config-isolated.yaml:/etc/otelcol-contrib/config.yaml
+    depends_on:
+      - loki-isolated
+      - prometheus-isolated
+    networks:
+      - zeebe_network
+
+  loki-isolated:
+    container_name: loki-isolated
+    image: grafana/loki:latest
+    ports:
+      - '23100:3100'
+    networks:
+      - zeebe_network
+
+  prometheus-isolated:
+    container_name: prometheus-isolated
+    image: prom/prometheus:latest
+    ports:
+      - '29090:9090'
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=native-histograms
+    networks:
+      - zeebe_network

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/otel-collector-config-isolated.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/otel-collector-config-isolated.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  deltatocumulative:
+
+exporters:
+  debug:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: http://prometheus-isolated:9090/api/v1/write
+  otlphttp/loki:
+    endpoint: http://loki-isolated:3100/otlp
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug, otlphttp/loki]
+    metrics:
+      receivers: [otlp]
+      processors: [deltatocumulative]
+      exporters: [debug, prometheusremotewrite]

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/prometheus.yaml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/prometheus.yaml
@@ -1,0 +1,2 @@
+global:
+  scrape_interval: 5s

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -197,7 +197,9 @@ const normalProjects = [
     // project so specs never run concurrently with each other and each
     // test's container lifecycle stays isolated from every other project.
     name: 'analytics-exporter-isolated',
-    testMatch: ['tests/api/v2/analytics-exporter/analytics-exporter-isolated/*.spec.ts'],
+    testMatch: [
+      'tests/api/v2/analytics-exporter/analytics-exporter-isolated/*.spec.ts',
+    ],
     use: devices['Desktop Chrome'],
     workers: 1,
     fullyParallel: false,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/playwright.config.ts
@@ -71,6 +71,7 @@ const apiTestIgnore = [
   'tests/api/v2/audit-log/*.spec.ts',
   'tests/api/v2/job/job-statistics-*.spec.ts',
   'tests/api/v2/optimize/**/*.spec.ts',
+  'tests/api/v2/analytics-exporter/**/*.spec.ts',
 ];
 // Projects
 const normalProjects = [
@@ -186,6 +187,20 @@ const normalProjects = [
     use: {
       ...devices['Desktop Chrome'],
     },
+  },
+  {
+    // Analytics exporter scenarios that can't share the main stack's
+    // long-running `camunda` container — N1 (disabled by default) and P7
+    // (counter/raw-count parity) — each run against their own standalone,
+    // throwaway broker variant. See config/docker-compose.analytics-isolated.yml
+    // and utils/dockerComposeControl.ts. Kept as its own single-worker
+    // project so specs never run concurrently with each other and each
+    // test's container lifecycle stays isolated from every other project.
+    name: 'analytics-exporter-isolated',
+    testMatch: ['tests/api/v2/analytics-exporter/analytics-exporter-isolated/*.spec.ts'],
+    use: devices['Desktop Chrome'],
+    workers: 1,
+    fullyParallel: false,
   },
 ];
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/analytics_parity_test.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/analytics_parity_test.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_analytics_parity" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="analytics_parity_test" name="Analytics Parity Test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0o0ofxe</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_1pozaqm" name="">
+      <bpmn:incoming>Flow_0o0ofxe</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0o0ofxe" sourceRef="StartEvent_1" targetRef="Event_1pozaqm" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="analytics_parity_test">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pozaqm_di" bpmnElement="Event_1pozaqm">
+        <dc:Bounds x="272" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0o0ofxe_di" bpmnElement="Flow_0o0ofxe">
+        <di:waypoint x="218" y="100" />
+        <di:waypoint x="272" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/counter-parity.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/counter-parity.spec.ts
@@ -71,20 +71,23 @@ test.describe.serial('Analytics Exporter Counter Parity', () => {
     const instanceCount = 20;
 
     await test.step('Deploy a dedicated, uniquely-named process', async () => {
-      const bpmn = readFileSync('./resources/analytics_parity_test.bpmn', 'utf-8').replace(
-        /analytics_parity_test/g,
-        processId,
-      );
-      const deployRes = await request.post(`${ISOLATED_BASE_URL}/v2/deployments`, {
-        headers: {Authorization: authHeader},
-        multipart: {
-          resources: {
-            name: `${processId}.bpmn`,
-            mimeType: 'application/xml',
-            buffer: Buffer.from(bpmn),
+      const bpmn = readFileSync(
+        './resources/analytics_parity_test.bpmn',
+        'utf-8',
+      ).replace(/analytics_parity_test/g, processId);
+      const deployRes = await request.post(
+        `${ISOLATED_BASE_URL}/v2/deployments`,
+        {
+          headers: {Authorization: authHeader},
+          multipart: {
+            resources: {
+              name: `${processId}.bpmn`,
+              mimeType: 'application/xml',
+              buffer: Buffer.from(bpmn),
+            },
           },
         },
-      });
+      );
       expect(deployRes.status()).toBe(200);
     });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/counter-parity.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/counter-parity.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {randomUUID} from 'node:crypto';
+import {readFileSync} from 'node:fs';
+import {test, expect, request as playwrightRequest} from '@playwright/test';
+import {encode} from '../../../../../utils/http';
+import {extendedAssertionOptions} from '../../../../../utils/constants';
+import {
+  startIsolatedEnvironmentWithExporter,
+  stopIsolatedEnvironment,
+} from '../../../../../utils/dockerComposeControl';
+import {
+  queryLoki,
+  queryPrometheus,
+  countLokiEntries,
+  firstPrometheusValue,
+  toLokiNanos,
+} from '../../../../../utils/analyticsQueryHelpers';
+
+// P7 — the analytics exporter's pre-aggregated Prometheus counter
+// (camunda_process_instance_created_total) must agree with the raw
+// process_instance_created event count in Loki for the same instances.
+//
+// This runs against a standalone, throwaway camunda broker (see
+// config/docker-compose.analytics-isolated.yml, camunda-analytics-isolated-exporter)
+// rather than the shared stack every other test in this suite depends on —
+// a dedicated broker means no other test's process instances can ever land
+// in the same count, so there's nothing to contaminate the parity check.
+
+const ISOLATED_BASE_URL =
+  process.env.ANALYTICS_ISOLATED_BASE_URL ?? 'http://localhost:28080';
+const ISOLATED_LOKI_URL =
+  process.env.ANALYTICS_ISOLATED_LOKI_URL ?? 'http://localhost:23100';
+const ISOLATED_PROMETHEUS_URL =
+  process.env.ANALYTICS_ISOLATED_PROMETHEUS_URL ?? 'http://localhost:29090';
+const authHeader = `Basic ${encode('demo:demo')}`;
+
+test.describe.serial('Analytics Exporter Counter Parity', () => {
+  test.setTimeout(5 * 60 * 1000);
+
+  test.beforeAll(async () => {
+    await startIsolatedEnvironmentWithExporter();
+
+    const context = await playwrightRequest.newContext();
+    try {
+      await expect(async () => {
+        const res = await context.get(`${ISOLATED_BASE_URL}/v2/topology`, {
+          headers: {Authorization: authHeader},
+        });
+        expect(res.status()).toBe(200);
+      }).toPass({intervals: [2_000, 5_000, 10_000], timeout: 120_000});
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  test.afterAll(async () => {
+    await stopIsolatedEnvironment();
+  });
+
+  test('Prometheus counter matches raw Loki event count for a known batch of process instances', async ({
+    request,
+  }) => {
+    const processId = `analytics-parity-${randomUUID().slice(0, 8)}`;
+    const instanceCount = 20;
+
+    await test.step('Deploy a dedicated, uniquely-named process', async () => {
+      const bpmn = readFileSync('./resources/analytics_parity_test.bpmn', 'utf-8').replace(
+        /analytics_parity_test/g,
+        processId,
+      );
+      const deployRes = await request.post(`${ISOLATED_BASE_URL}/v2/deployments`, {
+        headers: {Authorization: authHeader},
+        multipart: {
+          resources: {
+            name: `${processId}.bpmn`,
+            mimeType: 'application/xml',
+            buffer: Buffer.from(bpmn),
+          },
+        },
+      });
+      expect(deployRes.status()).toBe(200);
+    });
+
+    await test.step(`Create ${instanceCount} process instances`, async () => {
+      for (let i = 0; i < instanceCount; i++) {
+        const createRes = await request.post(
+          `${ISOLATED_BASE_URL}/v2/process-instances`,
+          {
+            headers: {
+              Authorization: authHeader,
+              'Content-Type': 'application/json',
+            },
+            data: {processDefinitionId: processId},
+          },
+        );
+        expect(createRes.status()).toBe(200);
+      }
+    });
+
+    await test.step('Verify Loki and Prometheus agree on the count', async () => {
+      await expect(async () => {
+        const loki = await queryLoki(
+          request,
+          `{service_name="camunda-zeebe"} | event_name="process_instance_created" | camunda_process_id="${processId}"`,
+          toLokiNanos(new Date(Date.now() - 10 * 60 * 1000)),
+          toLokiNanos(),
+          1000,
+          ISOLATED_LOKI_URL,
+        );
+        const lokiCount = countLokiEntries(loki);
+        expect(lokiCount).toBe(instanceCount);
+
+        const prometheus = await queryPrometheus(
+          request,
+          `sum(camunda_process_instance_created_total{camunda_process_id="${processId}"})`,
+          ISOLATED_PROMETHEUS_URL,
+        );
+        const prometheusCount = firstPrometheusValue(prometheus);
+        expect(prometheusCount).toBe(instanceCount);
+        // Retry budget must comfortably exceed the exporter's push-interval
+        // (PT30S) plus Prometheus scrape/remote-write lag — defaultAssertionOptions'
+        // 30s window races the 30s push-interval itself and flakes.
+      }).toPass(extendedAssertionOptions);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/default-off.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/default-off.spec.ts
@@ -13,7 +13,10 @@ import {
   startIsolatedEnvironmentWithoutExporter,
   stopIsolatedEnvironment,
 } from '../../../../../utils/dockerComposeControl';
-import {queryLoki, toLokiNanos} from '../../../../../utils/analyticsQueryHelpers';
+import {
+  queryLoki,
+  toLokiNanos,
+} from '../../../../../utils/analyticsQueryHelpers';
 
 // N1 — the analytics exporter is disabled by default: with no
 // CAMUNDA_DATA_EXPORTERS_ANALYTICS_* config set at all, zero analytics

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/default-off.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/analytics-exporter/analytics-exporter-isolated/default-off.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {readFileSync} from 'node:fs';
+import {test, expect, request as playwrightRequest} from '@playwright/test';
+import {encode} from '../../../../../utils/http';
+import {
+  startIsolatedEnvironmentWithoutExporter,
+  stopIsolatedEnvironment,
+} from '../../../../../utils/dockerComposeControl';
+import {queryLoki, toLokiNanos} from '../../../../../utils/analyticsQueryHelpers';
+
+// N1 — the analytics exporter is disabled by default: with no
+// CAMUNDA_DATA_EXPORTERS_ANALYTICS_* config set at all, zero analytics
+// records should ever reach Loki, regardless of how much process-instance
+// load runs against the broker.
+//
+// This runs against a standalone, throwaway camunda broker (see
+// config/docker-compose.analytics-isolated.yml) rather than the shared
+// stack every other test in this suite depends on, since the shared stack
+// has the exporter always-on (for the P7 counter-parity test) — testing
+// "disabled by default" requires an environment where it was never
+// configured in the first place.
+
+const ISOLATED_BASE_URL =
+  process.env.ANALYTICS_ISOLATED_BASE_URL ?? 'http://localhost:28080';
+const ISOLATED_LOKI_URL =
+  process.env.ANALYTICS_ISOLATED_LOKI_URL ?? 'http://localhost:23100';
+const authHeader = `Basic ${encode('demo:demo')}`;
+
+test.describe.serial('Analytics Exporter Default-Off', () => {
+  test.setTimeout(5 * 60 * 1000);
+
+  test.beforeAll(async () => {
+    await startIsolatedEnvironmentWithoutExporter();
+
+    const context = await playwrightRequest.newContext();
+    try {
+      await expect(async () => {
+        const res = await context.get(`${ISOLATED_BASE_URL}/v2/topology`, {
+          headers: {Authorization: authHeader},
+        });
+        expect(res.status()).toBe(200);
+      }).toPass({intervals: [2_000, 5_000, 10_000], timeout: 120_000});
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  test.afterAll(async () => {
+    await stopIsolatedEnvironment();
+  });
+
+  test('no analytics records reach Loki when the exporter is not configured', async ({
+    request,
+  }) => {
+    const startNs = toLokiNanos();
+
+    await test.step('Deploy a process and create instances', async () => {
+      const bpmn = readFileSync(
+        './resources/process_instance_api_test.bpmn',
+        'utf-8',
+      );
+      const deployRes = await request.post(
+        `${ISOLATED_BASE_URL}/v2/deployments`,
+        {
+          headers: {Authorization: authHeader},
+          multipart: {
+            resources: {
+              name: 'process_instance_api_test.bpmn',
+              mimeType: 'application/xml',
+              buffer: Buffer.from(bpmn),
+            },
+          },
+        },
+      );
+      expect(deployRes.status()).toBe(200);
+
+      for (let i = 0; i < 5; i++) {
+        const createRes = await request.post(
+          `${ISOLATED_BASE_URL}/v2/process-instances`,
+          {
+            headers: {
+              Authorization: authHeader,
+              'Content-Type': 'application/json',
+            },
+            data: {processDefinitionId: 'process_instance_api_test'},
+          },
+        );
+        expect(createRes.status()).toBe(200);
+      }
+    });
+
+    await test.step('Confirm zero analytics records reached Loki', async () => {
+      // Give the exporter every opportunity to have pushed something if it
+      // were somehow active — a fixed wait, not a retry-until-found loop,
+      // since we're asserting an absence, not waiting for eventual presence.
+      await new Promise((resolve) => setTimeout(resolve, 15_000));
+
+      const loki = await queryLoki(
+        request,
+        '{service_name="camunda-zeebe"}',
+        startNs,
+        toLokiNanos(),
+        1000,
+        ISOLATED_LOKI_URL,
+      );
+      expect(loki).toHaveLength(0);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/analyticsQueryHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/analyticsQueryHelpers.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext} from '@playwright/test';
+
+const defaultLokiBaseUrl = process.env.LOKI_URL ?? 'http://localhost:3100';
+const defaultPrometheusBaseUrl =
+  process.env.PROMETHEUS_URL ?? 'http://localhost:9090';
+
+export type LokiStreamResult = {
+  stream: Record<string, string>;
+  values: [string, string][];
+};
+
+export type LokiQueryRangeResponse = {
+  status: string;
+  data: {
+    resultType: string;
+    result: LokiStreamResult[];
+  };
+};
+
+export type PrometheusQueryResponse = {
+  status: string;
+  data: {
+    resultType: string;
+    result: Array<{
+      metric: Record<string, string>;
+      value: [number, string];
+    }>;
+  };
+};
+
+/**
+ * Queries Loki's HTTP API directly (no Grafana UI). Returns the raw
+ * "streams" result array: one entry per unique label-set, each carrying
+ * that record's structured metadata under `stream` and its timestamped
+ * (empty-body) log lines under `values`.
+ *
+ * `baseUrl` defaults to the shared stack's Loki (LOKI_URL env var, or
+ * localhost:3100). Pass it explicitly to target a different instance, e.g.
+ * the isolated environment's Loki on a different port.
+ */
+export async function queryLoki(
+  request: APIRequestContext,
+  query: string,
+  startNs: string,
+  endNs: string,
+  limit = 1000,
+  baseUrl: string = defaultLokiBaseUrl,
+): Promise<LokiStreamResult[]> {
+  const response = await request.get(`${baseUrl}/loki/api/v1/query_range`, {
+    params: {query, start: startNs, end: endNs, limit: String(limit)},
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `Loki query failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as LokiQueryRangeResponse;
+  return body.data.result;
+}
+
+/** Total number of log lines returned across every stream in the result. */
+export function countLokiEntries(streams: LokiStreamResult[]): number {
+  return streams.reduce((sum, s) => sum + s.values.length, 0);
+}
+
+/**
+ * Queries Prometheus's instant-query HTTP API directly (no Grafana UI).
+ * Returns the raw result array; each entry's `value` is `[timestamp, "asString"]`.
+ *
+ * `baseUrl` defaults to the shared stack's Prometheus (PROMETHEUS_URL env
+ * var, or localhost:9090). Pass it explicitly to target a different instance.
+ */
+export async function queryPrometheus(
+  request: APIRequestContext,
+  promQL: string,
+  baseUrl: string = defaultPrometheusBaseUrl,
+): Promise<PrometheusQueryResponse['data']['result']> {
+  const response = await request.get(`${baseUrl}/api/v1/query`, {
+    params: {query: promQL},
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `Prometheus query failed: ${response.status()} ${await response.text()}`,
+    );
+  }
+  const body = (await response.json()) as PrometheusQueryResponse;
+  return body.data.result;
+}
+
+/** Convenience: the scalar value of a single-series instant query, or undefined if empty. */
+export function firstPrometheusValue(
+  result: PrometheusQueryResponse['data']['result'],
+): number | undefined {
+  const raw = result[0]?.value?.[1];
+  return raw === undefined ? undefined : Number(raw);
+}
+
+/** Converts a JS Date (or now) to the nanosecond-string timestamp Loki's API expects. */
+export function toLokiNanos(date: Date = new Date()): string {
+  return `${date.getTime()}000000`;
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
@@ -30,16 +30,15 @@ const PROJECT_NAME = 'analytics-isolated';
 // targeting only the isolated services with --no-deps. DATABASE just needs
 // any valid value to satisfy that validation; the isolated services don't
 // use it themselves.
-const COMPOSE_ENV = {...process.env, DATABASE: process.env.DATABASE ?? 'elasticsearch'};
+const COMPOSE_ENV = {
+  ...process.env,
+  DATABASE: process.env.DATABASE ?? 'elasticsearch',
+};
 
 function composeCommand(args: string[]): string {
-  return [
-    'docker compose',
-    ...COMPOSE_FILES,
-    '-p',
-    PROJECT_NAME,
-    ...args,
-  ].join(' ');
+  return ['docker compose', ...COMPOSE_FILES, '-p', PROJECT_NAME, ...args].join(
+    ' ',
+  );
 }
 
 /**

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {exec} from 'node:child_process';
+import {promisify} from 'node:util';
+import path from 'node:path';
+
+const execAsync = promisify(exec);
+
+// Resolved against the CWD Playwright is invoked from (the suite's project
+// root), matching how other specs in this repo reference relative paths
+// (e.g. deployWithSubstitutions('./resources/*.bpmn')).
+const CONFIG_DIR = path.resolve(process.cwd(), 'config');
+const COMPOSE_FILES = [
+  '-f',
+  'docker-compose.yml',
+  '-f',
+  'docker-compose.analytics-isolated.yml',
+];
+const PROJECT_NAME = 'analytics-isolated';
+
+// Combining docker-compose.yml with the isolated override means Compose
+// validates the *entire* merged service graph up front — including the
+// shared `camunda` service's `depends_on: [${DATABASE}]` — even when
+// targeting only the isolated services with --no-deps. DATABASE just needs
+// any valid value to satisfy that validation; the isolated services don't
+// use it themselves.
+const COMPOSE_ENV = {...process.env, DATABASE: process.env.DATABASE ?? 'elasticsearch'};
+
+function composeCommand(args: string[]): string {
+  return [
+    'docker compose',
+    ...COMPOSE_FILES,
+    '-p',
+    PROJECT_NAME,
+    ...args,
+  ].join(' ');
+}
+
+/**
+ * Brings up the isolated environment with the exporter NOT configured at
+ * all (N1: proving it's disabled by default). Intentionally isolated from
+ * the shared, long-running stack every other test depends on — see
+ * config/docker-compose.analytics-isolated.yml.
+ */
+export async function startIsolatedEnvironmentWithoutExporter(): Promise<void> {
+  await execAsync(
+    composeCommand([
+      'up',
+      '-d',
+      '--no-deps',
+      'camunda-analytics-isolated',
+      'otel-collector-isolated',
+      'loki-isolated',
+      'prometheus-isolated',
+    ]),
+    {cwd: CONFIG_DIR, env: COMPOSE_ENV},
+  );
+}
+
+/**
+ * Brings up the isolated environment with the exporter enabled (P7: counter
+ * vs. raw-event-count parity) — a separate camunda variant from the one
+ * above, on the same host ports; only one is ever started at a time. See
+ * config/docker-compose.analytics-isolated.yml.
+ */
+export async function startIsolatedEnvironmentWithExporter(): Promise<void> {
+  await execAsync(
+    composeCommand([
+      'up',
+      '-d',
+      '--no-deps',
+      'camunda-analytics-isolated-exporter',
+      'otel-collector-isolated',
+      'loki-isolated',
+      'prometheus-isolated',
+    ]),
+    {cwd: CONFIG_DIR, env: COMPOSE_ENV},
+  );
+}
+
+/** Tears down the isolated environment (whichever camunda variant is running). Safe to call even if it was never started. */
+export async function stopIsolatedEnvironment(): Promise<void> {
+  await execAsync(composeCommand(['down', '-v']), {
+    cwd: CONFIG_DIR,
+    env: COMPOSE_ENV,
+  });
+}
+
+/** Fetches recent logs from a service in the isolated environment, for assertions/debugging. */
+export async function getIsolatedServiceLogs(
+  serviceName: string,
+): Promise<string> {
+  const {stdout, stderr} = await execAsync(
+    composeCommand(['logs', '--no-color', serviceName]),
+    {cwd: CONFIG_DIR, env: COMPOSE_ENV},
+  );
+  return stdout + stderr;
+}


### PR DESCRIPTION
## Summary
Automates 2 of the manually-validated QA scenarios from the analytics-exporter QA pass tracked in [product-hub#3750](https://github.com/camunda/product-hub/issues/3750):

- **P7** — Prometheus's pre-aggregated counter (`camunda_process_instance_created_total`) agrees with the raw Loki event count for a known batch of process instances.
- **N1** — the exporter is disabled by default: zero analytics records reach Loki when no `CAMUNDA_DATA_EXPORTERS_ANALYTICS_*` config is set.

Both run against a standalone, throwaway broker (`config/docker-compose.analytics-isolated.yml`, new Playwright project `analytics-exporter-isolated`) rather than the shared, long-running stack the rest of this suite depends on:
- P7 needs an exact instance count with nothing else able to contribute to it — a dedicated broker removes any risk of other concurrently-running tests polluting the count.
- N1 needs to prove the exporter is *absent* by default — impossible to demonstrate on the shared stack once anything else enables it.

Brought up/torn down per test via `utils/dockerComposeControl.ts`; wired into the nightly `main`-only API test job (gated, since this project doesn't exist yet on `stable/8.7`/`8.8`/`8.9` until backported).

**Already covered by the dev team** (unit/IT tests in `zeebe/exporters/analytics-exporter/src/test/`), not duplicated here: PI-created event emission, ad-hoc subprocess events, usage metrics (isolated), heartbeat, sequence contiguity (in-process), missing license, queue overflow, unreachable/insecure endpoint validation, invalid config validation (`max-batch-size`/`max-queue-size`/sampling bounds), sampling-rate 0.0, PII exclusion, and the N10 PI-key-off-by-one regression (`ProcessInstanceCreationHandlerTest`).

**Deliberately out of scope for this PR** — N7 (invalid config rejected at real broker startup, not just the config object) and N4 (broker crash / kill mid-flush): both need the same isolated-environment plumbing this PR adds, so they're natural, cheap follow-ups on top of it rather than blocking this change.

## Test plan
- [x] `npx playwright test --project=analytics-exporter-isolated` run locally end-to-end against real Docker containers — both specs pass.
- [x] `tsc --noEmit` clean.
- [x] `actionlint` clean on the modified workflow.
- [x] Confirmed the shared `docker-compose.yml`/`camunda` service and `api-tests`/`api-tests-subset`/`chromium` projects are unaffected (no diff, no new test matches).
- [ ] CI run on this PR (nightly-only job — `analytics-exporter-isolated` step is gated to `main`, won't run on the PR's own required checks; verify via a manual `workflow_dispatch` of the nightly workflow if you want CI confirmation before merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)