### PR TITLE
test: backport missing expectProcessState helper to unblock stable/8.8 E2E

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -175,3 +175,24 @@ export async function expectProcessInstanceCanBeFound(
     timeout: 180_000,
   });
 }
+
+export async function expectProcessState(
+  request: APIRequestContext,
+  processInstanceKey: string,
+  state: string,
+  assertionOptions: {
+    intervals?: number[];
+    timeout?: number;
+  } = defaultAssertionOptions,
+): Promise<void> {
+  await expect(async () => {
+    const res = await request.post(buildUrl('/process-instances/search'), {
+      headers: jsonHeaders(),
+      data: {filter: {processInstanceKey}},
+    });
+    await assertStatusCode(res, 200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(1);
+    expect(json.items[0].state).toBe(state);
+  }).toPass(assertionOptions);
+}


### PR DESCRIPTION
## Description

The orchestration-cluster E2E suite on `stable/8.8` fails to collect (0 tests run) with:

```
SyntaxError: The requested module '@requestHelpers' does not provide an export named 'expectProcessState'
```

**Root cause:** backport #58375 ("[Backport stable/8.8] test: add Tasklist E2E for user task with custom task headers", the stable/8.8 backport of #58311) added `import {findUserTask, expectProcessState} from '@requestHelpers'` and a call to `expectProcessState` in `tests/tasklist/task-details.spec.ts`, but **did not** backport the `expectProcessState` helper itself. On `main` the helper is defined and exported in `utils/requestHelpers/process-instance-requestHelpers.ts`; the backport dropped it. Because Playwright fails module resolution during collection, the **entire** suite aborts before any test runs — in both Tasklist v1 and v2 modes (both collect `tests/tasklist/task-details.spec.ts`).

**Confirmed via on-demand run** [29920158526](https://github.com/camunda/camunda/actions/runs/29920158526) (branch `stable/8.8`): both `E2E Tests (Tasklist v1)` and `E2E Tests (Tasklist v2)` report `stats.total = 0` with the SyntaxError above.

**Fix:** add the `expectProcessState` helper verbatim from `main` to `process-instance-requestHelpers.ts` (picked up by the existing `export *` in `requestHelpers/index.ts`). All its dependencies (`expect`, `buildUrl`, `jsonHeaders`, `assertStatusCode`, `defaultAssertionOptions`) are already imported in that file on `stable/8.8`, so no other change is needed.

This is the 8.8 counterpart of the same fix included in the stable/8.9 PR #58380.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Introduced by #58375. Confirmed by on-demand run https://github.com/camunda/camunda/actions/runs/29920158526
