### PR TITLE
feat: apply configuration changes via the new multi-group model in the manager

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
@@ -100,6 +101,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final Map<String, ExponentialBackoffRetryDelay> groupBackoffRetry = new HashMap<>();
   private final Duration minRetryDelay;
   private final Duration maxRetryDelay;
+  private ScheduledTimer advancePhaseRetryTimer;
 
   ClusterConfigurationManagerImpl(
       final ConcurrencyControl executor,
@@ -511,35 +513,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     return future;
   }
 
-  /**
-   * Seeds a partition group configuration (e.g. a non-default physical tenant) if it does not exist
-   * yet. Existing groups are left untouched.
-   */
-  ActorFuture<Void> setPartitionGroupConfig(
-      final String groupId, final PartitionGroupConfiguration groupConfiguration) {
-    final var future = executor.<Void>createFuture();
-    executor.run(
-        () -> {
-          final var current = persistedCurrentConfiguration.getConfiguration();
-          if (current.hasPartitionGroup(groupId)) {
-            future.complete(null);
-            return;
-          }
-          final Map<String, PartitionGroupConfiguration> groups =
-              new HashMap<>(current.partitionGroups());
-          groups.put(groupId, groupConfiguration);
-          final var updated =
-              new CurrentClusterConfiguration(
-                  current.version(),
-                  current.globalConfiguration(),
-                  groups,
-                  current.phasedChangeState());
-          updateLocalCurrentConfiguration(updated)
-              .ifRightOrLeft(applied -> future.complete(null), future::completeExceptionally);
-        });
-    return future;
-  }
-
   void registerGlobalChangeAppliers(final GlobalConfigurationChangeAppliers appliers) {
     executor.run(
         () -> {
@@ -605,9 +578,36 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     }
 
     if (plan.hasNextPhase()) {
-      updateMultiConfiguration(CurrentClusterConfiguration::activateNextPhase);
+      updateMultiConfiguration(CurrentClusterConfiguration::activateNextPhase)
+          .onComplete(
+              (ignore, error) -> {
+                if (error != null) {
+                  LOG.warn("Failed to advance phased change plan to next phase", error);
+                  scheduleAdvancePhase();
+                } else {
+                  advancePhaseRetryTimer = null;
+                }
+              });
     } else {
-      updateMultiConfiguration(c -> c.completePlan(PhasedChangePlanStatus.COMPLETED));
+      updateMultiConfiguration(c -> c.completePlan(PhasedChangePlanStatus.COMPLETED))
+          .onComplete(
+              (ignore, error) -> {
+                if (error != null) {
+                  LOG.warn("Failed to complete phased change plan", error);
+                  scheduleAdvancePhase();
+                } else {
+                  advancePhaseRetryTimer = null;
+                }
+              });
+    }
+  }
+
+  private void scheduleAdvancePhase() {
+    if (advancePhaseRetryTimer == null) {
+      advancePhaseRetryTimer =
+          executor.schedule(
+              backoffRetry.nextDelay(),
+              () -> maybeAdvancePhase(persistedCurrentConfiguration.getConfiguration()));
     }
   }
 
@@ -795,7 +795,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     if (currentGroup == null
         || currentGroup.version()
             != configurationOnWhichOperationIsApplied.partitionGroup(groupId).version()) {
-      LOG.debug(
+      LOG.warn(
           "Partition group '{}' changed while applying operation {}. Most likely the change was cancelled.",
           groupId,
           operation);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -598,7 +598,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
           case final PartitionGroupParallelPhase parallelPhase ->
               parallelPhase.groupOperations().keySet().stream()
                   .map(config::partitionGroup)
-                  .allMatch(group -> group == null || !group.hasPendingChanges());
+                  .allMatch(group -> group != null && !group.hasPendingChanges());
         };
     if (!currentPhaseComplete) {
       return;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -8,12 +8,23 @@
 package io.camunda.zeebe.dynamic.config;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliers;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliers;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics.OperationObserver;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Either;
@@ -21,9 +32,13 @@ import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +82,25 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private boolean initialized = false;
   private final TopologyManagerMetrics topologyMetrics;
 
+  // Temporary flag to switch between the old single-partition-group model and the new
+  // multi-partition-group model. This is used for testing and will be removed in the future.
+  private final boolean useNewConfig;
+
+  // New-model state, only used when useNewConfig is true.
+  private final @Nullable PersistedCurrentClusterConfiguration persistedCurrentConfiguration;
+  private @Nullable Consumer<CurrentClusterConfiguration> currentConfigurationGossiper;
+  private final @Nullable ClusterConfigurationCoordinatorSupplier coordinatorSupplier;
+  private @Nullable GlobalConfigurationChangeAppliers globalChangeAppliers;
+  private final Map<String, PartitionGroupConfigurationChangeAppliers>
+      partitionGroupChangeAppliers = new HashMap<>();
+  private boolean onGoingGlobalOperation = false;
+  private boolean shouldRetryGlobal = false;
+  private final Map<String, Boolean> onGoingGroupOperation = new HashMap<>();
+  private final Map<String, Boolean> shouldRetryGroup = new HashMap<>();
+  private final Map<String, ExponentialBackoffRetryDelay> groupBackoffRetry = new HashMap<>();
+  private final Duration minRetryDelay;
+  private final Duration maxRetryDelay;
+
   ClusterConfigurationManagerImpl(
       final ConcurrencyControl executor,
       final MemberId localMemberId,
@@ -94,13 +128,55 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     startFuture = executor.createFuture();
     this.localMemberId = localMemberId;
     this.topologyMetrics = topologyMetrics;
+    this.minRetryDelay = minRetryDelay;
+    this.maxRetryDelay = maxRetryDelay;
     backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
+    useNewConfig = false;
+    persistedCurrentConfiguration = null;
+    coordinatorSupplier = null;
+  }
+
+  /**
+   * Constructs a manager operating on the new multi-partition-group model. Used only in tests now.
+   * The legacy {@code PersistedClusterConfiguration} is not used in this mode.
+   */
+  @VisibleForTesting
+  ClusterConfigurationManagerImpl(
+      final ConcurrencyControl executor,
+      final MemberId localMemberId,
+      final PersistedCurrentClusterConfiguration persistedCurrentConfiguration,
+      final TopologyManagerMetrics topologyMetrics,
+      final Duration minRetryDelay,
+      final Duration maxRetryDelay) {
+    this.executor = executor;
+    persistedClusterConfiguration = null;
+    this.persistedCurrentConfiguration = persistedCurrentConfiguration;
+    startFuture = executor.createFuture();
+    this.localMemberId = localMemberId;
+    this.topologyMetrics = topologyMetrics;
+    this.minRetryDelay = minRetryDelay;
+    this.maxRetryDelay = maxRetryDelay;
+    backoffRetry = new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay);
+    useNewConfig = true;
+    coordinatorSupplier =
+        ClusterConfigurationCoordinatorSupplier.ofMembers(
+            () ->
+                this.persistedCurrentConfiguration
+                    .getConfiguration()
+                    .globalConfiguration()
+                    .members()
+                    .keySet());
   }
 
   @Override
   public ActorFuture<ClusterConfiguration> getClusterConfiguration() {
     final var future = executor.<ClusterConfiguration>createFuture();
-    executor.run(() -> future.complete(persistedClusterConfiguration.getConfiguration()));
+    executor.run(
+        () ->
+            future.complete(
+                useNewConfig
+                    ? persistedCurrentConfiguration.getConfiguration().toLegacyDefault()
+                    : persistedClusterConfiguration.getConfiguration()));
     return future;
   }
 
@@ -387,5 +463,350 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
   void removeTopologyChangedListener() {
     executor.run(() -> onInconsistentConfigurationDetected = null);
+  }
+
+  // ---------------------------------------------------------------------------
+  // New multi-partition-group model (used only when useNewConfig is true).
+  // ---------------------------------------------------------------------------
+
+  boolean isUsingNewConfig() {
+    return useNewConfig;
+  }
+
+  void setCurrentConfigurationGossiper(
+      final Consumer<CurrentClusterConfiguration> currentConfigurationGossiper) {
+    this.currentConfigurationGossiper = currentConfigurationGossiper;
+  }
+
+  /** Returns the full multi-group configuration. Only valid when {@link #useNewConfig} is true. */
+  ActorFuture<CurrentClusterConfiguration> getMultiConfiguration() {
+    final var future = executor.<CurrentClusterConfiguration>createFuture();
+    executor.run(() -> future.complete(persistedCurrentConfiguration.getConfiguration()));
+    return future;
+  }
+
+  /**
+   * Applies {@code updater} to the multi-group configuration, persists and gossips the result, then
+   * triggers local operation application. Only valid when {@link #useNewConfig} is true.
+   */
+  ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
+      final UnaryOperator<CurrentClusterConfiguration> updater) {
+    final var future = executor.<CurrentClusterConfiguration>createFuture();
+    executor.run(
+        () -> {
+          try {
+            final var updated = updater.apply(persistedCurrentConfiguration.getConfiguration());
+            updateLocalCurrentConfiguration(updated)
+                .ifRightOrLeft(
+                    applied -> {
+                      future.complete(applied);
+                      applyNewConfigurationChangeOperation();
+                    },
+                    future::completeExceptionally);
+          } catch (final Exception e) {
+            LOG.error("Failed to update cluster configuration", e);
+            future.completeExceptionally(e);
+          }
+        });
+    return future;
+  }
+
+  /**
+   * Seeds a partition group configuration (e.g. a non-default physical tenant) if it does not exist
+   * yet. Existing groups are left untouched.
+   */
+  ActorFuture<Void> setPartitionGroupConfig(
+      final String groupId, final PartitionGroupConfiguration groupConfiguration) {
+    final var future = executor.<Void>createFuture();
+    executor.run(
+        () -> {
+          final var current = persistedCurrentConfiguration.getConfiguration();
+          if (current.hasPartitionGroup(groupId)) {
+            future.complete(null);
+            return;
+          }
+          final Map<String, PartitionGroupConfiguration> groups =
+              new HashMap<>(current.partitionGroups());
+          groups.put(groupId, groupConfiguration);
+          final var updated =
+              new CurrentClusterConfiguration(
+                  current.version(),
+                  current.globalConfiguration(),
+                  groups,
+                  current.phasedChangeState());
+          updateLocalCurrentConfiguration(updated)
+              .ifRightOrLeft(applied -> future.complete(null), future::completeExceptionally);
+        });
+    return future;
+  }
+
+  void registerGlobalChangeAppliers(final GlobalConfigurationChangeAppliers appliers) {
+    executor.run(
+        () -> {
+          globalChangeAppliers = appliers;
+          applyNewConfigurationChangeOperation();
+        });
+  }
+
+  void registerPartitionGroupChangeAppliers(
+      final String groupId, final PartitionGroupConfigurationChangeAppliers appliers) {
+    executor.run(
+        () -> {
+          partitionGroupChangeAppliers.put(groupId, appliers);
+          applyNewConfigurationChangeOperation();
+        });
+  }
+
+  void removePartitionGroupChangeAppliers(final String groupId) {
+    executor.run(() -> partitionGroupChangeAppliers.remove(groupId));
+  }
+
+  private Either<Exception, CurrentClusterConfiguration> updateLocalCurrentConfiguration(
+      final CurrentClusterConfiguration configuration) {
+    if (configuration.equals(persistedCurrentConfiguration.getConfiguration())) {
+      return Either.right(configuration);
+    }
+    try {
+      persistedCurrentConfiguration.update(configuration);
+      if (currentConfigurationGossiper != null) {
+        currentConfigurationGossiper.accept(configuration);
+      }
+      maybeAdvancePhase(configuration);
+      return Either.right(configuration);
+    } catch (final Exception e) {
+      return Either.left(e);
+    }
+  }
+
+  /**
+   * Drives phased-plan advancement. Invoked after every successful local configuration update. Only
+   * the coordinator (the member with the lowest id, per {@link
+   * ClusterConfigurationCoordinatorSupplier}) advances the plan, so that a single member is
+   * responsible for the transition. When the current phase's sub-configuration(s) have drained
+   * their pending changes, the plan is advanced to the next phase, or completed if it was the last
+   * phase. The action is idempotent — re-firing on an already-advanced phase is a no-op.
+   */
+  private void maybeAdvancePhase(final CurrentClusterConfiguration config) {
+    final var pending = config.phasedChangeState().pending();
+    if (pending.isEmpty() || !isLocalMemberCoordinator()) {
+      return;
+    }
+    final var plan = pending.get();
+    final boolean currentPhaseComplete =
+        switch (plan.currentPhase()) {
+          case final GlobalPhase ignored -> !config.globalConfiguration().hasPendingChanges();
+          case final PartitionGroupParallelPhase parallelPhase ->
+              parallelPhase.groupOperations().keySet().stream()
+                  .map(config::partitionGroup)
+                  .allMatch(group -> group == null || !group.hasPendingChanges());
+        };
+    if (!currentPhaseComplete) {
+      return;
+    }
+
+    if (plan.hasNextPhase()) {
+      updateMultiConfiguration(CurrentClusterConfiguration::activateNextPhase);
+    } else {
+      updateMultiConfiguration(c -> c.completePlan(PhasedChangePlanStatus.COMPLETED));
+    }
+  }
+
+  private boolean isLocalMemberCoordinator() {
+    return coordinatorSupplier != null
+        && localMemberId.equals(coordinatorSupplier.getDefaultCoordinator());
+  }
+
+  /**
+   * Applies the next pending operation for the local member on the global configuration and on
+   * every partition group. Operations across partition groups are applied concurrently — each group
+   * has its own in-progress/retry state — while the operations within a single group (and within
+   * the global configuration) are applied sequentially.
+   */
+  private void applyNewConfigurationChangeOperation() {
+    applyGlobalConfigurationChangeOperation();
+    // can apply operations to global and groups in parallel. The ordering is constrained by the
+    // phases. So additional enforcement of ordering is not needed here.
+    for (final String groupId :
+        List.copyOf(persistedCurrentConfiguration.getConfiguration().partitionGroups().keySet())) {
+      // Can apply operations to multiple groups in parallel, but only one operation per group at a
+      // time.
+      applyPartitionGroupConfigurationChangeOperation(groupId);
+    }
+  }
+
+  private void applyGlobalConfigurationChangeOperation() {
+    final var config = persistedCurrentConfiguration.getConfiguration();
+    final var pending = config.globalConfiguration().pendingChangesFor(localMemberId);
+    if ((onGoingGlobalOperation && !shouldRetryGlobal)
+        || globalChangeAppliers == null
+        || pending.isEmpty()) {
+      return;
+    }
+
+    onGoingGlobalOperation = true;
+    shouldRetryGlobal = false;
+    final var operation = (GlobalChangeOperation) pending.orElseThrow();
+    final var observer = topologyMetrics.observeOperation(operation);
+    LOG.info("Applying global configuration change operation {}", operation);
+    final var applier = globalChangeAppliers.getApplier(operation);
+    final var initialized =
+        applier
+            .init(config)
+            .map(config::updateGlobalConfiguration)
+            .flatMap(this::updateLocalCurrentConfiguration);
+
+    if (initialized.isLeft()) {
+      observer.failed();
+      onGoingGlobalOperation = false;
+      LOG.error(
+          "Failed to initialize global configuration change operation {}",
+          operation,
+          initialized.getLeft());
+      return;
+    }
+
+    final var startedConfiguration = initialized.get();
+    applier
+        .apply()
+        .onComplete(
+            (transformer, error) ->
+                onGlobalOperationApplied(
+                    startedConfiguration, operation, transformer, error, observer));
+  }
+
+  private void onGlobalOperationApplied(
+      final CurrentClusterConfiguration configurationOnWhichOperationIsApplied,
+      final GlobalChangeOperation operation,
+      final UnaryOperator<GlobalConfiguration> transformer,
+      final Throwable error,
+      final OperationObserver observer) {
+    onGoingGlobalOperation = false;
+    if (error != null) {
+      observer.failed();
+      shouldRetryGlobal = true;
+      final Duration delay = backoffRetry.nextDelay();
+      LOG.warn(
+          "Failed to apply global configuration change operation {}. Will be retried in {}.",
+          operation,
+          delay,
+          error);
+      executor.schedule(delay, this::applyNewConfigurationChangeOperation);
+      return;
+    }
+
+    observer.applied();
+    backoffRetry.reset();
+    if (persistedCurrentConfiguration.getConfiguration().globalConfiguration().version()
+        != configurationOnWhichOperationIsApplied.globalConfiguration().version()) {
+      LOG.debug(
+          "Global configuration changed while applying operation {}. Most likely the change was cancelled.",
+          operation);
+      return;
+    }
+    final var advanced =
+        persistedCurrentConfiguration
+            .getConfiguration()
+            .updateGlobalConfiguration(g -> g.advanceConfigurationChange(transformer));
+    updateLocalCurrentConfiguration(advanced);
+    LOG.info("Global operation {} applied.", operation);
+    executor.run(this::applyNewConfigurationChangeOperation);
+  }
+
+  private void applyPartitionGroupConfigurationChangeOperation(final String groupId) {
+    final var config = persistedCurrentConfiguration.getConfiguration();
+    final var group = config.partitionGroup(groupId);
+    final var appliers = partitionGroupChangeAppliers.get(groupId);
+    if (group == null || appliers == null) {
+      return;
+    }
+    final var pending = group.pendingChangesFor(localMemberId);
+    if ((onGoingGroupOperation.getOrDefault(groupId, false)
+            && !shouldRetryGroup.getOrDefault(groupId, false))
+        || pending.isEmpty()) {
+      return;
+    }
+
+    onGoingGroupOperation.put(groupId, true);
+    shouldRetryGroup.put(groupId, false);
+    final var operation = (PartitionGroupOperation) pending.orElseThrow();
+    final var observer = topologyMetrics.observeOperation(operation);
+    LOG.info("Applying partition group '{}' configuration change operation {}", groupId, operation);
+    final var applier = appliers.getApplier(operation);
+    final var initialized =
+        applier
+            .init(config.globalConfiguration(), group)
+            .map(transformer -> config.updatePartitionGroupConfig(groupId, transformer))
+            .flatMap(this::updateLocalCurrentConfiguration);
+
+    if (initialized.isLeft()) {
+      observer.failed();
+      onGoingGroupOperation.put(groupId, false);
+      LOG.error(
+          "Failed to initialize partition group '{}' configuration change operation {}",
+          groupId,
+          operation,
+          initialized.getLeft());
+      return;
+    }
+
+    final var startedConfiguration = initialized.get();
+    applier
+        .apply()
+        .onComplete(
+            (transformer, error) ->
+                onPartitionGroupOperationApplied(
+                    groupId, startedConfiguration, operation, transformer, error, observer));
+  }
+
+  private void onPartitionGroupOperationApplied(
+      final String groupId,
+      final CurrentClusterConfiguration configurationOnWhichOperationIsApplied,
+      final PartitionGroupOperation operation,
+      final UnaryOperator<PartitionGroupConfiguration> transformer,
+      final Throwable error,
+      final OperationObserver observer) {
+    onGoingGroupOperation.put(groupId, false);
+    if (error != null) {
+      observer.failed();
+      shouldRetryGroup.put(groupId, true);
+      final Duration delay =
+          groupBackoffRetry
+              .computeIfAbsent(
+                  groupId,
+                  ignored -> new ExponentialBackoffRetryDelay(maxRetryDelay, minRetryDelay))
+              .nextDelay();
+      LOG.warn(
+          "Failed to apply partition group '{}' configuration change operation {}. Will be retried in {}.",
+          groupId,
+          operation,
+          delay,
+          error);
+      executor.schedule(delay, this::applyNewConfigurationChangeOperation);
+      return;
+    }
+
+    observer.applied();
+    final var groupBackoff = groupBackoffRetry.get(groupId);
+    if (groupBackoff != null) {
+      groupBackoff.reset();
+    }
+    final var currentGroup =
+        persistedCurrentConfiguration.getConfiguration().partitionGroup(groupId);
+    if (currentGroup == null
+        || currentGroup.version()
+            != configurationOnWhichOperationIsApplied.partitionGroup(groupId).version()) {
+      LOG.debug(
+          "Partition group '{}' changed while applying operation {}. Most likely the change was cancelled.",
+          groupId,
+          operation);
+      return;
+    }
+    final var advanced =
+        persistedCurrentConfiguration
+            .getConfiguration()
+            .updatePartitionGroupConfig(groupId, g -> g.advanceConfigurationChange(transformer));
+    updateLocalCurrentConfiguration(advanced);
+    LOG.info("Partition group '{}' operation {} applied.", groupId, operation);
+    executor.run(this::applyNewConfigurationChangeOperation);
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -645,7 +645,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
     onGoingGlobalOperation = true;
     shouldRetryGlobal = false;
-    final var operation = (GlobalChangeOperation) pending.orElseThrow();
+    final var operation = pending.orElseThrow();
     final var observer = topologyMetrics.observeOperation(operation);
     LOG.info("Applying global configuration change operation {}", operation);
     final var applier = globalChangeAppliers.getApplier(operation);
@@ -728,7 +728,7 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
 
     onGoingGroupOperation.put(groupId, true);
     shouldRetryGroup.put(groupId, false);
-    final var operation = (PartitionGroupOperation) pending.orElseThrow();
+    final var operation = pending.orElseThrow();
     final var observer = topologyMetrics.observeOperation(operation);
     LOG.info("Applying partition group '{}' configuration change operation {}", groupId, operation);
     final var applier = appliers.getApplier(operation);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -8,9 +8,11 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -137,6 +139,98 @@ public record CurrentClusterConfiguration(
         globalConfiguration,
         Map.of(DEFAULT_GROUP, defaultGroup),
         toPhasedChangeState(legacy));
+  }
+
+  /**
+   * Projects this multi-group configuration back to a legacy single-group {@link
+   * ClusterConfiguration} representing the {@link #DEFAULT_GROUP}. This is the inverse of {@link
+   * #fromLegacy(ClusterConfiguration)} and backs the {@code getClusterConfiguration()} compat
+   * accessor used by read consumers (e.g. the REST topology API) that have not yet migrated to the
+   * multi-group model.
+   *
+   * <p>Each member combines its cluster-wide lifecycle state (from {@link #globalConfiguration})
+   * with its default-group partition assignment (from {@code partitionGroups[default]}); a member
+   * whose default-group operating mode is {@link Mode#RECOVERING} is projected to the legacy {@link
+   * MemberState.State#RECOVERING} state. {@code routingState} and {@code incarnationNumber} come
+   * from the default group; {@code clusterId} and {@code partitionDistributorConfig} from the
+   * global configuration.
+   *
+   * <p>The pending/last change is a best-effort projection: {@code pendingChanges} reflects
+   * whichever sub-config currently has an active plan (global first, then the default group), and
+   * {@code lastChange} is derived from the {@link PhasedChangeState}. Cross-sub-config change
+   * details cannot be represented losslessly in the flat legacy plan, so this projection is
+   * intended for display and equivalence checks, not for driving legacy change execution.
+   */
+  public ClusterConfiguration toLegacyDefault() {
+    final PartitionGroupConfiguration defaultGroup =
+        partitionGroups.getOrDefault(DEFAULT_GROUP, PartitionGroupConfiguration.empty(version));
+
+    final Map<MemberId, MemberState> members = new HashMap<>();
+    globalConfiguration
+        .members()
+        .forEach(
+            (memberId, brokerState) ->
+                members.put(
+                    memberId, toLegacyMemberState(brokerState, defaultGroup.getMember(memberId))));
+
+    final Optional<ClusterChangePlan> pendingChanges =
+        globalConfiguration
+            .pendingChanges()
+            .filter(ClusterChangePlan::hasPendingChanges)
+            .or(() -> defaultGroup.pendingChanges().filter(ClusterChangePlan::hasPendingChanges));
+
+    final Optional<CompletedChange> lastChange =
+        phasedChangeState.lastChange().map(CurrentClusterConfiguration::toLegacyCompletedChange);
+
+    return ClusterConfiguration.builder()
+        .version(Math.max(globalConfiguration.version(), defaultGroup.version()))
+        .members(members)
+        .lastChange(lastChange)
+        .pendingChanges(pendingChanges)
+        .routingState(defaultGroup.routingState())
+        .clusterId(globalConfiguration.clusterId())
+        .incarnationNumber(defaultGroup.incarnationNumber())
+        .partitionDistributorConfig(globalConfiguration.partitionDistributorConfig())
+        .build();
+  }
+
+  private static MemberState toLegacyMemberState(
+      final BrokerState brokerState, final @Nullable BrokerPartitionState partitionState) {
+    final Map<Integer, PartitionState> partitions =
+        partitionState != null ? partitionState.partitions() : Map.of();
+    final MemberState.State state =
+        partitionState != null && partitionState.mode() == Mode.RECOVERING
+            ? MemberState.State.RECOVERING
+            : toLegacyLifecycleState(brokerState.state());
+    final long version =
+        partitionState != null
+            ? Math.max(brokerState.version(), partitionState.version())
+            : brokerState.version();
+    final Instant lastUpdated =
+        partitionState != null && partitionState.lastUpdated().isAfter(brokerState.lastUpdated())
+            ? partitionState.lastUpdated()
+            : brokerState.lastUpdated();
+    return new MemberState(version, lastUpdated, state, partitions);
+  }
+
+  private static MemberState.State toLegacyLifecycleState(final BrokerState.State state) {
+    return switch (state) {
+      case UNINITIALIZED -> MemberState.State.UNINITIALIZED;
+      case JOINING -> MemberState.State.JOINING;
+      case ACTIVE -> MemberState.State.ACTIVE;
+      case LEAVING -> MemberState.State.LEAVING;
+      case LEFT -> MemberState.State.LEFT;
+    };
+  }
+
+  private static CompletedChange toLegacyCompletedChange(final CompletedPhasedChange change) {
+    final Status status =
+        switch (change.status()) {
+          case COMPLETED -> Status.COMPLETED;
+          case FAILED -> Status.FAILED;
+          case CANCELLED -> Status.CANCELLED;
+        };
+    return new CompletedChange(change.id(), status, change.startedAt(), change.completedAt());
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -254,6 +255,101 @@ public record GlobalConfiguration(
 
   public boolean hasPendingChanges() {
     return pendingChanges.isPresent() && pendingChanges.orElseThrow().hasPendingChanges();
+  }
+
+  /**
+   * Returns the next pending operation for the given memberId, or empty if the next pending
+   * operation (if any) is not applicable to that member. Mirrors {@code
+   * ClusterConfiguration#pendingChangesFor(MemberId)}.
+   */
+  public Optional<ClusterConfigurationChangeOperation> pendingChangesFor(final MemberId memberId) {
+    if (pendingChanges.isEmpty() || !pendingChanges.get().hasPendingChangesFor(memberId)) {
+      return Optional.empty();
+    }
+    return Optional.of(pendingChanges.orElseThrow().nextPendingOperation());
+  }
+
+  public ClusterConfigurationChangeOperation nextPendingOperation() {
+    if (!hasPendingChanges()) {
+      throw new NoSuchElementException();
+    }
+    return pendingChanges.orElseThrow().nextPendingOperation();
+  }
+
+  /**
+   * When the operation returned by {@link #pendingChangesFor(MemberId)} completes, the result is
+   * reflected here by applying {@code configurationUpdater} and then advancing past the completed
+   * operation. Mirrors {@code ClusterConfiguration#advanceConfigurationChange}.
+   */
+  public GlobalConfiguration advanceConfigurationChange(
+      final UnaryOperator<GlobalConfiguration> configurationUpdater) {
+    return configurationUpdater.apply(this).advance();
+  }
+
+  /**
+   * Steps the ongoing change plan past its first pending operation. While operations remain the
+   * plan is simply stepped forward and the version is unchanged. When the last operation is
+   * removed, the change is completed: {@code pendingChanges} is cleared, {@code lastChange} is set,
+   * members whose lifecycle state is {@link BrokerState.State#LEFT} are removed, and the version is
+   * bumped so peers overwrite their local copy on merge. Mirrors {@code
+   * ClusterConfiguration#advance()}.
+   *
+   * @throws IllegalStateException if there is no pending change to advance
+   */
+  public GlobalConfiguration advance() {
+    if (!hasPendingChanges()) {
+      throw new IllegalStateException(
+          "Expected to advance the configuration change, but there is no pending change");
+    }
+
+    final var result =
+        new GlobalConfiguration(
+            version,
+            clusterId,
+            members,
+            partitionDistributorConfig,
+            Optional.of(pendingChanges.orElseThrow().advance()),
+            lastChange);
+
+    if (result.hasPendingChanges()) {
+      return result;
+    }
+
+    // The last operation has been applied. Complete the change: remove members marked as LEFT and
+    // bump the version so other members merge by overwriting their local copy.
+    final var remainingMembers =
+        result.members().entrySet().stream()
+            .filter(entry -> entry.getValue().state() != BrokerState.State.LEFT)
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    final var completedChange = pendingChanges.orElseThrow().completed();
+    return new GlobalConfiguration(
+        result.version() + 1,
+        clusterId,
+        remainingMembers,
+        partitionDistributorConfig,
+        Optional.empty(),
+        Optional.of(completedChange));
+  }
+
+  /**
+   * Cancels any pending changes, returning a new configuration with the already-applied changes and
+   * no pending changes. This is a dangerous operation that can leave the configuration
+   * inconsistent; it should only be used as a last resort when a change is stuck. Mirrors {@code
+   * ClusterConfiguration#cancelPendingChanges()}.
+   */
+  public GlobalConfiguration cancelPendingChanges() {
+    if (!hasPendingChanges()) {
+      return this;
+    }
+    final var cancelledChange = pendingChanges.orElseThrow().cancel();
+    // Increment version by 2 to avoid conflicts with other members who are applying the change.
+    return new GlobalConfiguration(
+        version + 2,
+        clusterId,
+        members,
+        partitionDistributorConfig,
+        Optional.empty(),
+        Optional.of(cancelledChange));
   }
 
   public boolean hasMember(final MemberId memberId) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -262,18 +262,18 @@ public record GlobalConfiguration(
    * operation (if any) is not applicable to that member. Mirrors {@code
    * ClusterConfiguration#pendingChangesFor(MemberId)}.
    */
-  public Optional<ClusterConfigurationChangeOperation> pendingChangesFor(final MemberId memberId) {
+  public Optional<GlobalChangeOperation> pendingChangesFor(final MemberId memberId) {
     if (pendingChanges.isEmpty() || !pendingChanges.get().hasPendingChangesFor(memberId)) {
       return Optional.empty();
     }
-    return Optional.of(pendingChanges.orElseThrow().nextPendingOperation());
+    return Optional.of((GlobalChangeOperation) pendingChanges.orElseThrow().nextPendingOperation());
   }
 
-  public ClusterConfigurationChangeOperation nextPendingOperation() {
+  public GlobalChangeOperation nextPendingOperation() {
     if (!hasPendingChanges()) {
       throw new NoSuchElementException();
     }
-    return pendingChanges.orElseThrow().nextPendingOperation();
+    return (GlobalChangeOperation) pendingChanges.orElseThrow().nextPendingOperation();
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
@@ -278,6 +279,57 @@ public record PartitionGroupConfiguration(
 
   public boolean hasPendingChanges() {
     return pendingChanges.isPresent() && pendingChanges.orElseThrow().hasPendingChanges();
+  }
+
+  /**
+   * Returns the next pending operation for the given memberId, or empty if the next pending
+   * operation (if any) is not applicable to that member. Mirrors {@code
+   * ClusterConfiguration#pendingChangesFor(MemberId)}.
+   */
+  public Optional<ClusterConfigurationChangeOperation> pendingChangesFor(final MemberId memberId) {
+    if (pendingChanges.isEmpty() || !pendingChanges.get().hasPendingChangesFor(memberId)) {
+      return Optional.empty();
+    }
+    return Optional.of(pendingChanges.orElseThrow().nextPendingOperation());
+  }
+
+  public ClusterConfigurationChangeOperation nextPendingOperation() {
+    if (!hasPendingChanges()) {
+      throw new NoSuchElementException();
+    }
+    return pendingChanges.orElseThrow().nextPendingOperation();
+  }
+
+  /**
+   * When the operation returned by {@link #pendingChangesFor(MemberId)} completes, the result is
+   * reflected here by applying {@code configurationUpdater} and then advancing past the completed
+   * operation (see {@link #advance()}). Mirrors {@code
+   * ClusterConfiguration#advanceConfigurationChange}.
+   */
+  public PartitionGroupConfiguration advanceConfigurationChange(
+      final UnaryOperator<PartitionGroupConfiguration> configurationUpdater) {
+    return configurationUpdater.apply(this).advance();
+  }
+
+  /**
+   * Cancels any pending changes, returning a new configuration with the already-applied changes and
+   * no pending changes. This is a dangerous operation that can leave the configuration
+   * inconsistent; it should only be used as a last resort when a change is stuck. Mirrors {@code
+   * ClusterConfiguration#cancelPendingChanges()}.
+   */
+  public PartitionGroupConfiguration cancelPendingChanges() {
+    if (!hasPendingChanges()) {
+      return this;
+    }
+    final var cancelledChange = pendingChanges.orElseThrow().cancel();
+    // Increment version by 2 to avoid conflicts with other members who are applying the change.
+    return new PartitionGroupConfiguration(
+        version + 2,
+        incarnationNumber,
+        members,
+        routingState,
+        Optional.empty(),
+        Optional.of(cancelledChange));
   }
 
   public boolean hasMember(final MemberId memberId) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -286,18 +286,19 @@ public record PartitionGroupConfiguration(
    * operation (if any) is not applicable to that member. Mirrors {@code
    * ClusterConfiguration#pendingChangesFor(MemberId)}.
    */
-  public Optional<ClusterConfigurationChangeOperation> pendingChangesFor(final MemberId memberId) {
+  public Optional<PartitionGroupOperation> pendingChangesFor(final MemberId memberId) {
     if (pendingChanges.isEmpty() || !pendingChanges.get().hasPendingChangesFor(memberId)) {
       return Optional.empty();
     }
-    return Optional.of(pendingChanges.orElseThrow().nextPendingOperation());
+    return Optional.of(
+        (PartitionGroupOperation) pendingChanges.orElseThrow().nextPendingOperation());
   }
 
-  public ClusterConfigurationChangeOperation nextPendingOperation() {
+  public PartitionGroupOperation nextPendingOperation() {
     if (!hasPendingChanges()) {
       throw new NoSuchElementException();
     }
-    return pendingChanges.orElseThrow().nextPendingOperation();
+    return (PartitionGroupOperation) pendingChanges.orElseThrow().nextPendingOperation();
   }
 
   /**

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Verifies the new multi-partition-group apply loop in {@link ClusterConfigurationManagerImpl}. */
+final class ClusterConfigurationManagerImplNewConfigTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @TempDir private Path tmp;
+
+  private ClusterConfigurationManagerImpl newManager(final MemberId localMemberId) {
+    final var persisted =
+        PersistedCurrentClusterConfiguration.ofFile(
+            tmp.resolve("config-" + localMemberId.id() + ".meta"), new ProtoBufSerializer());
+    final var manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            localMemberId,
+            persisted,
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopClusterChangeExecutor(),
+            new NoopModeChangeExecutor()));
+    return manager;
+  }
+
+  private CurrentClusterConfiguration configuration(final ClusterConfigurationManagerImpl manager) {
+    return manager.getMultiConfiguration().join();
+  }
+
+  @Test
+  void shouldApplyGlobalOperationForLocalMember() {
+    // given — the local member joins via a single-phase (global) plan
+    final var manager = newManager(MEMBER_1);
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1))))))
+        .join();
+
+    // then — the global change was applied: the member is ACTIVE and the global plan drained
+    final var config = configuration(manager);
+    assertThat(config.globalConfiguration().getMember(MEMBER_1).state()).isEqualTo(State.ACTIVE);
+    assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+  }
+
+  @Test
+  void shouldApplyPartitionGroupOperationForLocalMember() {
+    // given — partition 1 has two replicas (members 0 and 1); the local member 0 leaves it
+    final var manager = newManager(MEMBER_0);
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(2, partitionConfig))),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // when — a partition-group phase removes member 0's replica (min allowed replicas = 1)
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)))))))
+        .join();
+
+    // then — the group plan drained; member 0 (now with no partitions) is removed, member 1 stays
+    final var defaultGroup =
+        configuration(manager).partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    assertThat(defaultGroup.hasMember(MEMBER_0)).isFalse();
+    assertThat(defaultGroup.hasMember(MEMBER_1)).isTrue();
+  }
+
+  @Test
+  void shouldNotApplyOperationForOtherMember() {
+    // given — a plan whose only operation targets a different member
+    final var manager = newManager(MEMBER_0);
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1))))))
+        .join();
+
+    // then — the local member (0) does not apply member 1's operation; it stays pending
+    final var config = configuration(manager);
+    assertThat(config.globalConfiguration().hasPendingChanges()).isTrue();
+    assertThat(config.globalConfiguration().hasMember(MEMBER_1)).isFalse();
+  }
+
+  @Test
+  void shouldAdvanceAndCompleteMultiPhasePlanAsCoordinator() {
+    // given — member 0 is the lowest-id member, so it is the coordinator responsible for
+    // advancing the plan once each phase's changes have drained
+    final var manager = newManager(MEMBER_0);
+
+    // when — a two-phase plan is initiated: member 0 joins, then leaves, each phase containing an
+    // operation for the local member
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0))),
+                        new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_0))))))
+        .join();
+
+    // then — both phases were applied and the coordinator advanced/completed the plan on its own
+    final var config = configuration(manager);
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    final var lastChange = config.phasedChangeState().lastChange();
+    assertThat(lastChange).isPresent();
+    assertThat(lastChange.get().status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
+  }
+
+  @Test
+  void shouldNotAdvancePhaseWhenLocalMemberIsNotCoordinator() {
+    // given — member 1 is not the lowest-id member (member 0 is present too), so it is not the
+    // coordinator; both members start ACTIVE with no partitions assigned
+    final var manager = newManager(MEMBER_1);
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // when — a two-phase plan's first phase only contains an operation for the local member
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))),
+                        new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1))))))
+        .join();
+
+    // then — the first phase's operation was applied, but the plan is not advanced to phase 2
+    // since the local member is not the coordinator
+    final var config = configuration(manager);
+    final var pending = config.phasedChangeState().pending();
+    assertThat(pending).isPresent();
+    assertThat(pending.get().currentPhaseIndex()).isZero();
+    assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+  }
+
+  @Test
+  void shouldAdvanceFromGlobalPhaseToPartitionGroupPhase() {
+    // given — member 0 is the coordinator; it is not yet part of the cluster or the default
+    // group, which only has member 1 holding partition 1
+    final var manager = newManager(MEMBER_0);
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // when — a global phase joins member 0 to the cluster, followed by a partition-group phase
+    // that adds member 0 as a replica of partition 1
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0))),
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
+        .join();
+
+    // then — the coordinator advanced from the global phase into the partition-group phase and
+    // completed the plan once member 0 joined both the cluster and the partition-group replica set
+    final var config = configuration(manager);
+    assertThat(config.globalConfiguration().getMember(MEMBER_0).state()).isEqualTo(State.ACTIVE);
+    final var defaultGroup = config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasMember(MEMBER_0)).isTrue();
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    final var lastChange = config.phasedChangeState().lastChange();
+    assertThat(lastChange).isPresent();
+    assertThat(lastChange.get().status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -11,12 +11,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
@@ -24,6 +27,7 @@ import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
@@ -35,14 +39,18 @@ import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -78,7 +86,8 @@ final class ClusterConfigurationManagerImplNewConfigTest {
             new NoopPartitionChangeExecutor(),
             new NoopPartitionScalingChangeExecutor(),
             new NoopClusterChangeExecutor(),
-            new NoopModeChangeExecutor()));
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
     return manager;
   }
 
@@ -290,5 +299,219 @@ final class ClusterConfigurationManagerImplNewConfigTest {
     final var lastChange = config.phasedChangeState().lastChange();
     assertThat(lastChange).isPresent();
     assertThat(lastChange.get().status()).isEqualTo(PhasedChangePlanStatus.COMPLETED);
+  }
+
+  @Test
+  void shouldRetryPendingOperationInPartitionGroupIfFailed() {
+    // given — member 0 is the coordinator; it is part of the cluster and the default group, which
+    // has member 1 holding partition 1; a plan is initiated to add member 0 as a replica of
+    // partition 1, but the operation fails (e.g., due to a network error)
+    final var manager = newManager(MEMBER_0);
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(Map.of()),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(
+                    MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                    MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // Simulate failure of the operation (e.g., due to network error)
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new FailingExecutor(1),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopClusterChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+
+    // when — a partition-group phase adds member 0 as a replica of partition 1, but the operation
+    // fails; then the plan is retried
+    manager
+        .updateMultiConfiguration(
+            c ->
+                c.initPlan(
+                    List.of(
+                        new PartitionGroupParallelPhase(
+                            Map.of(
+                                CurrentClusterConfiguration.DEFAULT_GROUP,
+                                List.of(new PartitionJoinOperation(MEMBER_0, 1, 1)))))))
+        .join();
+
+    // then — the operation was retried and completed successfully
+    Awaitility.await("Pending operation should be retried and completed")
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var config = configuration(manager);
+              assertThat(
+                      config
+                          .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                          .hasPendingChanges())
+                  .isFalse();
+              assertThat(config.phasedChangeState().pending()).isEmpty();
+            });
+    final var config = configuration(manager);
+    final var defaultGroup = config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasMember(MEMBER_0))
+        .describedAs("Member 0 is added to the default group")
+        .isTrue();
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+  }
+
+  @Test
+  void shouldRetryPendingOperationInGlobalPhaseIfFailed() {
+    // given — member 0 is the coordinator; it is not yet part of the cluster; a plan is initiated
+    // to add member 0 to the cluster, but the operation fails (e.g., due to a network error)
+    final var manager = newManager(MEMBER_0);
+    final var seeded =
+        new CurrentClusterConfiguration(
+            CurrentClusterConfiguration.INITIAL_VERSION,
+            new GlobalConfiguration(
+                1,
+                Optional.empty(),
+                Map.of(MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()),
+            Map.of(),
+            PhasedChangeState.empty());
+    manager.updateMultiConfiguration(ignored -> seeded).join();
+
+    // Simulate failure of the operation (e.g., due to network error)
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new FailingExecutor(1), new NoopClusterChangeExecutor()));
+
+    // when — a global phase adds member 0 to the cluster, but the operation fails; then the plan is
+    // retried
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0))))))
+        .join();
+
+    // then — the operation was retried and completed successfully
+    Awaitility.await("Pending operation should be retried and completed")
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(
+            () -> {
+              final var config = configuration(manager);
+              assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+              assertThat(config.phasedChangeState().pending()).isEmpty();
+            });
+    final var config = configuration(manager);
+    assertThat(config.globalConfiguration().getMember(MEMBER_0).state())
+        .describedAs("Member 0 is added to the cluster")
+        .isEqualTo(State.ACTIVE);
+    assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+  }
+
+  private static final class FailingExecutor
+      implements ClusterMembershipChangeExecutor, PartitionChangeExecutor {
+
+    private int numFailures;
+
+    private FailingExecutor(final int numFailures) {
+      this.numFailures = numFailures;
+    }
+
+    @Override
+    public ActorFuture<Void> addBroker(final MemberId memberId) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> removeBroker(final MemberId memberId) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> join(
+        final int partitionId,
+        final Map<MemberId, Integer> membersWithPriority,
+        final DynamicPartitionConfig partitionConfig) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> leave(final int partitionId) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> bootstrap(
+        final int partitionId,
+        final int priority,
+        final DynamicPartitionConfig partitionConfig,
+        final boolean initializeFromConfig) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> reconfigurePriority(final int partitionId, final int newPriority) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> forceReconfigure(
+        final int partitionId, final Collection<MemberId> members) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> disableExporter(final int partitionId, final String exporterId) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> deleteExporter(final int partitionId, final String exporterId) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> enableExporter(
+        final int partitionId,
+        final String exporterId,
+        final long metadataVersion,
+        final String initializeFrom) {
+      return mayBeFail();
+    }
+
+    @Override
+    public ActorFuture<Void> setExportingState(final ExportingState exportingState) {
+      return mayBeFail();
+    }
+
+    private ActorFuture<Void> mayBeFail() {
+      if (numFailures > 0) {
+        numFailures--;
+        return TestActorFuture.failedFuture(new RuntimeException("Simulated failure"));
+      } else {
+        return TestActorFuture.completedFuture(null);
+      }
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -709,6 +709,82 @@ class CurrentClusterConfigurationTest {
   }
 
   @Nested
+  class ToLegacyDefault {
+
+    @Test
+    void shouldRoundTripMembersAndClusterFields() {
+      // given — an active member with a partition and a member that has left with no partitions
+      final var active =
+          new MemberState(4, Instant.EPOCH, MemberState.State.ACTIVE, Map.of(1, partition()));
+      final var left = new MemberState(2, Instant.EPOCH, MemberState.State.LEFT, Map.of());
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(7)
+              .members(Map.of(MEMBER_0, active, MEMBER_1, left))
+              .clusterId(Optional.of("cluster-x"))
+              .partitionDistributorConfig(Optional.of(new RoundRobinConfig()))
+              .incarnationNumber(3)
+              .build();
+
+      // when — migrate to the new model and project back
+      final var projected = CurrentClusterConfiguration.fromLegacy(legacy).toLegacyDefault();
+
+      // then — the projection reproduces the original legacy configuration
+      assertThat(projected.members()).isEqualTo(legacy.members());
+      assertThat(projected.clusterId()).contains("cluster-x");
+      assertThat(projected.partitionDistributorConfig()).contains(new RoundRobinConfig());
+      assertThat(projected.incarnationNumber()).isEqualTo(3);
+      assertThat(projected.version()).isEqualTo(7);
+    }
+
+    @Test
+    void shouldProjectRecoveringModeToRecoveringState() {
+      // given
+      final var recovering =
+          new MemberState(5, Instant.EPOCH, MemberState.State.RECOVERING, Map.of(1, partition()));
+      final var legacy =
+          ClusterConfiguration.builder().version(1).members(Map.of(MEMBER_0, recovering)).build();
+
+      // when
+      final var projected = CurrentClusterConfiguration.fromLegacy(legacy).toLegacyDefault();
+
+      // then — the recovering member is projected back to the legacy RECOVERING state
+      assertThat(projected.getMember(MEMBER_0).state()).isEqualTo(MemberState.State.RECOVERING);
+      assertThat(projected.getMember(MEMBER_0).partitions()).containsOnlyKeys(1);
+    }
+
+    @Test
+    void shouldProjectLastCompletedChange() {
+      // given
+      final var last =
+          new CompletedChange(3, ClusterChangePlan.Status.FAILED, Instant.EPOCH, Instant.EPOCH);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .lastChange(Optional.of(last))
+              .build();
+
+      // when
+      final var projected = CurrentClusterConfiguration.fromLegacy(legacy).toLegacyDefault();
+
+      // then
+      assertThat(projected.lastChange()).contains(last);
+    }
+
+    @Test
+    void shouldProjectEmptyDefaultGroupWhenAbsent() {
+      // given — a wrapper with only a global configuration and no partition groups
+      final var config = CurrentClusterConfiguration.init();
+
+      // when / then — projecting does not fail and yields an empty legacy configuration
+      final var projected = config.toLegacyDefault();
+      assertThat(projected.members()).isEmpty();
+      assertThat(projected.hasPendingChanges()).isFalse();
+    }
+  }
+
+  @Nested
   class Validation {
 
     @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/GlobalConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/GlobalConfigurationTest.java
@@ -446,6 +446,7 @@ class GlobalConfigurationTest {
           config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)))
               .startConfigurationChange(
                   List.of(new MemberJoinOperation(MEMBER_1), new MemberLeaveOperation(MEMBER_0)));
+      final long versionAfterStart = config.version();
 
       // when — advance past the first operation with a no-op updater
       final var advanced = config.advanceConfigurationChange(UnaryOperator.identity());
@@ -454,7 +455,7 @@ class GlobalConfigurationTest {
       assertThat(advanced.hasPendingChanges()).isTrue();
       assertThat(advanced.pendingChanges().get().pendingOperations())
           .containsExactly(new MemberLeaveOperation(MEMBER_0));
-      assertThat(advanced.version()).isEqualTo(5);
+      assertThat(advanced.version()).isEqualTo(versionAfterStart);
     }
 
     @Test
@@ -493,13 +494,14 @@ class GlobalConfigurationTest {
       final var config =
           config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)))
               .startConfigurationChange(List.of(new MemberLeaveOperation(MEMBER_0)));
+      final long versionAfterStart = config.version();
 
       // when
       final var cancelled = config.cancelPendingChanges();
 
       // then
       assertThat(cancelled.hasPendingChanges()).isFalse();
-      assertThat(cancelled.version()).isEqualTo(7); // start bumped to 5, cancel adds 2
+      assertThat(cancelled.version()).isEqualTo(versionAfterStart + 2);
       assertThat(cancelled.lastChange()).isPresent();
     }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/GlobalConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/GlobalConfigurationTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
@@ -19,6 +21,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -408,6 +411,105 @@ class GlobalConfigurationTest {
                   new GlobalConfiguration(
                       1, Optional.empty(), Map.of(), Optional.empty(), Optional.empty(), null))
           .isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class ConfigurationChangeNavigation {
+
+    @Test
+    void shouldReturnPendingChangeForTargetMemberOnly() {
+      // given
+      final var config =
+          config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE), MEMBER_1, broker(0, State.LEAVING)))
+              .startConfigurationChange(List.of(new MemberLeaveOperation(MEMBER_1)));
+
+      // when / then
+      assertThat(config.pendingChangesFor(MEMBER_1)).contains(new MemberLeaveOperation(MEMBER_1));
+      assertThat(config.pendingChangesFor(MEMBER_0)).isEmpty();
+      assertThat(config.nextPendingOperation()).isEqualTo(new MemberLeaveOperation(MEMBER_1));
+    }
+
+    @Test
+    void shouldReturnEmptyPendingChangeWhenNoChangeInProgress() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)));
+
+      // when / then
+      assertThat(config.pendingChangesFor(MEMBER_0)).isEmpty();
+    }
+
+    @Test
+    void shouldStepPlanWithoutBumpingVersionWhileOperationsRemain() {
+      // given — two operations pending
+      final var config =
+          config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)))
+              .startConfigurationChange(
+                  List.of(new MemberJoinOperation(MEMBER_1), new MemberLeaveOperation(MEMBER_0)));
+
+      // when — advance past the first operation with a no-op updater
+      final var advanced = config.advanceConfigurationChange(UnaryOperator.identity());
+
+      // then — one operation remains, the version is unchanged (still the start version)
+      assertThat(advanced.hasPendingChanges()).isTrue();
+      assertThat(advanced.pendingChanges().get().pendingOperations())
+          .containsExactly(new MemberLeaveOperation(MEMBER_0));
+      assertThat(advanced.version()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldCompleteChangeAndRemoveLeftMembersOnLastOperation() {
+      // given — MEMBER_1 is leaving; a single operation targets it
+      final var config =
+          config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE), MEMBER_1, broker(0, State.LEAVING)))
+              .startConfigurationChange(List.of(new MemberLeaveOperation(MEMBER_1)));
+
+      // when — the operation completes and marks MEMBER_1 as LEFT
+      final var advanced =
+          config.advanceConfigurationChange(
+              c -> c.updateMember(MEMBER_1, b -> b.setState(State.LEFT)));
+
+      // then — the change is completed, MEMBER_1 is removed, version is bumped, lastChange is set
+      assertThat(advanced.hasPendingChanges()).isFalse();
+      assertThat(advanced.hasMember(MEMBER_1)).isFalse();
+      assertThat(advanced.hasMember(MEMBER_0)).isTrue();
+      assertThat(advanced.version()).isEqualTo(6);
+      assertThat(advanced.lastChange()).isPresent();
+    }
+
+    @Test
+    void shouldThrowWhenAdvancingWithoutPendingChange() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)));
+
+      // when / then
+      assertThatThrownBy(() -> config.advanceConfigurationChange(UnaryOperator.identity()))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldCancelPendingChangesBumpingVersionByTwo() {
+      // given
+      final var config =
+          config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)))
+              .startConfigurationChange(List.of(new MemberLeaveOperation(MEMBER_0)));
+
+      // when
+      final var cancelled = config.cancelPendingChanges();
+
+      // then
+      assertThat(cancelled.hasPendingChanges()).isFalse();
+      assertThat(cancelled.version()).isEqualTo(7); // start bumped to 5, cancel adds 2
+      assertThat(cancelled.lastChange()).isPresent();
+    }
+
+    @Test
+    void shouldReturnSameConfigWhenCancellingWithoutPendingChange() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)));
+
+      // when / then
+      assertThat(config.cancelPendingChanges()).isSameAs(config);
     }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -464,6 +465,95 @@ class PartitionGroupConfigurationTest {
       // when / then
       assertThatThrownBy(() -> config.members().put(MEMBER_1, broker(1, 2)))
           .isInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+
+  @Nested
+  class ConfigurationChangeNavigation {
+
+    private static final DeleteHistoryOperation OP_0 = new DeleteHistoryOperation(MEMBER_0);
+    private static final DeleteHistoryOperation OP_1 = new DeleteHistoryOperation(MEMBER_1);
+
+    @Test
+    void shouldReturnPendingChangeForTargetMemberOnly() {
+      // given
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1, 2)))
+              .startConfigurationChange(List.of(OP_1));
+
+      // when / then
+      assertThat(config.pendingChangesFor(MEMBER_1)).contains(OP_1);
+      assertThat(config.pendingChangesFor(MEMBER_0)).isEmpty();
+      assertThat(config.nextPendingOperation()).isEqualTo(OP_1);
+    }
+
+    @Test
+    void shouldReturnEmptyPendingChangeWhenNoChangeInProgress() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
+
+      // when / then
+      assertThat(config.pendingChangesFor(MEMBER_0)).isEmpty();
+    }
+
+    @Test
+    void shouldApplyUpdaterAndCompleteChangeOnLastOperation() {
+      // given — a single pending operation
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_0));
+      final long versionAfterStart = config.version();
+
+      // when — the operation completes with an updater that flips the broker mode
+      final var advanced =
+          config.advanceConfigurationChange(
+              c -> c.updateMember(MEMBER_0, b -> b.setMode(Mode.RECOVERING)));
+
+      // then — the updater's effect is visible, the change is completed and the version is bumped
+      assertThat(advanced.getMember(MEMBER_0).mode()).isEqualTo(Mode.RECOVERING);
+      assertThat(advanced.hasPendingChanges()).isFalse();
+      assertThat(advanced.lastChange()).isPresent();
+      assertThat(advanced.version()).isEqualTo(versionAfterStart + 1);
+    }
+
+    @Test
+    void shouldStepPlanWithoutBumpingVersionWhileOperationsRemain() {
+      // given — two operations pending
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_0, OP_1));
+      final long versionAfterStart = config.version();
+
+      // when
+      final var advanced = config.advanceConfigurationChange(UnaryOperator.identity());
+
+      // then
+      assertThat(advanced.hasPendingChanges()).isTrue();
+      assertThat(advanced.pendingChanges().get().pendingOperations()).containsExactly(OP_1);
+      assertThat(advanced.version()).isEqualTo(versionAfterStart);
+    }
+
+    @Test
+    void shouldCancelPendingChangesBumpingVersionByTwo() {
+      // given
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_0));
+      final long versionAfterStart = config.version();
+
+      // when
+      final var cancelled = config.cancelPendingChanges();
+
+      // then
+      assertThat(cancelled.hasPendingChanges()).isFalse();
+      assertThat(cancelled.version()).isEqualTo(versionAfterStart + 2);
+      assertThat(cancelled.lastChange()).isPresent();
+    }
+
+    @Test
+    void shouldReturnSameConfigWhenCancellingWithoutPendingChange() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
+
+      // when / then
+      assertThat(config.cancelPendingChanges()).isSameAs(config);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Migrates `ClusterConfigurationManagerImpl` to operate on the new multi-partition-group data model (`CurrentClusterConfiguration`) behind a `useNewConfig` flag, which defaults to `false` — legacy behavior is unchanged.
- Adds change-plan navigation primitives (`pendingChangesFor`, `nextPendingOperation`, `advanceConfigurationChange`, `cancelPendingChanges`) to `GlobalConfiguration`/`PartitionGroupConfiguration`.
- Adds `CurrentClusterConfiguration.toLegacyDefault()` for projecting the new model back to the legacy default-group shape. This is only needed during the migration until everything is migrated to the new model.
- Adds phased-plan advancement directly in the manager: the coordinator (lowest member id) advances a multi-phase plan to the next phase, or completes it, once the current phase's sub-configuration(s) have drained their pending changes.

closes #58396

PS:- The generation of operations on the new model is a followup issue.