### PR TITLE
feat: persist CurrentClusterConfiguration with header v2 and v1 migration

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfiguration.java
@@ -133,7 +133,7 @@ public final class PersistedClusterConfiguration {
   }
 
   public static final class UnexpectedVersion extends RuntimeException {
-    private UnexpectedVersion(final Path topologyFile, final byte version) {
+    UnexpectedVersion(final Path topologyFile, final byte version) {
       super(
           "Topology file %s had version '%s', but expected version '%s'"
               .formatted(topologyFile, version, VERSION));
@@ -141,7 +141,7 @@ public final class PersistedClusterConfiguration {
   }
 
   public static final class MissingHeader extends RuntimeException {
-    private MissingHeader(final Path topologyFile, final Object fileSize) {
+    MissingHeader(final Path topologyFile, final Object fileSize) {
       super(
           "Topology file %s is too small to contain the expected header: %s bytes"
               .formatted(topologyFile, fileSize));
@@ -149,7 +149,7 @@ public final class PersistedClusterConfiguration {
   }
 
   public static final class ChecksumMismatch extends RuntimeException {
-    private ChecksumMismatch(
+    ChecksumMismatch(
         final Path topologyFile, final long expectedChecksum, final long actualChecksum) {
       super(
           "Corrupted topology file: %s. Expected checksum: '%d', actual checksum: '%d'"

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationSerializer;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.zip.CRC32C;
+
+/**
+ * The multi-partition-group counterpart of {@link PersistedClusterConfiguration}. Reads and writes
+ * a {@link CurrentClusterConfiguration} in a local persisted file, sharing the same on-disk header
+ * layout (a version byte followed by a CRC32C checksum) as the legacy file so that a single file
+ * can be migrated in place.
+ *
+ * <p>This class is used only when the new configuration model is enabled. It is kept separate from
+ * {@link PersistedClusterConfiguration} so the legacy (feature-flag-off) persistence path stays
+ * byte-for-byte identical and untouched.
+ *
+ * <h4>Versioning &amp; migration</h4>
+ *
+ * <ul>
+ *   <li>Header version {@value #VERSION_LEGACY}: a legacy {@link
+ *       io.camunda.zeebe.dynamic.config.state.ClusterConfiguration} body. On read it is migrated to
+ *       the new model via {@link CurrentClusterConfiguration#fromLegacy}. The migrated value is
+ *       written back as version {@value #VERSION} on the next {@link
+ *       #update(CurrentClusterConfiguration)}.
+ *   <li>Header version {@value #VERSION}: a {@link CurrentClusterConfiguration} body.
+ * </ul>
+ *
+ * First-boot migration after an upgrade is therefore automatic and requires no separate step.
+ */
+public final class PersistedCurrentClusterConfiguration {
+
+  static final byte VERSION_LEGACY = 1;
+  static final byte VERSION = 2;
+  private static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
+
+  private final Path configurationFile;
+  private final ClusterConfigurationSerializer serializer;
+  private CurrentClusterConfiguration configuration;
+
+  private PersistedCurrentClusterConfiguration(
+      final Path configurationFile,
+      final ClusterConfigurationSerializer serializer,
+      final CurrentClusterConfiguration configuration) {
+    this.configurationFile = configurationFile;
+    this.serializer = serializer;
+    this.configuration = configuration;
+  }
+
+  /**
+   * Creates a new {@link PersistedCurrentClusterConfiguration}. If the file does not exist yet, the
+   * configuration is the empty {@link CurrentClusterConfiguration#uninitialized()} and {@link
+   * #isUninitialized()} returns {@code true}. If it exists with a legacy (version 1) body, it is
+   * migrated on read; the migrated value is written back as version 2 on the next {@link #update}.
+   *
+   * @throws UncheckedIOException if any unexpected IO error occurs
+   * @throws PersistedClusterConfiguration.UnexpectedVersion if the header version is neither 1 nor
+   *     2
+   * @throws PersistedClusterConfiguration.ChecksumMismatch if the checksum does not match
+   * @throws PersistedClusterConfiguration.MissingHeader if the file is too small for the header
+   */
+  public static PersistedCurrentClusterConfiguration ofFile(
+      final Path configurationFile, final ClusterConfigurationSerializer serializer) {
+    final CurrentClusterConfiguration currentlyPersisted;
+    try {
+      currentlyPersisted = readFromFile(configurationFile, serializer);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return new PersistedCurrentClusterConfiguration(
+        configurationFile, serializer, currentlyPersisted);
+  }
+
+  public CurrentClusterConfiguration getConfiguration() {
+    return configuration;
+  }
+
+  public void update(final CurrentClusterConfiguration updatedConfiguration) throws IOException {
+    if (configuration.equals(updatedConfiguration)) {
+      return;
+    }
+    writeToFile(updatedConfiguration);
+    configuration = updatedConfiguration;
+  }
+
+  /**
+   * Returns {@code true} while no configuration has been persisted yet, i.e. the cluster has no
+   * members and no partition groups. Mirrors {@code
+   * PersistedClusterConfiguration#isUninitialized()} for the new model.
+   */
+  public boolean isUninitialized() {
+    return configuration.isUninitialized();
+  }
+
+  private static CurrentClusterConfiguration readFromFile(
+      final Path configurationFile, final ClusterConfigurationSerializer serializer)
+      throws IOException {
+    if (!Files.exists(configurationFile)) {
+      return CurrentClusterConfiguration.uninitialized();
+    }
+
+    final var content = Files.readAllBytes(configurationFile);
+    if (content.length < HEADER_LENGTH) {
+      throw new PersistedClusterConfiguration.MissingHeader(configurationFile, content.length);
+    }
+    final var header = ByteBuffer.wrap(content, 0, HEADER_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+    final var version = header.get();
+    final var expectedChecksum = header.getLong();
+
+    final var actualChecksum = checksum(content, HEADER_LENGTH, content.length - HEADER_LENGTH);
+    if (expectedChecksum != actualChecksum) {
+      throw new PersistedClusterConfiguration.ChecksumMismatch(
+          configurationFile, expectedChecksum, actualChecksum);
+    }
+
+    return switch (version) {
+      case VERSION ->
+          serializer.decodeCurrentClusterConfiguration(
+              content, HEADER_LENGTH, content.length - HEADER_LENGTH);
+      case VERSION_LEGACY ->
+          CurrentClusterConfiguration.fromLegacy(
+              serializer.decodeClusterTopology(
+                  content, HEADER_LENGTH, content.length - HEADER_LENGTH));
+      default ->
+          throw new PersistedClusterConfiguration.UnexpectedVersion(configurationFile, version);
+    };
+  }
+
+  private void writeToFile(final CurrentClusterConfiguration updatedConfiguration)
+      throws IOException {
+    final var body = serializer.encodeCurrentClusterConfiguration(updatedConfiguration);
+    final var checksum = checksum(body, 0, body.length);
+    final var buffer =
+        ByteBuffer.allocate(HEADER_LENGTH + body.length)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put(VERSION)
+            .putLong(checksum)
+            .put(body);
+    Files.write(
+        configurationFile,
+        buffer.array(),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.DSYNC);
+  }
+
+  private static long checksum(final byte[] bytes, final int offset, final int length) {
+    final var checksum = new CRC32C();
+    checksum.update(bytes, offset, length);
+    return checksum.getValue();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfiguration.java
@@ -32,10 +32,9 @@ import java.util.zip.CRC32C;
  *
  * <ul>
  *   <li>Header version {@value #VERSION_LEGACY}: a legacy {@link
- *       io.camunda.zeebe.dynamic.config.state.ClusterConfiguration} body. On read it is migrated to
- *       the new model via {@link CurrentClusterConfiguration#fromLegacy}. The migrated value is
- *       written back as version {@value #VERSION} on the next {@link
- *       #update(CurrentClusterConfiguration)}.
+ *       io.camunda.zeebe.dynamic.config.state.ClusterConfiguration} body. On read, it is migrated
+ *       to the new model via {@link CurrentClusterConfiguration#fromLegacy}. The migrated value is
+ *       written back as version {@value #VERSION} immediately.
  *   <li>Header version {@value #VERSION}: a {@link CurrentClusterConfiguration} body.
  * </ul>
  *
@@ -92,7 +91,7 @@ public final class PersistedCurrentClusterConfiguration {
     if (configuration.equals(updatedConfiguration)) {
       return;
     }
-    writeToFile(updatedConfiguration);
+    writeToFile(updatedConfiguration, configurationFile, serializer);
     configuration = updatedConfiguration;
   }
 
@@ -130,16 +129,23 @@ public final class PersistedCurrentClusterConfiguration {
       case VERSION ->
           serializer.decodeCurrentClusterConfiguration(
               content, HEADER_LENGTH, content.length - HEADER_LENGTH);
-      case VERSION_LEGACY ->
-          CurrentClusterConfiguration.fromLegacy(
-              serializer.decodeClusterTopology(
-                  content, HEADER_LENGTH, content.length - HEADER_LENGTH));
+      case VERSION_LEGACY -> {
+        final var migratedConfig =
+            CurrentClusterConfiguration.fromLegacy(
+                serializer.decodeClusterTopology(
+                    content, HEADER_LENGTH, content.length - HEADER_LENGTH));
+        writeToFile(migratedConfig, configurationFile, serializer);
+        yield migratedConfig;
+      }
       default ->
           throw new PersistedClusterConfiguration.UnexpectedVersion(configurationFile, version);
     };
   }
 
-  private void writeToFile(final CurrentClusterConfiguration updatedConfiguration)
+  private static void writeToFile(
+      final CurrentClusterConfiguration updatedConfiguration,
+      final Path configurationFile,
+      final ClusterConfigurationSerializer serializer)
       throws IOException {
     final var body = serializer.encodeCurrentClusterConfiguration(updatedConfiguration);
     final var checksum = checksum(body, 0, body.length);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationSerializer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.serializer;
 
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 
 public interface ClusterConfigurationSerializer {
 
@@ -20,4 +21,9 @@ public interface ClusterConfigurationSerializer {
 
   ClusterConfiguration decodeClusterTopology(
       byte[] encodedClusterTopology, final int offset, final int length);
+
+  byte[] encodeCurrentClusterConfiguration(CurrentClusterConfiguration configuration);
+
+  CurrentClusterConfiguration decodeCurrentClusterConfiguration(
+      byte[] encoded, int offset, int length);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1586,14 +1586,21 @@ public class ProtoBufSerializer
   // Additive encode/decode for CurrentClusterConfiguration and its sub-types. These are not yet
   // wired into gossip or persistence; they exist for the Phase-3 handoff.
 
+  @Override
   public byte[] encodeCurrentClusterConfiguration(final CurrentClusterConfiguration configuration) {
     return encodeCurrentClusterConfigurationProto(configuration).toByteArray();
   }
 
   public CurrentClusterConfiguration decodeCurrentClusterConfiguration(final byte[] encoded) {
+    return decodeCurrentClusterConfiguration(encoded, 0, encoded.length);
+  }
+
+  @Override
+  public CurrentClusterConfiguration decodeCurrentClusterConfiguration(
+      final byte[] encoded, final int offset, final int length) {
     try {
       return decodeCurrentClusterConfiguration(
-          Topology.CurrentClusterConfiguration.parseFrom(encoded));
+          Topology.CurrentClusterConfiguration.parseFrom(ByteBuffer.wrap(encoded, offset, length)));
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -57,6 +57,15 @@ public record CurrentClusterConfiguration(
     partitionGroups = Map.copyOf(partitionGroups);
   }
 
+  public static CurrentClusterConfiguration uninitialized() {
+    return new CurrentClusterConfiguration(
+        INITIAL_VERSION, GlobalConfiguration.uninitialized(), Map.of(), PhasedChangeState.empty());
+  }
+
+  public boolean isUninitialized() {
+    return globalConfiguration.isUninitialized();
+  }
+
   /**
    * Creates an empty configuration with an initial global configuration and no partition groups.
    */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -54,6 +54,7 @@ public record GlobalConfiguration(
     Optional<ClusterChangePlan> pendingChanges,
     Optional<CompletedChange> lastChange) {
 
+  public static final long UNINITIALIZED_VERSION = 0;
   public static final long INITIAL_VERSION = 1;
 
   public GlobalConfiguration {
@@ -81,6 +82,16 @@ public record GlobalConfiguration(
         partitionDistributorConfig,
         pendingChanges,
         lastChange);
+  }
+
+  public static GlobalConfiguration uninitialized() {
+    return new GlobalConfiguration(
+        UNINITIALIZED_VERSION,
+        Optional.empty(),
+        Map.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
   }
 
   /** Creates an empty global configuration at {@link #INITIAL_VERSION} with no members. */
@@ -256,5 +267,9 @@ public record GlobalConfiguration(
   private GlobalConfiguration withMembers(final Map<MemberId, BrokerState> updatedMembers) {
     return new GlobalConfiguration(
         version, clusterId, updatedMembers, partitionDistributorConfig, pendingChanges, lastChange);
+  }
+
+  public boolean isUninitialized() {
+    return version == UNINITIALIZED_VERSION;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfigurationTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration.ChecksumMismatch;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class PersistedCurrentClusterConfigurationTest {
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final ProtoBufSerializer serializer = new ProtoBufSerializer();
+
+  @TempDir private Path tmp;
+
+  private CurrentClusterConfiguration sampleConfiguration() {
+    final var legacy =
+        ClusterConfiguration.init()
+            .addMember(
+                MemberId.from("0"),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))))
+            .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()));
+    return CurrentClusterConfiguration.fromLegacy(legacy);
+  }
+
+  @Test
+  void shouldBeUninitializedWhenFileDoesNotExist() {
+    // given
+    final var file = tmp.resolve("config.meta");
+
+    // when
+    final var persisted = PersistedCurrentClusterConfiguration.ofFile(file, serializer);
+
+    // then
+    assertThat(persisted.isUninitialized()).isTrue();
+  }
+
+  @Test
+  void shouldPersistAndReloadVersion2() throws IOException {
+    // given
+    final var file = tmp.resolve("config.meta");
+    final var config = sampleConfiguration();
+    PersistedCurrentClusterConfiguration.ofFile(file, serializer).update(config);
+
+    // when — reload from disk
+    final var reloaded = PersistedCurrentClusterConfiguration.ofFile(file, serializer);
+
+    // then
+    assertThat(reloaded.isUninitialized()).isFalse();
+    assertThat(reloaded.getConfiguration()).isEqualTo(config);
+  }
+
+  @Test
+  void shouldWriteHeaderVersion2() throws IOException {
+    // given
+    final var file = tmp.resolve("config.meta");
+
+    // when
+    PersistedCurrentClusterConfiguration.ofFile(file, serializer).update(sampleConfiguration());
+
+    // then — the first header byte is the new version
+    assertThat(Files.readAllBytes(file)[0]).isEqualTo(PersistedCurrentClusterConfiguration.VERSION);
+  }
+
+  @Test
+  void shouldMigrateLegacyVersion1FileOnRead() throws IOException {
+    // given — a legacy (version 1) file written by the legacy persistence class
+    final var file = tmp.resolve("config.meta");
+    final var legacy =
+        ClusterConfiguration.init()
+            .addMember(
+                MemberId.from("0"),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))));
+    PersistedClusterConfiguration.ofFile(file, serializer).update(legacy);
+    assertThat(Files.readAllBytes(file)[0]).isEqualTo((byte) 1);
+
+    // when — read it through the new persistence class
+    final var persisted = PersistedCurrentClusterConfiguration.ofFile(file, serializer);
+
+    // then — it is migrated to the new model, equivalent to fromLegacy
+    assertThat(persisted.isUninitialized()).isFalse();
+    assertThat(persisted.getConfiguration())
+        .isEqualTo(CurrentClusterConfiguration.fromLegacy(legacy));
+  }
+
+  @Test
+  void shouldWriteBackAsVersion2AfterMigration() throws IOException {
+    // given — a legacy version 1 file
+    final var file = tmp.resolve("config.meta");
+    final var legacy =
+        ClusterConfiguration.init()
+            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()));
+    PersistedClusterConfiguration.ofFile(file, serializer).update(legacy);
+
+    // when — read (migrate) and persist a change
+    final var persisted = PersistedCurrentClusterConfiguration.ofFile(file, serializer);
+    final var updated =
+        persisted.getConfiguration().updateGlobalConfiguration(g -> g.setClusterId("cluster-x"));
+    persisted.update(updated);
+
+    // then — the file is now version 2 and reloads to the updated configuration
+    assertThat(Files.readAllBytes(file)[0]).isEqualTo(PersistedCurrentClusterConfiguration.VERSION);
+    assertThat(PersistedCurrentClusterConfiguration.ofFile(file, serializer).getConfiguration())
+        .isEqualTo(updated);
+  }
+
+  @Test
+  void shouldDetectChecksumMismatch() throws IOException {
+    // given
+    final var file = tmp.resolve("config.meta");
+    PersistedCurrentClusterConfiguration.ofFile(file, serializer).update(sampleConfiguration());
+
+    // when — corrupt the body
+    Files.write(file, "extra".getBytes(), StandardOpenOption.APPEND);
+
+    // then
+    assertThatCode(() -> PersistedCurrentClusterConfiguration.ofFile(file, serializer))
+        .isInstanceOf(ChecksumMismatch.class);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedCurrentClusterConfigurationTest.java
@@ -116,14 +116,11 @@ final class PersistedCurrentClusterConfigurationTest {
 
     // when — read (migrate) and persist a change
     final var persisted = PersistedCurrentClusterConfiguration.ofFile(file, serializer);
-    final var updated =
-        persisted.getConfiguration().updateGlobalConfiguration(g -> g.setClusterId("cluster-x"));
-    persisted.update(updated);
 
     // then — the file is now version 2 and reloads to the updated configuration
     assertThat(Files.readAllBytes(file)[0]).isEqualTo(PersistedCurrentClusterConfiguration.VERSION);
     assertThat(PersistedCurrentClusterConfiguration.ofFile(file, serializer).getConfiguration())
-        .isEqualTo(updated);
+        .isEqualTo(persisted.getConfiguration());
   }
 
   @Test


### PR DESCRIPTION
## Description

Add PersistedCurrentClusterConfiguration, the multi-group counterpart of PersistedClusterConfiguration, used when the new configuration model is enabled. It shares the on-disk header layout (version byte + CRC32C checksum) so a single file migrates in place:

- header version 1 (legacy ClusterConfiguration body) is migrated on read via CurrentClusterConfiguration.fromLegacy and written back as version 2 on the next update;
- header version 2 carries a CurrentClusterConfiguration body.

The class is kept separate so the legacy persistence path stays byte-for-byte identical. Expose the encode/decode wrapper methods on the ClusterConfigurationSerializer interface (adding an offset/length decode overload) so persistence depends on the interface, and relax the shared header-exception constructors to package-private for reuse.

## Related issues

related #56018 
Pre-requisite to #58396 
