### PR TITLE
fix: do not throw exception when archiver processed documents is higher than expected

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplier.java
@@ -194,13 +194,20 @@ public class ArchiveByIdTaskSupplier<SortFieldType> {
 
   private long validateProcessedCount(
       final String operation, final long processedCount, final int expectedCount) {
-    if (processedCount != expectedCount) {
+    if (processedCount < expectedCount) {
       throw new BatchCountMismatchException(
           operation,
           String.format(
               "The '%s' operation for a batch when archiving %s processed %d docs, however was "
                   + "expecting %d docs",
               operation, sourceIdx, processedCount, expectedCount));
+    } else if (processedCount > expectedCount) {
+      logger.warn(
+          "The '{}' operation for a batch when archiving {} processed {} docs, however was expecting {} docs",
+          operation,
+          sourceIdx,
+          processedCount,
+          expectedCount);
     }
     return processedCount;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiveByIdTaskSupplierTest.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -162,6 +164,120 @@ class ArchiveByIdTaskSupplierTest {
     // then - should throw immediately without retrying
     assertThatThrownBy(future::join).isInstanceOf(CompletionException.class);
     verify(metrics, times(0)).recordArchiverBatchRetry();
+  }
+
+  @Test
+  void shouldRetryAndNotLogWarningWhenReindexProcessesFewerDocsThanExpected() {
+    // given - reindex reports processing only 1 of the 2 expected docs
+    final var logger = mock(Logger.class);
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1"), IdWithRouting.of("doc2")),
+                        List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.completedFuture(1L),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            logger);
+
+    // when - the undercount is treated as a retryable BatchCountMismatchException
+    final var result = taskSupplier.moveNextBatch().join();
+
+    // then
+    assertThat(result).isEqualTo(0L);
+    assertThat(taskSupplier.isComplete()).isFalse();
+    verify(metrics, times(1)).recordArchiverBatchRetry();
+    // an undercount throws before reaching the "processedCount > expectedCount" warning
+    verify(logger, times(0)).warn(any(String.class), any(), any(), any(), any());
+  }
+
+  @Test
+  void shouldNotThrowAndLogWarningWhenReindexProcessesMoreDocsThanExpected() {
+    // given - reindex reports processing more docs than were sent; only an undercount
+    // (processedCount < expectedCount) is treated as a mismatch
+    final var logger = mock(Logger.class);
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.completedFuture(2L),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            logger);
+
+    // when
+    final var result = taskSupplier.moveNextBatch().join();
+
+    // then - no exception, no retry, but the overcount is logged
+    assertThat(result).isEqualTo(1L);
+    assertThat(taskSupplier.isComplete()).isFalse();
+    verify(metrics, times(0)).recordArchiverBatchRetry();
+    verify(logger).warn(any(String.class), eq("reindex"), eq("source-idx"), eq(2L), eq(1));
+  }
+
+  @Test
+  void shouldNotThrowAndLogWarningWhenDeleteProcessesMoreDocsThanExpected() {
+    // given - delete reports processing more docs than were sent
+    final var logger = mock(Logger.class);
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            (source, ids) -> CompletableFuture.completedFuture(2L),
+            DIRECT_EXECUTOR,
+            metrics,
+            logger);
+
+    // when
+    final var result = taskSupplier.moveNextBatch().join();
+
+    // then - no exception, no retry, but the overcount is logged
+    assertThat(result).isEqualTo(2L);
+    assertThat(taskSupplier.isComplete()).isFalse();
+    verify(metrics, times(0)).recordArchiverBatchRetry();
+    verify(logger).warn(any(String.class), eq("delete"), eq("source-idx"), eq(2L), eq(1));
+  }
+
+  @Test
+  void shouldNotLogWarningWhenProcessedCountMatchesExpected() {
+    // given - reindex and delete both process exactly the expected number of docs
+    final var logger = mock(Logger.class);
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            historyConfigWithMaxRetry(3),
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            metrics,
+            logger);
+
+    // when
+    final var result = taskSupplier.moveNextBatch().join();
+
+    // then - an exact match is neither a mismatch nor an overcount, so no warning is logged
+    assertThat(result).isEqualTo(1L);
+    verify(logger, times(0)).warn(any(String.class), any(), any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As explained in https://github.com/camunda/camunda/pull/56526 (see **Update (2026-07-22): possible edge case**)
Avoid throwing exception when the processed documents is higher than expected, but just log a warning

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/56117
