### PR TITLE
feat: add metric to track how many PIs we are waiting for

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/ProcessInstanceStartMeter.java
@@ -51,6 +51,9 @@ public class ProcessInstanceStartMeter implements AutoCloseable {
             .register(registry);
     this.availabilityCheckInterval = availabilityCheckInterval;
     this.availabilityChecker = availabilityChecker;
+    MicrometerUtil.buildGauge(
+            StarterLatencyMetricsDoc.PENDING_PROCESS_INSTANCES, startedInstances::size)
+        .register(registry);
   }
 
   /** Starts the periodic checking for process instance availability. */

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterLatencyMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterLatencyMetricsDoc.java
@@ -188,6 +188,24 @@ public enum StarterLatencyMetricsDoc implements ExtendedMeterDocumentation {
     public Duration[] getTimerSLOs() {
       return BUCKETS;
     }
+  },
+
+  PENDING_PROCESS_INSTANCES {
+
+    @Override
+    public String getDescription() {
+      return "The number of process instances that have been started by the starter, but are not yet available for querying.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.data.availability.pending.process.instances";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
   };
 
   public enum StarterLatencyMetricKeyNames implements KeyName {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.util.micrometer;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
@@ -21,6 +22,7 @@ import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
 /** Collection of disparate convenience methods for Micrometer. */
@@ -104,6 +106,14 @@ public final class MicrometerUtil {
     return DistributionSummary.builder(documentation.getName())
         .description(documentation.getDescription())
         .serviceLevelObjectives(documentation.getDistributionSLOs());
+  }
+
+  /** Returns a gauge builder pre-configured based on the given documentation. */
+  public static <T extends Number> Gauge.Builder<Supplier<T>> buildGauge(
+      final ExtendedMeterDocumentation documentation, final Supplier<T> valueSupplier) {
+    return Gauge.builder(documentation.getName(), valueSupplier)
+        .description(documentation.getDescription())
+        .strongReference(true);
   }
 
   /**


### PR DESCRIPTION
## Description

Add `starter_data_availability_pending_process_instances` metric that tracks how many process instances the load testing app is currently waiting for. This helps to gives us insight into whether we are checking for available process instances fast enough or not.

Doing this as part of trying to work out why the availability latency increases under load.

## Related issues

refs #43121
