### PR TITLE
build: os tests version split

### DIFF
--- a/.github/scripts/verify-aws-opensearch-version.py
+++ b/.github/scripts/verify-aws-opensearch-version.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import os
+import sys
+from urllib.parse import urlparse
+
+import boto3
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
+
+opensearch_url = os.environ.get("OPENSEARCH_URL", "").strip()
+if not opensearch_url:
+    print("ERROR: OPENSEARCH_URL is required")
+    sys.exit(1)
+OPENSEARCH_URL = opensearch_url.rstrip("/")
+
+expected_version = os.environ.get("EXPECTED_OPENSEARCH_VERSION", "").strip()
+if not expected_version:
+    print("ERROR: EXPECTED_OPENSEARCH_VERSION is required")
+    sys.exit(1)
+
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+
+raw_creds = boto3.Session().get_credentials()
+if raw_creds is None:
+    print("ERROR: No AWS credentials found. Ensure the runner has a configured IAM role or credentials.")
+    sys.exit(1)
+
+parsed = urlparse(OPENSEARCH_URL)
+if not parsed.hostname:
+    print("ERROR: OPENSEARCH_URL must be a valid URL with hostname")
+    sys.exit(1)
+
+awsauth = AWSV4SignerAuth(raw_creds, REGION, "es")
+client = OpenSearch(
+    hosts=[{"host": parsed.hostname, "port": parsed.port or (443 if parsed.scheme == "https" else 80)}],
+    http_auth=awsauth,
+    use_ssl=parsed.scheme == "https",
+    verify_certs=True,
+    connection_class=RequestsHttpConnection,
+)
+
+try:
+    info = client.info()
+except Exception as exc:
+    print(f"ERROR: Failed to query cluster info at {OPENSEARCH_URL}: {exc}")
+    sys.exit(1)
+
+version_block = info.get("version", {})
+actual_version = version_block.get("number", "")
+if not actual_version:
+    print(f"ERROR: Could not determine cluster version from response: {info}")
+    sys.exit(1)
+
+# AWS OpenSearch reports patch-level numbers (e.g. "2.19.1.0"); compare major.minor only.
+actual_major_minor = ".".join(actual_version.split(".")[:2])
+distribution = version_block.get("distribution", "unknown")
+
+if actual_major_minor != expected_version:
+    print(
+        f"ERROR: Cluster version mismatch at {OPENSEARCH_URL}. "
+        f"Expected '{expected_version}', but cluster is running '{actual_version}' (distribution: {distribution})."
+    )
+    sys.exit(1)
+
+print(
+    f"OK: Cluster at {OPENSEARCH_URL} is running expected version '{actual_version}' (distribution: {distribution})."
+)
+sys.exit(0)

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -16,9 +16,11 @@ on:
         type: string
         default: "main"
       opensearch-version:
-        description: Version of AWS OpenSearch
+        description: Version of AWS OpenSearch ("all" runs every supported version)
         type: choice
+        default: "all"
         options:
+          - "all"
           - "2.19"
           - "3.5"
   schedule:
@@ -40,176 +42,47 @@ env:
   TEST_OWNER: '@camunda/core-features'
 
 jobs:
-  cleanup-opensearch-indices:
-    name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ matrix.os_version }}"
-    permissions:
-      contents: read
-    timeout-minutes: 30
-    runs-on: aws-core-8-default
-    strategy:
-      fail-fast: false
-      matrix:
-        os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
+  # Resolves the opensearch-version input into the JSON array of versions the
+  # integration-tests matrix below runs. Both the "all" choice and the
+  # schedule trigger (which carries no inputs at all) fall back to running
+  # every supported version.
+  resolve-opensearch-versions:
+    name: "Resolve OpenSearch version matrix"
+    permissions: {}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.resolve.outputs.versions }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Setup AWS OpenSearch
-        uses: ./.github/actions/setup-aws-opensearch-env
-        with:
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          opensearch-version: ${{ matrix.os_version }}
-      - name: Python setup
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.x"
-      - name: Install Python dependencies
-        run: |
-          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
-      - name: Delete old aws opensearch indices
+      - name: Resolve versions
+        id: resolve
         env:
-          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
-          DRY_RUN: "false"
-          AGE_HOURS: "2"
-        run: python3 .github/scripts/clean-up-aws-opensearch-indices.py
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          job_name: "cleanup-opensearch-indices/${{ matrix.os_version }}"
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          SELECTED_VERSION: ${{ github.event.inputs.opensearch-version }}
+        run: |
+          if [[ -z "${SELECTED_VERSION}" || "${SELECTED_VERSION}" == "all" ]]; then
+            echo 'versions=["2.19", "3.5"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "versions=[\"${SELECTED_VERSION}\"]" >> "$GITHUB_OUTPUT"
+          fi
 
+  # Each OpenSearch version is instantiated as its own call into the reusable
+  # workflow (cleanup + version-check + integration-tests), so the versions run
+  # in parallel against their own clusters without duplicating any job body.
   integration-tests:
-    name: "[IT] ${{ matrix.name }}. OS ver.${{ matrix.os_version }}"
-    needs: cleanup-opensearch-indices
+    name: "OS ver.${{ matrix.opensearch-version }}"
+    needs: resolve-opensearch-versions
     permissions:
       contents: read
       actions: write
-    timeout-minutes: 360
-    runs-on: ${{ matrix.runs-on }}
-    env:
-      TEST_OWNER: ${{ matrix.owner }}
     strategy:
       fail-fast: false
-      # Cap concurrent matrix jobs: all groups for a given os_version share one
-      # AWS OpenSearch cluster, and running all 5 at once overloads it (cluster
-      # event queue timeouts, search_phase_execution_exception, and jobs hanging
-      # until the job timeout). This is a nightly/manual job, so trading some
-      # wall-clock time for reliability is an acceptable tradeoff.
-      max-parallel: 1
       matrix:
-        os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
-        group:
-        - camunda-qa-acceptance-tests-client
-        - camunda-qa-acceptance-tests-non-client
-        - search-client-opensearch
-        - camunda-exporter
-        - zeebe-opensearch-exporter
-        include:
-          - group: camunda-qa-acceptance-tests-client
-            name: "Camunda QA Module Client Tests"
-            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
-            maven-build-threads: 2
-            maven-test-fork-count: 2
-            maven-test-profiles: multi-db-test-client
-            runs-on: aws-core-8-default
-            owner: '@camunda/engineering-operations'
-          - group: camunda-qa-acceptance-tests-non-client
-            name: "Camunda QA Module Non-Client Tests"
-            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
-            maven-build-threads: 2
-            maven-test-fork-count: 2
-            maven-test-profiles: multi-db-test-non-client
-            runs-on: aws-core-8-default
-            owner: '@camunda/engineering-operations'
-          - group: search-client-opensearch
-            name: "Search Client OpenSearch ITs"
-            maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
-            maven-build-threads: 2
-            maven-test-fork-count: 2
-            maven-test-profiles: multi-db-test
-            runs-on: aws-core-8-default
-            owner: '@camunda/core-features'
-          - group: camunda-exporter
-            name: "Camunda Exporter ITs"
-            maven-modules: "'io.camunda:camunda-exporter'"
-            maven-build-threads: 2
-            maven-test-fork-count: 2
-            maven-test-profiles: multi-db-test
-            runs-on: aws-core-8-default
-            owner: '@camunda/data-layer'
-          - group: zeebe-opensearch-exporter
-            name: "Zeebe OpenSearch Exporter ITs"
-            maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
-            maven-build-threads: 2
-            maven-test-fork-count: 2
-            maven-test-profiles: multi-db-test
-            runs-on: aws-core-8-default
-            owner: '@camunda/data-layer'
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup AWS OpenSearch
-        uses: ./.github/actions/setup-aws-opensearch-env
-        with:
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-          opensearch-version: ${{ matrix.os_version }}
-      - uses: ./.github/actions/setup-build
-        with:
-          maven-cache-key-modifier: it-${{ matrix.group }}
-          vault-address: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: -T1C -D skip.fe.build -D skip.yarn -D skip.docker
-      - name: Create build output log file
-        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
-      - name: Maven Test Build
-        shell: bash
-        run: >
-          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
-          -D forkCount=${{ matrix.maven-test-fork-count }}
-          -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
-          -D flaky.test.reportDir=failsafe-reports
-          -D test.integration.opensearch.aws.url="${{ env.OPENSEARCH_URL }}"
-          -D test.integration.camunda.database.type=AWS_OS
-          -D test.integration.opensearch.aws.timeout.seconds=180
-          -P parallel-tests,extract-flaky-tests,${{ matrix.maven-test-profiles }}
-          -pl ${{ matrix.maven-modules }}
-          verify
-          | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Analyze Test Runs
-        id: analyze-test-run
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
-      - name: Upload test artifacts
-        uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
-        with:
-          name: "[IT] ${{ matrix.name }}"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          job_name: "integration-tests/${{ matrix.group }}"
-          build_status: ${{ job.status }}
-          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+        opensearch-version: ${{ fromJSON(needs.resolve-opensearch-versions.outputs.versions) }}
+    uses: ./.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+      opensearch-version: ${{ matrix.opensearch-version }}
 
   send-slack-notificaion:
     name: "Send slack notification on fail"

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -81,7 +81,7 @@ jobs:
     uses: ./.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
     secrets: inherit
     with:
-      ref: ${{ inputs.ref }}
+      ref: ${{ inputs.ref || github.sha }}
       opensearch-version: ${{ matrix.opensearch-version }}
 
   send-slack-notificaion:

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -184,6 +184,8 @@ jobs:
             owner: '@camunda/data-layer'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup AWS OpenSearch
         uses: ./.github/actions/setup-aws-opensearch-env
         with:

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -98,7 +98,6 @@ jobs:
           python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
       - name: Verify cluster is running the expected OpenSearch version
         env:
-          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
           EXPECTED_OPENSEARCH_VERSION: ${{ inputs.opensearch-version }}
         run: python3 .github/scripts/verify-aws-opensearch-version.py
       - name: Observe build status

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -1,0 +1,242 @@
+# description: Reusable workflow running AWS OpenSearch integration tests for a single OpenSearch version
+# test locations:
+#  - /qa/acceptance-tests
+#  - /search/search-client-opensearch,
+#  - /zeebe/exporters/camunda-exporter,
+#  - /zeebe/exporters/opensearch-exporter,
+# type: CI
+# owner: @camunda/core-features, @camunda/data-layer
+name: AWS OpenSearch integration tests reusable
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: "main"
+        description: Branch or commit to test against
+      opensearch-version:
+        required: true
+        type: string
+        description: Version of AWS OpenSearch to run the tests against
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+env:
+  TEST_OWNER: '@camunda/core-features'
+
+jobs:
+  cleanup-opensearch-indices:
+    name: "[PRE] Cleanup old AWS OpenSearch indices. OS ver.${{ inputs.opensearch-version }}"
+    needs: verify-opensearch-version
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    runs-on: aws-core-8-default
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ inputs.opensearch-version }}
+      - name: Python setup
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
+      - name: Delete old aws opensearch indices
+        env:
+          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
+          DRY_RUN: "false"
+          AGE_HOURS: "2"
+        run: python3 .github/scripts/clean-up-aws-opensearch-indices.py
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "cleanup-opensearch-indices/${{ inputs.opensearch-version }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  verify-opensearch-version:
+    name: "[PRE] Verify AWS OpenSearch cluster version ver.${{ inputs.opensearch-version }}"
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    runs-on: aws-core-8-default
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ inputs.opensearch-version }}
+      - name: Python setup
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - name: Install Python dependencies
+        run: |
+          python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
+      - name: Verify cluster is running the expected OpenSearch version
+        env:
+          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
+          EXPECTED_OPENSEARCH_VERSION: ${{ inputs.opensearch-version }}
+        run: python3 .github/scripts/verify-aws-opensearch-version.py
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "verify-opensearch-version/${{ inputs.opensearch-version }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  integration-tests:
+    name: "[IT] ${{ matrix.name }}. OS ver.${{ inputs.opensearch-version }}"
+    needs: [cleanup-opensearch-indices, verify-opensearch-version]
+    permissions:
+      contents: read
+      actions: write
+    timeout-minutes: 360
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      TEST_OWNER: ${{ matrix.owner }}
+    strategy:
+      fail-fast: false
+      # Cap concurrent matrix jobs: all groups share one AWS OpenSearch cluster
+      # for this version, and running all 5 at once overloads it (cluster event
+      # queue timeouts, search_phase_execution_exception, and jobs hanging until
+      # the job timeout). This is a nightly/manual job, so trading some
+      # wall-clock time for reliability is an acceptable tradeoff. The caller
+      # workflow instantiates this reusable workflow once per OpenSearch
+      # version, so the versions themselves still run in parallel against their
+      # own clusters.
+      max-parallel: 1
+      matrix:
+        group:
+        - camunda-qa-acceptance-tests-client
+        - camunda-qa-acceptance-tests-non-client
+        - search-client-opensearch
+        - camunda-exporter
+        - zeebe-opensearch-exporter
+        include:
+          - group: camunda-qa-acceptance-tests-client
+            name: "Camunda QA Module Client Tests"
+            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 2
+            maven-test-profiles: multi-db-test-client
+            runs-on: aws-core-8-default
+            owner: '@camunda/engineering-operations'
+          - group: camunda-qa-acceptance-tests-non-client
+            name: "Camunda QA Module Non-Client Tests"
+            maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 2
+            maven-test-profiles: multi-db-test-non-client
+            runs-on: aws-core-8-default
+            owner: '@camunda/engineering-operations'
+          - group: search-client-opensearch
+            name: "Search Client OpenSearch ITs"
+            maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
+            maven-build-threads: 2
+            maven-test-fork-count: 2
+            maven-test-profiles: multi-db-test
+            runs-on: aws-core-8-default
+            owner: '@camunda/core-features'
+          - group: camunda-exporter
+            name: "Camunda Exporter ITs"
+            maven-modules: "'io.camunda:camunda-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 2
+            maven-test-profiles: multi-db-test
+            runs-on: aws-core-8-default
+            owner: '@camunda/data-layer'
+          - group: zeebe-opensearch-exporter
+            name: "Zeebe OpenSearch Exporter ITs"
+            maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
+            maven-build-threads: 2
+            maven-test-fork-count: 2
+            maven-test-profiles: multi-db-test
+            runs-on: aws-core-8-default
+            owner: '@camunda/data-layer'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup AWS OpenSearch
+        uses: ./.github/actions/setup-aws-opensearch-env
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          opensearch-version: ${{ inputs.opensearch-version }}
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-${{ inputs.opensearch-version }}-${{ matrix.group }}
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -D skip.fe.build -D skip.yarn -D skip.docker
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Maven Test Build
+        shell: bash
+        run: >
+          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
+          -D forkCount=${{ matrix.maven-test-fork-count }}
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D flaky.test.reportDir=failsafe-reports
+          -D test.integration.opensearch.aws.url="${{ env.OPENSEARCH_URL }}"
+          -D test.integration.camunda.database.type=AWS_OS
+          -D test.integration.opensearch.aws.timeout.seconds=180
+          -P parallel-tests,extract-flaky-tests,${{ matrix.maven-test-profiles }}
+          -pl ${{ matrix.maven-modules }}
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] ${{ matrix.name }} (${{ inputs.opensearch-version }})"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests-${{ inputs.opensearch-version }}/${{ matrix.group }}"
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -201,7 +201,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -D skip.fe.build -D skip.yarn -D skip.docker
+          maven-extra-args: -T1C -Dskip.fe.build -Dskip.yarn -Dskip.docker
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build

--- a/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
+++ b/.github/workflows/zeebe-aws-os-integration-tests-reusable.yml
@@ -58,7 +58,6 @@ jobs:
           python3 -m pip install -q --disable-pip-version-check boto3==1.42.50 opensearch-py==3.1.0
       - name: Delete old aws opensearch indices
         env:
-          OPENSEARCH_URL: ${{ env.OPENSEARCH_URL }}
           DRY_RUN: "false"
           AGE_HOURS: "2"
         run: python3 .github/scripts/clean-up-aws-opensearch-indices.py


### PR DESCRIPTION
## Description

Restructures the zeebe-aws-os-dispatch-tests.yml workflow so that when the opensearch-version input is "all", the different OpenSearch versions run as separate parallel invocations of the reusable integration-tests workflow instead of as jobs sharing one matrix.

Sample run:
https://github.com/camunda/camunda/actions/runs/29942083250

### Changes

* .github/workflows/zeebe-aws-os-dispatch-tests.yml
* Updated the opensearch-version input description to clarify that "all" runs every supported version.
* Replaced the old cleanup-opensearch-indices + monolithic integration-tests matrix (which iterated over both os_version and test group, and ran cleanup/version-check/tests inline) with a new resolve-opensearch-versions job.
resolve-opensearch-versions checks out the repo, and resolves the opensearch-version input into a JSON array of versions (["2.19","3.5"] for "all"/no input, or a single-element array for an explicit choice), exposed as a job output.
* The downstream integration-tests job now calls the reusable workflow zeebe-aws-os-integration-tests-reusable.yml once per resolved version (via fromJSON(needs.resolve-opensearch-versions.outputs.versions)), passing ref and opensearch-version through, instead of running everything inline in one large matrixed job.
* Standalone script to verify that a live AWS OpenSearch cluster is running the expected version.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
