### PR TITLE
feat: validate, generate and apply operations on the new model in the coordinator

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManager.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config;
 
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.function.UnaryOperator;
 
@@ -17,6 +18,30 @@ public interface ClusterConfigurationManager {
 
   ActorFuture<ClusterConfiguration> updateClusterConfiguration(
       UnaryOperator<ClusterConfiguration> updatedConfiguration);
+
+  /**
+   * Whether this manager operates on the new multi-partition-group model. When {@code false}, the
+   * {@code *MultiConfiguration} methods below are not supported.
+   */
+  default boolean isUsingNewConfig() {
+    return false;
+  }
+
+  /** Returns the full multi-partition-group configuration. Only valid when the new model is on. */
+  default ActorFuture<CurrentClusterConfiguration> getMultiConfiguration() {
+    throw new UnsupportedOperationException(
+        "getMultiConfiguration is only supported with the new configuration model");
+  }
+
+  /**
+   * Applies {@code updater} to the multi-partition-group configuration, persists and gossips it,
+   * and triggers local operation application. Only valid when the new model is on.
+   */
+  default ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
+      final UnaryOperator<CurrentClusterConfiguration> updater) {
+    throw new UnsupportedOperationException(
+        "updateMultiConfiguration is only supported with the new configuration model");
+  }
 
   /**
    * A listener that is invoked, when the local member state in the local configuration is older

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -471,7 +471,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   // New multi-partition-group model (used only when useNewConfig is true).
   // ---------------------------------------------------------------------------
 
-  boolean isUsingNewConfig() {
+  @Override
+  public boolean isUsingNewConfig() {
     return useNewConfig;
   }
 
@@ -481,7 +482,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   /** Returns the full multi-group configuration. Only valid when {@link #useNewConfig} is true. */
-  ActorFuture<CurrentClusterConfiguration> getMultiConfiguration() {
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> getMultiConfiguration() {
     final var future = executor.<CurrentClusterConfiguration>createFuture();
     executor.run(() -> future.complete(persistedCurrentConfiguration.getConfiguration()));
     return future;
@@ -491,7 +493,8 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
    * Applies {@code updater} to the multi-group configuration, persists and gossips the result, then
    * triggers local operation application. Only valid when {@link #useNewConfig} is true.
    */
-  ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
       final UnaryOperator<CurrentClusterConfiguration> updater) {
     final var future = executor.<CurrentClusterConfiguration>createFuture();
     executor.run(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinator.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.dynamic.config.changes;
 
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
@@ -76,6 +78,31 @@ public interface ConfigurationChangeCoordinator {
      */
     Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
         final ClusterConfiguration clusterConfiguration);
+
+    /**
+     * Returns the phases to execute for this request, on the new multi-partition-group model. The
+     * default implementation derives them from {@link #operations(ClusterConfiguration)} using the
+     * same operation-kind-run splitting that {@link CurrentClusterConfiguration#toPhases(List)}
+     * applies when migrating a legacy plan: each maximal run of consecutive operations of the same
+     * kind becomes one phase, and every {@link
+     * io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation} run targets the default group.
+     *
+     * <p>This is the only method the new-model coordinator path calls to determine what to validate
+     * and apply — {@link #operations(ClusterConfiguration)} is not called directly on that path. A
+     * future request implementation that targets non-default groups only needs to override this
+     * method to build {@link
+     * io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase}s for
+     * those groups; no change is needed in the coordinator, the manager, or any other new-model
+     * code.
+     *
+     * @param clusterConfiguration the current cluster configuration
+     * @return Either with the list of phases to apply or an exception if the request is not valid.
+     */
+    default Either<Exception, List<Phase>> phases(
+        final CurrentClusterConfiguration clusterConfiguration) {
+      return operations(clusterConfiguration.toLegacyDefault())
+          .map(CurrentClusterConfiguration::toPhases);
+    }
 
     default boolean isForced() {
       return false;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -16,13 +16,26 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +106,9 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
 
   private ActorFuture<ConfigurationChangeResult> applyOrDryRun(
       final boolean dryRun, final ConfigurationChangeRequest request) {
+    if (clusterTopologyManager.isUsingNewConfig()) {
+      return applyOrDryRunNewModel(dryRun, request);
+    }
     final ActorFuture<ConfigurationChangeResult> future = executor.createFuture();
     executor.run(
         () ->
@@ -337,5 +353,366 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
     // return false if there are currently no known members, which means it will be uninitialized.
     return localMemberId.equals(
         clusterConfiguration.members().keySet().stream().min(MemberId::compareTo).orElse(null));
+  }
+
+  // ---------------------------------------------------------------------------
+  // New multi-partition-group model.
+  // ---------------------------------------------------------------------------
+
+  private ActorFuture<ConfigurationChangeResult> applyOrDryRunNewModel(
+      final boolean dryRun, final ConfigurationChangeRequest request) {
+    final ActorFuture<ConfigurationChangeResult> future = executor.createFuture();
+    executor.run(
+        () ->
+            clusterTopologyManager
+                .getMultiConfiguration()
+                .onComplete(
+                    (currentConfiguration, errorOnGettingConfig) -> {
+                      if (errorOnGettingConfig != null) {
+                        failFuture(future, errorOnGettingConfig);
+                        return;
+                      }
+                      if (!request.isForced() && !isCoordinator(currentConfiguration)) {
+                        failFuture(
+                            future,
+                            new ClusterConfigurationRequestFailedException.InternalError(
+                                String.format(
+                                    "Cannot process request to change the configuration. The broker '%s' is not the coordinator.",
+                                    localMemberId)));
+                        return;
+                      }
+                      // Request transformers are unchanged: they still read a legacy
+                      // ClusterConfiguration (the default-group projection) to generate the
+                      // phases to run. Everything past this point — validation, simulation, and
+                      // application — uses the new multi-group model directly, so supporting
+                      // non-default groups in the future only requires changing what phases()
+                      // returns, not this coordinator.
+                      final var generatedPhases = request.phases(currentConfiguration);
+                      if (generatedPhases.isLeft()) {
+                        failFuture(future, generatedPhases.getLeft());
+                        return;
+                      }
+                      applyOrDryRunOnConfigurationNewModel(
+                          dryRun, currentConfiguration, generatedPhases.get(), future);
+                    },
+                    executor));
+    return future;
+  }
+
+  private void applyOrDryRunOnConfigurationNewModel(
+      final boolean dryRun,
+      final CurrentClusterConfiguration currentConfiguration,
+      final List<Phase> phases,
+      final ActorFuture<ConfigurationChangeResult> future) {
+    if (phases.isEmpty()) {
+      final var legacyView = currentConfiguration.toLegacyDefault();
+      future.complete(
+          new ConfigurationChangeResult(
+              legacyView,
+              legacyView,
+              currentConfiguration
+                  .phasedChangeState()
+                  .lastChange()
+                  .map(CompletedPhasedChange::id)
+                  .orElse(0L),
+              List.of()));
+      return;
+    }
+
+    final ActorFuture<CurrentClusterConfiguration> validation =
+        validateNewModelChangeRequest(currentConfiguration, phases);
+
+    validation.onComplete(
+        (simulatedFinalConfiguration, validationError) -> {
+          if (validationError != null) {
+            failFuture(future, validationError);
+            return;
+          }
+
+          final var operations = flattenPhases(phases);
+          if (dryRun) {
+            final long changeId =
+                currentConfiguration
+                    .phasedChangeState()
+                    .lastChange()
+                    .map(c -> c.id() + 1)
+                    .orElse(1L);
+            future.complete(
+                new ConfigurationChangeResult(
+                    currentConfiguration.toLegacyDefault(),
+                    simulatedFinalConfiguration.toLegacyDefault(),
+                    changeId,
+                    operations));
+            return;
+          }
+
+          clusterTopologyManager
+              .updateMultiConfiguration(
+                  config -> {
+                    checkConcurrentModification(config, currentConfiguration, phases);
+                    return config.initPlan(phases);
+                  })
+              .onComplete(
+                  (updated, error) -> {
+                    if (error != null) {
+                      failFuture(future, error);
+                      return;
+                    }
+                    final long changeId =
+                        updated.phasedChangeState().pending().map(PhasedChangePlan::id).orElse(0L);
+                    future.complete(
+                        new ConfigurationChangeResult(
+                            currentConfiguration.toLegacyDefault(),
+                            simulatedFinalConfiguration.toLegacyDefault(),
+                            changeId,
+                            operations));
+                  },
+                  executor);
+        });
+  }
+
+  private void checkConcurrentModification(
+      final CurrentClusterConfiguration latestConfig,
+      final CurrentClusterConfiguration configUsedForGeneratingOperations,
+      final List<Phase> phases) {
+
+    if (latestConfig.phasedChangeState().pending().isPresent()) {
+      throw new ConcurrentModificationException(
+          "Cannot apply configuration change. Another configuration change is in progress.");
+    }
+
+    // simple equality check on the whole configuration is not enough, because we allow concurrent
+    // changes to different partition groups.
+
+    // for each phase check if the corresponding state in latestConfig is the same as in
+    // configUsedForGeneratingOperations
+    for (final var phase : phases) {
+      switch (phase) {
+        case final GlobalPhase globalPhase -> {
+          final var latestGlobalConfig = latestConfig.globalConfiguration();
+          final var usedGlobalConfig = configUsedForGeneratingOperations.globalConfiguration();
+          if (!Objects.equals(latestGlobalConfig, usedGlobalConfig)) {
+            throw new ConcurrentModificationException(
+                "Cannot apply configuration change. The global configuration has changed since the request was generated.");
+          }
+        }
+        case final PartitionGroupParallelPhase parallelPhase -> {
+          for (final var groupId : parallelPhase.groupOperations().keySet()) {
+            final var latestGroupConfig = latestConfig.partitionGroup(groupId);
+            final var usedGroupConfig = configUsedForGeneratingOperations.partitionGroup(groupId);
+            if (!Objects.equals(latestGroupConfig, usedGroupConfig)) {
+              throw new ConcurrentModificationException(
+                  String.format(
+                      "Cannot apply configuration change. The partition group '%s' configuration has changed since the request was generated.",
+                      groupId));
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Validates a phased plan by simulating it against the new model: not initialized / a change
+   * already in progress fail immediately; otherwise the plan is started via {@link
+   * CurrentClusterConfiguration#initPlan(List)} and simulated phase by phase using the same
+   * dispatch tables the manager uses to actually apply changes ({@link
+   * GlobalConfigurationChangeAppliersImpl}, {@link PartitionGroupConfigurationChangeAppliersImpl}),
+   * backed by no-op executors. The returned configuration is the fully-drained plan (no pending
+   * changes, the plan moved into {@code lastChange}), used as the expected final configuration.
+   */
+  private ActorFuture<CurrentClusterConfiguration> validateNewModelChangeRequest(
+      final CurrentClusterConfiguration currentConfiguration, final List<Phase> phases) {
+    final ActorFuture<CurrentClusterConfiguration> validationFuture = executor.createFuture();
+
+    if (currentConfiguration.globalConfiguration().members().isEmpty()) {
+      failFuture(
+          validationFuture,
+          new OperationNotAllowed(
+              "Cannot apply configuration change. The configuration is not initialized."));
+    } else if (currentConfiguration.phasedChangeState().pending().isPresent()) {
+      failFuture(
+          validationFuture,
+          new ConcurrentModificationException(
+              String.format(
+                  "Cannot apply configuration change. Another configuration change [%d] is in progress.",
+                  currentConfiguration
+                      .phasedChangeState()
+                      .pending()
+                      .map(PhasedChangePlan::id)
+                      .orElseThrow())));
+    } else {
+      final var globalSimulator =
+          new GlobalConfigurationChangeAppliersImpl(
+              new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor());
+      final var groupSimulator =
+          new PartitionGroupConfigurationChangeAppliersImpl(
+              new NoopPartitionChangeExecutor(),
+              new NoopPartitionScalingChangeExecutor(),
+              new NoopClusterChangeExecutor(),
+              new NoopModeChangeExecutor(),
+              new NoopRestoreChangeExecutor());
+      try {
+        final var withPlan = currentConfiguration.initPlan(phases);
+        simulateNewModelChange(withPlan, globalSimulator, groupSimulator, validationFuture);
+      } catch (final Exception e) {
+        failFuture(validationFuture, e);
+      }
+    }
+    return validationFuture;
+  }
+
+  private void simulateNewModelChange(
+      final CurrentClusterConfiguration config,
+      final GlobalConfigurationChangeAppliers globalSimulator,
+      final PartitionGroupConfigurationChangeAppliers groupSimulator,
+      final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
+    final var pending = config.phasedChangeState().pending();
+    if (pending.isEmpty()) {
+      simulationCompleted.complete(config);
+      return;
+    }
+    switch (pending.get().currentPhase()) {
+      case final GlobalPhase ignored ->
+          simulateGlobalPhase(config, globalSimulator, groupSimulator, simulationCompleted);
+      case final PartitionGroupParallelPhase parallelPhase ->
+          simulatePartitionGroupPhase(
+              config,
+              new ArrayList<>(parallelPhase.groupOperations().keySet()),
+              0,
+              globalSimulator,
+              groupSimulator,
+              simulationCompleted);
+    }
+  }
+
+  private void simulateGlobalPhase(
+      final CurrentClusterConfiguration config,
+      final GlobalConfigurationChangeAppliers globalSimulator,
+      final PartitionGroupConfigurationChangeAppliers groupSimulator,
+      final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
+    if (!config.globalConfiguration().hasPendingChanges()) {
+      advancePhaseAndContinueSimulation(
+          config, globalSimulator, groupSimulator, simulationCompleted);
+      return;
+    }
+    final var operation =
+        (GlobalChangeOperation) config.globalConfiguration().nextPendingOperation();
+    final var applier = globalSimulator.getApplier(operation);
+    final var result = applier.init(config);
+    if (result.isLeft()) {
+      failFuture(simulationCompleted, new InvalidRequest(result.getLeft()));
+      return;
+    }
+    final var configWithInit = config.updateGlobalConfiguration(result.get());
+    applier
+        .apply()
+        .onComplete(
+            (transformer, error) -> {
+              if (error != null) {
+                failFuture(simulationCompleted, new InvalidRequest(error));
+                return;
+              }
+              final var advanced =
+                  configWithInit.updateGlobalConfiguration(
+                      g -> g.advanceConfigurationChange(transformer));
+              simulateGlobalPhase(advanced, globalSimulator, groupSimulator, simulationCompleted);
+            });
+  }
+
+  private void simulatePartitionGroupPhase(
+      final CurrentClusterConfiguration config,
+      final List<String> groupIds,
+      final int index,
+      final GlobalConfigurationChangeAppliers globalSimulator,
+      final PartitionGroupConfigurationChangeAppliers groupSimulator,
+      final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
+    if (index >= groupIds.size()) {
+      advancePhaseAndContinueSimulation(
+          config, globalSimulator, groupSimulator, simulationCompleted);
+      return;
+    }
+    simulatePartitionGroupOperations(
+        config,
+        groupIds.get(index),
+        groupSimulator,
+        drained ->
+            simulatePartitionGroupPhase(
+                drained, groupIds, index + 1, globalSimulator, groupSimulator, simulationCompleted),
+        simulationCompleted);
+  }
+
+  private void simulatePartitionGroupOperations(
+      final CurrentClusterConfiguration config,
+      final String groupId,
+      final PartitionGroupConfigurationChangeAppliers groupSimulator,
+      final Consumer<CurrentClusterConfiguration> onGroupDrained,
+      final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
+    final var group = config.partitionGroup(groupId);
+    if (group != null && !group.hasPendingChanges()) {
+      onGroupDrained.accept(config);
+      return;
+    }
+    final var operation = (PartitionGroupOperation) group.nextPendingOperation();
+    final var applier = groupSimulator.getApplier(operation);
+    final var result = applier.init(config.globalConfiguration(), group);
+    if (result.isLeft()) {
+      failFuture(simulationCompleted, new InvalidRequest(result.getLeft()));
+      return;
+    }
+    final var configWithInit = config.updatePartitionGroupConfig(groupId, result.get());
+    applier
+        .apply()
+        .onComplete(
+            (transformer, error) -> {
+              if (error != null) {
+                failFuture(simulationCompleted, new InvalidRequest(error));
+                return;
+              }
+              final var advanced =
+                  configWithInit.updatePartitionGroupConfig(
+                      groupId, g -> g.advanceConfigurationChange(transformer));
+              simulatePartitionGroupOperations(
+                  advanced, groupId, groupSimulator, onGroupDrained, simulationCompleted);
+            });
+  }
+
+  private void advancePhaseAndContinueSimulation(
+      final CurrentClusterConfiguration config,
+      final GlobalConfigurationChangeAppliers globalSimulator,
+      final PartitionGroupConfigurationChangeAppliers groupSimulator,
+      final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
+    final var plan = config.phasedChangeState().pending().orElseThrow();
+    final var next =
+        plan.hasNextPhase()
+            ? config.activateNextPhase()
+            : config.completePlan(PhasedChangePlanStatus.COMPLETED);
+    simulateNewModelChange(next, globalSimulator, groupSimulator, simulationCompleted);
+  }
+
+  /**
+   * Flattens a phase list back into the flat operation list expected by {@link
+   * ConfigurationChangeResult#operations()}, preserving phase order. Within a {@link
+   * PartitionGroupParallelPhase} the operations of each group are concatenated; the order between
+   * groups is unspecified (they apply concurrently), but is irrelevant while only the default group
+   * is used.
+   */
+  private static List<ClusterConfigurationChangeOperation> flattenPhases(final List<Phase> phases) {
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+    for (final var phase : phases) {
+      switch (phase) {
+        case final GlobalPhase globalPhase -> operations.addAll(globalPhase.operations());
+        case final PartitionGroupParallelPhase parallelPhase ->
+            parallelPhase.groupOperations().values().forEach(operations::addAll);
+      }
+    }
+    return operations;
+  }
+
+  private boolean isCoordinator(final CurrentClusterConfiguration currentConfiguration) {
+    return localMemberId.equals(
+        currentConfiguration.globalConfiguration().members().keySet().stream()
+            .min(MemberId::compareTo)
+            .orElse(null));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
 import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
@@ -649,11 +648,12 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       final Consumer<CurrentClusterConfiguration> onGroupDrained,
       final ActorFuture<CurrentClusterConfiguration> simulationCompleted) {
     final var group = config.partitionGroup(groupId);
-    if (group != null && !group.hasPendingChanges()) {
+    Objects.requireNonNull(group);
+    if (!group.hasPendingChanges()) {
       onGroupDrained.accept(config);
       return;
     }
-    final var operation = (PartitionGroupOperation) group.nextPendingOperation();
+    final var operation = group.nextPendingOperation();
     final var applier = groupSimulator.getApplier(operation);
     final var result = applier.init(config.globalConfiguration(), group);
     if (result.isLeft()) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -315,6 +315,7 @@ public record CurrentClusterConfiguration(
       throw new IllegalArgumentException(
           "Expected to init a plan with at least one phase, but the phase list is empty");
     }
+
     final var newState = phasedChangeState.initPlan(phases);
     final var plan = newState.pending().orElseThrow();
     return withPhasedChangeState(newState).applyPhase(plan);
@@ -457,8 +458,11 @@ public record CurrentClusterConfiguration(
    * becomes a {@link PartitionGroupParallelPhase} targeting the default group. For example {@code
    * [MemberJoin, PartitionJoin, PartitionLeave, MemberLeave]} yields three phases: a global phase,
    * a default-group phase with the two partition operations, and another global phase.
+   *
+   * <p>Also used by the coordinator to turn a freshly generated flat operation list (from the
+   * unchanged request transformers) into a {@link PhasedChangePlan} for the default group.
    */
-  private static List<Phase> toPhases(final List<ClusterConfigurationChangeOperation> operations) {
+  public static List<Phase> toPhases(final List<ClusterConfigurationChangeOperation> operations) {
     final List<Phase> phases = new ArrayList<>();
     final List<GlobalChangeOperation> globalRun = new ArrayList<>();
     final List<PartitionGroupOperation> partitionRun = new ArrayList<>();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelConfigurationChangeCoordinatorTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.Either;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end tests of the new multi-partition-group path through the real {@link
+ * ConfigurationChangeCoordinatorImpl} + {@link ClusterConfigurationManagerImpl}, exercising plan
+ * generation, phased dispatch and phase advancement for the default tenant.
+ */
+final class NewModelConfigurationChangeCoordinatorTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @TempDir private Path tmp;
+
+  private ClusterConfigurationManagerImpl manager;
+  private ConfigurationChangeCoordinatorImpl coordinator;
+
+  private void wire(final MemberId localMemberId, final CurrentClusterConfiguration seed) {
+    final var persisted =
+        PersistedCurrentClusterConfiguration.ofFile(
+            tmp.resolve("config-" + localMemberId.id() + ".meta"), new ProtoBufSerializer());
+    manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            localMemberId,
+            persisted,
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopClusterChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    coordinator = new ConfigurationChangeCoordinatorImpl(manager, localMemberId, executor);
+    manager.updateMultiConfiguration(ignored -> seed).join();
+  }
+
+  /** Two active members, both replicating partition 1 in the default group. */
+  private CurrentClusterConfiguration twoMemberCluster() {
+    final var group =
+        new PartitionGroupConfiguration(
+            1,
+            0,
+            Map.of(
+                MEMBER_0,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(2, partitionConfig))),
+                MEMBER_1,
+                BrokerPartitionState.initialize(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        new GlobalConfiguration(
+            1,
+            Optional.empty(),
+            Map.of(
+                MEMBER_0, new BrokerState(0, Instant.EPOCH, State.ACTIVE),
+                MEMBER_1, new BrokerState(0, Instant.EPOCH, State.ACTIVE)),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty()),
+        Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, group),
+        PhasedChangeState.empty());
+  }
+
+  private CurrentClusterConfiguration configuration() {
+    return manager.getMultiConfiguration().join();
+  }
+
+  @Test
+  void shouldGenerateApplyAndAdvanceAMultiPhasePlan() {
+    // given — a two-member cluster; the local member 0 is the coordinator
+    wire(MEMBER_0, twoMemberCluster());
+    // a request producing a global operation followed by a partition operation, both targeting
+    // member 0 → a two-phase plan (global phase, then a default-group partition phase)
+    final ConfigurationChangeRequest request =
+        current ->
+            Either.right(
+                List.of(
+                    new PreScalingOperation(MEMBER_0, Set.of(MEMBER_0, MEMBER_1)),
+                    new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when
+    final var result = coordinator.applyOperations(request).join();
+
+    // then — the generated operations are returned, the plan drains phase by phase and completes
+    assertThat(result.operations())
+        .containsExactly(
+            new PreScalingOperation(MEMBER_0, Set.of(MEMBER_0, MEMBER_1)),
+            new PartitionLeaveOperation(MEMBER_0, 1, 1));
+
+    final var config = configuration();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(config.phasedChangeState().lastChange())
+        .hasValueSatisfying(
+            last -> assertThat(last.status()).isEqualTo(PhasedChangePlanStatus.COMPLETED));
+    assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+    final var defaultGroup = config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    // member 0 left partition 1; member 1 still hosts it
+    assertThat(defaultGroup.hasMember(MEMBER_0)).isFalse();
+    assertThat(defaultGroup.hasMember(MEMBER_1)).isTrue();
+  }
+
+  @Test
+  void shouldRejectWhenNotCoordinator() {
+    // given — the local member is 1, but member 0 (lower id) is the coordinator
+    wire(MEMBER_1, twoMemberCluster());
+    final ConfigurationChangeRequest request =
+        current -> Either.right(List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when / then — the non-coordinator refuses to apply the change
+    assertThat(coordinator.applyOperations(request)).failsWithin(Duration.ofSeconds(5));
+    assertThat(configuration().phasedChangeState().pending()).isEmpty();
+  }
+
+  @Test
+  void shouldNotStartPlanOnDryRun() {
+    // given
+    wire(MEMBER_0, twoMemberCluster());
+    final ConfigurationChangeRequest request =
+        current -> Either.right(List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when
+    final var result = coordinator.simulateOperations(request).join();
+
+    // then — the operations are returned but no plan is started
+    assertThat(result.operations()).containsExactly(new PartitionLeaveOperation(MEMBER_0, 1, 1));
+    assertThat(configuration().phasedChangeState().pending()).isEmpty();
+    final var defaultGroup =
+        configuration().partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasPendingChanges()).isFalse();
+    assertThat(defaultGroup.hasMember(MEMBER_0)).isTrue();
+  }
+
+  @Test
+  void shouldCompleteWithoutChangesWhenNoOperationsGenerated() {
+    // given
+    wire(MEMBER_0, twoMemberCluster());
+    final ConfigurationChangeRequest request = current -> Either.right(List.of());
+
+    // when
+    final var result = coordinator.applyOperations(request).join();
+
+    // then
+    assertThat(result.operations()).isEmpty();
+    assertThat(configuration().phasedChangeState().pending()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectInvalidOperationUsingRealAppliers() {
+    // given — a request whose second operation is invalid: member 0 leaves partition 1 twice,
+    // but after the first leave it no longer hosts the partition. Validation must catch this via
+    // the real PartitionGroupConfigurationChangeAppliersImpl dispatch table, not a legacy
+    // simulator.
+    wire(MEMBER_0, twoMemberCluster());
+    final ConfigurationChangeRequest request =
+        current ->
+            Either.right(
+                List.of(
+                    new PartitionLeaveOperation(MEMBER_0, 1, 1),
+                    new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when
+    final var applyFuture = coordinator.applyOperations(request);
+
+    // then — rejected during validation; no plan is started
+    assertThat(applyFuture)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(InvalidRequest.class);
+    assertThat(configuration().phasedChangeState().pending()).isEmpty();
+    final var defaultGroup =
+        configuration().partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+    assertThat(defaultGroup.hasMember(MEMBER_0)).isTrue();
+  }
+
+  @Test
+  void shouldRejectWhenAnotherChangeIsInProgress() {
+    // given — a plan is already pending (its only operation targets member 1, so it never drains
+    // on this member)
+    wire(MEMBER_0, twoMemberCluster());
+    manager
+        .updateMultiConfiguration(
+            c -> c.initPlan(List.of(new GlobalPhase(List.of(new MemberLeaveOperation(MEMBER_1))))))
+        .join();
+    final ConfigurationChangeRequest request =
+        current -> Either.right(List.of(new PartitionLeaveOperation(MEMBER_0, 1, 1)));
+
+    // when
+    final var applyFuture = coordinator.applyOperations(request);
+
+    // then — rejected because a change is already in progress
+    assertThat(applyFuture)
+        .failsWithin(Duration.ofSeconds(5))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(ConcurrentModificationException.class);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -1,0 +1,615 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreResolvedRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestsHandler;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestValidator;
+import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor.NoopModeChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor.NoopRestoreChangeExecutor;
+import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
+import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.util.Either;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that every {@link io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementApi}
+ * endpoint generates the expected plan for the <em>default</em> tenant when the new configuration
+ * model is enabled, driven through the real request handler + coordinator + manager. Mirrors the
+ * scenarios in {@code ClusterConfigurationManagementApiTest} (which runs against a recording
+ * coordinator on the legacy model), asserting the same planned changes on the new path.
+ */
+final class NewModelManagementApiEndpointsTest {
+
+  private static final MemberId ID_0 = MemberId.from("0");
+  private static final MemberId ID_1 = MemberId.from("1");
+  private static final MemberId ID_2 = MemberId.from("2");
+  private static final MemberId ID_3 = MemberId.from("3");
+  private final TestConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @TempDir private Path tmp;
+
+  private ClusterConfigurationManagerImpl manager;
+  private ClusterConfigurationManagementRequestsHandler handler;
+
+  /** Wires the real handler → coordinator → manager (new model) seeded from a legacy topology. */
+  private void wire(final ClusterConfiguration seed) {
+    final var persisted =
+        PersistedCurrentClusterConfiguration.ofFile(
+            tmp.resolve("config.meta"), new ProtoBufSerializer());
+    manager =
+        new ClusterConfigurationManagerImpl(
+            executor,
+            ID_0,
+            persisted,
+            new TopologyManagerMetrics(new SimpleMeterRegistry()),
+            Duration.ofMillis(1),
+            Duration.ofMillis(1));
+    manager.setCurrentConfigurationGossiper(ignored -> {});
+    manager.registerGlobalChangeAppliers(
+        new GlobalConfigurationChangeAppliersImpl(
+            new NoopClusterMembershipChangeExecutor(), new NoopClusterChangeExecutor()));
+    manager.registerPartitionGroupChangeAppliers(
+        CurrentClusterConfiguration.DEFAULT_GROUP,
+        new PartitionGroupConfigurationChangeAppliersImpl(
+            new NoopPartitionChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor(),
+            new NoopClusterChangeExecutor(),
+            new NoopModeChangeExecutor(),
+            new NoopRestoreChangeExecutor()));
+    final var coordinator = new ConfigurationChangeCoordinatorImpl(manager, ID_0, executor);
+
+    final var validatorRegistry = new RequestValidatorRegistry();
+    validatorRegistry.registerValidator(
+        null,
+        new ClusterConfigurationRequestValidator<RestoreRequest, RestoreResolvedRequest>() {
+          @Override
+          public Class<RestoreRequest> requestType() {
+            return RestoreRequest.class;
+          }
+
+          @Override
+          public Either<Exception, RestoreResolvedRequest> validate(final RestoreRequest request) {
+            return Either.right(
+                new RestoreResolvedRequest(
+                    Map.of(1, request.backupIds().stream().mapToLong(l -> l).toArray()), false));
+          }
+        });
+
+    handler =
+        new ClusterConfigurationManagementRequestsHandler(
+            coordinator, ID_0, executor, validatorRegistry);
+    manager
+        .updateMultiConfiguration(ignored -> CurrentClusterConfiguration.fromLegacy(seed))
+        .join();
+  }
+
+  private ClusterConfiguration singleActiveMember() {
+    return ClusterConfiguration.init().addMember(ID_0, MemberState.initializeAsActive(Map.of()));
+  }
+
+  @Test
+  void shouldPlanAddMembers() {
+    // given
+    wire(singleActiveMember());
+
+    // when
+    final var response = handler.addMembers(new AddMembersRequest(Set.of(ID_1), false)).join();
+
+    // then
+    assertThat(response.plannedChanges()).containsExactly(new MemberJoinOperation(ID_1));
+  }
+
+  @Test
+  void shouldPlanRemoveMembers() {
+    // given
+    wire(
+        singleActiveMember()
+            .addMember(ID_1, MemberState.initializeAsActive(Map.of()))
+            .addMember(ID_2, MemberState.initializeAsActive(Map.of())));
+
+    // when
+    final var response =
+        handler.removeMembers(new RemoveMembersRequest(Set.of(ID_1, ID_2), false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactlyElementsOf(
+            List.of(new MemberLeaveOperation(ID_1), new MemberLeaveOperation(ID_2)));
+  }
+
+  @Test
+  void shouldPlanJoinPartition() {
+    // given — partition 1 already has an active member (ID_0), so ID_1 can join it
+    wire(
+        ClusterConfiguration.init()
+            .addMember(
+                ID_0,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))))
+            .addMember(ID_1, MemberState.initializeAsActive(Map.of())));
+
+    // when
+    final var response = handler.joinPartition(new JoinPartitionRequest(ID_1, 1, 3, false)).join();
+
+    // then
+    assertThat(response.plannedChanges()).containsExactly(new PartitionJoinOperation(ID_1, 1, 3));
+  }
+
+  @Test
+  void shouldPlanLeavePartition() {
+    // given — partition 1 has two replicas so ID_1 can leave without dropping below the minimum
+    wire(
+        ClusterConfiguration.init()
+            .addMember(
+                ID_0,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(2, partitionConfig))))
+            .addMember(
+                ID_1,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when
+    final var response = handler.leavePartition(new LeavePartitionRequest(ID_1, 1, false)).join();
+
+    // then
+    assertThat(response.plannedChanges()).containsExactly(new PartitionLeaveOperation(ID_1, 1, 1));
+  }
+
+  @Test
+  void shouldPlanReassignPartitions() {
+    // given
+    wire(
+        singleActiveMember()
+            .addMember(
+                ID_1,
+                MemberState.initializeAsActive(
+                    Map.of(
+                        1,
+                        PartitionState.active(1, partitionConfig),
+                        2,
+                        PartitionState.active(1, partitionConfig))))
+            .addMember(ID_2, MemberState.initializeAsActive(Map.of())));
+
+    // when
+    final var response =
+        handler.reassignPartitions(new ReassignPartitionsRequest(Set.of(ID_1, ID_2), false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactly(
+            new PartitionJoinOperation(ID_2, 2, 1), new PartitionLeaveOperation(ID_1, 2, 1));
+  }
+
+  @Test
+  void shouldPlanScaleBrokers() {
+    // given
+    wire(
+        singleActiveMember()
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(ID_0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig))));
+
+    // when
+    final var response =
+        handler.scaleMembers(new BrokerScaleRequest(Set.of(ID_0, ID_1), false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactly(
+            new PreScalingOperation(ID_0, Set.of(ID_0, ID_1)),
+            new MemberJoinOperation(ID_1),
+            new PartitionJoinOperation(ID_1, 2, 1),
+            new PartitionLeaveOperation(ID_0, 2, 1),
+            new PostScalingOperation(ID_0, Set.of(ID_0, ID_1)));
+  }
+
+  @Test
+  void shouldPlanScaleCluster() {
+    // given
+    wire(
+        singleActiveMember()
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(ID_0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig))));
+
+    // when — scale the cluster to two brokers, keeping the current partition count (no scale-up)
+    final var response =
+        handler
+            .scaleCluster(
+                new ClusterScaleRequest(
+                    Optional.of(2), Optional.of(2), Optional.empty(), Optional.empty(), false))
+            .join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .startsWith(new PreScalingOperation(ID_0, Set.of(ID_0, ID_1)))
+        .endsWith(new PostScalingOperation(ID_0, Set.of(ID_0, ID_1)))
+        .contains(new MemberJoinOperation(ID_1));
+  }
+
+  @Test
+  void shouldPlanPatchCluster() {
+    // given
+    wire(
+        singleActiveMember()
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(ID_0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig))));
+
+    // when — add a broker, keeping the current partition count (no scale-up)
+    final var response =
+        handler
+            .patchCluster(
+                new ClusterPatchRequest(
+                    Set.of(ID_1), Set.of(), Optional.of(2), Optional.empty(), false))
+            .join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .startsWith(new PreScalingOperation(ID_0, Set.of(ID_0, ID_1)))
+        .endsWith(new PostScalingOperation(ID_0, Set.of(ID_0, ID_1)))
+        .contains(new MemberJoinOperation(ID_1));
+  }
+
+  @Test
+  void shouldPlanForceScaleDown() {
+    // given
+    wire(fourMemberTwoPartitionCluster());
+
+    // when
+    final var response =
+        handler.forceScaleDown(new BrokerScaleRequest(Set.of(ID_0, ID_2), false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactlyInAnyOrder(
+            new PartitionForceReconfigureOperation(ID_0, 1, Set.of(ID_0)),
+            new PartitionForceReconfigureOperation(ID_2, 2, Set.of(ID_2)),
+            new MemberRemoveOperation(ID_0, ID_1),
+            new MemberRemoveOperation(ID_0, ID_3));
+  }
+
+  @Test
+  void shouldPlanForceRemoveBrokers() {
+    // given
+    wire(fourMemberTwoPartitionCluster());
+
+    // when
+    final var response =
+        handler.forceRemoveBrokers(new ForceRemoveBrokersRequest(Set.of(ID_1, ID_3), false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactlyInAnyOrder(
+            new PartitionForceReconfigureOperation(ID_0, 1, Set.of(ID_0)),
+            new PartitionForceReconfigureOperation(ID_2, 2, Set.of(ID_2)),
+            new MemberRemoveOperation(ID_0, ID_1),
+            new MemberRemoveOperation(ID_0, ID_3));
+  }
+
+  @Test
+  void shouldPlanDisableExporter() {
+    // given
+    final var exporterId = "exporterId";
+    final var partitionConfigWithExporter =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+    wire(
+        singleActiveMember()
+            .updateMember(
+                ID_0,
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter))));
+
+    // when
+    final var response =
+        handler.disableExporter(new ExporterDisableRequest(exporterId, false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactly(new PartitionDisableExporterOperation(ID_0, 1, exporterId));
+  }
+
+  @Test
+  void shouldApplyDisableExporterEndToEndForLocalMember() {
+    // given — the exporter lives on the local member's partition
+    final var exporterId = "exporterId";
+    final var partitionConfigWithExporter =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
+    wire(
+        singleActiveMember()
+            .updateMember(
+                ID_0,
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter))));
+
+    // when
+    handler.disableExporter(new ExporterDisableRequest(exporterId, false)).join();
+
+    // then — the plan is applied on the local member and completes
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    final var exporterState =
+        config
+            .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+            .getMember(ID_0)
+            .partitions()
+            .get(1)
+            .config()
+            .exporting()
+            .exporters()
+            .get(exporterId);
+    assertThat(exporterState.state()).isEqualTo(State.DISABLED);
+  }
+
+  @Test
+  void shouldPlanDeleteExporter() {
+    // given — the exporter is in CONFIG_NOT_FOUND, the state a delete requires
+    final var exporterId = "exporterId";
+    final var configWithExporter =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of(
+                    exporterId, new ExporterState(1, State.CONFIG_NOT_FOUND, Optional.empty()))));
+    wire(
+        singleActiveMember()
+            .updateMember(
+                ID_0, m -> m.addPartition(1, PartitionState.active(1, configWithExporter))));
+
+    // when
+    final var response =
+        handler.deleteExporter(new ExporterDeleteRequest(exporterId, false)).join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactly(new PartitionDeleteExporterOperation(ID_0, 1, exporterId));
+  }
+
+  @Test
+  void shouldPlanEnableExporter() {
+    // given — the exporter is DISABLED so it can be enabled
+    final var exporterId = "exporterId";
+    final var configWithExporter =
+        new DynamicPartitionConfig(
+            new ExportingConfig(
+                ExportingState.EXPORTING,
+                Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
+    wire(
+        singleActiveMember()
+            .updateMember(
+                ID_0, m -> m.addPartition(1, PartitionState.active(1, configWithExporter))));
+
+    // when
+    final var response =
+        handler
+            .enableExporter(new ExporterEnableRequest(exporterId, Optional.empty(), false))
+            .join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactly(
+            new PartitionEnableExporterOperation(ID_0, 1, exporterId, Optional.empty()));
+  }
+
+  @Test
+  void shouldPlanPurge() {
+    // given — a member with a partition
+    wire(
+        singleActiveMember()
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
+
+    // when
+    final var response = handler.purge(new PurgeRequest(false)).join();
+
+    // then — purge produces a plan and preserves the partition assignment of every member
+    assertThat(response.plannedChanges()).isNotEmpty();
+    assertThat(response.expectedConfiguration())
+        .containsOnlyKeys(response.currentConfiguration().keySet().toArray(MemberId[]::new));
+  }
+
+  @Test
+  void shouldApplyModeChangeEndToEndForLocalMember() {
+    // given — the local member is active and processing in the default group
+    wire(
+        ClusterConfiguration.init()
+            .addMember(
+                ID_0,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig)))));
+
+    // when — switch to recovery mode
+    handler.modeChange(new ModeChangeRequest(Mode.RECOVERING, false)).join();
+
+    // then — the plan is applied and the local member is now in recovery mode
+    final var config = manager.getMultiConfiguration().join();
+    assertThat(config.phasedChangeState().pending()).isEmpty();
+    assertThat(
+            config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).getMember(ID_0).mode())
+        .isEqualTo(Mode.RECOVERING);
+  }
+
+  @Test
+  void shouldPlanUpdateRoutingState() {
+    // given
+    wire(
+        singleActiveMember()
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
+    final var routingState = RoutingState.initializeWithPartitionCount(1);
+
+    // when
+    final var response =
+        handler
+            .updateRoutingState(new UpdateRoutingStateRequest(Optional.of(routingState), false))
+            .join();
+
+    // then
+    assertThat(response.plannedChanges())
+        .containsExactly(new UpdateRoutingState(ID_0, Optional.of(routingState)));
+  }
+
+  @Test
+  void shouldRejectUpdatePartitionDistributionForNonZoneAwareConfig() {
+    // given — a bare cluster and a non-zone-aware config, which the transformer rejects
+    wire(
+        singleActiveMember()
+            .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
+
+    // when / then — the endpoint is reachable on the new model and rejects the invalid request
+    assertThatCode(
+            () ->
+                handler
+                    .updatePartitionDistribution(
+                        new UpdatePartitionDistributorConfigRequest(new RoundRobinConfig(), false))
+                    .join())
+        .hasMessageContaining("ZONE_AWARE");
+  }
+
+  @Test
+  void shouldValidateRestoreOnlyWhenRecovering() {
+    // given — the local member is in recovery mode. It must host a partition: recovery mode lives
+    // on BrokerPartitionState, so a partitionless member is not in the default group and its mode
+    // would not survive the round-trip through toLegacyDefault.
+    wire(
+        ClusterConfiguration.init()
+            .addMember(
+                ID_0,
+                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, partitionConfig)))
+                    .toRecovering()));
+
+    // when — a dry-run restore is validated
+    final var result =
+        handler.restore(
+            new RestoreRequest(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                List.of(100L),
+                null,
+                null,
+                "elasticsearch",
+                false,
+                true));
+
+    // then — accepted, because toLegacyDefault projects the member back to RECOVERING
+    assertThatCode(result::join).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectRestoreWhenNotRecovering() {
+    // given — the local member is active (not recovering)
+    wire(singleActiveMember());
+
+    // when / then — restore is rejected
+    assertThatCode(
+            () ->
+                handler
+                    .restore(
+                        new RestoreRequest(
+                            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                            List.of(100L),
+                            null,
+                            null,
+                            "elasticsearch",
+                            false,
+                            false))
+                    .join())
+        .hasMessageContaining("recovery mode");
+  }
+
+  // cancelTopologyChange on the new model is implemented separately (issue #58398); not covered
+  // here.
+
+  @Test
+  void shouldGetTopology() {
+    // given
+    wire(singleActiveMember().addMember(ID_1, MemberState.initializeAsActive(Map.of())));
+
+    // when
+    final var topology = handler.getTopology().join();
+
+    // then — the default-group projection carries all cluster members
+    assertThat(topology.members()).containsKeys(ID_0, ID_1);
+  }
+
+  private ClusterConfiguration fourMemberTwoPartitionCluster() {
+    return ClusterConfiguration.init()
+        .addMember(ID_0, MemberState.initializeAsActive(Map.of()))
+        .addMember(ID_1, MemberState.initializeAsActive(Map.of()))
+        .addMember(ID_2, MemberState.initializeAsActive(Map.of()))
+        .addMember(ID_3, MemberState.initializeAsActive(Map.of()))
+        .updateMember(ID_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+        .updateMember(ID_1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+        .updateMember(ID_2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+        .updateMember(ID_3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+  }
+}


### PR DESCRIPTION
## Summary
Stacked on #58410 (dd-58396-manager-new-model).

- `ConfigurationChangeCoordinatorImpl`'s new-model path (`applyOrDryRunNewModel`) now runs entirely on `CurrentClusterConfiguration`: request transformers still generate a flat operation list against the default-group projection, but validation/simulation and application use the new multi-group model directly.
- Validation simulates the phased plan phase-by-phase using the real `GlobalConfigurationChangeAppliersImpl`/`PartitionGroupConfigurationChangeAppliersImpl` dispatch tables (backed by no-op executors) — the same tables the manager uses to actually apply changes — instead of the legacy simulator.
- Adds `ConfigurationChangeRequest.phases(CurrentClusterConfiguration)`, a default method deriving phases from the existing `operations(ClusterConfiguration)` via the same operation-kind-run splitting `CurrentClusterConfiguration.toPhases` already uses. The new-model path calls only `phases()`, never `operations()` directly. Supporting per-tenant or cluster wide operations could be done fully on the transformers by overriding `phases()`.

closes #58397