### PR TITLE
deps: adopt camunda-security-library 0.1.0-alpha57

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminOidcSecurityConfiguration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.clusteradmin;
 
-import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_WEBAPP_API;
+import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_API;
 
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
@@ -48,7 +48,7 @@ public class ClusterAdminOidcSecurityConfiguration {
   private static final String CLUSTER_ADMIN_API_PATTERN = "/cluster/v2/**";
 
   @Bean
-  @Order(ORDER_WEBAPP_API)
+  @Order(ORDER_API)
   public SecurityFilterChain clusterAdminOidcSecurityFilterChain(
       final HttpSecurity http,
       final Environment environment,

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.authentication.clusteradmin;
 
-import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_WEBAPP_API;
+import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_API;
 
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
@@ -76,7 +76,7 @@ public class ClusterAdminSecurityConfiguration {
       LoggerFactory.getLogger(ClusterAdminSecurityConfiguration.class);
 
   @Bean
-  @Order(ORDER_WEBAPP_API)
+  @Order(ORDER_API)
   public SecurityFilterChain clusterAdminSecurityFilterChain(
       final HttpSecurity http,
       final Environment environment,

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -23,7 +23,7 @@ public class SecurityPathAdapter implements SecurityPathPort {
   // Tenant-prefixed paths (/physical-tenants/<id>/...) are deliberately NOT listed here. They are
   // owned exclusively by the per-tenant scoped security chains that PhysicalTenantScopeProvider
   // contributes (CSL derives each scope's matcher as basePath + these apiPaths, e.g.
-  // /physical-tenants/<id>/v2/**). The cluster chain and a scoped chain share ORDER_WEBAPP_API, so
+  // /physical-tenants/<id>/v2/**). The cluster chain and a scoped chain share ORDER_API, so
   // listing the tenant prefix here would let the cluster chain also match a tenant request and, if
   // it wins the same-order tie-break, validate the token against the cluster's providers instead of
   // the tenant's — breaking per-tenant audience isolation. Keep this list cluster-only.

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcChainIsolationTest.java
@@ -41,7 +41,7 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminOidcConverterWiringTest.java
@@ -44,7 +44,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
@@ -36,7 +36,7 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -55,7 +55,7 @@ import org.springframework.web.util.UriComponentsBuilder;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com",

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcSaaSWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcSaaSWebSecurityConfigTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com",

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcWebSecurityConfigTest.java
@@ -69,7 +69,7 @@ import org.springframework.test.web.servlet.assertj.MvcTestResult;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
@@ -58,7 +58,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.prefer-id-token-claims=true",

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -61,7 +61,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
       "camunda.security.authentication.unprotected-api=false",
       "camunda.security.authentication.method=oidc",
       "camunda.security.authentication.oidc.client-id=example",
-      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.redirect-uri=https://redirect.example.com",
       "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
       "camunda.security.authentication.oidc.token-uri=token.example.com",
       "camunda.security.authentication.oidc.groups-claim=groups",

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOverridePolicyValidation.java
@@ -94,6 +94,7 @@ final class PhysicalTenantOverridePolicyValidation {
               "security.authentication.method",
               "security.authentication.unprotected-api",
               "security.authentication.webapp-enabled",
+              "security.authentication.catch-all-unhandled-paths-enabled",
               "security.csrf",
               "security.http-headers",
               // forward declaration — property lands with #54898

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -69,6 +69,7 @@ cluster.size
 cluster.zone
 data.secondary-storage.rdbms.max-varchar-field-length
 license.key
+security.authentication.catch-all-unhandled-paths-enabled
 security.authentication.method
 security.authentication.unprotected-api
 security.authentication.webapp-enabled

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.85</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha56</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha57</version.camunda-security-library>
     <version.checkstyle>13.8.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminOidcAuthenticationIT.java
@@ -95,7 +95,7 @@ public class ClusterAdminOidcAuthenticationIT {
         c -> {
           c.getAuthentication().getOidc().setIssuerUri(issuerUri);
           c.getAuthentication().getOidc().setClientId("example");
-          c.getAuthentication().getOidc().setRedirectUri("example.com");
+          c.getAuthentication().getOidc().setRedirectUri("https://example.com");
         });
     BROKER.start();
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/nodb/OidcNoSecondaryStorageTest.java
@@ -73,7 +73,7 @@ public class OidcNoSecondaryStorageTest {
                     .getOidc()
                     .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
                 c.getAuthentication().getOidc().setClientId("example");
-                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setRedirectUri("https://example.com");
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/qa/util/src/main/java/io/camunda/qa/util/compatibility/CompatibilityTestExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/compatibility/CompatibilityTestExtension.java
@@ -283,7 +283,8 @@ public class CompatibilityTestExtension
           "CAMUNDA_SECURITY_AUTHENTICATION_OIDC_ISSUER_URI",
           keycloakContainer.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
       camundaContainer.withEnv("CAMUNDA_SECURITY_AUTHENTICATION_OIDC_CLIENT_ID", "example");
-      camundaContainer.withEnv("CAMUNDA_SECURITY_AUTHENTICATION_OIDC_REDIRECT_URI", "example.com");
+      camundaContainer.withEnv(
+          "CAMUNDA_SECURITY_AUTHENTICATION_OIDC_REDIRECT_URI", "https://example.com");
     }
 
     camundaContainer.start();

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -850,7 +850,7 @@ public class CamundaMultiDBExtension
           .withSecurityConfig(
               c -> {
                 c.getAuthentication().getOidc().setClientId("example");
-                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setRedirectUri("https://example.com");
                 c.getAuthentication().getOidc().setIssuerUri(issuerUri);
               });
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverGrpcIT.java
@@ -82,7 +82,7 @@ public class OidcAuthOverGrpcIT {
                     .getOidc()
                     .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
                 c.getAuthentication().getOidc().setClientId("example");
-                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setRedirectUri("https://example.com");
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestIT.java
@@ -82,7 +82,7 @@ public class OidcAuthOverRestIT {
                     .getOidc()
                     .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
                 c.getAuthentication().getOidc().setClientId("example");
-                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setRedirectUri("https://example.com");
                 c.getAuthorizations().setEnabled(true);
                 c.getInitialization()
                     .setMappingRules(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestInitializerIT.java
@@ -56,7 +56,7 @@ public class OidcAuthOverRestInitializerIT {
                     .getOidc()
                     .setIssuerUri(KEYCLOAK.getAuthServerUrl() + "/realms/" + KEYCLOAK_REALM);
                 c.getAuthentication().getOidc().setClientId("example");
-                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setRedirectUri("https://example.com");
                 c.getAuthorizations().setEnabled(true);
                 // add a preconfigured user. This should not be allowed with OIDC
                 c.getInitialization()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestStartupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/authorization/OidcAuthOverRestStartupIT.java
@@ -45,7 +45,7 @@ public class OidcAuthOverRestStartupIT {
               c -> {
                 c.getAuthentication().getOidc().setIssuerUri(UNREACHABLE_ISSUER_URI);
                 c.getAuthentication().getOidc().setClientId("example");
-                c.getAuthentication().getOidc().setRedirectUri("example.com");
+                c.getAuthentication().getOidc().setRedirectUri("https://example.com");
                 c.getAuthorizations().setEnabled(true);
                 final var defaultRoles = new HashMap<>(c.getInitialization().getDefaultRoles());
                 defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER_ID)));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
@@ -70,7 +70,7 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
   private static final String CLIENT_AUTHENTICATOR_TYPE = "client-secret";
   private static final String USER_ID_CLAIM_NAME = "sub";
   private static final String EXAMPLE_CLIENT_ID = "example";
-  private static final String EXAMPLE_REDIRECT_URI = "example.com";
+  private static final String EXAMPLE_REDIRECT_URI = "https://example.com";
   private static final String ADMIN_ROLE = "admin";
   private static final String USERS_KEY = "users";
   private static final String USERNAME = "zeebe-service-account";


### PR DESCRIPTION
## Description

Adopt `camunda-security-library` **0.1.0-alpha57** (from alpha56).

The goal of this PR is narrow: bump the CSL version so downstream work can build and run against
it, to **unblock the Optimize CSL integration** (camunda/camunda-security-library#564). It is not a
feature change.

### Changes

- `parent/pom.xml`: `version.camunda-security-library` alpha56 → alpha57.
- **Filter-chain order-constant rename** (alpha57): `ORDER_WEBAPP_API` was split into `ORDER_API`
  (1) and `ORDER_WEBAPP` (2). The cluster-admin chains (`ClusterAdminSecurityConfiguration`,
  `ClusterAdminOidcSecurityConfiguration`) are bearer/basic API chains on `/cluster/v2/**`, so they
  map to `ORDER_API`, which keeps the same numeric value (1) `ORDER_WEBAPP_API` had — relative
  chain ordering is unchanged. `SecurityPathAdapter` comment updated to the new name.
- **`oidc.redirect-uri` validation** (alpha57): the library now rejects a configured `redirect-uri`
  that is not `{baseUrl}...` or an absolute `scheme://host` URL, because the `redirect_uri` sent to
  the IdP must be absolute. Several OIDC test fixtures used bare placeholders (`example.com`,
  `redirect.example.com`) that are never exercised in those bearer/API/wiring tests but now fail
  context startup. Prefixed them with `https://` so the context loads; behavior is unchanged. No
  production config used a bare value.

### Verification

- `authentication` and `configuration` modules compile clean against alpha57.
- No `ORDER_WEBAPP_API` references remain; no bare `oidc.redirect-uri` values remain.

Refs camunda/camunda-security-library#564
