### PR TITLE
fix: remove stale bulk override from local-dev elasticsearch/opensearch profiles

### DIFF
--- a/dist/src/main/resources/application-elasticsearch.yaml
+++ b/dist/src/main/resources/application-elasticsearch.yaml
@@ -43,10 +43,6 @@ camunda:
               verifyHostname: true
               selfSigned: false
 
-          bulk:
-            delay: 5
-            size: 1000
-
           index:
             prefix:
             zeebeIndexPrefix: zeebe-record

--- a/dist/src/main/resources/application-opensearch.yaml
+++ b/dist/src/main/resources/application-opensearch.yaml
@@ -43,10 +43,6 @@ zeebe:
               verifyHostname: true
               selfSigned: false
 
-          bulk:
-            delay: 5
-            size: 1000
-
           index:
             prefix:
             zeebeIndexPrefix: zeebe-record


### PR DESCRIPTION
## Summary

These look to be remnants of a past when we were first introducing the Camunda Exporter. We should stick to the default values where possible.

A companion fix removes the same stale override from the CamundaExporter args in the SaaS `camunda-operator` template: camunda/camunda-operator#5796

Refs: camunda/camunda#57760