### PR TITLE
refactor: convert 7 RDBMS DbModels to records

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -25,16 +25,12 @@ public record AuthorizationDbModel(
     implements DbModel<AuthorizationDbModel> {
 
   public AuthorizationDbModel {
-    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
-    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
-    // Immutable defaults (e.g. Set.of()) would cause UnsupportedOperationException at runtime.
+    // Must stay mutable: MyBatis appends to this via <collection> after construction.
     permissionTypes = permissionTypes != null ? permissionTypes : new HashSet<>();
   }
 
-  // Used by authorizationResultMap's <constructor>, which never supplies permissionTypes -- it's
-  // populated separately by the sibling <collection> element, which requires (and only works
-  // with) an exact-arity constructor match; MyBatis does not default missing constructor args to
-  // null.
+  // Matches authorizationResultMap's <constructor>, which omits permissionTypes -- populated
+  // separately via the sibling <collection> element.
   public AuthorizationDbModel(
       final Long authorizationKey,
       final String ownerId,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -31,6 +31,29 @@ public record AuthorizationDbModel(
     permissionTypes = permissionTypes != null ? permissionTypes : new HashSet<>();
   }
 
+  // Used by authorizationResultMap's <constructor>, which never supplies permissionTypes -- it's
+  // populated separately by the sibling <collection> element, which requires (and only works
+  // with) an exact-arity constructor match; MyBatis does not default missing constructor args to
+  // null.
+  public AuthorizationDbModel(
+      final Long authorizationKey,
+      final String ownerId,
+      final String ownerType,
+      final String resourceType,
+      final Short resourceMatcher,
+      final String resourceId,
+      final String resourcePropertyName) {
+    this(
+        authorizationKey,
+        ownerId,
+        ownerType,
+        resourceType,
+        resourceMatcher,
+        resourceId,
+        resourcePropertyName,
+        null);
+  }
+
   @Override
   public AuthorizationDbModel copy(
       final Function<ObjectBuilder<AuthorizationDbModel>, ObjectBuilder<AuthorizationDbModel>>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -9,82 +9,26 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.util.ObjectBuilder;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
-public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
+public record AuthorizationDbModel(
+    Long authorizationKey,
+    String ownerId,
+    String ownerType,
+    String resourceType,
+    Short resourceMatcher,
+    String resourceId,
+    String resourcePropertyName,
+    Set<PermissionType> permissionTypes)
+    implements DbModel<AuthorizationDbModel> {
 
-  private Long authorizationKey;
-  private String ownerId;
-  private String ownerType;
-  private String resourceType;
-  private Short resourceMatcher;
-  private String resourceId;
-  private String resourcePropertyName;
-  private Set<PermissionType> permissionTypes;
-
-  public Long authorizationKey() {
-    return authorizationKey;
-  }
-
-  public void authorizationKey(final Long authorizationKey) {
-    this.authorizationKey = authorizationKey;
-  }
-
-  public String ownerId() {
-    return ownerId;
-  }
-
-  public void ownerId(final String ownerId) {
-    this.ownerId = ownerId;
-  }
-
-  public String ownerType() {
-    return ownerType;
-  }
-
-  public void ownerType(final String ownerType) {
-    this.ownerType = ownerType;
-  }
-
-  public String resourceType() {
-    return resourceType;
-  }
-
-  public void resourceType(final String resourceType) {
-    this.resourceType = resourceType;
-  }
-
-  public Short resourceMatcher() {
-    return resourceMatcher;
-  }
-
-  public void resourceMatcher(final Short resourceMatcher) {
-    this.resourceMatcher = resourceMatcher;
-  }
-
-  public String resourceId() {
-    return resourceId;
-  }
-
-  public void resourceId(final String resourceId) {
-    this.resourceId = resourceId;
-  }
-
-  public String resourcePropertyName() {
-    return resourcePropertyName;
-  }
-
-  public void resourcePropertyName(final String resourcePropertyName) {
-    this.resourcePropertyName = resourcePropertyName;
-  }
-
-  public Set<PermissionType> permissionTypes() {
-    return permissionTypes;
-  }
-
-  public void permissionTypes(final Set<PermissionType> permissionTypes) {
-    this.permissionTypes = permissionTypes;
+  public AuthorizationDbModel {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. Set.of()) would cause UnsupportedOperationException at runtime.
+    permissionTypes = permissionTypes != null ? permissionTypes : new HashSet<>();
   }
 
   @Override
@@ -160,16 +104,15 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
 
     @Override
     public AuthorizationDbModel build() {
-      final AuthorizationDbModel model = new AuthorizationDbModel();
-      model.authorizationKey(authorizationKey);
-      model.ownerId(ownerId);
-      model.ownerType(ownerType);
-      model.resourceMatcher(resourceMatcher);
-      model.resourceId(resourceId);
-      model.resourcePropertyName(resourcePropertyName);
-      model.resourceType(resourceType);
-      model.permissionTypes(permissionTypes);
-      return model;
+      return new AuthorizationDbModel(
+          authorizationKey,
+          ownerId,
+          ownerType,
+          resourceType,
+          resourceMatcher,
+          resourceId,
+          resourcePropertyName,
+          permissionTypes);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.domain;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.util.ObjectBuilder;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -26,7 +27,7 @@ public record AuthorizationDbModel(
 
   public AuthorizationDbModel {
     // Must stay mutable: MyBatis appends to this via <collection> after construction.
-    permissionTypes = permissionTypes != null ? permissionTypes : new HashSet<>();
+    permissionTypes = Objects.requireNonNullElse(permissionTypes, new HashSet<>());
   }
 
   // Matches authorizationResultMap's <constructor>, which omits permissionTypes -- populated

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -33,16 +33,12 @@ public record BatchOperationDbModel(
     implements Copyable<BatchOperationDbModel> {
 
   public BatchOperationDbModel {
-    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
-    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
-    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    // Must stay mutable: MyBatis appends to this via <collection> after construction.
     errors = errors != null ? errors : new ArrayList<>();
   }
 
-  // Used by BatchOperationResultMap's <constructor>, which never supplies errors -- it's
-  // populated separately by the sibling <collection> element, which requires (and only works
-  // with) an exact-arity constructor match; MyBatis does not default missing constructor args to
-  // null.
+  // Matches BatchOperationResultMap's <constructor>, which omits errors -- populated separately
+  // via the sibling <collection> element.
   public BatchOperationDbModel(
       final String batchOperationKey,
       final BatchOperationState state,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -16,33 +16,33 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
+public record BatchOperationDbModel(
+    String batchOperationKey,
+    BatchOperationState state,
+    BatchOperationType operationType,
+    OffsetDateTime startDate,
+    OffsetDateTime endDate,
+    // The type/id of the actor that performed the operation. @since 8.9.0 -- null for older
+    // versions.
+    AuditLogActorType actorType,
+    String actorId,
+    Integer operationsTotalCount,
+    Integer operationsFailedCount,
+    Integer operationsCompletedCount,
+    List<BatchOperationErrorDbModel> errors)
+    implements Copyable<BatchOperationDbModel> {
 
-  private String batchOperationKey;
-  private BatchOperationState state;
-  private BatchOperationType operationType;
-  private OffsetDateTime startDate;
-  private OffsetDateTime endDate;
+  public BatchOperationDbModel {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    errors = errors != null ? errors : new ArrayList<>();
+  }
 
-  /**
-   * The type of the actor that performed the operation.
-   *
-   * @since 8.9.0 - so null for older versions
-   */
-  private final AuditLogActorType actorType;
-
-  /**
-   * The id of the actor that performed the operation.
-   *
-   * @since 8.9.0 - so null for older versions
-   */
-  private final String actorId;
-
-  private Integer operationsTotalCount;
-  private Integer operationsFailedCount;
-  private Integer operationsCompletedCount;
-  private List<BatchOperationErrorDbModel> errors = new ArrayList<>();
-
+  // Used by BatchOperationResultMap's <constructor>, which never supplies errors -- it's
+  // populated separately by the sibling <collection> element, which requires (and only works
+  // with) an exact-arity constructor match; MyBatis does not default missing constructor args to
+  // null.
   public BatchOperationDbModel(
       final String batchOperationKey,
       final BatchOperationState state,
@@ -54,41 +54,18 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
       final Integer operationsTotalCount,
       final Integer operationsFailedCount,
       final Integer operationsCompletedCount) {
-    this.batchOperationKey = batchOperationKey;
-    this.state = state;
-    this.operationType = operationType;
-    this.startDate = startDate;
-    this.endDate = endDate;
-    this.actorType = actorType;
-    this.actorId = actorId;
-    this.operationsTotalCount = operationsTotalCount;
-    this.operationsFailedCount = operationsFailedCount;
-    this.operationsCompletedCount = operationsCompletedCount;
-  }
-
-  public BatchOperationDbModel(
-      final String batchOperationKey,
-      final BatchOperationState state,
-      final BatchOperationType operationType,
-      final OffsetDateTime startDate,
-      final OffsetDateTime endDate,
-      final AuditLogActorType actorType,
-      final String actorId,
-      final Integer operationsTotalCount,
-      final Integer operationsFailedCount,
-      final Integer operationsCompletedCount,
-      final List<BatchOperationErrorDbModel> errors) {
-    this.batchOperationKey = batchOperationKey;
-    this.state = state;
-    this.operationType = operationType;
-    this.startDate = startDate;
-    this.endDate = endDate;
-    this.actorType = actorType;
-    this.actorId = actorId;
-    this.operationsTotalCount = operationsTotalCount;
-    this.operationsFailedCount = operationsFailedCount;
-    this.operationsCompletedCount = operationsCompletedCount;
-    this.errors = errors != null ? errors : new ArrayList<>();
+    this(
+        batchOperationKey,
+        state,
+        operationType,
+        startDate,
+        endDate,
+        actorType,
+        actorId,
+        operationsTotalCount,
+        operationsFailedCount,
+        operationsCompletedCount,
+        null);
   }
 
   @Override
@@ -96,88 +73,6 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
       final Function<ObjectBuilder<BatchOperationDbModel>, ObjectBuilder<BatchOperationDbModel>>
           copyFunction) {
     return copyFunction.apply(toBuilder()).build();
-  }
-
-  // Methods without get/set prefix
-
-  public String batchOperationKey() {
-    return batchOperationKey;
-  }
-
-  public void batchOperationKey(final String batchOperationKey) {
-    this.batchOperationKey = batchOperationKey;
-  }
-
-  public BatchOperationState state() {
-    return state;
-  }
-
-  public void state(final BatchOperationState state) {
-    this.state = state;
-  }
-
-  public BatchOperationType operationType() {
-    return operationType;
-  }
-
-  public void operationType(final BatchOperationType operationType) {
-    this.operationType = operationType;
-  }
-
-  public OffsetDateTime startDate() {
-    return startDate;
-  }
-
-  public void startDate(final OffsetDateTime startDate) {
-    this.startDate = startDate;
-  }
-
-  public OffsetDateTime endDate() {
-    return endDate;
-  }
-
-  public void endDate(final OffsetDateTime endDate) {
-    this.endDate = endDate;
-  }
-
-  public AuditLogActorType actorType() {
-    return actorType;
-  }
-
-  public String actorId() {
-    return actorId;
-  }
-
-  public Integer operationsTotalCount() {
-    return operationsTotalCount;
-  }
-
-  public void operationsTotalCount(final Integer operationsTotalCount) {
-    this.operationsTotalCount = operationsTotalCount;
-  }
-
-  public Integer operationsFailedCount() {
-    return operationsFailedCount;
-  }
-
-  public void operationsFailedCount(final Integer operationsFailedCount) {
-    this.operationsFailedCount = operationsFailedCount;
-  }
-
-  public Integer operationsCompletedCount() {
-    return operationsCompletedCount;
-  }
-
-  public void operationsCompletedCount(final Integer operationsCompletedCount) {
-    this.operationsCompletedCount = operationsCompletedCount;
-  }
-
-  public List<BatchOperationErrorDbModel> errors() {
-    return errors;
-  }
-
-  public void errors(final List<BatchOperationErrorDbModel> errors) {
-    this.errors = errors;
   }
 
   public Builder toBuilder() {
@@ -287,35 +182,5 @@ public class BatchOperationDbModel implements Copyable<BatchOperationDbModel> {
     }
   }
 
-  public static class BatchOperationErrorDbModel {
-    private Integer partitionId;
-    private String type;
-    private String message;
-
-    public BatchOperationErrorDbModel() {}
-
-    public Integer partitionId() {
-      return partitionId;
-    }
-
-    public void partitionId(final Integer partitionId) {
-      this.partitionId = partitionId;
-    }
-
-    public String type() {
-      return type;
-    }
-
-    public void type(final String type) {
-      this.type = type;
-    }
-
-    public String message() {
-      return message;
-    }
-
-    public void message(final String message) {
-      this.message = message;
-    }
-  }
+  public record BatchOperationErrorDbModel(Integer partitionId, String type, String message) {}
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -14,6 +14,7 @@ import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public record BatchOperationDbModel(
@@ -34,7 +35,7 @@ public record BatchOperationDbModel(
 
   public BatchOperationDbModel {
     // Must stay mutable: MyBatis appends to this via <collection> after construction.
-    errors = errors != null ? errors : new ArrayList<>();
+    errors = Objects.requireNonNullElse(errors, new ArrayList<>());
   }
 
   // Matches BatchOperationResultMap's <constructor>, which omits errors -- populated separately

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
@@ -26,15 +26,12 @@ public record GlobalListenerDbModel(
     List<String> eventTypes) {
 
   public GlobalListenerDbModel {
-    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
-    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
-    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    // Must stay mutable: MyBatis appends to this via <collection> after construction.
     eventTypes = eventTypes != null ? eventTypes : new ArrayList<>();
   }
 
-  // Used by searchResultMap's <constructor>, which never supplies eventTypes -- it's populated
-  // separately by the sibling <collection> element, which requires (and only works with) an
-  // exact-arity constructor match; MyBatis does not default missing constructor args to null.
+  // Matches searchResultMap's <constructor>, which omits eventTypes -- populated separately via
+  // the sibling <collection> element.
   public GlobalListenerDbModel(
       final String id,
       final String listenerId,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
@@ -11,116 +11,40 @@ import io.camunda.search.entities.GlobalListenerSource;
 import io.camunda.search.entities.GlobalListenerType;
 import io.camunda.util.GlobalListenerUtil;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.List;
 
-// Note: this is not a record in order to be able to use <collection> to aggregate event types in
-// the MyBatis mapping file
-public class GlobalListenerDbModel {
-  private String id;
-  private String listenerId;
-  private String type;
-  private Integer retries;
-  private List<String> eventTypes;
-  private boolean afterNonGlobal;
-  private Integer priority;
-  private GlobalListenerSource source;
-  private GlobalListenerType listenerType;
+public record GlobalListenerDbModel(
+    String id,
+    String listenerId,
+    String type,
+    Integer retries,
+    boolean afterNonGlobal,
+    Integer priority,
+    GlobalListenerSource source,
+    GlobalListenerType listenerType,
+    List<String> eventTypes) {
 
-  public GlobalListenerDbModel(final String id) {
-    this.id = id;
+  public GlobalListenerDbModel {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    eventTypes = eventTypes != null ? eventTypes : new ArrayList<>();
   }
 
+  // Used by searchResultMap's <constructor>, which never supplies eventTypes -- it's populated
+  // separately by the sibling <collection> element, which requires (and only works with) an
+  // exact-arity constructor match; MyBatis does not default missing constructor args to null.
   public GlobalListenerDbModel(
       final String id,
       final String listenerId,
       final String type,
       final Integer retries,
-      final List<String> eventTypes,
       final boolean afterNonGlobal,
       final Integer priority,
       final GlobalListenerSource source,
       final GlobalListenerType listenerType) {
-    this.id = id;
-    this.listenerId = listenerId;
-    this.type = type;
-    this.retries = retries;
-    this.eventTypes = eventTypes;
-    this.afterNonGlobal = afterNonGlobal;
-    this.priority = priority;
-    this.source = source;
-    this.listenerType = listenerType;
-  }
-
-  public String id() {
-    return id;
-  }
-
-  public void id(final String id) {
-    this.id = id;
-  }
-
-  public String listenerId() {
-    return listenerId;
-  }
-
-  public void listenerId(final String listenerId) {
-    this.listenerId = listenerId;
-  }
-
-  public String type() {
-    return type;
-  }
-
-  public void type(final String type) {
-    this.type = type;
-  }
-
-  public Integer retries() {
-    return retries;
-  }
-
-  public void retries(final Integer retries) {
-    this.retries = retries;
-  }
-
-  public List<String> eventTypes() {
-    return eventTypes;
-  }
-
-  public void eventTypes(final List<String> eventTypes) {
-    this.eventTypes = eventTypes;
-  }
-
-  public boolean afterNonGlobal() {
-    return afterNonGlobal;
-  }
-
-  public void afterNonGlobal(final boolean afterNonGlobal) {
-    this.afterNonGlobal = afterNonGlobal;
-  }
-
-  public Integer priority() {
-    return priority;
-  }
-
-  public void priority(final Integer priority) {
-    this.priority = priority;
-  }
-
-  public GlobalListenerSource source() {
-    return source;
-  }
-
-  public void source(final GlobalListenerSource source) {
-    this.source = source;
-  }
-
-  public GlobalListenerType listenerType() {
-    return listenerType;
-  }
-
-  public void listenerType(final GlobalListenerType listenerType) {
-    this.listenerType = listenerType;
+    this(id, listenerId, type, retries, afterNonGlobal, priority, source, listenerType, null);
   }
 
   public static class GlobalListenerDbModelBuilder implements ObjectBuilder<GlobalListenerDbModel> {
@@ -180,11 +104,11 @@ public class GlobalListenerDbModel {
           listenerId,
           type,
           retries,
-          eventTypes,
           afterNonGlobal,
           priority,
           source,
-          listenerType);
+          listenerType,
+          eventTypes);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GlobalListenerDbModel.java
@@ -13,6 +13,7 @@ import io.camunda.util.GlobalListenerUtil;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public record GlobalListenerDbModel(
     String id,
@@ -27,7 +28,7 @@ public record GlobalListenerDbModel(
 
   public GlobalListenerDbModel {
     // Must stay mutable: MyBatis appends to this via <collection> after construction.
-    eventTypes = eventTypes != null ? eventTypes : new ArrayList<>();
+    eventTypes = Objects.requireNonNullElse(eventTypes, new ArrayList<>());
   }
 
   // Matches searchResultMap's <constructor>, which omits eventTypes -- populated separately via

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
@@ -27,6 +27,14 @@ public record GroupDbModel(
     members = members != null ? members : new ArrayList<>();
   }
 
+  // Used by groupResultMap's <constructor>, which never supplies members -- it's populated
+  // separately by the sibling <collection> element, which requires (and only works with) an
+  // exact-arity constructor match; MyBatis does not default missing constructor args to null.
+  public GroupDbModel(
+      final Long groupKey, final String groupId, final String name, final String description) {
+    this(groupKey, groupId, name, description, null);
+  }
+
   @Override
   public GroupDbModel copy(
       final Function<ObjectBuilder<GroupDbModel>, ObjectBuilder<GroupDbModel>> copyFunction) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
@@ -21,15 +21,12 @@ public record GroupDbModel(
     implements DbModel<GroupDbModel> {
 
   public GroupDbModel {
-    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
-    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
-    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    // Must stay mutable: MyBatis appends to this via <collection> after construction.
     members = members != null ? members : new ArrayList<>();
   }
 
-  // Used by groupResultMap's <constructor>, which never supplies members -- it's populated
-  // separately by the sibling <collection> element, which requires (and only works with) an
-  // exact-arity constructor match; MyBatis does not default missing constructor args to null.
+  // Matches groupResultMap's <constructor>, which omits members -- populated separately via the
+  // sibling <collection> element.
   public GroupDbModel(
       final Long groupKey, final String groupId, final String name, final String description) {
     this(groupKey, groupId, name, description, null);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
@@ -38,7 +38,15 @@ public record GroupDbModel(
   @Override
   public GroupDbModel copy(
       final Function<ObjectBuilder<GroupDbModel>, ObjectBuilder<GroupDbModel>> copyFunction) {
-    return copyFunction.apply(new Builder().groupKey(groupKey).name(name).members(members)).build();
+    return copyFunction
+        .apply(
+            new Builder()
+                .groupKey(groupKey)
+                .groupId(groupId)
+                .name(name)
+                .description(description)
+                .members(members))
+        .build();
   }
 
   public static class Builder implements ObjectBuilder<GroupDbModel> {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
@@ -8,78 +8,29 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-public class GroupDbModel implements DbModel<GroupDbModel> {
+public record GroupDbModel(
+    Long groupKey,
+    String groupId,
+    String name,
+    String description,
+    List<GroupMemberDbModel> members)
+    implements DbModel<GroupDbModel> {
 
-  private Long groupKey;
-  private String groupId;
-  private String name;
-  private String description;
-  private List<GroupMemberDbModel> members;
-
-  public Long groupKey() {
-    return groupKey;
-  }
-
-  public void groupKey(final Long groupKey) {
-    this.groupKey = groupKey;
-  }
-
-  public String groupId() {
-    return groupId;
-  }
-
-  public void groupId(final String groupId) {
-    this.groupId = groupId;
-  }
-
-  public String name() {
-    return name;
-  }
-
-  public void name(final String name) {
-    this.name = name;
-  }
-
-  public String description() {
-    return description;
-  }
-
-  public void description(final String description) {
-    this.description = description;
-  }
-
-  public List<GroupMemberDbModel> members() {
-    return members;
-  }
-
-  public void members(final List<GroupMemberDbModel> members) {
-    this.members = members;
+  public GroupDbModel {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    members = members != null ? members : new ArrayList<>();
   }
 
   @Override
   public GroupDbModel copy(
       final Function<ObjectBuilder<GroupDbModel>, ObjectBuilder<GroupDbModel>> copyFunction) {
     return copyFunction.apply(new Builder().groupKey(groupKey).name(name).members(members)).build();
-  }
-
-  @Override
-  public String toString() {
-    return "GroupDbModel{"
-        + "groupKey="
-        + groupKey
-        + ", groupId='"
-        + groupId
-        + ", name='"
-        + name
-        + ", description='"
-        + description
-        + '\''
-        + ", members="
-        + members
-        + '}';
   }
 
   public static class Builder implements ObjectBuilder<GroupDbModel> {
@@ -119,13 +70,7 @@ public class GroupDbModel implements DbModel<GroupDbModel> {
 
     @Override
     public GroupDbModel build() {
-      final GroupDbModel model = new GroupDbModel();
-      model.groupKey(groupKey);
-      model.groupId(groupId);
-      model.name(name);
-      model.description(description);
-      model.members(members);
-      return model;
+      return new GroupDbModel(groupKey, groupId, name, description, members);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/GroupDbModel.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.domain;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public record GroupDbModel(
@@ -22,7 +23,7 @@ public record GroupDbModel(
 
   public GroupDbModel {
     // Must stay mutable: MyBatis appends to this via <collection> after construction.
-    members = members != null ? members : new ArrayList<>();
+    members = Objects.requireNonNullElse(members, new ArrayList<>());
   }
 
   // Matches groupResultMap's <constructor>, which omits members -- populated separately via the

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -23,6 +23,14 @@ public record RoleDbModel(
     members = members != null ? members : new ArrayList<>();
   }
 
+  // Used by roleResultMap's <constructor>, which never supplies members -- it's populated
+  // separately by the sibling <collection> element, which requires (and only works with) an
+  // exact-arity constructor match; MyBatis does not default missing constructor args to null.
+  public RoleDbModel(
+      final Long roleKey, final String roleId, final String name, final String description) {
+    this(roleKey, roleId, name, description, null);
+  }
+
   @Override
   public RoleDbModel copy(
       final Function<ObjectBuilder<RoleDbModel>, ObjectBuilder<RoleDbModel>> copyFunction) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -8,78 +8,25 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-public class RoleDbModel implements DbModel<RoleDbModel> {
+public record RoleDbModel(
+    Long roleKey, String roleId, String name, String description, List<RoleMemberDbModel> members)
+    implements DbModel<RoleDbModel> {
 
-  private Long roleKey;
-  private String roleId;
-  private String name;
-  private String description;
-  private List<RoleMemberDbModel> members;
-
-  public Long roleKey() {
-    return roleKey;
-  }
-
-  public void roleKey(final Long roleKey) {
-    this.roleKey = roleKey;
-  }
-
-  public String roleId() {
-    return roleId;
-  }
-
-  public void roleId(final String roleId) {
-    this.roleId = roleId;
-  }
-
-  public String name() {
-    return name;
-  }
-
-  public void name(final String name) {
-    this.name = name;
-  }
-
-  public String description() {
-    return description;
-  }
-
-  public void description(final String description) {
-    this.description = description;
-  }
-
-  public List<RoleMemberDbModel> members() {
-    return members;
-  }
-
-  public void members(final List<RoleMemberDbModel> members) {
-    this.members = members;
+  public RoleDbModel {
+    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
+    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
+    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    members = members != null ? members : new ArrayList<>();
   }
 
   @Override
   public RoleDbModel copy(
       final Function<ObjectBuilder<RoleDbModel>, ObjectBuilder<RoleDbModel>> copyFunction) {
     return copyFunction.apply(new Builder().roleKey(roleKey).name(name).members(members)).build();
-  }
-
-  @Override
-  public String toString() {
-    return "RoleDbModel{"
-        + "roleKey="
-        + roleKey
-        + ", roleId='"
-        + roleId
-        + ", name='"
-        + name
-        + ", description='"
-        + description
-        + '\''
-        + ", members="
-        + members
-        + '}';
   }
 
   public static class Builder implements ObjectBuilder<RoleDbModel> {
@@ -119,13 +66,7 @@ public class RoleDbModel implements DbModel<RoleDbModel> {
 
     @Override
     public RoleDbModel build() {
-      final RoleDbModel model = new RoleDbModel();
-      model.roleKey(roleKey);
-      model.roleId(roleId);
-      model.name(name);
-      model.description(description);
-      model.members(members);
-      return model;
+      return new RoleDbModel(roleKey, roleId, name, description, members);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -34,7 +34,15 @@ public record RoleDbModel(
   @Override
   public RoleDbModel copy(
       final Function<ObjectBuilder<RoleDbModel>, ObjectBuilder<RoleDbModel>> copyFunction) {
-    return copyFunction.apply(new Builder().roleKey(roleKey).name(name).members(members)).build();
+    return copyFunction
+        .apply(
+            new Builder()
+                .roleKey(roleKey)
+                .roleId(roleId)
+                .name(name)
+                .description(description)
+                .members(members))
+        .build();
   }
 
   public static class Builder implements ObjectBuilder<RoleDbModel> {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -17,15 +17,12 @@ public record RoleDbModel(
     implements DbModel<RoleDbModel> {
 
   public RoleDbModel {
-    // Mutable collections are required: MyBatis hydrates collection-mapped fields (e.g. from a
-    // <collection> result map or a LEFT JOIN) by calling .add() on the existing instance.
-    // Immutable defaults (e.g. List.of()) would cause UnsupportedOperationException at runtime.
+    // Must stay mutable: MyBatis appends to this via <collection> after construction.
     members = members != null ? members : new ArrayList<>();
   }
 
-  // Used by roleResultMap's <constructor>, which never supplies members -- it's populated
-  // separately by the sibling <collection> element, which requires (and only works with) an
-  // exact-arity constructor match; MyBatis does not default missing constructor args to null.
+  // Matches roleResultMap's <constructor>, which omits members -- populated separately via the
+  // sibling <collection> element.
   public RoleDbModel(
       final Long roleKey, final String roleId, final String name, final String description) {
     this(roleKey, roleId, name, description, null);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleDbModel.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.domain;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public record RoleDbModel(
@@ -18,7 +19,7 @@ public record RoleDbModel(
 
   public RoleDbModel {
     // Must stay mutable: MyBatis appends to this via <collection> after construction.
-    members = members != null ? members : new ArrayList<>();
+    members = Objects.requireNonNullElse(members, new ArrayList<>());
   }
 
   // Matches roleResultMap's <constructor>, which omits members -- populated separately via the

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
@@ -11,51 +11,40 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
 import java.util.function.Function;
 
-public final class SequenceFlowDbModel implements DbModel<SequenceFlowDbModel> {
+public record SequenceFlowDbModel(
+    String flowNodeId,
+    Long processInstanceKey,
+    Long rootProcessInstanceKey,
+    Long processDefinitionKey,
+    String processDefinitionId,
+    String tenantId,
+    int partitionId)
+    implements DbModel<SequenceFlowDbModel> {
 
   private static final String ID_PATTERN = "%s_%s";
-  private String flowNodeId;
-  private Long processInstanceKey;
-  private Long rootProcessInstanceKey;
-  private Long processDefinitionKey;
-  private String processDefinitionId;
-  private String tenantId;
-  private int partitionId;
+
+  // Used by the search resultMap, which never returns PARTITION_ID (write-only, insert-only
+  // column) -- mirrors the previous no-arg-constructor-plus-setters behavior where an unset int
+  // field defaulted to 0.
+  public SequenceFlowDbModel(
+      final String flowNodeId,
+      final Long processInstanceKey,
+      final Long rootProcessInstanceKey,
+      final Long processDefinitionKey,
+      final String processDefinitionId,
+      final String tenantId) {
+    this(
+        flowNodeId,
+        processInstanceKey,
+        rootProcessInstanceKey,
+        processDefinitionKey,
+        processDefinitionId,
+        tenantId,
+        0);
+  }
 
   public String sequenceFlowId() {
     return ID_PATTERN.formatted(processInstanceKey, flowNodeId);
-  }
-
-  public void flowNodeId(final String flowNodeId) {
-    this.flowNodeId = flowNodeId;
-  }
-
-  public void processInstanceKey(final Long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public void rootProcessInstanceKey(final Long rootProcessInstanceKey) {
-    this.rootProcessInstanceKey = rootProcessInstanceKey;
-  }
-
-  public void processDefinitionKey(final Long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public void processDefinitionId(final String processDefinitionId) {
-    this.processDefinitionId = processDefinitionId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public int partitionId() {
-    return partitionId;
-  }
-
-  public void partitionId(final int partitionId) {
-    this.partitionId = partitionId;
   }
 
   @Override
@@ -74,30 +63,8 @@ public final class SequenceFlowDbModel implements DbModel<SequenceFlowDbModel> {
         .build();
   }
 
-  public String flowNodeId() {
-    return flowNodeId;
-  }
-
-  public Long processInstanceKey() {
-    return processInstanceKey;
-  }
-
-  public Long rootProcessInstanceKey() {
-    return rootProcessInstanceKey;
-  }
-
-  public Long processDefinitionKey() {
-    return processDefinitionKey;
-  }
-
-  public String processDefinitionId() {
-    return processDefinitionId;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
+  // partitionId is broker-partition metadata, not part of this entity's identity -- two
+  // otherwise-identical flow records must remain equal regardless of which partition wrote them.
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -124,18 +91,6 @@ public final class SequenceFlowDbModel implements DbModel<SequenceFlowDbModel> {
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(processDefinitionId, that.processDefinitionId)
         && Objects.equals(tenantId, that.tenantId);
-  }
-
-  @Override
-  public String toString() {
-    return "SequenceFlowDbModel[flowNodeId=%s, processInstanceKey=%d, rootProcessInstanceKey=%d, processDefinitionKey=%d, processDefinitionId=%s, tenantId=%s]"
-        .formatted(
-            flowNodeId,
-            processInstanceKey,
-            rootProcessInstanceKey,
-            processDefinitionKey,
-            processDefinitionId,
-            tenantId);
   }
 
   public static class Builder implements ObjectBuilder<SequenceFlowDbModel> {
@@ -185,15 +140,14 @@ public final class SequenceFlowDbModel implements DbModel<SequenceFlowDbModel> {
 
     @Override
     public SequenceFlowDbModel build() {
-      final var dbModel = new SequenceFlowDbModel();
-      dbModel.flowNodeId(flowNodeId);
-      dbModel.processInstanceKey(processInstanceKey);
-      dbModel.rootProcessInstanceKey(rootProcessInstanceKey);
-      dbModel.processDefinitionKey(processDefinitionKey);
-      dbModel.processDefinitionId(processDefinitionId);
-      dbModel.tenantId(tenantId);
-      dbModel.partitionId(partitionId);
-      return dbModel;
+      return new SequenceFlowDbModel(
+          flowNodeId,
+          processInstanceKey,
+          rootProcessInstanceKey,
+          processDefinitionKey,
+          processDefinitionId,
+          tenantId,
+          partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
@@ -65,6 +65,8 @@ public record SequenceFlowDbModel(
 
   // partitionId is broker-partition metadata, not part of this entity's identity -- two
   // otherwise-identical flow records must remain equal regardless of which partition wrote them.
+  // toString() is overridden to match, so it doesn't print a field the type deliberately excludes
+  // from identity.
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -91,6 +93,18 @@ public record SequenceFlowDbModel(
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(processDefinitionId, that.processDefinitionId)
         && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public String toString() {
+    return "SequenceFlowDbModel[flowNodeId=%s, processInstanceKey=%d, rootProcessInstanceKey=%d, processDefinitionKey=%d, processDefinitionId=%s, tenantId=%s]"
+        .formatted(
+            flowNodeId,
+            processInstanceKey,
+            rootProcessInstanceKey,
+            processDefinitionKey,
+            processDefinitionId,
+            tenantId);
   }
 
   public static class Builder implements ObjectBuilder<SequenceFlowDbModel> {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
@@ -59,7 +59,8 @@ public record SequenceFlowDbModel(
                 .rootProcessInstanceKey(rootProcessInstanceKey)
                 .processDefinitionKey(processDefinitionKey)
                 .processDefinitionId(processDefinitionId)
-                .tenantId(tenantId))
+                .tenantId(tenantId)
+                .partitionId(partitionId))
         .build();
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/SequenceFlowDbModel.java
@@ -23,9 +23,8 @@ public record SequenceFlowDbModel(
 
   private static final String ID_PATTERN = "%s_%s";
 
-  // Used by the search resultMap, which never returns PARTITION_ID (write-only, insert-only
-  // column) -- mirrors the previous no-arg-constructor-plus-setters behavior where an unset int
-  // field defaulted to 0.
+  // Matches the search resultMap's <constructor>, which omits PARTITION_ID (write-only, never
+  // read back).
   public SequenceFlowDbModel(
       final String flowNodeId,
       final Long processInstanceKey,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantDbModel.java
@@ -8,31 +8,10 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
-import java.util.List;
 import java.util.function.Function;
 
-public class TenantDbModel implements DbModel<TenantDbModel> {
-
-  private Long tenantKey;
-  private String tenantId;
-  private String name;
-  private String description;
-  private List<TenantMemberDbModel> members;
-
-  public TenantDbModel() {}
-
-  private TenantDbModel(
-      final String tenantId,
-      final Long tenantKey,
-      final String name,
-      final String description,
-      final List<TenantMemberDbModel> members) {
-    this.tenantKey = tenantKey;
-    this.tenantId = tenantId;
-    this.name = name;
-    this.description = description;
-    this.members = members;
-  }
+public record TenantDbModel(String tenantId, Long tenantKey, String name, String description)
+    implements DbModel<TenantDbModel> {
 
   @Override
   public TenantDbModel copy(
@@ -47,58 +26,15 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
         .build();
   }
 
-  public Long tenantKey() {
-    return tenantKey;
-  }
-
-  public void tenantKey(final Long tenantKey) {
-    this.tenantKey = tenantKey;
-  }
-
-  public String tenantId() {
-    return tenantId;
-  }
-
-  public void tenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  public String name() {
-    return name;
-  }
-
-  public void name(final String name) {
-    this.name = name;
-  }
-
-  public String description() {
-    return description;
-  }
-
-  public void description(final String description) {
-    this.description = description;
-  }
-
-  public List<TenantMemberDbModel> members() {
-    return members;
-  }
-
-  public void members(final List<TenantMemberDbModel> members) {
-    this.members = members;
-  }
-
   public static class Builder implements ObjectBuilder<TenantDbModel> {
 
     private Long tenantKey;
     private String tenantId;
     private String name;
     private String description;
-    private List<TenantMemberDbModel> members;
 
-    // Public constructor to initialize the builder
     public Builder() {}
 
-    // Builder methods for each field
     public Builder tenantKey(final Long tenantKey) {
       this.tenantKey = tenantKey;
       return this;
@@ -119,14 +55,9 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
       return this;
     }
 
-    public Builder members(final List<TenantMemberDbModel> members) {
-      this.members = members;
-      return this;
-    }
-
     @Override
     public TenantDbModel build() {
-      return new TenantDbModel(tenantId, tenantKey, name, description, members);
+      return new TenantDbModel(tenantId, tenantKey, name, description);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -117,13 +117,16 @@
 
   <resultMap id="authorizationResultMap"
     type="io.camunda.db.rdbms.write.domain.AuthorizationDbModel">
-    <id column="AUTHORIZATION_KEY" property="authorizationKey"/>
-    <id column="OWNER_ID" property="ownerId"/>
-    <id column="OWNER_TYPE" property="ownerType"/>
-    <id column="RESOURCE_TYPE" property="resourceType"/>
-    <id column="RESOURCE_MATCHER" property="resourceMatcher"/>
-    <id column="RESOURCE_ID" property="resourceId"/>
-    <id column="RESOURCE_PROPERTY_NAME" property="resourcePropertyName"/>
+    <constructor>
+      <idArg name="authorizationKey" column="AUTHORIZATION_KEY" javaType="java.lang.Long"/>
+      <idArg name="ownerId" column="OWNER_ID" javaType="java.lang.String"/>
+      <idArg name="ownerType" column="OWNER_TYPE" javaType="java.lang.String"/>
+      <idArg name="resourceType" column="RESOURCE_TYPE" javaType="java.lang.String"/>
+      <idArg name="resourceMatcher" column="RESOURCE_MATCHER" javaType="java.lang.Short"/>
+      <idArg name="resourceId" column="RESOURCE_ID" javaType="java.lang.String"/>
+      <idArg name="resourcePropertyName" column="RESOURCE_PROPERTY_NAME"
+        javaType="java.lang.String"/>
+    </constructor>
     <collection property="permissionTypes"
       ofType="io.camunda.security.api.model.authz.PermissionType"
       javaType="java.util.Set">

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -8,24 +8,28 @@
   <resultMap id="BatchOperationResultMap"
     type="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     <constructor>
-      <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
-      <arg column="STATE"
+      <idArg name="batchOperationKey" column="BATCH_OPERATION_KEY" javaType="java.lang.String"/>
+      <arg name="state" column="STATE"
         javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationState"/>
-      <arg column="OPERATION_TYPE" javaType="io.camunda.search.entities.BatchOperationType"/>
-      <arg column="START_DATE" javaType="java.time.OffsetDateTime"/>
-      <arg column="END_DATE" javaType="java.time.OffsetDateTime"/>
-      <arg column="ACTOR_TYPE"
+      <arg name="operationType" column="OPERATION_TYPE"
+        javaType="io.camunda.search.entities.BatchOperationType"/>
+      <arg name="startDate" column="START_DATE" javaType="java.time.OffsetDateTime"/>
+      <arg name="endDate" column="END_DATE" javaType="java.time.OffsetDateTime"/>
+      <arg name="actorType" column="ACTOR_TYPE"
         javaType="io.camunda.search.entities.AuditLogEntity$AuditLogActorType"/>
-      <arg column="ACTOR_ID" javaType="java.lang.String"/>
-      <arg column="OPERATIONS_TOTAL_COUNT" javaType="int"/>
-      <arg column="OPERATIONS_FAILED_COUNT" javaType="int"/>
-      <arg column="OPERATIONS_COMPLETED_COUNT" javaType="int"/>
+      <arg name="actorId" column="ACTOR_ID" javaType="java.lang.String"/>
+      <arg name="operationsTotalCount" column="OPERATIONS_TOTAL_COUNT" javaType="int"/>
+      <arg name="operationsFailedCount" column="OPERATIONS_FAILED_COUNT" javaType="int"/>
+      <arg name="operationsCompletedCount" column="OPERATIONS_COMPLETED_COUNT" javaType="int"/>
     </constructor>
     <collection property="errors"
-      ofType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel$BatchOperationErrorDbModel">
-      <result property="partitionId" column="PARTITION_ID"/>
-      <result property="type" column="TYPE"/>
-      <result property="message" column="MESSAGE"/>
+      ofType="io.camunda.db.rdbms.write.domain.BatchOperationDbModel$BatchOperationErrorDbModel"
+      javaType="java.util.List">
+      <constructor>
+        <arg name="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
+        <arg name="type" column="TYPE" javaType="java.lang.String"/>
+        <arg name="message" column="MESSAGE" javaType="java.lang.String"/>
+      </constructor>
     </collection>
   </resultMap>
 

--- a/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GlobalListenerMapper.xml
@@ -71,15 +71,16 @@
 
   <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.GlobalListenerDbModel">
     <constructor>
-      <idArg column="ID" javaType="java.lang.String"/>
+      <idArg name="id" column="ID" javaType="java.lang.String"/>
+      <arg name="listenerId" column="LISTENER_ID" javaType="java.lang.String"/>
+      <arg name="type" column="TYPE" javaType="java.lang.String"/>
+      <arg name="retries" column="RETRIES" javaType="java.lang.Integer"/>
+      <arg name="afterNonGlobal" column="AFTER_NON_GLOBAL" javaType="_boolean"/>
+      <arg name="priority" column="PRIORITY" javaType="java.lang.Integer"/>
+      <arg name="source" column="SOURCE" javaType="io.camunda.search.entities.GlobalListenerSource"/>
+      <arg name="listenerType" column="LISTENER_TYPE"
+        javaType="io.camunda.search.entities.GlobalListenerType"/>
     </constructor>
-    <result property="listenerId" column="LISTENER_ID" javaType="java.lang.String"/>
-    <result property="type" column="TYPE" javaType="java.lang.String"/>
-    <result property="retries" column="RETRIES" javaType="java.lang.Integer"/>
-    <result property="afterNonGlobal" column="AFTER_NON_GLOBAL" javaType="java.lang.Boolean"/>
-    <result property="priority" column="PRIORITY" javaType="java.lang.Integer"/>
-    <result property="source" column="SOURCE" javaType="io.camunda.search.entities.GlobalListenerSource"/>
-    <result property="listenerType" column="LISTENER_TYPE" javaType="io.camunda.search.entities.GlobalListenerType"/>
     <collection property="eventTypes" ofType="java.lang.String" javaType="java.util.List">
       <id column="EVENT_TYPE"/>
     </collection>

--- a/db/rdbms/src/main/resources/mapper/GroupMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/GroupMapper.xml
@@ -150,10 +150,12 @@ SELECT
   </sql>
 
   <resultMap id="groupResultMap" type="io.camunda.db.rdbms.write.domain.GroupDbModel">
-    <id column="GROUP_ID" property="groupId"/>
-    <result column="GROUP_KEY" property="groupKey" />
-    <result column="NAME" property="name"/>
-    <result column="DESCRIPTION" property="description"/>
+    <constructor>
+      <arg name="groupKey" column="GROUP_KEY" javaType="java.lang.Long"/>
+      <idArg name="groupId" column="GROUP_ID" javaType="java.lang.String"/>
+      <arg name="name" column="NAME" javaType="java.lang.String"/>
+      <arg name="description" column="DESCRIPTION" javaType="java.lang.String"/>
+    </constructor>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.GroupMemberDbModel"
       javaType="java.util.List">
       <constructor>

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -138,10 +138,12 @@ FROM (
   </sql>
 
   <resultMap id="roleResultMap" type="io.camunda.db.rdbms.write.domain.RoleDbModel">
-    <id column="ROLE_ID" property="roleId"/>
-    <result column="ROLE_KEY" property="roleKey"/>
-    <result column="NAME" property="name"/>
-    <result column="DESCRIPTION" property="description"/>
+    <constructor>
+      <arg name="roleKey" column="ROLE_KEY" javaType="java.lang.Long"/>
+      <idArg name="roleId" column="ROLE_ID" javaType="java.lang.String"/>
+      <arg name="name" column="NAME" javaType="java.lang.String"/>
+      <arg name="description" column="DESCRIPTION" javaType="java.lang.String"/>
+    </constructor>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
       javaType="java.util.List">
       <constructor>

--- a/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/SequenceFlowMapper.xml
@@ -14,12 +14,15 @@
 
   <resultMap id="SequenceFlowResultMap"
     type="io.camunda.db.rdbms.write.domain.SequenceFlowDbModel">
-    <result column="FLOW_NODE_ID" property="flowNodeId" />
-    <result column="PROCESS_INSTANCE_KEY" property="processInstanceKey" />
-    <result column="ROOT_PROCESS_INSTANCE_KEY" property="rootProcessInstanceKey" />
-    <result column="PROCESS_DEFINITION_KEY" property="processDefinitionKey" />
-    <result column="PROCESS_DEFINITION_ID" property="processDefinitionId" />
-    <result column="TENANT_ID" property="tenantId" />
+    <constructor>
+      <arg name="flowNodeId" column="FLOW_NODE_ID" javaType="java.lang.String"/>
+      <arg name="processInstanceKey" column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg name="rootProcessInstanceKey" column="ROOT_PROCESS_INSTANCE_KEY"
+        javaType="java.lang.Long"/>
+      <arg name="processDefinitionKey" column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <arg name="processDefinitionId" column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg name="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
+    </constructor>
   </resultMap>
 
   <select id="search"

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -133,10 +133,12 @@
   </sql>
 
   <resultMap id="tenantResultMap" type="io.camunda.db.rdbms.write.domain.TenantDbModel">
-    <id column="TENANT_ID" property="tenantId"/>
-    <result column="TENANT_KEY" property="tenantKey"/>
-    <result column="NAME" property="name"/>
-    <result column="DESCRIPTION" property="description"/>
+    <constructor>
+      <idArg name="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
+      <arg name="tenantKey" column="TENANT_KEY" javaType="java.lang.Long"/>
+      <arg name="name" column="NAME" javaType="java.lang.String"/>
+      <arg name="description" column="DESCRIPTION" javaType="java.lang.String"/>
+    </constructor>
   </resultMap>
 
   <resultMap id="tenantMemberResultMap" type="io.camunda.db.rdbms.write.domain.TenantMemberDbModel">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapperTest.java
@@ -22,10 +22,8 @@ class BatchOperationEntityMapperTest {
 
   @Test
   void shouldMapDbModelToEntity() {
-    final var errorDbModel = new BatchOperationDbModel.BatchOperationErrorDbModel();
-    errorDbModel.partitionId(1);
-    errorDbModel.type("ERROR_TYPE");
-    errorDbModel.message("stacktrace");
+    final var errorDbModel =
+        new BatchOperationDbModel.BatchOperationErrorDbModel(1, "ERROR_TYPE", "stacktrace");
 
     final var dbModel =
         new BatchOperationDbModel.Builder()
@@ -82,10 +80,8 @@ class BatchOperationEntityMapperTest {
 
   @Test
   void shouldMapErrorDbModelToErrorEntity() {
-    final var errorDbModel = new BatchOperationDbModel.BatchOperationErrorDbModel();
-    errorDbModel.partitionId(42);
-    errorDbModel.type("SOME_ERROR");
-    errorDbModel.message("trace");
+    final var errorDbModel =
+        new BatchOperationDbModel.BatchOperationErrorDbModel(42, "SOME_ERROR", "trace");
 
     final var errorEntity = BatchOperationEntityMapper.toErrorEntity(errorDbModel);
 


### PR DESCRIPTION
## Summary

First step towards converting all RDBMS `*DbModel`s to records, so we can add an ArchUnit rule enforcing it (tracked in #58450). Converts 7 of the remaining plain-class ones: `TenantDbModel`, `RoleDbModel`, `GroupDbModel`, `SequenceFlowDbModel`, `AuthorizationDbModel`, `GlobalListenerDbModel`, `BatchOperationDbModel` (+ nested `BatchOperationErrorDbModel`).

Why records:
- DbModels flow through `ExecutionQueue`'s merge/copy path. Immutability makes "an item handed to the queue can't change before flush" true by construction instead of relying on discipline.
- Consistency: 22/40 DbModels were already records before this PR.
- Less code, removes some of the boiler plote
- Sets up the ArchUnit rule that will stop new mutable DbModels from being added.

Each mapper's resultMap moves from property-based to constructor-based mapping, since records have no setters.