### PR TITLE
56575 Aws secrets store implementation

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -20,11 +20,11 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *
  * <ul>
  *   <li>{@code camunda.secrets.stores.file.<id>.path}
- *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.region}
- *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.path-prefix}
- *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.batch-enabled}
- *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.batch-size}
- *   <li>{@code camunda.secrets.stores.aws-secrets-manager.<id>.container-secret-id}
+ *   <li>{@code camunda.secrets.stores.aws.<id>.region}
+ *   <li>{@code camunda.secrets.stores.aws.<id>.path-prefix}
+ *   <li>{@code camunda.secrets.stores.aws.<id>.batch-enabled}
+ *   <li>{@code camunda.secrets.stores.aws.<id>.batch-size}
+ *   <li>{@code camunda.secrets.stores.aws.<id>.container-secret-id}
  * </ul>
  *
  * <p>Secrets configuration is overridable per physical tenant via {@code
@@ -46,7 +46,7 @@ public class Secrets {
   public static class Stores {
 
     private Map<String, FileStore> file = new LinkedHashMap<>();
-    private Map<String, AwsSecretsManagerStore> awsSecretsManager = new LinkedHashMap<>();
+    private Map<String, AwsSecretsManagerStore> aws = new LinkedHashMap<>();
 
     public Map<String, FileStore> getFile() {
       return file;
@@ -62,13 +62,13 @@ public class Secrets {
      *     contradictory: batching fetches multiple distinct secrets in one call, while a container
      *     secret id means only one secret is ever fetched)
      */
-    public Map<String, AwsSecretsManagerStore> getAwsSecretsManager() {
-      awsSecretsManager.forEach((id, store) -> store.validate(id));
-      return awsSecretsManager;
+    public Map<String, AwsSecretsManagerStore> getAws() {
+      aws.forEach((id, store) -> store.validate(id));
+      return aws;
     }
 
-    public void setAwsSecretsManager(final Map<String, AwsSecretsManagerStore> awsSecretsManager) {
-      this.awsSecretsManager = awsSecretsManager;
+    public void setAws(final Map<String, AwsSecretsManagerStore> aws) {
+      this.aws = aws;
     }
   }
 
@@ -126,8 +126,12 @@ public class Secrets {
 
     /**
      * Opt-in: instead of one AWS secret per reference, treat every reference as a JSON key inside
-     * this one named secret (e.g. {@code app-config}, a JSON object of key-value pairs). Mutually
-     * exclusive with {@link #batchEnabled}, since only this single secret is ever fetched.
+     * this one named secret (e.g. {@code app-config}). Mutually exclusive with {@link
+     * #batchEnabled}, since only this single secret is ever fetched.
+     *
+     * <p>The named secret's string value must be a flat JSON object mapping each reference name to
+     * a JSON string value (e.g. {@code {"db-password": "s3cr3t"}}); nested objects/arrays are not
+     * supported, and a non-object value makes the store unusable.
      */
     private @Nullable String containerSecretId;
 
@@ -172,22 +176,33 @@ public class Secrets {
     }
 
     /**
-     * @throws IllegalArgumentException if batch-size is outside the 1..20 range AWS accepts, or if
-     *     both batch-enabled and container-secret-id are set (the two are contradictory: batching
-     *     fetches multiple distinct secrets in one call, while a container secret id means only one
-     *     secret is ever fetched)
+     * Mirrors the invariants of {@code io.camunda.secretstore.aws.AwsSecretsManagerStoreConfig}'s
+     * canonical constructor in the {@code secret-store-aws} module (not depended on from here, to
+     * keep this module free of the AWS SDK) — with property-path-aware messages instead of that
+     * record's generic ones. Keep both in sync: a new rule added to one but not the other leaves a
+     * gap for whichever path skips this one (Spring config binding here vs. any other caller of
+     * that record's constructor directly).
+     *
+     * @throws IllegalArgumentException if batch-size is outside the 1..20 range AWS accepts, if
+     *     container-secret-id is blank, or if both batch-enabled and container-secret-id are set
+     *     (the two are contradictory: batching fetches multiple distinct secrets in one call, while
+     *     a container secret id means only one secret is ever fetched)
      */
     void validate(final String storeId) {
       if (batchSize < 1 || batchSize > 20) {
         throw new IllegalArgumentException(
-            "camunda.secrets.stores.aws-secrets-manager."
+            "camunda.secrets.stores.aws."
                 + storeId
                 + ".batch-size must be between 1 and 20, but was "
                 + batchSize);
       }
+      if (containerSecretId != null && containerSecretId.isBlank()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.aws." + storeId + ".container-secret-id must not be blank");
+      }
       if (batchEnabled && containerSecretId != null) {
         throw new IllegalArgumentException(
-            "camunda.secrets.stores.aws-secrets-manager."
+            "camunda.secrets.stores.aws."
                 + storeId
                 + ".batch-enabled and .container-secret-id are mutually exclusive, but both were "
                 + "configured");

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
@@ -16,10 +16,10 @@ import java.util.List;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Per-tenant {@link Secrets} resolution: registers the {@code stores.file} and {@code
- * stores.aws-secrets-manager} named maps so that {@link PhysicalTenantMapOverlay} deep-merges them
- * per physical tenant (the generic two-bind has a defect that drops unmentioned root entries when a
- * tenant overrides only some map keys).
+ * Per-tenant {@link Secrets} resolution: registers the {@code stores.file} and {@code stores.aws}
+ * named maps so that {@link PhysicalTenantMapOverlay} deep-merges them per physical tenant (the
+ * generic two-bind has a defect that drops unmentioned root entries when a tenant overrides only
+ * some map keys).
  */
 @NullMarked
 final class PhysicalTenantSecretConfigurations {
@@ -32,9 +32,7 @@ final class PhysicalTenantSecretConfigurations {
           List.of(
               new MapDescriptor<>("stores.file", FileStore.class, s -> s.getStores().getFile()),
               new MapDescriptor<>(
-                  "stores.aws-secrets-manager",
-                  AwsSecretsManagerStore.class,
-                  s -> s.getStores().getAwsSecretsManager())),
+                  "stores.aws", AwsSecretsManagerStore.class, s -> s.getStores().getAws())),
           MapOverlaySpec.noHook(),
           Camunda::setSecrets);
 

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -66,9 +66,9 @@ class SecretsTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.secrets.stores.aws-secrets-manager.aws-prod.region=eu-west-1",
-        "camunda.secrets.stores.aws-secrets-manager.aws-prod.path-prefix=camunda/",
-        "camunda.secrets.stores.aws-secrets-manager.aws-minimal.path-prefix=team/"
+        "camunda.secrets.stores.aws.aws-prod.region=eu-west-1",
+        "camunda.secrets.stores.aws.aws-prod.path-prefix=camunda/",
+        "camunda.secrets.stores.aws.aws-minimal.path-prefix=team/"
       })
   class WithAwsSecretsManagerStoreConfigured {
     private final UnifiedConfiguration unifiedConfiguration;
@@ -80,12 +80,12 @@ class SecretsTest {
 
     @Test
     void shouldBindAwsSecretsManagerStoreProperties() {
-      // given the camunda.secrets.stores.aws-secrets-manager.aws-prod.* properties are set
+      // given the camunda.secrets.stores.aws.aws-prod.* properties are set
       // when the unified configuration is bound
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then the named store is present and its fields are bound
-      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-prod"))
+      assertThat(secrets.getStores().getAws().get("aws-prod"))
           .satisfies(
               store -> {
                 assertThat(store.getRegion()).isEqualTo("eu-west-1");
@@ -100,7 +100,7 @@ class SecretsTest {
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then batching defaults to off, with the standard AWS batch size as an inert default
-      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-prod"))
+      assertThat(secrets.getStores().getAws().get("aws-prod"))
           .satisfies(
               store -> {
                 assertThat(store.isBatchEnabled()).isFalse();
@@ -115,19 +115,17 @@ class SecretsTest {
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then it defaults to the flat one-secret-per-reference mode
-      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-prod").getContainerSecretId())
-          .isNull();
+      assertThat(secrets.getStores().getAws().get("aws-prod").getContainerSecretId()).isNull();
     }
 
     @Test
     void shouldBindMultipleStoresKeyedById() {
-      // given two aws-secrets-manager stores are configured (see @TestPropertySource)
+      // given two aws stores are configured (see @TestPropertySource)
       // when the unified configuration is bound
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then both store ids are present
-      assertThat(secrets.getStores().getAwsSecretsManager())
-          .containsKeys("aws-prod", "aws-minimal");
+      assertThat(secrets.getStores().getAws()).containsKeys("aws-prod", "aws-minimal");
     }
 
     @Test
@@ -137,7 +135,7 @@ class SecretsTest {
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then region is null and path-prefix is still bound
-      assertThat(secrets.getStores().getAwsSecretsManager().get("aws-minimal"))
+      assertThat(secrets.getStores().getAws().get("aws-minimal"))
           .satisfies(
               store -> {
                 assertThat(store.getRegion()).isNull();
@@ -149,8 +147,8 @@ class SecretsTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.secrets.stores.aws-secrets-manager.batched.batch-enabled=true",
-        "camunda.secrets.stores.aws-secrets-manager.batched.batch-size=5"
+        "camunda.secrets.stores.aws.batched.batch-enabled=true",
+        "camunda.secrets.stores.aws.batched.batch-size=5"
       })
   class WithBatchingConfigured {
     private final UnifiedConfiguration unifiedConfiguration;
@@ -166,7 +164,7 @@ class SecretsTest {
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then both are bound onto the named store
-      assertThat(secrets.getStores().getAwsSecretsManager().get("batched"))
+      assertThat(secrets.getStores().getAws().get("batched"))
           .satisfies(
               store -> {
                 assertThat(store.isBatchEnabled()).isTrue();
@@ -177,9 +175,7 @@ class SecretsTest {
 
   @Nested
   @TestPropertySource(
-      properties = {
-        "camunda.secrets.stores.aws-secrets-manager.bundled.container-secret-id=app-config"
-      })
+      properties = {"camunda.secrets.stores.aws.bundled.container-secret-id=app-config"})
   class WithContainerSecretIdConfigured {
     private final UnifiedConfiguration unifiedConfiguration;
 
@@ -194,7 +190,7 @@ class SecretsTest {
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
       // then it is bound onto the named store
-      assertThat(secrets.getStores().getAwsSecretsManager().get("bundled").getContainerSecretId())
+      assertThat(secrets.getStores().getAws().get("bundled").getContainerSecretId())
           .isEqualTo("app-config");
     }
   }
@@ -202,8 +198,8 @@ class SecretsTest {
   @Nested
   @TestPropertySource(
       properties = {
-        "camunda.secrets.stores.aws-secrets-manager.conflicted.batch-enabled=true",
-        "camunda.secrets.stores.aws-secrets-manager.conflicted.container-secret-id=app-config"
+        "camunda.secrets.stores.aws.conflicted.batch-enabled=true",
+        "camunda.secrets.stores.aws.conflicted.container-secret-id=app-config"
       })
   class WithBatchingAndContainerSecretIdBothConfigured {
     private final UnifiedConfiguration unifiedConfiguration;
@@ -221,13 +217,12 @@ class SecretsTest {
       final Secrets.Stores stores = secrets.getStores();
 
       // then reading the store map throws, since the combination is contradictory
-      assertThatThrownBy(stores::getAwsSecretsManager).isInstanceOf(IllegalArgumentException.class);
+      assertThatThrownBy(stores::getAws).isInstanceOf(IllegalArgumentException.class);
     }
   }
 
   @Nested
-  @TestPropertySource(
-      properties = {"camunda.secrets.stores.aws-secrets-manager.oversized.batch-size=50"})
+  @TestPropertySource(properties = {"camunda.secrets.stores.aws.oversized.batch-size=50"})
   class WithBatchSizeOutOfRange {
     private final UnifiedConfiguration unifiedConfiguration;
 
@@ -243,7 +238,28 @@ class SecretsTest {
       final Secrets.Stores stores = secrets.getStores();
 
       // then reading the store map throws
-      assertThatThrownBy(stores::getAwsSecretsManager).isInstanceOf(IllegalArgumentException.class);
+      assertThatThrownBy(stores::getAws).isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.aws.blank.container-secret-id= "})
+  class WithBlankContainerSecretId {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBlankContainerSecretId(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectBlankContainerSecretId() {
+      // given container-secret-id is set to a blank string (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getAws).isInstanceOf(IllegalArgumentException.class);
     }
   }
 
@@ -262,8 +278,8 @@ class SecretsTest {
       // when the unified configuration is bound
       final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
 
-      // then the aws-secrets-manager map is empty
-      assertThat(secrets.getStores().getAwsSecretsManager()).isEmpty();
+      // then the aws map is empty
+      assertThat(secrets.getStores().getAws()).isEmpty();
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
@@ -149,12 +149,12 @@ class PhysicalTenantSecretsOverlayTest {
 
   @Test
   void shouldOverlayAwsSecretsManagerStorePerTenant() {
-    // given a root aws-secrets-manager store and a tenant that overrides its path-prefix
+    // given a root aws store and a tenant that overrides its path-prefix
     setProperties(
         new HashMap<>(
             Map.of(
-                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
-                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.path-prefix",
+                "camunda.secrets.stores.aws.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws.shared.path-prefix",
                     "tenanta/")),
         "tenanta");
 
@@ -167,7 +167,7 @@ class PhysicalTenantSecretsOverlayTest {
                 .forPhysicalTenant("tenanta")
                 .getSecrets()
                 .getStores()
-                .getAwsSecretsManager()
+                .getAws()
                 .get("shared")
                 .getPathPrefix())
         .isEqualTo("tenanta/");
@@ -176,7 +176,7 @@ class PhysicalTenantSecretsOverlayTest {
                 .forPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .getSecrets()
                 .getStores()
-                .getAwsSecretsManager()
+                .getAws()
                 .get("shared")
                 .getPathPrefix())
         .isEqualTo("camunda/");
@@ -184,10 +184,9 @@ class PhysicalTenantSecretsOverlayTest {
 
   @Test
   void shouldInheritRootAwsSecretsManagerStoreWhenTenantHasNoSecretsOverride() {
-    // given only a root aws-secrets-manager store; the tenant overrides no secrets field
+    // given only a root aws store; the tenant overrides no secrets field
     setProperties(
-        new HashMap<>(
-            Map.of("camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/")),
+        new HashMap<>(Map.of("camunda.secrets.stores.aws.shared.path-prefix", "camunda/")),
         "tenanta");
 
     // when the resolver produces a Camunda per tenant
@@ -199,7 +198,7 @@ class PhysicalTenantSecretsOverlayTest {
                 .forPhysicalTenant("tenanta")
                 .getSecrets()
                 .getStores()
-                .getAwsSecretsManager()
+                .getAws()
                 .get("shared")
                 .getPathPrefix())
         .isEqualTo("camunda/");
@@ -211,10 +210,9 @@ class PhysicalTenantSecretsOverlayTest {
     setProperties(
         new HashMap<>(
             Map.of(
-                "camunda.secrets.stores.aws-secrets-manager.shared.region", "eu-west-1",
-                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
-                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.region",
-                    "us-east-1")),
+                "camunda.secrets.stores.aws.shared.region", "eu-west-1",
+                "camunda.secrets.stores.aws.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws.shared.region", "us-east-1")),
         "tenanta");
 
     // when the resolver produces a Camunda per tenant
@@ -222,12 +220,7 @@ class PhysicalTenantSecretsOverlayTest {
 
     // then tenanta's region is overridden but path-prefix survives the deep merge from root
     final var store =
-        resolver
-            .forPhysicalTenant("tenanta")
-            .getSecrets()
-            .getStores()
-            .getAwsSecretsManager()
-            .get("shared");
+        resolver.forPhysicalTenant("tenanta").getSecrets().getStores().getAws().get("shared");
     assertThat(store.getRegion()).isEqualTo("us-east-1");
     assertThat(store.getPathPrefix()).isEqualTo("camunda/");
   }
@@ -238,8 +231,8 @@ class PhysicalTenantSecretsOverlayTest {
     setProperties(
         new HashMap<>(
             Map.of(
-                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
-                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.batch-enabled",
+                "camunda.secrets.stores.aws.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws.shared.batch-enabled",
                     "true")),
         "tenanta");
 
@@ -248,12 +241,7 @@ class PhysicalTenantSecretsOverlayTest {
 
     // then tenanta's batch-enabled is overridden but path-prefix survives the deep merge
     final var store =
-        resolver
-            .forPhysicalTenant("tenanta")
-            .getSecrets()
-            .getStores()
-            .getAwsSecretsManager()
-            .get("shared");
+        resolver.forPhysicalTenant("tenanta").getSecrets().getStores().getAws().get("shared");
     assertThat(store.isBatchEnabled()).isTrue();
     assertThat(store.getPathPrefix()).isEqualTo("camunda/");
     assertThat(
@@ -261,7 +249,7 @@ class PhysicalTenantSecretsOverlayTest {
                 .forPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .getSecrets()
                 .getStores()
-                .getAwsSecretsManager()
+                .getAws()
                 .get("shared")
                 .isBatchEnabled())
         .isFalse();
@@ -274,8 +262,8 @@ class PhysicalTenantSecretsOverlayTest {
     setProperties(
         new HashMap<>(
             Map.of(
-                "camunda.secrets.stores.aws-secrets-manager.shared.path-prefix", "camunda/",
-                "camunda.physical-tenants.tenanta.secrets.stores.aws-secrets-manager.shared.path-prefix",
+                "camunda.secrets.stores.aws.shared.path-prefix", "camunda/",
+                "camunda.physical-tenants.tenanta.secrets.stores.aws.shared.path-prefix",
                     "tenanta/")),
         "tenanta");
 
@@ -284,19 +272,13 @@ class PhysicalTenantSecretsOverlayTest {
 
     // then it contains a Secrets per tenant with the correct per-tenant path-prefix
     assertThat(registry).containsKeys("tenanta", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    assertThat(
-            registry
-                .get("tenanta")
-                .getStores()
-                .getAwsSecretsManager()
-                .get("shared")
-                .getPathPrefix())
+    assertThat(registry.get("tenanta").getStores().getAws().get("shared").getPathPrefix())
         .isEqualTo("tenanta/");
     assertThat(
             registry
                 .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .getStores()
-                .getAwsSecretsManager()
+                .getAws()
                 .get("shared")
                 .getPathPrefix())
         .isEqualTo("camunda/");

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -314,7 +314,7 @@ provider-auth.aws.role-arn
 provider-auth.aws.secret-key
 provider-auth.aws.session-token
 provider-auth.aws.web-identity-token-file
-secrets.stores.aws-secrets-manager
+secrets.stores.aws
 secrets.stores.file
 security.authentication
 security.authentication.authentication-refresh-interval

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -456,6 +456,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-aws</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -12,9 +12,13 @@ import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretStore;
 import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
+import io.camunda.secretstore.aws.AwsSecretsManagerStoreConfig;
 import io.camunda.secretstore.file.FileBasedSecretStore;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
@@ -33,46 +37,105 @@ public class SecretStoreConfiguration {
   @Bean
   public SecretStoreRegistries secretStoreRegistries(final PhysicalTenantResolver resolver) {
     final Map<String, SecretStoreRegistry> registries = new LinkedHashMap<>();
-    resolver
-        .mapValues(Camunda::getSecrets)
-        .forEach(
-            (tenantId, secrets) -> {
-              final var fileStores = secrets.getStores().getFile();
-              if (fileStores.size() > 1) {
-                throw new IllegalStateException(
-                    "Physical tenant '"
-                        + tenantId
-                        + "' has "
-                        + fileStores.size()
-                        + " secret stores configured, but only one is supported at this time");
-              }
-              final Map<String, SecretStore> stores = new LinkedHashMap<>();
-              fileStores.forEach(
-                  (storeId, fileStore) -> {
-                    final var path = fileStore.getPath();
-                    if (path.isBlank()) {
-                      throw new IllegalStateException(
-                          "File store '"
-                              + storeId
-                              + "' for physical tenant '"
-                              + tenantId
-                              + "' has no path configured");
-                    }
-                    stores.put(
-                        storeId.trim().toLowerCase(), new FileBasedSecretStore(Path.of(path)));
-                    LOG.info(
-                        "Registered file secret store '{}' for physical tenant '{}'",
-                        storeId.trim().toLowerCase(),
-                        tenantId);
-                  });
-              if (stores.isEmpty()) {
-                stores.put("default", NOOP_STORE);
-                LOG.info(
-                    "No secret stores configured for physical tenant '{}', using noop store",
-                    tenantId);
-              }
-              registries.put(tenantId, new SecretStoreRegistry(Map.copyOf(stores)));
-            });
+    // tracks every store successfully constructed across all tenants processed so far, so a
+    // failure partway through (e.g. a later tenant's AWS store failing to build) can close
+    // them instead of leaking their underlying clients/connections
+    final List<SecretStore> created = new ArrayList<>();
+    try {
+      resolver
+          .mapValues(Camunda::getSecrets)
+          .forEach(
+              (tenantId, secrets) -> {
+                final var fileStores = secrets.getStores().getFile();
+                final var awsStores = secrets.getStores().getAws();
+                // cap is one store total per tenant, counted across all store types combined
+                final var totalStores = fileStores.size() + awsStores.size();
+                if (totalStores > 1) {
+                  throw new IllegalStateException(
+                      "Physical tenant '"
+                          + tenantId
+                          + "' has "
+                          + totalStores
+                          + " secret stores configured, but only one is supported at this time");
+                }
+                final Map<String, SecretStore> stores = new LinkedHashMap<>();
+                fileStores.forEach(
+                    (storeId, fileStore) -> {
+                      final var path = fileStore.getPath();
+                      if (path.isBlank()) {
+                        throw new IllegalStateException(
+                            "File store '"
+                                + storeId
+                                + "' for physical tenant '"
+                                + tenantId
+                                + "' has no path configured");
+                      }
+                      registerStore(
+                          stores,
+                          created,
+                          storeId,
+                          tenantId,
+                          "file",
+                          new FileBasedSecretStore(Path.of(path)));
+                    });
+                awsStores.forEach(
+                    (storeId, awsStore) -> {
+                      final var config =
+                          new AwsSecretsManagerStoreConfig(
+                              awsStore.getRegion(),
+                              awsStore.getPathPrefix(),
+                              awsStore.getContainerSecretId(),
+                              null,
+                              AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+                              awsStore.isBatchEnabled(),
+                              awsStore.getBatchSize());
+                      registerStore(
+                          stores,
+                          created,
+                          storeId,
+                          tenantId,
+                          "AWS Secrets Manager",
+                          AwsSecretsManagerSecretStore.fromConfig(config));
+                    });
+                if (stores.isEmpty()) {
+                  stores.put("default", NOOP_STORE);
+                  LOG.info(
+                      "No secret stores configured for physical tenant '{}', using noop store",
+                      tenantId);
+                }
+                registries.put(tenantId, new SecretStoreRegistry(Map.copyOf(stores)));
+              });
+    } catch (final RuntimeException e) {
+      closeAll(created);
+      throw e;
+    }
     return new SecretStoreRegistries(Map.copyOf(registries));
+  }
+
+  private static void closeAll(final List<SecretStore> stores) {
+    for (final var store : stores) {
+      try {
+        store.close();
+      } catch (final RuntimeException closeFailure) {
+        LOG.warn("Failed to close secret store while rolling back a failed startup", closeFailure);
+      }
+    }
+  }
+
+  private static void registerStore(
+      final Map<String, SecretStore> stores,
+      final List<SecretStore> created,
+      final String storeId,
+      final String tenantId,
+      final String storeType,
+      final SecretStore store) {
+    final var normalizedId = storeId.trim().toLowerCase();
+    stores.put(normalizedId, store);
+    created.add(store);
+    LOG.info(
+        "Registered {} secret store '{}' for physical tenant '{}'",
+        storeType,
+        normalizedId,
+        tenantId);
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -14,6 +14,7 @@ import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.aws.AwsSecretsManagerSecretStore;
 import io.camunda.secretstore.file.FileBasedSecretStore;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -160,6 +161,41 @@ class SecretStoreConfigurationTest {
     assertThat(registries).containsKeys("tenanta", "tenantb");
     assertThat(registries.get("tenanta").getStores()).containsKey("main");
     assertThat(registries.get("tenantb").getStores()).containsKey("other");
+  }
+
+  @Test
+  void shouldBuildAwsSecretsManagerStoreWhenConfigured() {
+    // given
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.secrets.stores.aws.aws-main.region", "eu-west-1",
+                "camunda.secrets.stores.aws.aws-main.path-prefix", "camunda/"));
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver).byPhysicalTenant();
+
+    // then
+    final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(registry.getStores()).containsKey("aws-main");
+    assertThat(registry.getStores().get("aws-main"))
+        .isInstanceOf(AwsSecretsManagerSecretStore.class);
+  }
+
+  @Test
+  void shouldThrowWhenFileAndAwsSecretsManagerStoresCombinedExceedOne() {
+    // given one file store and one aws store for the same tenant
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.secrets.stores.file.file-store.path", "/etc/camunda/secrets",
+                "camunda.secrets.stores.aws.aws-store.region", "eu-west-1"));
+
+    // when / then
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .withMessageContaining("only one is supported");
   }
 
   private static PhysicalTenantResolver resolverFor(final Map<String, Object> properties) {

--- a/secret-store/secret-store-aws/pom.xml
+++ b/secret-store/secret-store-aws/pom.xml
@@ -18,41 +18,98 @@
 
   <name>Camunda Secret Store AWS Secrets Manager Implementation</name>
 
-  <properties>
-    <!-- Remove this property and the empty-javadoc-jar execution below once this module has
-         public classes to document. -->
-    <maven.javadoc.skip>true</maven.javadoc.skip>
-  </properties>
-
   <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
 
-  <build>
-    <plugins>
-      <!-- maven.javadoc.skip disables the real javadoc jar, so attach an empty placeholder to
-           satisfy the "every non-pom artifact ships a javadoc jar" release requirement. -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>empty-javadoc-jar</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${basedir}/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>secretsmanager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>retries</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>retries-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-localstack</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretResolver.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * One AWS Secrets Manager resolution algorithm: how reference names are mapped to secret ids and
+ * read. {@link AwsSecretsManagerSecretStore} picks exactly one implementation at construction time
+ * based on configuration and delegates every call to it.
+ */
+interface AwsSecretResolver {
+
+  /**
+   * @throws SecretStoreUnavailableException if the backing store cannot be accessed
+   */
+  Map<String, SecretResolutionResult> resolve(Set<String> names);
+
+  /**
+   * @throws SecretStoreUnavailableException if the backing store cannot be accessed or its content
+   *     is malformed
+   */
+  List<String> list();
+}

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerErrors.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerErrors.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static io.camunda.secretstore.SecretErrorCode.ACCESS_DENIED;
+import static io.camunda.secretstore.SecretErrorCode.INVALID_REF;
+import static io.camunda.secretstore.SecretErrorCode.NOT_FOUND;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+/** AWS error classification and messaging shared by every {@link AwsSecretResolver}. */
+final class AwsSecretsManagerErrors {
+
+  private AwsSecretsManagerErrors() {}
+
+  /**
+   * Maps a per-secret AWS Secrets Manager exception (the shape thrown by single-item calls such as
+   * {@code GetSecretValue}) to a {@link SecretErrorCode}, via the same AWS error-code string that
+   * {@link #classifyErrorCode} uses for batch per-item errors — the code string is present on both
+   * shapes ({@link SecretsManagerException#awsErrorDetails()} vs. {@code
+   * APIErrorType#errorCode()}), so one classification table serves both instead of a separate
+   * exception-type-based mapping.
+   *
+   * @throws SecretStoreUnavailableException if {@code e} indicates a store-wide failure rather than
+   *     a per-secret one (e.g. throttling, service error)
+   */
+  static SecretErrorCode classify(final SecretsManagerException e) {
+    final var code = classifyErrorCode(errorCodeOf(e));
+    if (code != null) {
+      return code;
+    }
+    // fallback for a denial that doesn't carry a recognizable error-code string
+    if (isAccessDenied(e)) {
+      return ACCESS_DENIED;
+    }
+    throw storeUnavailable(e);
+  }
+
+  private static @Nullable String errorCodeOf(final SecretsManagerException e) {
+    final var details = e.awsErrorDetails();
+    return details != null ? details.errorCode() : null;
+  }
+
+  /**
+   * Classifies a raw per-item AWS error code from a {@code BatchGetSecretValue} error entry (which
+   * carries only a code string, not an exception to throw).
+   *
+   * @return the classified code, or {@code null} if it isn't one of the known per-secret codes,
+   *     meaning it's a store-wide problem the caller must handle separately
+   */
+  static @Nullable SecretErrorCode classifyErrorCode(final @Nullable String errorCode) {
+    if (errorCode == null) {
+      return null;
+    }
+    // defensive: tolerate incidental leading/trailing whitespace AWS shouldn't send but hasn't
+    // contractually promised never to
+    final var normalized = errorCode.strip();
+    return switch (normalized) {
+      case "ResourceNotFoundException" -> NOT_FOUND;
+      case "InvalidParameterException", "InvalidRequestException" -> INVALID_REF;
+      case "DecryptionFailure", "DecryptionFailureException", "AccessDeniedException" ->
+          ACCESS_DENIED;
+      default -> normalized.contains("AccessDenied") ? ACCESS_DENIED : null;
+    };
+  }
+
+  static boolean isAccessDenied(final SecretsManagerException e) {
+    final var details = e.awsErrorDetails();
+    if (details != null && details.errorCode() != null) {
+      return details.errorCode().contains("AccessDenied");
+    }
+    return e.statusCode() == 403;
+  }
+
+  /**
+   * A human-readable per-secret failure message, shared by every resolver so the wording is
+   * consistent regardless of resolution mode.
+   *
+   * @param what what {@code id} identifies, e.g. {@code "secret"} or {@code "container secret"}
+   */
+  static String messageFor(final SecretErrorCode code, final String what, final String id) {
+    return switch (code) {
+      case NOT_FOUND -> capitalize(what) + " not found: " + id;
+      case INVALID_REF -> "Invalid " + what + " reference: " + id;
+      case ACCESS_DENIED -> "Access denied for " + what + ": " + id;
+      case UNREADABLE -> capitalize(what) + " is unreadable: " + id;
+    };
+  }
+
+  private static String capitalize(final String s) {
+    return s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+  }
+
+  static SecretStoreUnavailableException storeUnavailable(final Exception e) {
+    return new SecretStoreUnavailableException(
+        "AWS Secrets Manager is unavailable: " + e.getMessage(), e);
+  }
+}

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.DefaultRetryStrategy;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+
+/**
+ * A {@link SecretStore} backed by AWS Secrets Manager.
+ *
+ * <p>References are mapped to AWS secret ids by prepending the configured {@code pathPrefix}.
+ * Values are read from the {@code AWSCURRENT} version stage (the SDK default). Authentication uses
+ * the AWS SDK default credentials provider chain.
+ *
+ * <p>How a reference is actually looked up is delegated to one {@link AwsSecretResolver}, chosen
+ * once at construction time: {@link FlatSecretResolver} by default (one AWS secret per reference,
+ * optionally batched via {@code BatchGetSecretValue}), or {@link ContainerSecretResolver} when a
+ * container secret id is set (every reference is a JSON key inside one shared secret). This class
+ * itself only owns the AWS client and picks the resolver; adding a new resolution mode means adding
+ * a new {@link AwsSecretResolver} implementation, not touching this class or the existing ones.
+ *
+ * <p>Per-secret failures (missing secret, access denied, invalid reference) are returned as {@link
+ * SecretResolutionResult.Failed} results. Store-wide failures (connectivity, throttling after
+ * retries, service errors) are surfaced as {@link SecretStoreUnavailableException} so callers can
+ * retry or back off.
+ *
+ * <p>This class is thread-safe: {@link SecretsManagerClient} is thread-safe, {@link
+ * AwsSecretResolver} implementations keep no mutable state between calls, and neither does this
+ * class.
+ */
+public final class AwsSecretsManagerSecretStore implements SecretStore {
+
+  private final SecretsManagerClient client;
+  private final AwsSecretResolver resolver;
+
+  /**
+   * Creates a store using an already-built client, with batching disabled and no container secret.
+   * Primarily for testing; production code should use {@link
+   * #fromConfig(AwsSecretsManagerStoreConfig)}.
+   */
+  public AwsSecretsManagerSecretStore(
+      final SecretsManagerClient client, final @Nullable String pathPrefix) {
+    this(client, pathPrefix, false, AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+  }
+
+  /**
+   * Creates a store using an already-built client, with explicit batching control. Primarily for
+   * testing; production code should use {@link #fromConfig(AwsSecretsManagerStoreConfig)}.
+   */
+  public AwsSecretsManagerSecretStore(
+      final SecretsManagerClient client,
+      final @Nullable String pathPrefix,
+      final boolean batchEnabled,
+      final int batchSize) {
+    if (batchSize < 1 || batchSize > AwsSecretsManagerStoreConfig.MAX_BATCH_SIZE) {
+      throw new IllegalArgumentException(
+          "batchSize must be between 1 and "
+              + AwsSecretsManagerStoreConfig.MAX_BATCH_SIZE
+              + ", but was "
+              + batchSize);
+    }
+    this.client = client;
+    resolver = new FlatSecretResolver(client, normalize(pathPrefix), batchEnabled, batchSize);
+  }
+
+  private AwsSecretsManagerSecretStore(
+      final SecretsManagerClient client, final AwsSecretResolver resolver) {
+    this.client = client;
+    this.resolver = resolver;
+  }
+
+  /**
+   * Builds a store from configuration, eagerly constructing the underlying client. Building the
+   * client does not itself contact AWS, so a bad region, unreachable endpoint, or invalid
+   * credentials is not detected here — it only surfaces on the first real {@link #resolve} or
+   * {@link #list} call.
+   */
+  public static AwsSecretsManagerSecretStore fromConfig(final AwsSecretsManagerStoreConfig config) {
+    final var builder =
+        SecretsManagerClient.builder()
+            .credentialsProvider(DefaultCredentialsProvider.builder().build())
+            .overrideConfiguration(
+                ClientOverrideConfiguration.builder()
+                    .retryStrategy(
+                        DefaultRetryStrategy.standardStrategyBuilder()
+                            // maxAttempts counts the initial try, maxRetries doesn't
+                            .maxAttempts(config.maxRetries() + 1)
+                            .build())
+                    .build());
+    if (config.region() != null && !config.region().isBlank()) {
+      builder.region(Region.of(config.region()));
+    }
+    if (config.endpoint() != null) {
+      builder.endpointOverride(config.endpoint());
+    }
+    final SecretsManagerClient client;
+    try {
+      client = builder.build();
+    } catch (final RuntimeException e) {
+      throw new SecretStoreUnavailableException(
+          "Failed to initialize AWS Secrets Manager client: " + e.getMessage(), e);
+    }
+    final var pathPrefix = normalize(config.pathPrefix());
+    final AwsSecretResolver resolver =
+        config.containerSecretId() != null
+            ? new ContainerSecretResolver(client, pathPrefix, config.containerSecretId())
+            : new FlatSecretResolver(client, pathPrefix, config.batchEnabled(), config.batchSize());
+    return new AwsSecretsManagerSecretStore(client, resolver);
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    return resolver.resolve(names);
+  }
+
+  @Override
+  public List<String> list() {
+    return resolver.list();
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  private static String normalize(final @Nullable String pathPrefix) {
+    return pathPrefix == null || pathPrefix.isBlank() ? "" : pathPrefix;
+  }
+}

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfig.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import java.net.URI;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Configuration for an {@link AwsSecretsManagerSecretStore}.
+ *
+ * <p>Authentication uses the AWS SDK default credentials provider chain (e.g. IRSA/STS
+ * web-identity, instance profile, environment variables, system properties). This config does not
+ * accept explicit credentials fields.
+ *
+ * @param region the AWS region, or {@code null} to let the SDK resolve it from the environment
+ *     ({@code AWS_REGION}) or instance metadata
+ * @param pathPrefix optional prefix prepended to every reference name to form the AWS secret id
+ *     (e.g. {@code camunda/}); {@code null} or blank means references map to bare secret names
+ * @param containerSecretId opt-in: instead of one AWS secret per reference, treat every reference
+ *     as a JSON key inside this one named secret. Mutually exclusive with {@code batchEnabled}
+ * @param endpoint optional endpoint override, primarily for testing against LocalStack; {@code
+ *     null} uses the default AWS endpoint for the resolved region
+ * @param maxRetries number of retries the SDK performs on transient failures (throttling, 5xx);
+ *     must be {@code >= 0}
+ * @param batchEnabled opt-in: resolve via {@code BatchGetSecretValue} instead of one {@code
+ *     GetSecretValue} call per reference. Off by default since it requires the {@code
+ *     secretsmanager:BatchGetSecretValue} IAM action in addition to {@code GetSecretValue}.
+ *     Mutually exclusive with {@code containerSecretId}
+ * @param batchSize maximum secret ids per {@code BatchGetSecretValue} call when {@code
+ *     batchEnabled} is set; must be between 1 and {@value #MAX_BATCH_SIZE} (AWS's hard limit)
+ */
+public record AwsSecretsManagerStoreConfig(
+    @Nullable String region,
+    @Nullable String pathPrefix,
+    @Nullable String containerSecretId,
+    @Nullable URI endpoint,
+    int maxRetries,
+    boolean batchEnabled,
+    int batchSize) {
+
+  /** Default number of retries applied when none is configured. */
+  public static final int DEFAULT_MAX_RETRIES = 3;
+
+  /** Maximum secret ids AWS accepts in a single {@code BatchGetSecretValue} call. */
+  public static final int MAX_BATCH_SIZE = 20;
+
+  /** Default batch size when batching is enabled but none is configured. */
+  public static final int DEFAULT_BATCH_SIZE = MAX_BATCH_SIZE;
+
+  // batchSize/containerSecretId invariants below are mirrored (with property-path-aware messages)
+  // by io.camunda.configuration.Secrets.AwsSecretsManagerStore#validate in the configuration
+  // module, which can't depend on this module's AWS SDK dependency. Keep both in sync.
+  public AwsSecretsManagerStoreConfig {
+    if (maxRetries < 0) {
+      throw new IllegalArgumentException("maxRetries must not be negative, but was " + maxRetries);
+    }
+    if (batchSize < 1 || batchSize > MAX_BATCH_SIZE) {
+      throw new IllegalArgumentException(
+          "batchSize must be between 1 and " + MAX_BATCH_SIZE + ", but was " + batchSize);
+    }
+    if (containerSecretId != null && containerSecretId.isBlank()) {
+      throw new IllegalArgumentException("containerSecretId must not be blank, but was empty");
+    }
+    if (batchEnabled && containerSecretId != null) {
+      throw new IllegalArgumentException(
+          "batchEnabled and containerSecretId are mutually exclusive, but both were set");
+    }
+  }
+
+  /**
+   * Creates a config with only a path prefix, default retries, and batching disabled; region
+   * resolved by the SDK.
+   */
+  public static AwsSecretsManagerStoreConfig of(final @Nullable String pathPrefix) {
+    return new AwsSecretsManagerStoreConfig(
+        null, pathPrefix, null, null, DEFAULT_MAX_RETRIES, false, DEFAULT_BATCH_SIZE);
+  }
+}

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/ContainerSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/ContainerSecretResolver.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static io.camunda.secretstore.SecretErrorCode.INVALID_REF;
+import static io.camunda.secretstore.SecretErrorCode.NOT_FOUND;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.classify;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.messageFor;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.storeUnavailable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+/**
+ * JSON-container resolution mode: every reference is a key inside one shared AWS secret (a JSON
+ * object of key-value pairs), fetched once per {@link #resolve}/{@link #list} call instead of one
+ * AWS secret per reference.
+ *
+ * <p>Expected format: the container secret's string value must be a flat JSON <b>object</b> whose
+ * top-level values are all JSON strings, e.g. {@code {"db-password": "s3cr3t", "api-token":
+ * "tok3n"}}. Nested objects/arrays are not traversed. Deviations are handled as follows:
+ *
+ * <ul>
+ *   <li>Not valid JSON at all &mdash; {@link #resolve} fails every requested reference with {@link
+ *       io.camunda.secretstore.SecretErrorCode#INVALID_REF}; {@link #list} throws {@link
+ *       io.camunda.secretstore.SecretStoreUnavailableException}.
+ *   <li>Valid JSON but not an object (e.g. an array or a bare string/number) &mdash; same as above;
+ *       the container secret is unusable regardless of which method is called.
+ *   <li>The requested key is absent, or present with a JSON {@code null} value &mdash; {@link
+ *       #resolve} fails only that reference with {@link
+ *       io.camunda.secretstore.SecretErrorCode#NOT_FOUND}; {@link #list} is unaffected, since a
+ *       missing/null key simply isn't in the field names it returns.
+ *   <li>A valid object whose value for a requested key is present but not a JSON string (number,
+ *       object, array) &mdash; {@link #resolve} fails only that reference with {@link
+ *       io.camunda.secretstore.SecretErrorCode#INVALID_REF}; {@link #list} is unaffected, since it
+ *       only inspects field names, not values.
+ * </ul>
+ */
+final class ContainerSecretResolver implements AwsSecretResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerSecretResolver.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final SecretsManagerClient client;
+  private final String containerId;
+
+  ContainerSecretResolver(
+      final SecretsManagerClient client, final String pathPrefix, final String containerSecretId) {
+    this.client = client;
+    containerId = pathPrefix + containerSecretId;
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    if (names.isEmpty()) {
+      return Map.of();
+    }
+    LOG.debug(
+        "Resolving {} secret refs from AWS Secrets Manager container '{}'",
+        names.size(),
+        containerId);
+    final JsonNode json;
+    try {
+      final var raw = fetchRawSecret();
+      if (raw == null) {
+        return failAll(
+            names,
+            INVALID_REF,
+            "Container secret '" + containerId + "' has no string value (binary secret)");
+      }
+      json = OBJECT_MAPPER.readTree(raw);
+    } catch (final JsonProcessingException e) {
+      return failAll(
+          names, INVALID_REF, "Container secret '" + containerId + "' is not valid JSON");
+    } catch (final SecretsManagerException e) {
+      final var code = classify(e);
+      return failAll(names, code, messageFor(code, "container secret", containerId));
+    } catch (final SdkClientException e) {
+      throw storeUnavailable(e);
+    }
+    if (!json.isObject()) {
+      return failAll(
+          names,
+          INVALID_REF,
+          "Container secret '"
+              + containerId
+              + "' is not a JSON object (was "
+              + json.getNodeType()
+              + ")");
+    }
+
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(names.size());
+    for (final var name : names) {
+      results.put(name, extractKey(json, name));
+    }
+    return results;
+  }
+
+  @Override
+  public List<String> list() {
+    LOG.debug("Listing keys from AWS Secrets Manager container secret '{}'", containerId);
+    try {
+      final var raw = fetchRawSecret();
+      if (raw == null) {
+        return List.of();
+      }
+      final var json = OBJECT_MAPPER.readTree(raw);
+      if (!json.isObject()) {
+        throw new SecretStoreUnavailableException(
+            "Container secret '"
+                + containerId
+                + "' is not a JSON object (was "
+                + json.getNodeType()
+                + ")");
+      }
+      final var names = new ArrayList<String>();
+      json.fieldNames().forEachRemaining(names::add);
+      return names;
+    } catch (final JsonProcessingException e) {
+      throw new SecretStoreUnavailableException(
+          "Container secret '" + containerId + "' is not valid JSON");
+    } catch (final SecretsManagerException | SdkClientException e) {
+      throw storeUnavailable(e);
+    }
+  }
+
+  /**
+   * Raw {@code secretString} of the container secret. AWS returns exactly one of {@code
+   * secretString}/{@code secretBinary} per secret; {@code null} here means the value lives in
+   * {@code secretBinary} instead, which this store doesn't support resolving.
+   */
+  private @Nullable String fetchRawSecret() {
+    final var response =
+        client.getSecretValue(GetSecretValueRequest.builder().secretId(containerId).build());
+    return response.secretString();
+  }
+
+  private SecretResolutionResult extractKey(final JsonNode container, final String key) {
+    final var node = container.get(key);
+    if (node == null || node.isNull()) {
+      return new Failed(
+          NOT_FOUND, "Key '" + key + "' not found in container secret '" + containerId + "'", null);
+    }
+    if (!node.isTextual()) {
+      return new Failed(
+          INVALID_REF,
+          "Key '" + key + "' in container secret '" + containerId + "' is not a string value",
+          null);
+    }
+    return new Resolved(node.asText());
+  }
+
+  private static Map<String, SecretResolutionResult> failAll(
+      final Set<String> names, final SecretErrorCode code, final String message) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(names.size());
+    for (final var name : names) {
+      results.put(name, new Failed(code, message, null));
+    }
+    return results;
+  }
+}

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/FlatSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/FlatSecretResolver.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static io.camunda.secretstore.SecretErrorCode.ACCESS_DENIED;
+import static io.camunda.secretstore.SecretErrorCode.INVALID_REF;
+import static io.camunda.secretstore.SecretErrorCode.NOT_FOUND;
+import static io.camunda.secretstore.SecretErrorCode.UNREADABLE;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.classify;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.classifyErrorCode;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.isAccessDenied;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.messageFor;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.storeUnavailable;
+
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.APIErrorType;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.ListSecretsRequest;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+/**
+ * Default resolution mode: each reference name maps 1:1 to an AWS secret id ({@code pathPrefix +
+ * name}). Issues one {@code GetSecretValue} call per reference by default; switches to batched
+ * {@code BatchGetSecretValue} calls (up to {@code batchSize} ids each) when {@code batchEnabled}.
+ */
+final class FlatSecretResolver implements AwsSecretResolver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FlatSecretResolver.class);
+
+  private final SecretsManagerClient client;
+  private final String pathPrefix;
+  private final boolean batchEnabled;
+  private final int batchSize;
+
+  FlatSecretResolver(
+      final SecretsManagerClient client,
+      final String pathPrefix,
+      final boolean batchEnabled,
+      final int batchSize) {
+    this.client = client;
+    this.pathPrefix = pathPrefix;
+    this.batchEnabled = batchEnabled;
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public Map<String, SecretResolutionResult> resolve(final Set<String> names) {
+    if (names.isEmpty()) {
+      return Map.of();
+    }
+    LOG.debug("Resolving {} secret refs from AWS Secrets Manager", names.size());
+    final Map<String, String> secretIdToName = new LinkedHashMap<>(names.size());
+    for (final var name : names) {
+      secretIdToName.put(secretId(name), name);
+    }
+    return batchEnabled ? resolveBatched(secretIdToName) : resolveOneByOne(secretIdToName);
+  }
+
+  private Map<String, SecretResolutionResult> resolveOneByOne(
+      final Map<String, String> secretIdToName) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(secretIdToName.size());
+    for (final var entry : secretIdToName.entrySet()) {
+      results.put(entry.getValue(), resolveSingle(entry.getKey()));
+    }
+    return results;
+  }
+
+  private SecretResolutionResult resolveSingle(final String secretId) {
+    try {
+      final var response =
+          client.getSecretValue(GetSecretValueRequest.builder().secretId(secretId).build());
+      return toResolutionResult(secretId, response.secretString());
+    } catch (final SecretsManagerException e) {
+      final var code = classify(e);
+      return new Failed(code, messageFor(code, "secret", secretId), e);
+    } catch (final SdkClientException e) {
+      throw storeUnavailable(e);
+    }
+  }
+
+  private Map<String, SecretResolutionResult> resolveBatched(
+      final Map<String, String> secretIdToName) {
+    final Map<String, SecretResolutionResult> results = new LinkedHashMap<>(secretIdToName.size());
+    for (final var batch : partition(secretIdToName.keySet(), batchSize)) {
+      resolveBatch(batch, secretIdToName, results);
+    }
+    return results;
+  }
+
+  /**
+   * Resolves one {@code BatchGetSecretValue} call and merges its outcome into {@code results}.
+   *
+   * <p>AWS reports failures for this API in two distinct shapes, handled differently here:
+   *
+   * <ul>
+   *   <li><b>Per-secret failure</b>: the call succeeds and returns a normal response; a secret that
+   *       couldn't be read (not found, access denied, etc.) shows up as an entry in {@code
+   *       response.errors()} alongside other secrets resolved fine in {@code
+   *       response.secretValues()}. Handled by {@link #mapBatchError}, scoped to that one secret.
+   *   <li><b>Whole-call failure</b>: {@code batchGetSecretValue} itself throws — no response body
+   *       exists at all (e.g. the caller lacks the {@code BatchGetSecretValue} action entirely).
+   *       There is no per-secret information to read in this case, so every id in {@code secretIds}
+   *       (this batch only, not other batches in the same {@link #resolve} call) is marked {@code
+   *       ACCESS_DENIED} or the call throws {@link
+   *       io.camunda.secretstore.SecretStoreUnavailableException}, below.
+   * </ul>
+   */
+  private void resolveBatch(
+      final List<String> secretIds,
+      final Map<String, String> secretIdToName,
+      final Map<String, SecretResolutionResult> results) {
+    try {
+      final var response =
+          client.batchGetSecretValue(
+              BatchGetSecretValueRequest.builder().secretIdList(secretIds).build());
+      final var pending = new LinkedHashSet<>(secretIds);
+      for (final var entry : response.secretValues()) {
+        final var name = secretIdToName.get(entry.name());
+        if (name == null) {
+          continue;
+        }
+        pending.remove(entry.name());
+        results.put(name, toResolutionResult(entry.name(), entry.secretString()));
+      }
+      for (final var error : response.errors()) {
+        final var name = secretIdToName.get(error.secretId());
+        if (name == null) {
+          continue;
+        }
+        pending.remove(error.secretId());
+        results.put(name, mapBatchError(error));
+      }
+      // defensive: guarantee a result for every name even if AWS omits one from both lists
+      for (final var secretId : pending) {
+        results.put(
+            secretIdToName.get(secretId),
+            new Failed(NOT_FOUND, "No result returned for secret: " + secretId, null));
+      }
+    } catch (final SecretsManagerException e) {
+      if (isAccessDenied(e)) {
+        for (final var secretId : secretIds) {
+          results.put(
+              secretIdToName.get(secretId),
+              new Failed(
+                  ACCESS_DENIED,
+                  "Secret '"
+                      + secretId
+                      + "': the entire batch request was denied ("
+                      + e.getMessage()
+                      + ")",
+                  e));
+        }
+        return;
+      }
+      throw storeUnavailable(e);
+    } catch (final SdkClientException e) {
+      throw storeUnavailable(e);
+    }
+  }
+
+  private static SecretResolutionResult mapBatchError(final APIErrorType error) {
+    final var classified = classifyErrorCode(error.errorCode());
+    if (classified != null) {
+      return new Failed(classified, "Secret '" + error.secretId() + "': " + error.message(), null);
+    }
+    // unrecognized AWS error code: not a known per-secret condition, so don't mislabel it
+    // INVALID_REF — surface as UNREADABLE without aborting the rest of the batch
+    return new Failed(
+        UNREADABLE,
+        messageFor(UNREADABLE, "secret", error.secretId())
+            + " (unrecognized AWS error code '"
+            + error.errorCode()
+            + "': "
+            + error.message()
+            + ")",
+        null);
+  }
+
+  private static SecretResolutionResult toResolutionResult(
+      final String secretId, final @Nullable String secretString) {
+    if (secretString == null) {
+      // AWS returns exactly one of secretString/secretBinary per secret; null here means the
+      // value lives in secretBinary instead, which this store doesn't support resolving.
+      return new Failed(
+          INVALID_REF, "Secret '" + secretId + "' has no string value (binary secret)", null);
+    }
+    return new Resolved(secretString);
+  }
+
+  private static List<List<String>> partition(final Collection<String> items, final int size) {
+    final var all = new ArrayList<>(items);
+    final List<List<String>> batches = new ArrayList<>();
+    for (int i = 0; i < all.size(); i += size) {
+      batches.add(all.subList(i, Math.min(i + size, all.size())));
+    }
+    return batches;
+  }
+
+  @Override
+  public List<String> list() {
+    LOG.debug("Listing secrets from AWS Secrets Manager with prefix '{}'", pathPrefix);
+    final var names = new ArrayList<String>();
+    String nextToken = null;
+    try {
+      do {
+        final var requestBuilder = ListSecretsRequest.builder().maxResults(100);
+        if (nextToken != null) {
+          requestBuilder.nextToken(nextToken);
+        }
+        final var response = client.listSecrets(requestBuilder.build());
+        for (final var entry : response.secretList()) {
+          final var name = entry.name();
+          if (name != null && name.startsWith(pathPrefix)) {
+            final var logicalName = name.substring(pathPrefix.length());
+            if (!logicalName.isBlank()) {
+              names.add(logicalName);
+            }
+          }
+        }
+        nextToken = response.nextToken();
+      } while (nextToken != null);
+      return names;
+    } catch (final SecretsManagerException | SdkClientException e) {
+      throw storeUnavailable(e);
+    }
+  }
+
+  private String secretId(final String name) {
+    return pathPrefix + name;
+  }
+}

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerErrorsTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerErrorsTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.classify;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.classifyErrorCode;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.isAccessDenied;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.messageFor;
+import static io.camunda.secretstore.aws.AwsSecretsManagerErrors.storeUnavailable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+class AwsSecretsManagerErrorsTest {
+
+  @Test
+  void shouldReturnNullForNullErrorCode() {
+    assertThat(classifyErrorCode(null)).isNull();
+  }
+
+  @Test
+  void shouldClassifyKnownPerSecretErrorCodes() {
+    assertThat(classifyErrorCode("ResourceNotFoundException")).isEqualTo(SecretErrorCode.NOT_FOUND);
+    assertThat(classifyErrorCode("InvalidParameterException"))
+        .isEqualTo(SecretErrorCode.INVALID_REF);
+    assertThat(classifyErrorCode("InvalidRequestException")).isEqualTo(SecretErrorCode.INVALID_REF);
+    assertThat(classifyErrorCode("DecryptionFailure")).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(classifyErrorCode("DecryptionFailureException"))
+        .isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(classifyErrorCode("AccessDeniedException")).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldClassifyAKnownCodeDespiteIncidentalWhitespace() {
+    // given a code AWS shouldn't send with surrounding whitespace, but hasn't contractually
+    // promised never to
+    assertThat(classifyErrorCode("  ResourceNotFoundException\n"))
+        .isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldClassifyUnrecognizedAccessDeniedVariantByNameFallback() {
+    // given a code that isn't the exact "AccessDeniedException" string AWS defines today, but
+    // still names access-denial (e.g. a future/regional variant)
+    final var code = "OrganizationAccessDeniedException";
+
+    // when / then
+    assertThat(classifyErrorCode(code)).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldReturnNullRatherThanThrowForAnUnrecognizedCode() {
+    // given a code that isn't one of the known per-secret codes and doesn't mention
+    // access-denial: this is the batch-per-item call site's signal to mark just that one secret
+    // UNREADABLE and keep resolving the rest of the batch (see FlatSecretResolver.mapBatchError)
+    // — classifyErrorCode itself must never throw, since the batch call site has no exception to
+    // attach as a cause and throwing here would abort every other secret in the same batch
+    final var code = "SomeFutureAwsExceptionType";
+
+    // when / then
+    assertThat(classifyErrorCode(code)).isNull();
+  }
+
+  @Test
+  void shouldClassifyAKnownCodeFromARealException() {
+    // given
+    final var exception = exceptionWithCode("ResourceNotFoundException", null);
+
+    // when / then
+    assertThat(classify(exception)).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldFallBackToAccessDeniedForAnUnrecognizedCodeThatNamesDenial() {
+    // given
+    final var exception = exceptionWithCode("SomeVendorAccessDeniedVariant", null);
+
+    // when / then
+    assertThat(classify(exception)).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldFallBackToAccessDeniedForA403WithNoRecognizableCode() {
+    // given — no error-code string at all, but the HTTP status is a plain 403
+    final var exception = exceptionWithCode(null, 403);
+
+    // when / then
+    assertThat(classify(exception)).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldThrowStoreUnavailableForAnUnrecognizedNonDenialCode() {
+    // given a store-wide failure shape (e.g. throttling) that classify() cannot attribute to one
+    // secret — unlike classifyErrorCode(), classify() always has the real exception in hand, so it
+    // throws here instead of returning null, preserving the original exception as the cause
+    final var exception = exceptionWithCode("ThrottlingException", 500);
+
+    // when / then
+    assertThatThrownBy(() -> classify(exception))
+        .isInstanceOf(SecretStoreUnavailableException.class)
+        .hasCause(exception);
+  }
+
+  @Test
+  void shouldDetectAccessDeniedByErrorCode() {
+    assertThat(isAccessDenied(exceptionWithCode("AccessDeniedException", null))).isTrue();
+  }
+
+  @Test
+  void shouldDetectAccessDeniedByStatusCodeWhenNoErrorCodePresent() {
+    assertThat(isAccessDenied(exceptionWithCode(null, 403))).isTrue();
+  }
+
+  @Test
+  void shouldNotDetectAccessDeniedForAnUnrelatedErrorWithoutA403Status() {
+    assertThat(isAccessDenied(exceptionWithCode("ThrottlingException", 500))).isFalse();
+  }
+
+  @Test
+  void shouldFormatMessagePerErrorCode() {
+    assertThat(messageFor(SecretErrorCode.NOT_FOUND, "secret", "db-password"))
+        .isEqualTo("Secret not found: db-password");
+    assertThat(messageFor(SecretErrorCode.INVALID_REF, "secret", "db-password"))
+        .isEqualTo("Invalid secret reference: db-password");
+    assertThat(messageFor(SecretErrorCode.ACCESS_DENIED, "secret", "db-password"))
+        .isEqualTo("Access denied for secret: db-password");
+    assertThat(messageFor(SecretErrorCode.UNREADABLE, "secret", "db-password"))
+        .isEqualTo("Secret is unreadable: db-password");
+  }
+
+  @Test
+  void shouldCapitalizeAMultiWordWhatInMessages() {
+    assertThat(messageFor(SecretErrorCode.NOT_FOUND, "container secret", "app-config"))
+        .isEqualTo("Container secret not found: app-config");
+  }
+
+  @Test
+  void shouldWrapTheOriginalExceptionAsStoreUnavailable() {
+    // given
+    final var exception = exceptionWithCode("ThrottlingException", 500);
+
+    // when
+    final var wrapped = storeUnavailable(exception);
+
+    // then
+    assertThat(wrapped.getCause()).isSameAs(exception);
+    assertThat(wrapped.getMessage())
+        .isEqualTo("AWS Secrets Manager is unavailable: " + exception.getMessage());
+  }
+
+  private static SecretsManagerException exceptionWithCode(
+      final String errorCode, final Integer statusCode) {
+    final var builder =
+        (SecretsManagerException.Builder)
+            SecretsManagerException.builder().message(errorCode == null ? "denied" : errorCode);
+    if (errorCode != null) {
+      builder.awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build());
+    }
+    if (statusCode != null) {
+      builder.statusCode(statusCode);
+    }
+    return (SecretsManagerException) builder.build();
+  }
+}

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreIT.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreIT.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
+
+@Testcontainers
+class AwsSecretsManagerSecretStoreIT {
+
+  @Container
+  private static final LocalStackContainer LOCALSTACK =
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:4.10"))
+          .withServices(Service.SECRETSMANAGER);
+
+  private static SecretsManagerClient adminClient;
+
+  @BeforeAll
+  static void setUp() {
+    adminClient =
+        SecretsManagerClient.builder()
+            .endpointOverride(LOCALSTACK.getEndpointOverride(Service.SECRETSMANAGER))
+            .region(Region.of(LOCALSTACK.getRegion()))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(
+                        LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey())))
+            .build();
+
+    createSecret("camunda/db-password", "s3cr3t");
+    createSecret("camunda/api-token", "tok3n");
+    createSecret("other/unrelated", "ignored");
+    createSecret("camunda/app-config", "{\"DB_PASSWORD\":\"c0nt41ner\",\"API_KEY\":\"k3y\"}");
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (adminClient != null) {
+      adminClient.close();
+    }
+  }
+
+  @Test
+  void shouldResolveSecretFromLocalStack() {
+    // given
+    try (final var store = storeWithClient("camunda/")) {
+      // when
+      final var ref = "db-password";
+      final var result = store.resolve(Set.of(ref));
+
+      // then
+      assertThat(result.get(ref))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("s3cr3t");
+    }
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingSecret() {
+    // given
+    try (final var store = storeWithClient("camunda/")) {
+      // when
+      final var ref = "does-not-exist";
+      final var result = store.resolve(Set.of(ref));
+
+      // then — the per-item error entry from BatchGetSecretValue maps to NOT_FOUND
+      assertThat(result.get(ref))
+          .isInstanceOf(Failed.class)
+          .extracting(r -> ((Failed) r).code())
+          .isEqualTo(SecretErrorCode.NOT_FOUND);
+    }
+  }
+
+  @Test
+  void shouldResolveMultipleSecretsWithBatchingDisabled() {
+    // given — the default path: one GetSecretValue call per reference
+    try (final var store = storeWithClient("camunda/")) {
+      // when
+      final var dbPassword = "db-password";
+      final var apiToken = "api-token";
+      final var missing = "does-not-exist";
+      final var result = store.resolve(Set.of(dbPassword, apiToken, missing));
+
+      // then
+      assertThat(result.get(dbPassword))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("s3cr3t");
+      assertThat(result.get(apiToken))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("tok3n");
+      assertThat(result.get(missing)).isInstanceOf(Failed.class);
+    }
+  }
+
+  @Test
+  void shouldResolveMultipleSecretsInOneBatchCallWhenBatchingEnabled() {
+    // given — opt-in batching: one BatchGetSecretValue call resolves all three at once
+    try (final var store = storeWithBatchClient("camunda/")) {
+      // when
+      final var dbPassword = "db-password";
+      final var apiToken = "api-token";
+      final var missing = "does-not-exist";
+      final var result = store.resolve(Set.of(dbPassword, apiToken, missing));
+
+      // then — the found secrets resolve and the missing one is a per-item error, not a
+      // store-wide failure
+      assertThat(result.get(dbPassword))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("s3cr3t");
+      assertThat(result.get(apiToken))
+          .isInstanceOf(Resolved.class)
+          .extracting(r -> ((Resolved) r).value())
+          .isEqualTo("tok3n");
+      assertThat(result.get(missing)).isInstanceOf(Failed.class);
+    }
+  }
+
+  @Test
+  void shouldResolveAllSecretsWhenCountExceedsMaxBatchSize() {
+    // given — more references than fit in a single BatchGetSecretValue call (20 max), so the
+    // resolver must issue more than one batch call and merge every result back together. Uses its
+    // own prefix (not "camunda/") so these secrets don't leak into other tests' prefix-scoped
+    // assertions against the shared LocalStack container.
+    final var expected = new LinkedHashMap<String, String>();
+    for (int i = 0; i < AwsSecretsManagerStoreConfig.MAX_BATCH_SIZE + 5; i++) {
+      final var ref = "bulk-" + i;
+      final var value = "value-" + i;
+      createSecret("batch-test/" + ref, value);
+      expected.put(ref, value);
+    }
+
+    try (final var store = storeWithBatchClient("batch-test/")) {
+      // when
+      final var result = store.resolve(expected.keySet());
+
+      // then — every secret resolved correctly, none dropped or mixed up across the batch split
+      assertThat(result).hasSize(expected.size());
+      expected.forEach(
+          (ref, value) ->
+              assertThat(result.get(ref))
+                  .isInstanceOf(Resolved.class)
+                  .extracting(r -> ((Resolved) r).value())
+                  .isEqualTo(value));
+    }
+  }
+
+  @Test
+  void shouldListSecretsUnderPrefix() {
+    // given
+    try (final var store = storeWithClient("camunda/")) {
+      // when
+      final var refs = store.list();
+
+      // then — exactly the camunda/* secrets, prefix stripped; "other/unrelated" excluded
+      assertThat(refs).containsExactlyInAnyOrder("db-password", "api-token", "app-config");
+    }
+  }
+
+  @Test
+  void shouldResolveViaFromConfigIdentityPath() {
+    // given — exercise the production build path (DefaultCredentialsProvider) with
+    // credentials supplied via system properties, mirroring how a pod identity injects them
+    System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
+    System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
+    try {
+      final var config =
+          new AwsSecretsManagerStoreConfig(
+              LOCALSTACK.getRegion(),
+              "camunda/",
+              null,
+              URI.create(LOCALSTACK.getEndpointOverride(Service.SECRETSMANAGER).toString()),
+              AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+              false,
+              AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+
+      try (final var store = AwsSecretsManagerSecretStore.fromConfig(config)) {
+        // when
+        final var ref = "api-token";
+        final var result = store.resolve(Set.of(ref));
+
+        // then
+        assertThat(result.get(ref))
+            .isInstanceOf(Resolved.class)
+            .extracting(r -> ((Resolved) r).value())
+            .isEqualTo("tok3n");
+      }
+    } finally {
+      System.clearProperty("aws.accessKeyId");
+      System.clearProperty("aws.secretAccessKey");
+    }
+  }
+
+  @Test
+  void shouldResolveViaFromConfigWithBatchingEnabled() {
+    // given — the opt-in flag wired all the way through fromConfig() to a real
+    // BatchGetSecretValue call against LocalStack, not just via the raw constructor
+    System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
+    System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
+    try {
+      final var config =
+          new AwsSecretsManagerStoreConfig(
+              LOCALSTACK.getRegion(),
+              "camunda/",
+              null,
+              URI.create(LOCALSTACK.getEndpointOverride(Service.SECRETSMANAGER).toString()),
+              AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+              true,
+              AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+
+      try (final var store = AwsSecretsManagerSecretStore.fromConfig(config)) {
+        // when
+        final var ref = "api-token";
+        final var result = store.resolve(Set.of(ref));
+
+        // then
+        assertThat(result.get(ref))
+            .isInstanceOf(Resolved.class)
+            .extracting(r -> ((Resolved) r).value())
+            .isEqualTo("tok3n");
+      }
+    } finally {
+      System.clearProperty("aws.accessKeyId");
+      System.clearProperty("aws.secretAccessKey");
+    }
+  }
+
+  private static AwsSecretsManagerSecretStore storeWithClient(final String prefix) {
+    return new AwsSecretsManagerSecretStore(localStackClient(), prefix);
+  }
+
+  private static AwsSecretsManagerSecretStore storeWithBatchClient(final String prefix) {
+    return new AwsSecretsManagerSecretStore(
+        localStackClient(), prefix, true, AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+  }
+
+  private static SecretsManagerClient localStackClient() {
+    return SecretsManagerClient.builder()
+        .endpointOverride(LOCALSTACK.getEndpointOverride(Service.SECRETSMANAGER))
+        .region(Region.of(LOCALSTACK.getRegion()))
+        .credentialsProvider(
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey())))
+        .build();
+  }
+
+  private static void createSecret(final String name, final String value) {
+    adminClient.createSecret(CreateSecretRequest.builder().name(name).secretString(value).build());
+  }
+}

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
@@ -1,0 +1,679 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.APIErrorType;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ListSecretsRequest;
+import software.amazon.awssdk.services.secretsmanager.model.ListSecretsResponse;
+import software.amazon.awssdk.services.secretsmanager.model.SecretListEntry;
+import software.amazon.awssdk.services.secretsmanager.model.SecretValueEntry;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+@ExtendWith(MockitoExtension.class)
+class AwsSecretsManagerSecretStoreTest {
+
+  @Mock private SecretsManagerClient client;
+
+  // ---- default path: one GetSecretValue call per reference (batching disabled) ----
+
+  @Test
+  void shouldResolveKnownSecret() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "camunda/");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("s3cr3t").build());
+
+    // when
+    final var ref = "db-password";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(result.get(ref))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+  }
+
+  @Test
+  void shouldPrependPathPrefixToSecretId() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "camunda/");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("v").build());
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then
+    final var captor = ArgumentCaptor.forClass(GetSecretValueRequest.class);
+    verify(client).getSecretValue(captor.capture());
+    assertThat(captor.getValue().secretId()).isEqualTo("camunda/token");
+  }
+
+  @Test
+  void shouldUseBareNameWhenPrefixIsNull() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, null);
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("v").build());
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then
+    final var captor = ArgumentCaptor.forClass(GetSecretValueRequest.class);
+    verify(client).getSecretValue(captor.capture());
+    assertThat(captor.getValue().secretId()).isEqualTo("token");
+  }
+
+  @Test
+  void shouldUseBareNameWhenPrefixIsBlank() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "   ");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("v").build());
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then
+    final var captor = ArgumentCaptor.forClass(GetSecretValueRequest.class);
+    verify(client).getSecretValue(captor.capture());
+    assertThat(captor.getValue().secretId()).isEqualTo("token");
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingSecret() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(
+            (SecretsManagerException)
+                SecretsManagerException.builder()
+                    .awsErrorDetails(
+                        AwsErrorDetails.builder().errorCode("ResourceNotFoundException").build())
+                    .message("missing")
+                    .build());
+
+    // when
+    final var ref = "missing";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(result.get(ref)).isInstanceOf(Failed.class);
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForInvalidParameter() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(
+            (SecretsManagerException)
+                SecretsManagerException.builder()
+                    .awsErrorDetails(
+                        AwsErrorDetails.builder().errorCode("InvalidParameterException").build())
+                    .message("bad")
+                    .build());
+
+    // when
+    final var ref = "bad";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnAccessDeniedForAccessDeniedError() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(
+            (SecretsManagerException)
+                SecretsManagerException.builder()
+                    .awsErrorDetails(
+                        AwsErrorDetails.builder().errorCode("AccessDeniedException").build())
+                    .statusCode(400)
+                    .message("denied")
+                    .build());
+
+    // when
+    final var ref = "secret";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForBinaryOnlySecret() {
+    // given — a secret with no string value (binary secret)
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().build());
+
+    // when
+    final var ref = "binary";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldThrowUnavailableOnConnectivityError() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(SdkClientException.create("connection refused"));
+
+    // when / then
+    assertThatThrownBy(() -> store.resolve(Set.of("any")))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldThrowUnavailableForUnrecognizedServiceError() {
+    // given — an AWS error code that isn't one of the known per-secret failures (e.g. throttling
+    // exhausted, internal service error) must propagate as a store-wide failure, not be silently
+    // swallowed as a per-secret Failed result
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(
+            (SecretsManagerException)
+                SecretsManagerException.builder()
+                    .awsErrorDetails(
+                        AwsErrorDetails.builder()
+                            .errorCode("InternalServiceErrorException")
+                            .build())
+                    .message("internal error")
+                    .build());
+
+    // when / then
+    assertThatThrownBy(() -> store.resolve(Set.of("any")))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldReturnResultForEveryRefInSet() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              final GetSecretValueRequest req = invocation.getArgument(0);
+              if (req.secretId().equals("known")) {
+                return GetSecretValueResponse.builder().secretString("value").build();
+              }
+              throw (SecretsManagerException)
+                  SecretsManagerException.builder()
+                      .awsErrorDetails(
+                          AwsErrorDetails.builder().errorCode("ResourceNotFoundException").build())
+                      .message("missing")
+                      .build();
+            });
+
+    // when
+    final var known = "known";
+    final var missing = "missing";
+    final var result = store.resolve(Set.of(known, missing));
+
+    // then
+    assertThat(result).containsKeys(known, missing);
+    assertThat(result.get(known)).isInstanceOf(Resolved.class);
+    assertThat(result.get(missing)).isInstanceOf(Failed.class);
+  }
+
+  @Test
+  void shouldReturnEmptyMapForEmptyRefs() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+
+    // when
+    final var result = store.resolve(Set.of());
+
+    // then
+    assertThat(result).isEmpty();
+    verifyNoInteractions(client);
+  }
+
+  // ---- opt-in path: BatchGetSecretValue (batchEnabled=true) ----
+
+  @Test
+  void shouldResolveKnownSecretWhenBatchEnabled() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "camunda/", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .secretValues(
+                    SecretValueEntry.builder()
+                        .name("camunda/db-password")
+                        .secretString("s3cr3t")
+                        .build())
+                .build());
+
+    // when
+    final var ref = "db-password";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(result.get(ref))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+  }
+
+  @Test
+  void shouldNotCallBatchApiWhenBatchDisabled() {
+    // given — the default 2-arg constructor must never call batchGetSecretValue
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("v").build());
+
+    // when
+    store.resolve(Set.of("token"));
+
+    // then
+    verify(client, times(0)).batchGetSecretValue(any(BatchGetSecretValueRequest.class));
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingSecretWhenBatchEnabled() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .errors(
+                    APIErrorType.builder()
+                        .secretId("missing")
+                        .errorCode("ResourceNotFoundException")
+                        .message("missing")
+                        .build())
+                .build());
+
+    // when
+    final var ref = "missing";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(result.get(ref)).isInstanceOf(Failed.class);
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForInvalidParameterWhenBatchEnabled() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .errors(
+                    APIErrorType.builder()
+                        .secretId("bad")
+                        .errorCode("InvalidParameterException")
+                        .message("bad")
+                        .build())
+                .build());
+
+    // when
+    final var ref = "bad";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnUnreadableForUnrecognizedBatchErrorCodeWithoutAbortingOtherItems() {
+    // given — one item has an error code the classifier doesn't recognize, the other resolves
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .errors(
+                    APIErrorType.builder()
+                        .secretId("mystery")
+                        .errorCode("SomeNewAwsExceptionType")
+                        .message("unexpected")
+                        .build())
+                .secretValues(SecretValueEntry.builder().name("ok").secretString("value").build())
+                .build());
+
+    // when
+    final var result = store.resolve(Set.of("mystery", "ok"));
+
+    // then — the unrecognized code doesn't mask as INVALID_REF, and doesn't abort the sibling
+    assertThat(((Failed) result.get("mystery")).code()).isEqualTo(SecretErrorCode.UNREADABLE);
+    assertThat(result.get("ok")).isInstanceOf(Resolved.class);
+  }
+
+  @Test
+  void shouldReturnAccessDeniedForOnePerItemDeniedSecretWithoutAbortingOtherItems() {
+    // given — one specific secret is denied via a per-item error entry (as opposed to the whole
+    // batch call being denied), the other resolves
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .errors(
+                    APIErrorType.builder()
+                        .secretId("denied")
+                        .errorCode("AccessDeniedException")
+                        .message("no permission for this secret")
+                        .build())
+                .secretValues(SecretValueEntry.builder().name("ok").secretString("value").build())
+                .build());
+
+    // when
+    final var result = store.resolve(Set.of("denied", "ok"));
+
+    // then — only the denied secret fails, the sibling still resolves
+    assertThat(((Failed) result.get("denied")).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(result.get("ok")).isInstanceOf(Resolved.class);
+  }
+
+  @Test
+  void shouldReturnAccessDeniedForPerItemDecryptionFailureWhenBatchEnabled() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .errors(
+                    APIErrorType.builder()
+                        .secretId("secret")
+                        .errorCode("DecryptionFailure")
+                        .message("cannot decrypt")
+                        .build())
+                .build());
+
+    // when
+    final var ref = "secret";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  void shouldReturnAccessDeniedWhenWholeBatchCallIsDenied() {
+    // given — the whole batch call is denied (e.g. IAM policy blocks the store's secret prefix
+    // entirely), as opposed to a single secret being denied via a per-item error entry
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    final var e =
+        (SecretsManagerException)
+            SecretsManagerException.builder()
+                .awsErrorDetails(
+                    AwsErrorDetails.builder().errorCode("AccessDeniedException").build())
+                .statusCode(400)
+                .message("denied")
+                .build();
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class))).thenThrow(e);
+
+    // when
+    final var ref = "secret";
+    final var result = store.resolve(Set.of(ref));
+
+    // then — message distinguishes this from a per-secret denial, not just the same generic text
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    assertThat(((Failed) result.get(ref)).message()).contains("entire batch request was denied");
+  }
+
+  @Test
+  void shouldReturnInvalidRefForBinaryOnlySecretWhenBatchEnabled() {
+    // given — a secret with no string value (binary secret)
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .secretValues(SecretValueEntry.builder().name("binary").build())
+                .build());
+
+    // when
+    final var ref = "binary";
+    final var result = store.resolve(Set.of(ref));
+
+    // then
+    assertThat(((Failed) result.get(ref)).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldThrowUnavailableOnConnectivityErrorWhenBatchEnabled() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenThrow(SdkClientException.create("connection refused"));
+
+    // when / then
+    assertThatThrownBy(() -> store.resolve(Set.of("any")))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldReturnResultForEveryRefInBatch() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .secretValues(
+                    SecretValueEntry.builder().name("known").secretString("value").build())
+                .errors(
+                    APIErrorType.builder()
+                        .secretId("missing")
+                        .errorCode("ResourceNotFoundException")
+                        .message("missing")
+                        .build())
+                .build());
+
+    // when
+    final var known = "known";
+    final var missing = "missing";
+    final var result = store.resolve(Set.of(known, missing));
+
+    // then
+    assertThat(result).containsKeys(known, missing);
+    assertThat(result.get(known)).isInstanceOf(Resolved.class);
+    assertThat(result.get(missing)).isInstanceOf(Failed.class);
+  }
+
+  @Test
+  void shouldGuaranteeResultForEveryRefEvenWhenAwsOmitsOne() {
+    // given — AWS returns neither a value nor an error entry for one requested id
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .secretValues(
+                    SecretValueEntry.builder().name("known").secretString("value").build())
+                .build());
+
+    // when
+    final var known = "known";
+    final var omitted = "omitted";
+    final var result = store.resolve(Set.of(known, omitted));
+
+    // then
+    assertThat(result.get(known)).isInstanceOf(Resolved.class);
+    assertThat(result.get(omitted)).isInstanceOf(Failed.class);
+    assertThat(((Failed) result.get(omitted)).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldBatchMoreThan20RefsAcrossMultipleCalls() {
+    // given 25 refs, one more than two full 20-id and 5-id AWS BatchGetSecretValue batches
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 20);
+    final var refs =
+        IntStream.range(0, 25)
+            .mapToObj(i -> "secret-" + i)
+            .collect(Collectors.toCollection(HashSet::new));
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              final BatchGetSecretValueRequest req = invocation.getArgument(0);
+              return BatchGetSecretValueResponse.builder()
+                  .secretValues(
+                      req.secretIdList().stream()
+                          .map(id -> SecretValueEntry.builder().name(id).secretString("v").build())
+                          .toList())
+                  .build();
+            });
+
+    // when
+    final var result = store.resolve(refs);
+
+    // then
+    final var captor = ArgumentCaptor.forClass(BatchGetSecretValueRequest.class);
+    verify(client, times(2)).batchGetSecretValue(captor.capture());
+    assertThat(captor.getAllValues())
+        .extracting(req -> req.secretIdList().size())
+        .containsExactlyInAnyOrder(20, 5);
+    assertThat(result).hasSize(25);
+    assertThat(result.values()).allMatch(Resolved.class::isInstance);
+  }
+
+  @Test
+  void shouldRespectConfiguredBatchSizeSmallerThanAwsLimit() {
+    // given 12 refs with a configured batch size of 5: 5 + 5 + 2
+    final var store = new AwsSecretsManagerSecretStore(client, "", true, 5);
+    final var refs =
+        IntStream.range(0, 12)
+            .mapToObj(i -> "secret-" + i)
+            .collect(Collectors.toCollection(HashSet::new));
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              final BatchGetSecretValueRequest req = invocation.getArgument(0);
+              return BatchGetSecretValueResponse.builder()
+                  .secretValues(
+                      req.secretIdList().stream()
+                          .map(id -> SecretValueEntry.builder().name(id).secretString("v").build())
+                          .toList())
+                  .build();
+            });
+
+    // when
+    final var result = store.resolve(refs);
+
+    // then
+    final var captor = ArgumentCaptor.forClass(BatchGetSecretValueRequest.class);
+    verify(client, times(3)).batchGetSecretValue(captor.capture());
+    assertThat(captor.getAllValues())
+        .extracting(req -> req.secretIdList().size())
+        .containsExactlyInAnyOrder(5, 5, 2);
+    assertThat(result).hasSize(12);
+  }
+
+  @Test
+  void shouldRejectBatchSizeOutsideValidRange() {
+    // when / then
+    assertThatThrownBy(() -> new AwsSecretsManagerSecretStore(client, "", true, 21))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchSize");
+    assertThatThrownBy(() -> new AwsSecretsManagerSecretStore(client, "", true, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchSize");
+  }
+
+  // ---- list(), unaffected by batching ----
+
+  @Test
+  void shouldListSecretsFilteredByPrefixAndStripIt() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "camunda/");
+    when(client.listSecrets(any(ListSecretsRequest.class)))
+        .thenReturn(
+            ListSecretsResponse.builder()
+                .secretList(
+                    SecretListEntry.builder().name("camunda/db").build(),
+                    SecretListEntry.builder().name("camunda/api").build(),
+                    SecretListEntry.builder().name("other/ignored").build())
+                .build());
+
+    // when
+    final var refs = store.list();
+
+    // then — only prefixed secrets, with the prefix stripped
+    assertThat(refs).containsExactlyInAnyOrder("db", "api");
+  }
+
+  @Test
+  void shouldPaginateListSecrets() {
+    // given — two pages joined by a nextToken
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.listSecrets(any(ListSecretsRequest.class)))
+        .thenReturn(
+            ListSecretsResponse.builder()
+                .secretList(SecretListEntry.builder().name("a").build())
+                .nextToken("page2")
+                .build())
+        .thenReturn(
+            ListSecretsResponse.builder()
+                .secretList(SecretListEntry.builder().name("b").build())
+                .build());
+
+    // when
+    final var refs = store.list();
+
+    // then
+    assertThat(refs).containsExactlyInAnyOrder("a", "b");
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenListFails() {
+    // given
+    final var store = new AwsSecretsManagerSecretStore(client, "");
+    when(client.listSecrets(any(ListSecretsRequest.class)))
+        .thenThrow(SdkClientException.create("boom"));
+
+    // when / then
+    assertThatThrownBy(store::list).isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldNotLeakSecretValueInResolvedToString() {
+    // given
+    final SecretResolutionResult resolved = new Resolved("super-secret");
+
+    // when / then — value must be masked in toString
+    assertThat(resolved.toString()).doesNotContain("super-secret");
+  }
+}

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfigTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerStoreConfigTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AwsSecretsManagerStoreConfigTest {
+
+  @Test
+  void shouldRejectNegativeMaxRetries() {
+    // when / then
+    assertThatThrownBy(
+            () -> new AwsSecretsManagerStoreConfig(null, null, null, null, -1, false, 20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxRetries");
+  }
+
+  @Test
+  void shouldRejectBatchSizeBelowOne() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new AwsSecretsManagerStoreConfig(
+                    null,
+                    null,
+                    null,
+                    null,
+                    AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+                    true,
+                    0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchSize");
+  }
+
+  @Test
+  void shouldRejectBatchSizeAboveMax() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new AwsSecretsManagerStoreConfig(
+                    null,
+                    null,
+                    null,
+                    null,
+                    AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+                    true,
+                    21))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batchSize");
+  }
+
+  @Test
+  void shouldRejectBatchEnabledWithContainerSecretId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new AwsSecretsManagerStoreConfig(
+                    null,
+                    null,
+                    "app-config",
+                    null,
+                    AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+                    true,
+                    20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("mutually exclusive");
+  }
+
+  @Test
+  void shouldRejectBlankContainerSecretId() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                new AwsSecretsManagerStoreConfig(
+                    null,
+                    null,
+                    "   ",
+                    null,
+                    AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+                    false,
+                    20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("containerSecretId");
+  }
+
+  @Test
+  void shouldDefaultRetriesAndBatchingInFactory() {
+    // when
+    final var config = AwsSecretsManagerStoreConfig.of("camunda/");
+
+    // then
+    assertThat(config.maxRetries()).isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES);
+    assertThat(config.pathPrefix()).isEqualTo("camunda/");
+    assertThat(config.region()).isNull();
+    assertThat(config.containerSecretId()).isNull();
+    assertThat(config.batchEnabled()).isFalse();
+    assertThat(config.batchSize()).isEqualTo(AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+  }
+}

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/ContainerSecretResolverTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/ContainerSecretResolverTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.secretstore.SecretErrorCode;
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+@ExtendWith(MockitoExtension.class)
+class ContainerSecretResolverTest {
+
+  @Mock private SecretsManagerClient client;
+
+  @Test
+  void shouldResolveEmptyMapWithoutFetchingContainerSecretForEmptyNames() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+
+    // when
+    final var result = resolver.resolve(Set.of());
+
+    // then
+    assertThat(result).isEmpty();
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldResolveKeyFromContainerJson() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(
+            GetSecretValueResponse.builder()
+                .secretString("{\"db-password\":\"s3cr3t\",\"api-token\":\"tok3n\"}")
+                .build());
+
+    // when
+    final var result = resolver.resolve(Set.of("db-password", "api-token"));
+
+    // then
+    assertThat(result.get("db-password"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+    assertThat(result.get("api-token"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("tok3n");
+  }
+
+  @Test
+  void shouldReturnNotFoundForMissingKey() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("{\"other\":\"v\"}").build());
+
+    // when
+    final var result = resolver.resolve(Set.of("missing"));
+
+    // then
+    assertThat(((Failed) result.get("missing")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnNotFoundForKeyPresentWithJsonNullValue() {
+    // given — the key exists but its value is an explicit JSON null, not a JSON string
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("{\"key\":null}").build());
+
+    // when
+    final var result = resolver.resolve(Set.of("key"));
+
+    // then — treated the same as a missing key, not INVALID_REF
+    assertThat(((Failed) result.get("key")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForNonStringValue() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("{\"key\":42}").build());
+
+    // when
+    final var result = resolver.resolve(Set.of("key"));
+
+    // then
+    assertThat(((Failed) result.get("key")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForMalformedJson() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("not-json").build());
+
+    // when
+    final var result = resolver.resolve(Set.of("key"));
+
+    // then
+    assertThat(((Failed) result.get("key")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForAllKeysWhenContainerSecretIsJsonArrayNotObject() {
+    // given — well-formed JSON, but not the expected object-of-key-value-pairs shape
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(
+            GetSecretValueResponse.builder()
+                .secretString("[\"db-password\",\"api-token\"]")
+                .build());
+
+    // when
+    final var result = resolver.resolve(Set.of("db-password", "api-token"));
+
+    // then
+    assertThat(((Failed) result.get("db-password")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+    assertThat(((Failed) result.get("api-token")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForAllKeysWhenContainerSecretIsJsonScalarNotObject() {
+    // given — well-formed JSON, but a bare string rather than an object
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("\"just-a-string\"").build());
+
+    // when
+    final var result = resolver.resolve(Set.of("key"));
+
+    // then
+    assertThat(((Failed) result.get("key")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldReturnInvalidRefForBinaryOnlyContainerSecret() {
+    // given — a secret with no string value (binary secret)
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().build());
+
+    // when
+    final var result = resolver.resolve(Set.of("key"));
+
+    // then
+    assertThat(((Failed) result.get("key")).code()).isEqualTo(SecretErrorCode.INVALID_REF);
+  }
+
+  @Test
+  void shouldFailAllKeysWhenContainerSecretNotFound() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(
+            (SecretsManagerException)
+                SecretsManagerException.builder()
+                    .awsErrorDetails(
+                        AwsErrorDetails.builder().errorCode("ResourceNotFoundException").build())
+                    .message("missing")
+                    .build());
+
+    // when
+    final var result = resolver.resolve(Set.of("a", "b"));
+
+    // then
+    assertThat(result.get("a")).isInstanceOf(Failed.class);
+    assertThat(((Failed) result.get("a")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+    assertThat(result.get("b")).isInstanceOf(Failed.class);
+    assertThat(((Failed) result.get("b")).code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+  }
+
+  @Test
+  void shouldThrowUnavailableOnConnectivityError() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(SdkClientException.create("connection refused"));
+
+    // when / then
+    assertThatThrownBy(() -> resolver.resolve(Set.of("key")))
+        .isInstanceOf(SecretStoreUnavailableException.class);
+  }
+
+  @Test
+  void shouldListKeysInContainerJson() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(
+            GetSecretValueResponse.builder()
+                .secretString("{\"db-password\":\"s3cr3t\",\"api-token\":\"tok3n\"}")
+                .build());
+
+    // when
+    final var keys = resolver.list();
+
+    // then
+    assertThat(keys).containsExactlyInAnyOrder("db-password", "api-token");
+  }
+
+  @Test
+  void shouldReturnEmptyListForBinaryOnlyContainerSecret() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().build());
+
+    // when
+    final var keys = resolver.list();
+
+    // then
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void shouldThrowUnavailableForMalformedJsonInList() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("not-json").build());
+
+    // when / then
+    assertThatThrownBy(resolver::list)
+        .isInstanceOf(SecretStoreUnavailableException.class)
+        .hasMessageContaining("not valid JSON");
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerSecretIsJsonArrayNotObject() {
+    // given — well-formed JSON, but not the expected object-of-key-value-pairs shape
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(
+            GetSecretValueResponse.builder()
+                .secretString("[\"db-password\",\"api-token\"]")
+                .build());
+
+    // when / then
+    assertThatThrownBy(resolver::list)
+        .isInstanceOf(SecretStoreUnavailableException.class)
+        .hasMessageContaining("is not a JSON object");
+  }
+
+  @Test
+  void shouldThrowUnavailableWhenContainerSecretIsJsonScalarNotObject() {
+    // given — well-formed JSON, but a bare string rather than an object
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("\"just-a-string\"").build());
+
+    // when / then
+    assertThatThrownBy(resolver::list)
+        .isInstanceOf(SecretStoreUnavailableException.class)
+        .hasMessageContaining("is not a JSON object");
+  }
+
+  @Test
+  void shouldPrependPathPrefixToContainerSecretId() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("{}").build());
+
+    // when
+    resolver.list();
+
+    // then
+    verify(client)
+        .getSecretValue(GetSecretValueRequest.builder().secretId("camunda/app-config").build());
+  }
+}

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/FlatSecretResolverTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/FlatSecretResolverTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.secretstore.SecretResolutionResult.Failed;
+import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ListSecretsRequest;
+import software.amazon.awssdk.services.secretsmanager.model.ListSecretsResponse;
+import software.amazon.awssdk.services.secretsmanager.model.SecretListEntry;
+import software.amazon.awssdk.services.secretsmanager.model.SecretValueEntry;
+import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException;
+
+/**
+ * Direct unit tests for {@link FlatSecretResolver}, constructed without going through {@link
+ * AwsSecretsManagerSecretStore} — the batching/partitioning behavior tested here is this class's
+ * own responsibility, not something a store-level test should have to prove indirectly.
+ */
+@ExtendWith(MockitoExtension.class)
+class FlatSecretResolverTest {
+
+  @Mock private SecretsManagerClient client;
+
+  @Test
+  void shouldResolveEmptyMapWithoutCallingAwsForEmptyNames() {
+    // given
+    final var resolver = new FlatSecretResolver(client, "", false, 20);
+
+    // when
+    final var result = resolver.resolve(Set.of());
+
+    // then
+    assertThat(result).isEmpty();
+    verifyNoInteractions(client);
+  }
+
+  @Test
+  void shouldResolveOneByOneWhenBatchingDisabled() {
+    // given
+    final var resolver = new FlatSecretResolver(client, "camunda/", false, 20);
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("s3cr3t").build());
+
+    // when
+    final var result = resolver.resolve(Set.of("db-password"));
+
+    // then
+    assertThat(result.get("db-password"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+  }
+
+  @Test
+  void shouldClassifyAPerSecretFailureWhenBatchingDisabled() {
+    // given
+    final var resolver = new FlatSecretResolver(client, "", false, 20);
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenThrow(
+            (SecretsManagerException)
+                SecretsManagerException.builder()
+                    .awsErrorDetails(
+                        AwsErrorDetails.builder().errorCode("ResourceNotFoundException").build())
+                    .message("missing")
+                    .build());
+
+    // when
+    final var result = resolver.resolve(Set.of("missing"));
+
+    // then
+    assertThat(result.get("missing")).isInstanceOf(Failed.class);
+  }
+
+  @Test
+  void shouldResolveAllInOneBatchCallWhenCountIsAtOrBelowBatchSize() {
+    // given
+    final var resolver = new FlatSecretResolver(client, "", true, 20);
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenReturn(
+            BatchGetSecretValueResponse.builder()
+                .secretValues(
+                    SecretValueEntry.builder().name("db-password").secretString("s3cr3t").build(),
+                    SecretValueEntry.builder().name("api-token").secretString("tok3n").build())
+                .build());
+
+    // when
+    final var result = resolver.resolve(Set.of("db-password", "api-token"));
+
+    // then
+    assertThat(result.get("db-password"))
+        .isInstanceOf(Resolved.class)
+        .extracting(r -> ((Resolved) r).value())
+        .isEqualTo("s3cr3t");
+    verify(client, times(1)).batchGetSecretValue(any(BatchGetSecretValueRequest.class));
+  }
+
+  @Test
+  void shouldSplitIntoMultipleBatchCallsWhenCountExceedsBatchSize() {
+    // given — 25 references with a batch size of 20 must split into a 20-item and a 5-item call
+    final var resolver = new FlatSecretResolver(client, "", true, 20);
+    final Set<String> names =
+        IntStream.range(0, 25)
+            .mapToObj(i -> "ref-" + i)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    when(client.batchGetSecretValue(any(BatchGetSecretValueRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              final BatchGetSecretValueRequest request = invocation.getArgument(0);
+              final var entries =
+                  request.secretIdList().stream()
+                      .map(id -> SecretValueEntry.builder().name(id).secretString("value").build())
+                      .toList();
+              return BatchGetSecretValueResponse.builder().secretValues(entries).build();
+            });
+
+    // when
+    final var result = resolver.resolve(names);
+
+    // then — every reference resolved, but AWS was called twice (one call cannot exceed 20 ids)
+    assertThat(result).hasSize(25);
+    assertThat(result.values()).allMatch(Resolved.class::isInstance);
+    verify(client, times(2)).batchGetSecretValue(any(BatchGetSecretValueRequest.class));
+  }
+
+  @Test
+  void shouldListNamesUnderPrefixWithPrefixStripped() {
+    // given
+    final var resolver = new FlatSecretResolver(client, "camunda/", false, 20);
+    when(client.listSecrets(any(ListSecretsRequest.class)))
+        .thenReturn(
+            ListSecretsResponse.builder()
+                .secretList(
+                    SecretListEntry.builder().name("camunda/db-password").build(),
+                    SecretListEntry.builder().name("other/unrelated").build())
+                .build());
+
+    // when
+    final var names = resolver.list();
+
+    // then
+    assertThat(names).containsExactly("db-password");
+  }
+}


### PR DESCRIPTION
## Description

Implements the `SecretStore` backend for AWS Secrets Manager, wired into the per-physical-tenant `SecretStoreRegistry`.

- **`camunda-secret-store-aws` module**: `AwsSecretsManagerSecretStore` built on AWS SDK v2's `SecretsManagerClient` with the default credentials provider chain (IRSA/STS, instance profile, environment) — no static credentials accepted by design.
- **Two resolution modes**: `FlatSecretResolver` (default — one AWS secret per reference, with an opt-in `BatchGetSecretValue` path for fewer round-trips) and `ContainerSecretResolver` (opt-in — every reference is a key inside one shared JSON-object secret).
- **Config**: `camunda.secrets.stores.aws-secrets-manager.<id>.*` (region, path-prefix, batch-enabled/batch-size, container-secret-id), overridable per physical tenant via the existing `camunda.physical-tenants.<id>.secrets.*` overlay.
- **Error classification**: AWS error codes map to the store-agnostic `SecretErrorCode` (`NOT_FOUND`, `ACCESS_DENIED`, `INVALID_REF`, `UNREADABLE`); an unrecognized per-item batch error code surfaces as `UNREADABLE` rather than being silently mislabeled `INVALID_REF`, and a whole-call denial is distinguished in its message from a single-secret denial.

## Related issues

closes #56575
