### PR TITLE
build: re-land camunda-spring-boot-4-starter sources jar + bump maven-source-plugin to 3.4.0

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -140,6 +140,23 @@
         </configuration>
       </plugin>
 
+      <!-- Build this module's own sources jar before the package phase, so the shade plugin
+           (createSourcesJar) can merge it with the base module sources. Reuses the release
+           parent's "attach-sources" execution id to move it from package to prepare-package. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+            <phase>prepare-package</phase>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Shade plugin to include and relocate classes from camunda-spring-boot-starter -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -153,6 +170,9 @@
             <phase>package</phase>
             <configuration>
               <createDependencyReducedPom>true</createDependencyReducedPom>
+              <!-- Also shade the sources jar so it carries the base module sources plus our
+                   overrides, instead of only this module's few files (see #48090). -->
+              <createSourcesJar>true</createSourcesJar>
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
@@ -170,6 +190,13 @@
                     <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.class</exclude>
                     <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.class</exclude>
+                    <!-- The same overrides in the shaded sources jar (createSourcesJar). Filters
+                         match by literal path, so the .class excludes above don't cover .java. -->
+                    <exclude>io/camunda/client/spring/actuator/CamundaClientHealthIndicator.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaActuatorConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/CamundaClientProdAutoConfiguration.java</exclude>
+                    <exclude>io/camunda/client/spring/configuration/ExecutorServiceConfiguration.java</exclude>
                     <!-- Exclude META-INF services that we override -->
                     <exclude>META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports</exclude>
                   </excludes>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -236,7 +236,7 @@
     <plugin.version.surefire>3.5.6</plugin.version.surefire>
     <plugin.version.versions>2.18.0</plugin.version.versions>
     <plugin.version.frontend-maven>1.15.1</plugin.version.frontend-maven>
-    <plugin.version.maven-source>3.3.1</plugin.version.maven-source>
+    <plugin.version.maven-source>3.4.0</plugin.version.maven-source>
 
     <!-- when updating this version, also change it in .idea/externalDependencies.xml -->
     <plugin.version.google-java-format>1.34.1</plugin.version.google-java-format>


### PR DESCRIPTION
## What

Re-lands the reverted sources-jar fix for `camunda-spring-boot-4-starter` (#58018, reverted in #58413), together with the change that makes it safe on this branch line: bumping `maven-source-plugin` 3.3.1 → 3.4.0.

Two commits:
1. `fix: ship complete sources jar...` — the exact change from #58018 (shade `createSourcesJar=true`, `attach-sources` → `prepare-package`, `.java` twins of the `.class` shade excludes).
2. `build: bump maven-source-plugin to 3.4.0` — the enabler.

## Why the revert happened, and why the bump fixes it

The deploy command runs `source:jar` directly (`./mvnw … source:jar javadoc:jar deploy`), which attaches a `sources` artifact for every module. The starter's pom additionally binds `source:jar-no-fork` (`attach-sources`, `attach=true` by default) at `prepare-package` so its sources jar exists before shade. On the starter that means `sources` is attached **twice**.

`maven-source-plugin` **3.3.1** treats the second (identical) attach as an error. On the hung run ([29863513048](https://github.com/camunda/camunda/actions/runs/29863513048)):

```
[INFO] --- source:3.3.1:jar-no-fork (attach-sources) @ camunda-spring-boot-4-starter ---
[ERROR] We have duplicated artifacts attached.
```

That is the **last line this module ever prints** — it never reaches shade/install/deploy. The thread wedges; ~6s later the last other module finishes, and every remaining thread then loops `[INFO] Waiting for other projects build to finish...` every 2s for ~21 min until the job hits its 25-min timeout.

`maven-source-plugin` **3.4.0** fixes exactly this via **MSOURCES-140** — *"fail only if re-attach different files"* (apache/maven-source-plugin#24) — so an identical re-attach becomes a no-op. On `main`'s healthy run the identical `source:3.4.0:jar-no-fork (attach-sources)` emits **zero** "duplicated artifacts" errors and proceeds to install → deploy → nexus-staging within ~0.8s.

| | source-plugin | duplicated-artifacts error | module outcome |
|---|---|---|---|
| main / stable/8.9 | 3.4.0 | 0 | deploys (fix present) |
| stable/8.8 / stable/8.7 | 3.3.1 | 1 (on the starter) | thread hangs → 25-min timeout |

Neither Maven core (3.9.16 everywhere) nor the change itself (structurally identical, still shipping on `main`/`stable/8.9`) is the determinant — only the source-plugin version, because only 3.3.1 errors on the double-attach.

## Validation

The hang only reproduces in the branch-level `Deploy snapshot artifacts` job, not on the PR itself. Recommend running that job on this branch (or after merge) to confirm the deploy completes before relying on it.

## Related

Re-lands #58018 (reverted #58413). The `stable/8.7` twin (reverted in #58436) is covered via the backport label.


## Follow-up

This bump is the minimal unblock. The redundant double-attach itself is removed in a follow-up so the build no longer depends on 3.4.0 tolerating it: #58463 (main, backport stable/8.9) and #58464 (stable/8.8, backport stable/8.7).

---
_Generated by [Claude Code](https://claude.com/claude-code)_