### PR TITLE
fix: do not double-attach the spring-boot-3-starter sources jar

### DIFF
--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -164,6 +164,13 @@
               <goal>jar-no-fork</goal>
             </goals>
             <phase>prepare-package</phase>
+            <!-- Build the sources jar on disk for shade (createSourcesJar) to consume, but do not
+                 attach it: the deploy command's source:jar already attaches the sources artifact and
+                 shade attaches the shaded one. Attaching here too triggers "duplicated artifacts
+                 attached" under maven-source-plugin < 3.4.0. -->
+            <configuration>
+              <attach>false</attach>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## What

Follow-up cleanup to the `camunda-spring-boot-3-starter` sources-jar build: stop double-attaching the sources artifact. Adds `<attach>false</attach>` to the `attach-sources` (`jar-no-fork`) execution.

## Why

The deploy command runs `source:jar` (default-cli), which attaches a `sources` artifact for every module, and the starter's `attach-sources` (`jar-no-fork`, `attach=true` by default) attaches it a second time. On `main`/`stable/8.9` (`maven-source-plugin` 3.4.0) that identical re-attach is a harmless no-op (MSOURCES-140, apache/maven-source-plugin#24). On `stable/8.8`/`stable/8.7` (3.3.1) the same re-attach is rejected with `We have duplicated artifacts attached.` and wedges the `Deploy snapshot artifacts` job under the `-T1C` reactor (the ~5-day incident; immediate stopgap: bump to 3.4.0 in #58462).

This makes the design robust regardless of plugin version: the execution still writes the sources jar to disk for shade to consume — shade's `createSourcesJar` reads the project's own sources jar **off disk** (`shadedSourcesArtifactFile()` + `isFile()`), not from the attached artifact — and shade attaches the shaded sources jar as the final `sources` artifact. So `attach=false` removes only the redundant attach, not the input shade needs, and it does not regress #48090.

## Validation

- `Deploy snapshot artifacts` completes with no `duplicated artifacts` line.
- The shipped `-sources.jar` still contains the base-module sources (shade merge intact).

## Related

Companion to #58462 (the 3.4.0 bump / re-land on `stable/8.8`). The `stable/8.8`+`stable/8.7` counterpart of this cleanup is #58464 (stacked on #58462).

---
_Generated by [Claude Code](https://claude.com/claude-code)_