### PR TITLE
fix: do not double-attach the spring-boot-4-starter sources jar

### DIFF
--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -153,6 +153,13 @@
               <goal>jar-no-fork</goal>
             </goals>
             <phase>prepare-package</phase>
+            <!-- Build the sources jar on disk for shade (createSourcesJar) to consume, but do not
+                 attach it: the deploy command's source:jar already attaches the sources artifact and
+                 shade attaches the shaded one. Attaching here too triggers "duplicated artifacts
+                 attached" under maven-source-plugin < 3.4.0. -->
+            <configuration>
+              <attach>false</attach>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## What

`stable/8.8` counterpart of the double-attach cleanup (#58463). Adds `<attach>false</attach>` to `camunda-spring-boot-4-starter`'s `attach-sources` (`jar-no-fork`) execution.

> **Stacked on #58462.** Base is `reland-sources-jar-8-8` (which re-lands the sources-jar fix + bumps `maven-source-plugin` to 3.4.0); GitHub will retarget this to `stable/8.8` once #58462 merges. Review after #58462.

## Why

The deploy command runs `source:jar` (default-cli), which attaches a `sources` artifact, and the starter's `attach-sources` (`jar-no-fork`, `attach=true` by default) attaches it again. Under `maven-source-plugin` 3.3.1 that re-attach was rejected with `We have duplicated artifacts attached.`, wedging the `Deploy snapshot artifacts` job under the `-T1C` reactor. #58462 unblocks by bumping to 3.4.0 (MSOURCES-140, apache/maven-source-plugin#24, makes the re-attach a no-op); this PR removes the redundant attach itself so the build no longer depends on that tolerance.

The execution still writes the sources jar to disk for shade to consume — shade's `createSourcesJar` reads the project's own sources jar **off disk** (`shadedSourcesArtifactFile()` + `isFile()`), not from the attached artifact — and shade attaches the shaded sources jar as the final `sources` artifact, so this does not regress #48090.

## Validation

- `Deploy snapshot artifacts` completes with no `duplicated artifacts` line.
- The shipped `-sources.jar` still contains the base-module sources (shade merge intact).

---
_Generated by [Claude Code](https://claude.com/claude-code)_