### PR TITLE
pg/56536-es-restore-validation

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/ContinuousBackupIT.java
@@ -303,6 +303,7 @@ final class ContinuousBackupIT {
     gcsConfig.setBasePath(basePath);
     gcsConfig.setBucketName(BUCKET_NAME);
     gcsConfig.setHost(GCS.externalEndpoint());
+    cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
     cfg.getData().getPrimaryStorage().getBackup().setGcs(gcsConfig);
     cfg.getData().getPrimaryStorage().getBackup().setStore(BackupStoreType.GCS);
   }

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -117,6 +117,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
@@ -129,7 +129,8 @@ public final class RestoreValidator
         Preconditions.test(!hasBackupIds, "No backupId specified");
         Preconditions.test(
             request.backupIds().size() > 1,
-            "Cannot restore from multiple backups against this database type");
+            "Cannot restore from multiple backups against database type %s"
+                .formatted(databaseType));
       }
       default ->
           throw new IllegalStateException("Invalid database type: " + request.databaseType());

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/validation/RestoreValidator.java
@@ -127,6 +127,9 @@ public final class RestoreValidator
             hasTimeRange,
             "Time range restore (from/to) is not supported for %s.".formatted(databaseType));
         Preconditions.test(!hasBackupIds, "No backupId specified");
+        Preconditions.test(
+            request.backupIds().size() > 1,
+            "Cannot restore from multiple backups against this database type");
       }
       default ->
           throw new IllegalStateException("Invalid database type: " + request.databaseType());

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
@@ -30,8 +30,6 @@ final class RestoreParameterValidatorTest {
   private static final String CONTINUOUS_MESSAGE =
       "Time range restore (from/to) is only supported for continuous backups.";
   private static final String NO_BACKUP_ID_MESSAGE = "No backupId specified";
-  private static final String MULTIPLE_BACKUP_IDS_MESSAGE =
-      "Cannot restore from multiple backups against this database type";
 
   private final RestoreValidator validator = new RestoreValidator(1, null, partitionId -> 1L);
 
@@ -191,13 +189,24 @@ final class RestoreParameterValidatorTest {
     }
 
     @Test
-    void shouldRejectMultipleBackupIds() {
+    void shouldRejectMultipleBackupIdsForElasticsearch() {
       // when / then
       assertThatExceptionOfType(IllegalArgumentException.class)
           .isThrownBy(
               () ->
                   validator.validateParameters(request(MULTIPLE_BACKUP_IDS, null, null, DB, false)))
-          .withMessage(MULTIPLE_BACKUP_IDS_MESSAGE);
+          .withMessage("Cannot restore from multiple backups against database type elasticsearch");
+    }
+
+    @Test
+    void shouldRejectMultipleBackupIdsForOpensearch() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  validator.validateParameters(
+                      request(MULTIPLE_BACKUP_IDS, null, null, "opensearch", false)))
+          .withMessage("Cannot restore from multiple backups against database type opensearch");
     }
   }
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
@@ -196,8 +196,7 @@ final class RestoreParameterValidatorTest {
       assertThatExceptionOfType(IllegalArgumentException.class)
           .isThrownBy(
               () ->
-                  RestoreValidator.validateParameters(
-                      request(MULTIPLE_BACKUP_IDS, null, null, DB, false)))
+                  validator.validateParameters(request(MULTIPLE_BACKUP_IDS, null, null, DB, false)))
           .withMessage(MULTIPLE_BACKUP_IDS_MESSAGE);
     }
   }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreParameterValidatorTest.java
@@ -22,6 +22,7 @@ final class RestoreParameterValidatorTest {
   private static final String EARLIER = "2026-01-01T10:00:00Z";
   private static final String LATER = "2026-01-01T12:00:00Z";
   private static final List<Long> BACKUP_ID = List.of(1L);
+  private static final List<Long> MULTIPLE_BACKUP_IDS = List.of(1L, 2L);
   private static final List<Long> NO_BACKUP_IDS = List.of();
 
   private static final String BOTH_MESSAGE =
@@ -29,6 +30,8 @@ final class RestoreParameterValidatorTest {
   private static final String CONTINUOUS_MESSAGE =
       "Time range restore (from/to) is only supported for continuous backups.";
   private static final String NO_BACKUP_ID_MESSAGE = "No backupId specified";
+  private static final String MULTIPLE_BACKUP_IDS_MESSAGE =
+      "Cannot restore from multiple backups against this database type";
 
   private final RestoreValidator validator = new RestoreValidator(1, null, partitionId -> 1L);
 
@@ -185,6 +188,17 @@ final class RestoreParameterValidatorTest {
           .isThrownBy(
               () -> validator.validateParameters(request(BACKUP_ID, EARLIER, null, DB, true)))
           .withMessage(BOTH_MESSAGE);
+    }
+
+    @Test
+    void shouldRejectMultipleBackupIds() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreValidator.validateParameters(
+                      request(MULTIPLE_BACKUP_IDS, null, null, DB, false)))
+          .withMessage(MULTIPLE_BACKUP_IDS_MESSAGE);
     }
   }
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
@@ -42,6 +42,8 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Exercises {@link RestoreValidator#validate(RestoreRequest)} against a mocked {@link BackupStore}.
@@ -439,14 +441,15 @@ final class RestoreValidatorResolverTest {
   @Nested
   final class NonRdbmsDatabaseTypes {
 
-    @Test
-    void shouldBroadcastExplicitBackupIdToAllPartitionsForElasticsearch() {
+    @ParameterizedTest
+    @ValueSource(strings = {"elasticsearch", "opensearch"})
+    void shouldBroadcastExplicitBackupIdToAllPartitions(final String databaseType) {
       // given
       stubBackupExists(1, 1L);
       stubBackupExists(2, 1L);
       final var validator = new RestoreValidator(2, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(1L), null, null, "elasticsearch", false, false);
+          new RestoreRequest("default", List.of(1L), null, null, databaseType, false, false);
 
       // when
       final var result = validator.validate(request);
@@ -455,51 +458,20 @@ final class RestoreValidatorResolverTest {
       assertValid(result, Map.of(1, new long[] {1L}, 2, new long[] {1L}), false);
     }
 
-    @Test
-    void shouldBroadcastExplicitBackupIdToAllPartitionsForOpensearch() {
-      // given
-      stubBackupExists(1, 1L);
-      stubBackupExists(2, 1L);
-      final var validator = new RestoreValidator(2, backupStore, null);
-      final var request =
-          new RestoreRequest("default", List.of(1L), null, null, "opensearch", false, false);
-
-      // when
-      final var result = validator.validate(request);
-
-      // then
-      assertValid(result, Map.of(1, new long[] {1L}, 2, new long[] {1L}), false);
-    }
-
-    @Test
-    void shouldRejectMultipleBackupIdsForElasticsearch() {
+    @ParameterizedTest
+    @ValueSource(strings = {"elasticsearch", "opensearch"})
+    void shouldRejectMultipleBackupIdsWithoutQueryingBackupStore(final String databaseType) {
       // given
       final var validator = new RestoreValidator(2, backupStore, null);
       final var request =
-          new RestoreRequest("default", List.of(1L, 2L), null, null, "elasticsearch", false, false);
+          new RestoreRequest("default", List.of(1L, 2L), null, null, databaseType, false, false);
 
       // when
       final var result = validator.validate(request);
 
       // then
       assertThat(assertInvalid(result))
-          .hasMessage("Cannot restore from multiple backups against database type elasticsearch");
-      verifyNoInteractions(backupStore);
-    }
-
-    @Test
-    void shouldRejectMultipleBackupIdsForOpensearch() {
-      // given
-      final var validator = new RestoreValidator(2, backupStore, null);
-      final var request =
-          new RestoreRequest("default", List.of(1L, 2L), null, null, "opensearch", false, false);
-
-      // when
-      final var result = validator.validate(request);
-
-      // then
-      assertThat(assertInvalid(result))
-          .hasMessage("Cannot restore from multiple backups against database type opensearch");
+          .hasMessage("Cannot restore from multiple backups against database type " + databaseType);
       verifyNoInteractions(backupStore);
     }
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
@@ -517,7 +517,7 @@ final class RestoreValidatorResolverTest {
 
       // then
       assertThat(assertInvalid(result))
-          .hasMessage("No completed backup found for partition 2 with backup id 1");
+          .hasMessage("Could not find a completed backup with id 1 for partition 2.");
     }
   }
 }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
@@ -517,7 +517,7 @@ final class RestoreValidatorResolverTest {
 
       // then
       assertThat(assertInvalid(result))
-          .hasMessage("Could not find a completed backup with id 1 for partition 2.");
+          .hasMessage("No completed backup found for partition 2 with backup id 1");
     }
   }
 }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
@@ -483,7 +483,23 @@ final class RestoreValidatorResolverTest {
 
       // then
       assertThat(assertInvalid(result))
-          .hasMessage("Cannot restore from multiple backups against this database type");
+          .hasMessage("Cannot restore from multiple backups against database type elasticsearch");
+      verifyNoInteractions(backupStore);
+    }
+
+    @Test
+    void shouldRejectMultipleBackupIdsForOpensearch() {
+      // given
+      final var validator = new RestoreValidator(2, backupStore, null);
+      final var request =
+          new RestoreRequest("default", List.of(1L, 2L), null, null, "opensearch", false, false);
+
+      // when
+      final var result = validator.validate(request);
+
+      // then
+      assertThat(assertInvalid(result))
+          .hasMessage("Cannot restore from multiple backups against database type opensearch");
       verifyNoInteractions(backupStore);
     }
 

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/validation/RestoreValidatorResolverTest.java
@@ -16,9 +16,11 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard.CheckpointPattern;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
+import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.backup.common.BackupMetadata;
 import io.camunda.zeebe.backup.common.BackupMetadata.CheckpointEntry;
 import io.camunda.zeebe.backup.common.BackupMetadata.RangeEntry;
@@ -119,6 +121,28 @@ final class RestoreValidatorResolverTest {
   private void stubNoBackupExists() {
     when(backupStore.list(any(BackupIdentifierWildcard.class)))
         .thenReturn(CompletableFuture.completedFuture(List.of()));
+  }
+
+  private void stubBackupExists(final int partitionId, final long backupId) {
+    final var pattern =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(backupId));
+    final var status =
+        new BackupStatusImpl(
+            new BackupIdentifierImpl(0, partitionId, backupId),
+            Optional.empty(),
+            BackupStatusCode.COMPLETED,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    when(backupStore.list(pattern)).thenReturn(CompletableFuture.completedFuture(List.of(status)));
+  }
+
+  private void stubBackupMissing(final int partitionId, final long backupId) {
+    final var pattern =
+        new BackupIdentifierWildcardImpl(
+            Optional.empty(), Optional.of(partitionId), CheckpointPattern.of(backupId));
+    when(backupStore.list(pattern)).thenReturn(CompletableFuture.completedFuture(List.of()));
   }
 
   private static byte[] serialize(final BackupMetadata metadata) {
@@ -409,6 +433,75 @@ final class RestoreValidatorResolverTest {
       // when / then
       final var result = validator.validate(request);
       assertThat(assertInvalid(result)).isInstanceOf(NoSuchElementException.class);
+    }
+  }
+
+  @Nested
+  final class NonRdbmsDatabaseTypes {
+
+    @Test
+    void shouldBroadcastExplicitBackupIdToAllPartitionsForElasticsearch() {
+      // given
+      stubBackupExists(1, 1L);
+      stubBackupExists(2, 1L);
+      final var validator = new RestoreValidator(2, backupStore, null);
+      final var request =
+          new RestoreRequest("default", List.of(1L), null, null, "elasticsearch", false, false);
+
+      // when
+      final var result = validator.validate(request);
+
+      // then
+      assertValid(result, Map.of(1, new long[] {1L}, 2, new long[] {1L}), false);
+    }
+
+    @Test
+    void shouldBroadcastExplicitBackupIdToAllPartitionsForOpensearch() {
+      // given
+      stubBackupExists(1, 1L);
+      stubBackupExists(2, 1L);
+      final var validator = new RestoreValidator(2, backupStore, null);
+      final var request =
+          new RestoreRequest("default", List.of(1L), null, null, "opensearch", false, false);
+
+      // when
+      final var result = validator.validate(request);
+
+      // then
+      assertValid(result, Map.of(1, new long[] {1L}, 2, new long[] {1L}), false);
+    }
+
+    @Test
+    void shouldRejectMultipleBackupIdsForElasticsearch() {
+      // given
+      final var validator = new RestoreValidator(2, backupStore, null);
+      final var request =
+          new RestoreRequest("default", List.of(1L, 2L), null, null, "elasticsearch", false, false);
+
+      // when
+      final var result = validator.validate(request);
+
+      // then
+      assertThat(assertInvalid(result))
+          .hasMessage("Cannot restore from multiple backups against this database type");
+      verifyNoInteractions(backupStore);
+    }
+
+    @Test
+    void shouldRejectWhenBackupIsMissingForAPartition() {
+      // given - partition 2 has no completed backup for the requested id
+      stubBackupExists(1, 1L);
+      stubBackupMissing(2, 1L);
+      final var validator = new RestoreValidator(2, backupStore, null);
+      final var request =
+          new RestoreRequest("default", List.of(1L), null, null, "elasticsearch", false, false);
+
+      // when
+      final var result = validator.validate(request);
+
+      // then
+      assertThat(assertInvalid(result))
+          .hasMessage("No completed backup found for partition 2 with backup id 1");
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Perform the ES/OS restore validation against the backup store. Most of the implementation is derived from the RDBMS restore validation, with the exception that for ES/OS we only allow 1 backupId to be present in the request.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/56536
