### PR TITLE
build: skip javadoc for empty secret-store-aws module

### DIFF
--- a/secret-store/secret-store-aws/pom.xml
+++ b/secret-store/secret-store-aws/pom.xml
@@ -18,11 +18,41 @@
 
   <name>Camunda Secret Store AWS Secrets Manager Implementation</name>
 
+  <properties>
+    <!-- Remove this property and the empty-javadoc-jar execution below once this module has
+         public classes to document. -->
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- maven.javadoc.skip disables the real javadoc jar, so attach an empty placeholder to
+           satisfy the "every non-pom artifact ships a javadoc jar" release requirement. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
## Description

The `camunda-secret-store-aws` module was scaffolded in #58101 with only a `package-info.java` and no public classes yet. The release process attaches a javadoc jar to every Java module, and `javadoc` treats `No public or protected classes found to document` as a hard error (exit 1):

```
[ERROR] Failed to execute goal maven-javadoc-plugin:3.12.0:jar (attach-javadocs)
        on project camunda-secret-store-aws: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1
[ERROR] error: No public or protected classes found to document.
```

This breaks the scheduled [Camunda Platform Release Dry Run from main](https://github.com/camunda/camunda/actions/runs/29972253501/job/89097895450) workflow, and will keep failing nightly until the module has documentable classes.

This PR skips javadoc generation for the module until it gains public classes, matching the convention already used by `zeebe/protocol-asserts`, `zeebe/expression-language`, `optimize`, `operate`, `tasklist`, and `webapp`.

## Verification

- Before: `./mvnw javadoc:jar -pl secret-store/secret-store-aws` fails with the error above.
- After: `[INFO] Skipping javadoc generation` → `BUILD SUCCESS`.

## Related issues

Part of https://github.com/camunda/camunda/issues/56574

🤖 Generated with [Claude Code](https://claude.com/claude-code)