### PR TITLE
feat: gossip CurrentClusterConfiguration with dual-write for rolling upgrades

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -537,6 +537,32 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(() -> partitionGroupChangeAppliers.remove(groupId));
   }
 
+  /**
+   * Merges a {@link CurrentClusterConfiguration} received via gossip into the local one. If the
+   * merge changes the local configuration, it is persisted, re-gossiped, and local operation
+   * application is triggered. Mirrors the legacy {@code onGossipReceived} merge behaviour.
+   */
+  void onGossipReceivedCurrent(final CurrentClusterConfiguration receivedConfiguration) {
+    executor.run(
+        () -> {
+          if (receivedConfiguration == null) {
+            return;
+          }
+          final var local = persistedCurrentConfiguration.getConfiguration();
+          final var merged = local.merge(receivedConfiguration);
+          if (!merged.equals(local)) {
+            updateLocalCurrentConfiguration(merged)
+                .ifRightOrLeft(
+                    applied -> applyNewConfigurationChangeOperation(),
+                    error ->
+                        LOG.warn(
+                            "Failed to process cluster configuration received via gossip. '{}'",
+                            receivedConfiguration,
+                            error));
+          }
+        });
+  }
+
   private Either<Exception, CurrentClusterConfiguration> updateLocalCurrentConfiguration(
       final CurrentClusterConfiguration configuration) {
     if (configuration.equals(persistedCurrentConfiguration.getConfiguration())) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -207,6 +207,46 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     return future;
   }
 
+  @Override
+  public boolean isUsingNewConfig() {
+    return useNewConfig;
+  }
+
+  /** Returns the full multi-group configuration. Only valid when {@link #useNewConfig} is true. */
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> getMultiConfiguration() {
+    final var future = executor.<CurrentClusterConfiguration>createFuture();
+    executor.run(() -> future.complete(persistedCurrentConfiguration.getConfiguration()));
+    return future;
+  }
+
+  /**
+   * Applies {@code updater} to the multi-group configuration, persists and gossips the result, then
+   * triggers local operation application. Only valid when {@link #useNewConfig} is true.
+   */
+  @Override
+  public ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
+      final UnaryOperator<CurrentClusterConfiguration> updater) {
+    final var future = executor.<CurrentClusterConfiguration>createFuture();
+    executor.run(
+        () -> {
+          try {
+            final var updated = updater.apply(persistedCurrentConfiguration.getConfiguration());
+            updateLocalCurrentConfiguration(updated)
+                .ifRightOrLeft(
+                    applied -> {
+                      future.complete(applied);
+                      applyNewConfigurationChangeOperation();
+                    },
+                    future::completeExceptionally);
+          } catch (final Exception e) {
+            LOG.error("Failed to update cluster configuration", e);
+            future.completeExceptionally(e);
+          }
+        });
+    return future;
+  }
+
   ActorFuture<Void> start(final ClusterConfigurationInitializer clusterConfigurationInitializer) {
     executor.run(
         () -> {
@@ -455,6 +495,10 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
         });
   }
 
+  // ---------------------------------------------------------------------------
+  // New multi-partition-group model (used only when useNewConfig is true).
+  // ---------------------------------------------------------------------------
+
   void removeTopologyChangeAppliers() {
     executor.run(() -> changeAppliers = null);
   }
@@ -467,53 +511,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     executor.run(() -> onInconsistentConfigurationDetected = null);
   }
 
-  // ---------------------------------------------------------------------------
-  // New multi-partition-group model (used only when useNewConfig is true).
-  // ---------------------------------------------------------------------------
-
-  @Override
-  public boolean isUsingNewConfig() {
-    return useNewConfig;
-  }
-
   void setCurrentConfigurationGossiper(
       final Consumer<CurrentClusterConfiguration> currentConfigurationGossiper) {
     this.currentConfigurationGossiper = currentConfigurationGossiper;
-  }
-
-  /** Returns the full multi-group configuration. Only valid when {@link #useNewConfig} is true. */
-  @Override
-  public ActorFuture<CurrentClusterConfiguration> getMultiConfiguration() {
-    final var future = executor.<CurrentClusterConfiguration>createFuture();
-    executor.run(() -> future.complete(persistedCurrentConfiguration.getConfiguration()));
-    return future;
-  }
-
-  /**
-   * Applies {@code updater} to the multi-group configuration, persists and gossips the result, then
-   * triggers local operation application. Only valid when {@link #useNewConfig} is true.
-   */
-  @Override
-  public ActorFuture<CurrentClusterConfiguration> updateMultiConfiguration(
-      final UnaryOperator<CurrentClusterConfiguration> updater) {
-    final var future = executor.<CurrentClusterConfiguration>createFuture();
-    executor.run(
-        () -> {
-          try {
-            final var updated = updater.apply(persistedCurrentConfiguration.getConfiguration());
-            updateLocalCurrentConfiguration(updated)
-                .ifRightOrLeft(
-                    applied -> {
-                      future.complete(applied);
-                      applyNewConfigurationChangeOperation();
-                    },
-                    future::completeExceptionally);
-          } catch (final Exception e) {
-            LOG.error("Failed to update cluster configuration", e);
-            future.completeExceptionally(e);
-          }
-        });
-    return future;
   }
 
   void registerGlobalChangeAppliers(final GlobalConfigurationChangeAppliers appliers) {
@@ -548,17 +548,24 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
           if (receivedConfiguration == null) {
             return;
           }
-          final var local = persistedCurrentConfiguration.getConfiguration();
-          final var merged = local.merge(receivedConfiguration);
-          if (!merged.equals(local)) {
-            updateLocalCurrentConfiguration(merged)
-                .ifRightOrLeft(
-                    applied -> applyNewConfigurationChangeOperation(),
-                    error ->
-                        LOG.warn(
-                            "Failed to process cluster configuration received via gossip. '{}'",
-                            receivedConfiguration,
-                            error));
+          try {
+            final var local = persistedCurrentConfiguration.getConfiguration();
+            final var merged = local.merge(receivedConfiguration);
+            if (!merged.equals(local)) {
+              updateLocalCurrentConfiguration(merged)
+                  .ifRightOrLeft(
+                      applied -> applyNewConfigurationChangeOperation(),
+                      error ->
+                          LOG.warn(
+                              "Failed to process cluster configuration received via gossip. '{}'",
+                              receivedConfiguration,
+                              error));
+            }
+          } catch (final Exception e) {
+            LOG.warn(
+                "Failed to process cluster configuration received via gossip. '{}'",
+                receivedConfiguration,
+                e);
           }
         });
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossipState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossipState.java
@@ -57,8 +57,8 @@ public final class ClusterConfigurationGossipState {
 
   @Override
   public String toString() {
-    return "ClusterTopologyGossipState{"
-        + "clusterTopology="
+    return "ClusterConfigurationGossipState{"
+        + "clusterConfiguration="
         + clusterConfiguration
         + ", currentClusterConfiguration="
         + currentClusterConfiguration

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossipState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossipState.java
@@ -8,11 +8,15 @@
 package io.camunda.zeebe.dynamic.config.gossip;
 
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import java.util.Objects;
 
 public final class ClusterConfigurationGossipState {
   // TODO: This should also tracks the BrokerInfo which is currently in SWIM member.properties
   private ClusterConfiguration clusterConfiguration;
+  // Field 2 of the gossiped state: the new multi-partition-group configuration, populated
+  // alongside clusterConfiguration by upgraded brokers (dual-write). Null on the legacy path.
+  private CurrentClusterConfiguration currentClusterConfiguration;
 
   public ClusterConfiguration getClusterConfiguration() {
     return clusterConfiguration;
@@ -22,9 +26,18 @@ public final class ClusterConfigurationGossipState {
     this.clusterConfiguration = clusterConfiguration;
   }
 
+  public CurrentClusterConfiguration getCurrentClusterConfiguration() {
+    return currentClusterConfiguration;
+  }
+
+  public void setCurrentClusterConfiguration(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    this.currentClusterConfiguration = currentClusterConfiguration;
+  }
+
   @Override
   public int hashCode() {
-    return clusterConfiguration != null ? clusterConfiguration.hashCode() : 0;
+    return Objects.hash(clusterConfiguration, currentClusterConfiguration);
   }
 
   @Override
@@ -38,11 +51,17 @@ public final class ClusterConfigurationGossipState {
 
     final ClusterConfigurationGossipState that = (ClusterConfigurationGossipState) o;
 
-    return Objects.equals(clusterConfiguration, that.clusterConfiguration);
+    return Objects.equals(clusterConfiguration, that.clusterConfiguration)
+        && Objects.equals(currentClusterConfiguration, that.currentClusterConfiguration);
   }
 
   @Override
   public String toString() {
-    return "ClusterTopologyGossipState{" + "clusterTopology=" + clusterConfiguration + '}';
+    return "ClusterTopologyGossipState{"
+        + "clusterTopology="
+        + clusterConfiguration
+        + ", currentClusterConfiguration="
+        + currentClusterConfiguration
+        + '}';
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -54,6 +55,9 @@ public final class ClusterConfigurationGossiper
 
   // The handler which can merge configuration updates and reacts to the changes.
   private final Consumer<ClusterConfiguration> clusterConfigurationUpdateHandler;
+  // New-model handler; when set, received gossip is delivered as a CurrentClusterConfiguration
+  // (field 2, or migrated from field 1) instead of through the legacy handler.
+  private Consumer<CurrentClusterConfiguration> currentConfigurationUpdateHandler;
   private final TopologyMetrics topologyMetrics;
 
   public ClusterConfigurationGossiper(
@@ -167,11 +171,27 @@ public final class ClusterConfigurationGossiper
   }
 
   private void update(final ClusterConfigurationGossipState receivedGossipState) {
-    if (!receivedGossipState.equals(gossipState)) {
-      final ClusterConfiguration topology = receivedGossipState.getClusterConfiguration();
-      if (topology != null) {
-        clusterConfigurationUpdateHandler.accept(topology);
+    if (receivedGossipState.equals(gossipState)) {
+      return;
+    }
+    if (currentConfigurationUpdateHandler != null) {
+      // New model: prefer field 2; fall back to migrating field 1 from an old broker.
+      final var received = receivedGossipState.getCurrentClusterConfiguration();
+      final CurrentClusterConfiguration wrapper =
+          received != null
+              ? received
+              : receivedGossipState.getClusterConfiguration() != null
+                  ? CurrentClusterConfiguration.fromLegacy(
+                      receivedGossipState.getClusterConfiguration())
+                  : null;
+      if (wrapper != null) {
+        currentConfigurationUpdateHandler.accept(wrapper);
       }
+      return;
+    }
+    final ClusterConfiguration topology = receivedGossipState.getClusterConfiguration();
+    if (topology != null) {
+      clusterConfigurationUpdateHandler.accept(topology);
     }
   }
 
@@ -181,6 +201,18 @@ public final class ClusterConfigurationGossiper
     gossip();
     notifyListeners(updatedConfiguration);
     topologyMetrics.updateFromTopology(updatedConfiguration);
+  }
+
+  private void onCurrentConfigurationUpdated(
+      final CurrentClusterConfiguration updatedConfiguration) {
+    // Dual-write: field 2 carries the full new model, field 1 the legacy view read by old brokers.
+    final var legacyView = updatedConfiguration.toLegacyDefault();
+    gossipState.setCurrentClusterConfiguration(updatedConfiguration);
+    gossipState.setClusterConfiguration(legacyView);
+    LOGGER.trace("Updated local gossipState to {}", updatedConfiguration);
+    gossip();
+    notifyListeners(legacyView);
+    topologyMetrics.updateFromTopology(legacyView);
   }
 
   private void notifyListeners(final ClusterConfiguration updatedTopology) {
@@ -206,6 +238,31 @@ public final class ClusterConfigurationGossiper
         () -> {
           if (!clusterConfiguration.equals(gossipState.getClusterConfiguration())) {
             onConfigurationUpdated(clusterConfiguration);
+          }
+        });
+  }
+
+  /**
+   * Sets the handler invoked with the received {@link CurrentClusterConfiguration} (new model).
+   * Setting it switches the receive path from the legacy handler to this one.
+   */
+  public void setCurrentConfigurationUpdateHandler(
+      final Consumer<CurrentClusterConfiguration> handler) {
+    executor.run(() -> currentConfigurationUpdateHandler = handler);
+  }
+
+  /**
+   * New-model counterpart of {@link #updateClusterConfiguration}; dual-writes both gossip fields.
+   */
+  public void updateCurrentClusterConfiguration(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    if (currentClusterConfiguration == null) {
+      return;
+    }
+    executor.run(
+        () -> {
+          if (!currentClusterConfiguration.equals(gossipState.getCurrentClusterConfiguration())) {
+            onCurrentConfigurationUpdated(currentClusterConfiguration);
           }
         });
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -119,6 +119,13 @@ public class ProtoBufSerializer
       builder.setClusterTopology(clusterTopology);
     }
 
+    final CurrentClusterConfiguration currentToEncode =
+        gossipState.getCurrentClusterConfiguration();
+    if (currentToEncode != null) {
+      builder.setCurrentClusterConfiguration(
+          encodeCurrentClusterConfigurationProto(currentToEncode));
+    }
+
     final var message = builder.build();
     return message.toByteArray();
   }
@@ -142,6 +149,17 @@ public class ProtoBufSerializer
       } catch (final Exception e) {
         throw new DecodingFailed(
             "Cluster topology could not be deserialized from gossiped state: %s"
+                .formatted(gossipState),
+            e);
+      }
+    }
+    if (gossipState.hasCurrentClusterConfiguration()) {
+      try {
+        clusterConfigurationGossipState.setCurrentClusterConfiguration(
+            decodeCurrentClusterConfiguration(gossipState.getCurrentClusterConfiguration()));
+      } catch (final Exception e) {
+        throw new DecodingFailed(
+            "Current cluster configuration could not be deserialized from gossiped state: %s"
                 .formatted(gossipState),
             e);
       }

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -5,7 +5,13 @@ import "google/protobuf/timestamp.proto";
 
 option java_package = "io.camunda.zeebe.dynamic.config.protocol";
 
-message GossipState { ClusterTopology clusterTopology = 1; }
+// During a rolling upgrade both fields are populated (dual-write): field 1
+// carries the legacy single-group view (read by old brokers), field 2 carries
+// the full multi-partition-group configuration (read by upgraded brokers).
+message GossipState {
+  ClusterTopology clusterTopology = 1;
+  CurrentClusterConfiguration currentClusterConfiguration = 2;
+}
 
 // ---- New multi-partition-group configuration model (8.10) ----
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -302,6 +302,24 @@ final class ClusterConfigurationManagerImplNewConfigTest {
   }
 
   @Test
+  void shouldMergeAndApplyOperationOnGossipReceived() {
+    // given — the local member (1) starts with an empty, initialized configuration
+    final var manager = newManager(MEMBER_1);
+    manager.updateMultiConfiguration(ignored -> CurrentClusterConfiguration.init()).join();
+
+    // when — a configuration received via gossip carries a pending plan joining the local member
+    final var received =
+        CurrentClusterConfiguration.init()
+            .initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_1)))));
+    manager.onGossipReceivedCurrent(received);
+
+    // then — the merge is persisted locally and the local member's join operation is applied
+    final var config = configuration(manager);
+    assertThat(config.globalConfiguration().getMember(MEMBER_1).state()).isEqualTo(State.ACTIVE);
+    assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
+  }
+
+  @Test
   void shouldRetryPendingOperationInPartitionGroupIfFailed() {
     // given — member 0 is the coordinator; it is part of the cluster and the default group, which
     // has member 1 holding partition 1; a plan is initiated to add member 0 as a replica of

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -100,7 +100,11 @@ final class ClusterConfigurationGossiperTest {
     // given — three upgraded brokers, all with the new-model handler wired
     final var config =
         new ClusterConfigurationGossiperConfig(
-            Duration.ofMillis(100), Duration.ofSeconds(1), 0, Duration.ofSeconds(1));
+            Duration.ofMillis(100),
+            Duration.ofSeconds(1),
+            0,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1));
     node1 =
         new TestGossiper(
             createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
@@ -140,7 +144,11 @@ final class ClusterConfigurationGossiperTest {
     // given — node 1 is not yet upgraded (legacy handler only); node 2 is upgraded
     final var config =
         new ClusterConfigurationGossiperConfig(
-            Duration.ofMillis(100), Duration.ofSeconds(1), 0, Duration.ofSeconds(1));
+            Duration.ofMillis(100),
+            Duration.ofSeconds(1),
+            0,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1));
     node1 =
         new TestGossiper(
             createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
@@ -164,6 +172,43 @@ final class ClusterConfigurationGossiperTest {
             () ->
                 assertThat(node2.currentClusterConfiguration)
                     .isEqualTo(CurrentClusterConfiguration.fromLegacy(node1Topology)));
+  }
+
+  @Test
+  void shouldStillGossipLegacyFieldToAnOldBrokerFromAnUpgradedBroker() {
+    // given — node 1 is upgraded (dual-write); node 2 is not yet upgraded (legacy handler only)
+    final var config =
+        new ClusterConfigurationGossiperConfig(
+            Duration.ofMillis(100),
+            Duration.ofSeconds(1),
+            0,
+            Duration.ofSeconds(1),
+            Duration.ofSeconds(1));
+    node1 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+    node2 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+
+    node1.start();
+    node2.start();
+    node1.enableNewModel();
+
+    final var node1Configuration =
+        CurrentClusterConfiguration.fromLegacy(
+            ClusterConfiguration.init()
+                .addMember(node1.id(), MemberState.initializeAsActive(Map.of())));
+
+    // when — the upgraded broker gossips the new-model configuration (dual-writing both fields)
+    node1.setCurrentClusterConfiguration(node1Configuration);
+
+    // then — the not-yet-upgraded broker still receives and merges the legacy field
+    Awaitility.await("Node 2 (not upgraded) has received the legacy field via gossip")
+        .untilAsserted(
+            () ->
+                assertThat(node2.clusterConfiguration)
+                    .isEqualTo(node1Configuration.toLegacyDefault()));
   }
 
   private Node createNode(final String id) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -17,6 +17,7 @@ import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -94,6 +95,77 @@ final class ClusterConfigurationGossiperTest {
         .untilAsserted(() -> assertThat(node3.clusterConfiguration).isEqualTo(node1Topology));
   }
 
+  @Test
+  void shouldConvergeCurrentClusterConfigurationBetweenUpgradedBrokers() {
+    // given — three upgraded brokers, all with the new-model handler wired
+    final var config =
+        new ClusterConfigurationGossiperConfig(
+            Duration.ofMillis(100), Duration.ofSeconds(1), 0, Duration.ofSeconds(1));
+    node1 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+    node2 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+    node3 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(2), clusterNodes), config, topologyMetrics);
+
+    node1.start();
+    node2.start();
+    node3.start();
+    node1.enableNewModel();
+    node2.enableNewModel();
+    node3.enableNewModel();
+
+    final var legacySeed =
+        ClusterConfiguration.init().addMember(node1.id(), MemberState.initializeAsActive(Map.of()));
+    final var node1Configuration = CurrentClusterConfiguration.fromLegacy(legacySeed);
+
+    // when — node 1 gossips the new-model configuration, with no persisted-file sharing between
+    // nodes (each TestGossiper only exchanges state over the real network)
+    node1.setCurrentClusterConfiguration(node1Configuration);
+
+    // then — nodes 2 and 3 converge on the same multi-group configuration via gossip alone
+    Awaitility.await("Node 2 has received the new-model configuration via gossip")
+        .untilAsserted(
+            () -> assertThat(node2.currentClusterConfiguration).isEqualTo(node1Configuration));
+    Awaitility.await("Node 3 has received the new-model configuration via gossip")
+        .untilAsserted(
+            () -> assertThat(node3.currentClusterConfiguration).isEqualTo(node1Configuration));
+  }
+
+  @Test
+  void shouldMigrateLegacyGossipFromAnOldBroker() {
+    // given — node 1 is not yet upgraded (legacy handler only); node 2 is upgraded
+    final var config =
+        new ClusterConfigurationGossiperConfig(
+            Duration.ofMillis(100), Duration.ofSeconds(1), 0, Duration.ofSeconds(1));
+    node1 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+    node2 =
+        new TestGossiper(
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+
+    node1.start();
+    node2.start();
+    node2.enableNewModel();
+
+    final var node1Topology =
+        ClusterConfiguration.init().addMember(node1.id(), MemberState.initializeAsActive(Map.of()));
+
+    // when — the old broker gossips only the legacy field
+    node1.setTopology(node1Topology);
+
+    // then — the upgraded broker migrates the received legacy view via fromLegacy
+    Awaitility.await("Node 2 has migrated the legacy gossip from the old broker")
+        .untilAsserted(
+            () ->
+                assertThat(node2.currentClusterConfiguration)
+                    .isEqualTo(CurrentClusterConfiguration.fromLegacy(node1Topology)));
+  }
+
   private Node createNode(final String id) {
     return Node.builder().withId(id).withPort(SocketUtil.getNextAddress().getPort()).build();
   }
@@ -111,6 +183,7 @@ final class ClusterConfigurationGossiperTest {
     private final ClusterConfigurationGossiper gossiper;
     private final AtomixCluster atomixCluster;
     private ClusterConfiguration clusterConfiguration;
+    private CurrentClusterConfiguration currentClusterConfiguration;
 
     private TestGossiper(
         final AtomixCluster atomixCluster,
@@ -148,6 +221,24 @@ final class ClusterConfigurationGossiperTest {
     private ActorFuture<ClusterConfiguration> mergeTopology(final ClusterConfiguration t) {
       clusterConfiguration = clusterConfiguration == null ? t : t.merge(clusterConfiguration);
       return TestActorFuture.completedFuture(clusterConfiguration);
+    }
+
+    /** Switches this broker onto the new-model gossip path (an "upgraded" broker). */
+    void enableNewModel() {
+      gossiper.setCurrentConfigurationUpdateHandler(this::mergeCurrentClusterConfiguration);
+    }
+
+    void setCurrentClusterConfiguration(
+        final CurrentClusterConfiguration currentClusterConfiguration) {
+      this.currentClusterConfiguration = currentClusterConfiguration;
+      gossiper.updateCurrentClusterConfiguration(currentClusterConfiguration);
+    }
+
+    private void mergeCurrentClusterConfiguration(final CurrentClusterConfiguration received) {
+      currentClusterConfiguration =
+          currentClusterConfiguration == null
+              ? received
+              : currentClusterConfiguration.merge(received);
     }
 
     public MemberId id() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
@@ -7,10 +7,17 @@
  */
 package io.camunda.zeebe.dynamic.config.serializer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.protobuf.Timestamp;
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Topology;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -58,5 +65,42 @@ final class CurrentClusterConfigurationSerializerTest {
     // when / then
     assertThatThrownBy(() -> serializer.decodeGlobalConfiguration(proto))
         .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldRoundTripGossipStateWithBothFields() {
+    // given — a gossip state carrying both the legacy view (field 1) and the new model (field 2)
+    final var legacy =
+        ClusterConfiguration.init()
+            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()));
+    final var state = new ClusterConfigurationGossipState();
+    state.setClusterConfiguration(legacy);
+    state.setCurrentClusterConfiguration(CurrentClusterConfiguration.fromLegacy(legacy));
+
+    // when
+    final var decoded = serializer.decode(serializer.encode(state));
+
+    // then — both fields survive the round-trip
+    assertThat(decoded).isEqualTo(state);
+    assertThat(decoded.getClusterConfiguration()).isEqualTo(legacy);
+    assertThat(decoded.getCurrentClusterConfiguration())
+        .isEqualTo(CurrentClusterConfiguration.fromLegacy(legacy));
+  }
+
+  @Test
+  void shouldRoundTripGossipStateWithOnlyLegacyField() {
+    // given — an old broker gossips only field 1
+    final var legacy =
+        ClusterConfiguration.init()
+            .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()));
+    final var state = new ClusterConfigurationGossipState();
+    state.setClusterConfiguration(legacy);
+
+    // when
+    final var decoded = serializer.decode(serializer.encode(state));
+
+    // then
+    assertThat(decoded.getClusterConfiguration()).isEqualTo(legacy);
+    assertThat(decoded.getCurrentClusterConfiguration()).isNull();
   }
 }


### PR DESCRIPTION
## Summary
Stacked on #58440 (dd-58397-coordinator-new-model).

- `ClusterConfigurationGossipState` gets a second field, the full multi-partition-group `CurrentClusterConfiguration`, alongside the existing legacy `clusterConfiguration` field. Both are carried through `equals`/`hashCode`/`toString` and the `ProtoBufSerializer` encode/decode.
- `ClusterConfigurationGossiper` gains a new-model send/receive path: `updateCurrentClusterConfiguration` dual-writes both fields (the real value plus its `toLegacyDefault()` projection) and gossips once; on receive, `setCurrentConfigurationUpdateHandler` switches dispatch to prefer field 2, falling back to migrating field 1 via `fromLegacy` when the sender is an old (not-yet-upgraded) broker. The legacy-only gossip path is completely unchanged.
- `ClusterConfigurationManagerImpl` gains `onGossipReceivedCurrent`, merging a received configuration into the local one and triggering local operation application — mirrors the legacy `onGossipReceived` merge behavior.

closes #58399
closes #56214

## Scope notes
- `onGossipReceivedCurrent` / `setCurrentConfigurationUpdateHandler` are **not wired to any production code path** on this branch — nothing in `ClusterConfigurationManagerService` yet calls `gossiper.setCurrentConfigurationUpdateHandler(manager::onGossipReceivedCurrent)`. That wiring is deliberately deferred to #58400 (service/broker wiring), consistent with this issue's scope (gossip mechanism only). This means the live multi-node test below validates the `ClusterConfigurationGossiper` dual-write/receive mechanism directly (via a test-local merge callback), and the manager's merge-then-apply behavior is validated separately at the unit level — the full wire wasn't end-to-end testable yet since nothing turns it on in production.
- No `initialized`-style guard was added to `onGossipReceivedCurrent` (the legacy `onGossipReceived` has one, to avoid a race with async startup). Harmless today since the new-model manager constructor is test-only; worth revisiting once #58400 adds real async initialization for the new model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)