### PR TITLE
feat: wire Camunda Security Library behind optimize.security.csl.enabled flag

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -116,6 +116,16 @@
       </exclusions>
     </dependency>
 
+    <!-- Camunda Security Library -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-library-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-library-spring-boot-starter</artifactId>
+    </dependency>
+
     <!-- Spring -->
     <!-- Do not add versions: parent/pom.xml manages spring-framework-bom -->
     <dependency>

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -57,9 +58,15 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
+// Backs off when CSL is active (optimize.security.csl.enabled=true) to avoid colliding chains. See
+// https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
 @Configuration
 @EnableWebSecurity
 @Conditional(CCSMCondition.class)
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
 public class CCSMSecurityConfigurerAdapter extends AbstractSecurityConfigurerAdapter {
 
   private static final Logger LOG = LoggerFactory.getLogger(CCSMSecurityConfigurerAdapter.class);

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -47,6 +47,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -80,9 +81,15 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.util.UriComponentsBuilder;
 
+// Backs off when CSL is active (optimize.security.csl.enabled=true) to avoid colliding chains. See
+// https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
 @Configuration
 @EnableWebSecurity
 @Conditional(CCSaaSCondition.class)
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
 public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerAdapter {
 
   public static final String CAMUNDA_CLUSTER_ID_CLAIM_NAME = "https://camunda.com/clusterId";

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaasAuth0WebSecurityConfig.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
 import io.camunda.optimize.service.util.configuration.security.CloudAuthConfiguration;
 import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -22,8 +23,15 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
+// Backs off under CSL: otherwise CSL adopts this legacy Auth0 ClientRegistrationRepository via
+// @ConditionalOnMissingBean and its sso-callback redirect overrides camunda.security.*.oidc config.
+// https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md
 @Configuration
 @Conditional(CCSaaSCondition.class)
+@ConditionalOnProperty(
+    name = "optimize.security.csl.enabled",
+    havingValue = "false",
+    matchIfMissing = true)
 public class CCSaasAuth0WebSecurityConfig {
 
   public static final String OAUTH_AUTH_ENDPOINT = "/sso";

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import io.camunda.security.core.port.out.SecurityPathPort;
+import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
+import io.camunda.security.spring.spi.OidcAuthenticationEntryPoint;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+/**
+ * Opt-in configuration that adopts CSL for Optimize. See <a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
+ *
+ * <p>Activated by {@code optimize.security.csl.enabled=true}. The legacy adapters ({@code
+ * CCSMSecurityConfigurerAdapter} / {@code CCSaaSSecurityConfigurerAdapter}) carry the inverse
+ * condition, so exactly one security setup is active at a time.
+ *
+ * <p>Because CSL gives the API and webapp chains distinct orders (API before webapp), Optimize can
+ * use the umbrella {@code CamundaSecurityAutoConfiguration} directly and return {@code /**} from
+ * {@link SecurityPathPort#webappPaths()}: the stock webapp chain becomes the catch-all that sorts
+ * below the bearer API chain. No custom webapp chain bean is needed.
+ *
+ * <p>Required application config:
+ *
+ * <ul>
+ *   <li>{@code optimize.security.csl.enabled=true}
+ *   <li>{@code camunda.security.authentication.method=oidc}
+ *   <li>{@code camunda.security.authentication.oidc.*} for the Identity (CCSM) / Auth0 (CCSaaS)
+ *       client registration
+ * </ul>
+ */
+@Configuration
+@ConditionalOnProperty(name = "optimize.security.csl.enabled", havingValue = "true")
+@ImportAutoConfiguration(CamundaSecurityAutoConfiguration.class)
+public class OptimizeCamundaSecurityConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  public SecurityPathPort securityPathPort() {
+    return new OptimizeSecurityPathAdapter();
+  }
+
+  /** Overrides CSL's default OIDC entry point; see {@link OptimizeOidcAuthenticationEntryPoint}. */
+  @Bean
+  @ConditionalOnMissingBean
+  public OidcAuthenticationEntryPoint oidcAuthenticationEntryPoint(
+      final ClientRegistrationRepository clientRegistrationRepository) {
+    return new OptimizeOidcAuthenticationEntryPoint(
+        resolveLoginRedirectTarget(clientRegistrationRepository));
+  }
+
+  // Mirrors CSL's redirect resolution: a single registered client redirects straight to its
+  // /oauth2/authorization/{id} endpoint; anything else falls back to /login so a picker can show.
+  private static String resolveLoginRedirectTarget(
+      final ClientRegistrationRepository clientRegistrationRepository) {
+    if (clientRegistrationRepository instanceof final Iterable<?> registrations) {
+      ClientRegistration single = null;
+      int count = 0;
+      for (final Object registration : registrations) {
+        if (registration instanceof final ClientRegistration clientRegistration) {
+          single = clientRegistration;
+          count++;
+        }
+      }
+      if (count == 1) {
+        return "/oauth2/authorization/" + single.getRegistrationId();
+      }
+    }
+    return "/login";
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeOidcAuthenticationEntryPoint.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeOidcAuthenticationEntryPoint.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import io.camunda.security.spring.spi.OidcAuthenticationEntryPoint;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+/**
+ * Entry point for the CSL OIDC webapp chain that restores Optimize's legacy "API returns 401,
+ * navigation redirects to login" contract. See <a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
+ *
+ * <p>CSL's built-in default only distinguishes bearer API calls (an {@code Authorization} header
+ * yields 401) from browser navigations (a 302 to the IdP). Optimize's single-page app authenticates
+ * its XHR calls with the server-side session cookie and sends no {@code Authorization} header, so
+ * those calls would receive a 302 to the OIDC authorization endpoint. The browser follows that
+ * redirect cross-origin to the IdP as a {@code fetch}, CORS blocks it, and the app hangs on a
+ * loading spinner (for example after logout, when every follow-up XHR is unauthenticated).
+ *
+ * <p>This entry point returns 401 for {@code /api/**} (the SPA's XHR surface) so the frontend's
+ * {@code PrivateRoute} handler reloads the page, which then navigates to the login. Every other
+ * unauthenticated request (SPA route loads, static resources) keeps the 302-to-IdP redirect.
+ */
+public final class OptimizeOidcAuthenticationEntryPoint implements OidcAuthenticationEntryPoint {
+
+  private static final String API_PATH = "/api";
+
+  private final AuthenticationEntryPoint apiEntryPoint =
+      new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED);
+  private final AuthenticationEntryPoint navigationEntryPoint;
+
+  public OptimizeOidcAuthenticationEntryPoint(final String loginRedirectTarget) {
+    navigationEntryPoint = new LoginUrlAuthenticationEntryPoint(loginRedirectTarget);
+  }
+
+  @Override
+  public void commence(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final AuthenticationException authException)
+      throws IOException, ServletException {
+    final String path = request.getRequestURI().substring(request.getContextPath().length());
+    // Match the bearer/API surface exactly like Spring's "/api/**" does, i.e. "/api" and
+    // "/api/...".
+    if (path.equals(API_PATH) || path.startsWith(API_PATH + "/")) {
+      apiEntryPoint.commence(request, response, authException);
+    } else {
+      navigationEntryPoint.commence(request, response, authException);
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static io.camunda.optimize.tomcat.OptimizeResourceConstants.ACTUATOR_ENDPOINT;
+
+import io.camunda.security.core.port.out.SecurityPathPort;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Optimize's implementation of the CSL {@link SecurityPathPort}. See <a
+ * href="https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md">ADR-0038</a>.
+ *
+ * <ul>
+ *   <li>{@link #apiPaths()} = the bearer-only public API surface. Only these are claimed by the CSL
+ *       OIDC API chain (bearer JWT). Everything else under {@code /api} is served by the catch-all
+ *       webapp chain and authenticated from the session.
+ *   <li>{@link #unprotectedApiPaths()} = the public subset of {@link #apiPaths()} (the subset
+ *       contract is kept). Empty for Optimize: the public API and ingestion endpoints are all
+ *       protected.
+ *   <li>{@link #unprotectedPaths()} = every public path outside the bearer surface. This is the
+ *       bucket the order-0 unprotected chain actually matches, so the public endpoints under {@code
+ *       /api} (readyz, ui-configuration, localization, external) go here too, not in {@link
+ *       #unprotectedApiPaths()}.
+ *   <li>{@link #webappPaths()} = {@code /**}. The webapp chain is the catch-all; with the CSL
+ *       API-before-webapp ordering it sorts below the bearer API chain.
+ * </ul>
+ */
+public final class OptimizeSecurityPathAdapter implements SecurityPathPort {
+
+  @Override
+  public Set<String> apiPaths() {
+    return Set.of("/api/public/**", "/api/ingestion/variable");
+  }
+
+  @Override
+  public Set<String> unprotectedApiPaths() {
+    return Set.of();
+  }
+
+  @Override
+  public Set<String> unprotectedPaths() {
+    return Set.of(
+        "/api/readyz",
+        "/api/ui-configuration",
+        "/api/localization",
+        "/api/external/**",
+        "/external/**",
+        "/static/**",
+        "/*.ico",
+        "/*.html",
+        // ACTUATOR_ENDPOINT is a mutable static bound at startup from
+        // management.endpoints.web.base-path (default /actuator), not a compile-time constant.
+        ACTUATOR_ENDPOINT + "/**");
+  }
+
+  @Override
+  public Set<String> webappPaths() {
+    return Set.of("/**");
+  }
+
+  @Override
+  public Set<String> webComponentNames() {
+    return Set.of("optimize");
+  }
+
+  /**
+   * ADR-0038: send a {@code post_logout_redirect_uri} back to Optimize's root after IdP logout so
+   * the user lands on the login flow again instead of the IdP's generic logged-out page. CSL
+   * expands this to {@code {baseUrl}/}; the unauthenticated root then triggers the webapp chain to
+   * redirect to the IdP login. The target must be registered as a valid post-logout redirect URI on
+   * the IdP client (Keycloak {@code optimize} client, provisioned from the Optimize root URL).
+   */
+  @Override
+  public Optional<String> postLogoutRedirectPath() {
+    return Optional.of("/");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.optimize.rest.security.CustomPreAuthenticatedAuthenticationProvider;
+import io.camunda.optimize.rest.security.ccsm.CCSMSecurityConfigurerAdapter;
+import io.camunda.optimize.rest.security.cloud.CCSaaSSecurityConfigurerAdapter;
+import io.camunda.optimize.rest.security.cloud.CCSaasAuth0WebSecurityConfig;
+import io.camunda.optimize.service.security.AuthCookieService;
+import io.camunda.optimize.service.security.CCSMTokenService;
+import io.camunda.optimize.service.security.SessionService;
+import io.camunda.optimize.service.security.UserIdMigrationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import io.camunda.security.core.port.out.SecurityPathPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+/**
+ * Verifies that exactly one security setup is active per {@code optimize.security.csl.enabled}
+ * state, for both the CCSM and CCSaaS editions (ADR-0038). Default (property absent/false) keeps
+ * the legacy adapters active with the CSL wiring absent; {@code true} flips this so the legacy
+ * adapters (and, for CCSaaS, the Auth0 client-registration publisher) back off while {@link
+ * OptimizeCamundaSecurityConfig} takes over.
+ */
+class CslSecurityChainSelectionTest {
+
+  private static final String CSL_FLAG_ENABLED = "optimize.security.csl.enabled=true";
+
+  // Explicit static endpoints (no issuer-uri) so CSL builds the OIDC client registration without
+  // any network/discovery call.
+  private static final String[] STATIC_OIDC_PROPERTIES = {
+    "camunda.security.authentication.method=oidc",
+    "camunda.security.authentication.oidc.client-id=test-client",
+    "camunda.security.authentication.oidc.client-secret=test-secret",
+    "camunda.security.authentication.oidc.authorization-uri=https://idp.example.com/authorize",
+    "camunda.security.authentication.oidc.token-uri=https://idp.example.com/token",
+    "camunda.security.authentication.oidc.jwk-set-uri=https://idp.example.com/jwks"
+  };
+
+  private final ApplicationContextRunner ccsmRunner =
+      new ApplicationContextRunner()
+          .withPropertyValues("spring.profiles.active=ccsm")
+          .withBean(
+              LazyInitializationBeanFactoryPostProcessor.class,
+              LazyInitializationBeanFactoryPostProcessor::new)
+          .withBean(
+              ConfigurationService.class, ConfigurationServiceBuilder::createDefaultConfiguration)
+          .withBean(
+              CustomPreAuthenticatedAuthenticationProvider.class,
+              () -> mock(CustomPreAuthenticatedAuthenticationProvider.class))
+          .withBean(SessionService.class, () -> mock(SessionService.class))
+          .withBean(AuthCookieService.class, () -> mock(AuthCookieService.class))
+          .withBean(CCSMTokenService.class, () -> mock(CCSMTokenService.class))
+          .withUserConfiguration(
+              CCSMSecurityConfigurerAdapter.class, OptimizeCamundaSecurityConfig.class);
+
+  private final ApplicationContextRunner ccsaasRunner =
+      new ApplicationContextRunner()
+          .withPropertyValues("spring.profiles.active=cloud")
+          .withBean(
+              LazyInitializationBeanFactoryPostProcessor.class,
+              LazyInitializationBeanFactoryPostProcessor::new)
+          .withBean(ConfigurationService.class, CslSecurityChainSelectionTest::cloudConfiguration)
+          .withBean(
+              CustomPreAuthenticatedAuthenticationProvider.class,
+              () -> mock(CustomPreAuthenticatedAuthenticationProvider.class))
+          .withBean(SessionService.class, () -> mock(SessionService.class))
+          .withBean(AuthCookieService.class, () -> mock(AuthCookieService.class))
+          .withBean(UserIdMigrationService.class, () -> mock(UserIdMigrationService.class))
+          .withUserConfiguration(
+              CCSaaSSecurityConfigurerAdapter.class,
+              CCSaasAuth0WebSecurityConfig.class,
+              OptimizeCamundaSecurityConfig.class);
+
+  private static ConfigurationService cloudConfiguration() {
+    final ConfigurationService configurationService =
+        ConfigurationServiceBuilder.createDefaultConfiguration();
+    final var cloudAuthConfiguration =
+        configurationService.getAuthConfiguration().getCloudAuthConfiguration();
+    cloudAuthConfiguration.setClientId("auth0-client");
+    cloudAuthConfiguration.setClientSecret("auth0-secret");
+    return configurationService;
+  }
+
+  @Test
+  void shouldActivateLegacyCcsmChainWhenFlagAbsent() {
+    ccsmRunner.run(
+        context -> {
+          assertThat(context).hasNotFailed();
+          assertThat(context).hasSingleBean(CCSMSecurityConfigurerAdapter.class);
+          assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
+          assertThat(context).doesNotHaveBean(SecurityPathPort.class);
+        });
+  }
+
+  @Test
+  void shouldActivateCslChainForCcsmWhenFlagEnabled() {
+    ccsmRunner
+        .withPropertyValues(STATIC_OIDC_PROPERTIES)
+        .withPropertyValues(CSL_FLAG_ENABLED)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(CCSMSecurityConfigurerAdapter.class);
+              assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
+              assertThat(context.getBean(SecurityPathPort.class))
+                  .isInstanceOf(OptimizeSecurityPathAdapter.class);
+            });
+  }
+
+  @Test
+  void shouldActivateLegacyCcsaasChainWhenFlagAbsent() {
+    ccsaasRunner.run(
+        context -> {
+          assertThat(context).hasNotFailed();
+          assertThat(context).hasSingleBean(CCSaaSSecurityConfigurerAdapter.class);
+          assertThat(context).hasSingleBean(CCSaasAuth0WebSecurityConfig.class);
+          assertThat(context).doesNotHaveBean(OptimizeCamundaSecurityConfig.class);
+        });
+  }
+
+  @Test
+  void shouldActivateCslChainForCcsaasWhenFlagEnabled() {
+    ccsaasRunner
+        .withPropertyValues(STATIC_OIDC_PROPERTIES)
+        .withPropertyValues(CSL_FLAG_ENABLED)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed();
+              assertThat(context).doesNotHaveBean(CCSaaSSecurityConfigurerAdapter.class);
+              assertThat(context).doesNotHaveBean(CCSaasAuth0WebSecurityConfig.class);
+              assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
+            });
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeOidcAuthenticationEntryPointTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeOidcAuthenticationEntryPointTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+class OptimizeOidcAuthenticationEntryPointTest {
+
+  private final OptimizeOidcAuthenticationEntryPoint entryPoint =
+      new OptimizeOidcAuthenticationEntryPoint("/login");
+
+  @Test
+  void shouldReturnUnauthorizedForApiSubPath() throws Exception {
+    assertThat(commence("/api/dashboard/1").getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  void shouldReturnUnauthorizedForExactApiPath() throws Exception {
+    // "/api" (no trailing slash) is part of the API surface, matching Spring's "/api/**".
+    assertThat(commence("/api").getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  void shouldRedirectToLoginForNavigation() throws Exception {
+    final MockHttpServletResponse response = commence("/dashboards");
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.FOUND.value());
+    assertThat(response.getRedirectedUrl()).endsWith("/login");
+  }
+
+  private MockHttpServletResponse commence(final String uri) throws IOException, ServletException {
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    entryPoint.commence(request, response, new BadCredentialsException("unauthenticated"));
+    return response;
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityPathAdapterTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static io.camunda.optimize.tomcat.OptimizeResourceConstants.ACTUATOR_ENDPOINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.tomcat.OptimizeResourceConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class OptimizeSecurityPathAdapterTest {
+
+  // ACTUATOR_ENDPOINT is a mutable static bound from management.endpoints.web.base-path; capture
+  // and restore it so a customized value in one test does not leak into others.
+  private final String originalActuatorEndpoint = ACTUATOR_ENDPOINT;
+  private final OptimizeSecurityPathAdapter pathAdapter = new OptimizeSecurityPathAdapter();
+
+  @AfterEach
+  void restoreActuatorEndpoint() {
+    OptimizeResourceConstants.ACTUATOR_ENDPOINT = originalActuatorEndpoint;
+  }
+
+  @Test
+  void shouldUnprotectActuatorAtDefaultBasePath() {
+    OptimizeResourceConstants.ACTUATOR_ENDPOINT = "/actuator";
+    assertThat(pathAdapter.unprotectedPaths()).contains("/actuator/**");
+  }
+
+  @Test
+  void shouldUnprotectActuatorAtCustomBasePath() {
+    OptimizeResourceConstants.ACTUATOR_ENDPOINT = "/management";
+    assertThat(pathAdapter.unprotectedPaths()).contains("/management/**");
+  }
+}


### PR DESCRIPTION
## Description

Introduces the `optimize.security.csl.enabled` feature flag (default `false`) and wires Optimize's
Camunda Security Library (CSL) security setup behind it. This is the Phase 1 keystone of the
Optimize CSL adoption ([ADR-0038](https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md)).

When the flag is **absent or `false`** the legacy Optimize security stack stays fully in charge and
nothing changes at runtime. When the flag is **`true`**, the legacy chains back off and CSL's
stateful OIDC webapp chain, bearer API chain, and unprotected chain take over.

## Changes

- **`OptimizeCamundaSecurityConfig`** — flag-gated `@Configuration` that activates the CSL umbrella
  (`CamundaSecurityAutoConfiguration`) and supplies the host contracts CSL needs. Both supplied
  beans are `@ConditionalOnMissingBean` so a host can override them.
- **`OptimizeSecurityPathAdapter`** (`SecurityPathPort`) — path split for Optimize:
  - `apiPaths()` = bearer-only public API (`/api/public/**`, `/api/ingestion/variable`)
  - `unprotectedApiPaths()` = empty
  - `unprotectedPaths()` = public endpoints (`/api/readyz`, `/api/ui-configuration`,
    `/api/localization`, `/api/external/**`, `/external/**`, static resources, `/actuator/**`)
  - `webappPaths()` = `/**` (catch-all, sorts below the bearer API chain via CSL's
    API-before-webapp ordering)
  - `postLogoutRedirectPath()` = `/`
- **`OptimizeOidcAuthenticationEntryPoint`** — returns 401 for unauthenticated `/api/**` XHR and
  302-to-login for navigations, preserving Optimize's SPA auth contract.
- **Legacy back-off** — `CCSMSecurityConfigurerAdapter`, `CCSaaSSecurityConfigurerAdapter`, and the
  Auth0 `ClientRegistrationRepository` publisher in `CCSaasAuth0WebSecurityConfig` now carry the
  inverse `@ConditionalOnProperty`, so exactly one security setup registers (ADR-0038 consequence 6).
- **Dependency** — adds `camunda-security-library-core` and `-spring-boot-starter` to
  `optimize/backend/pom.xml` (versions already managed in `parent/pom.xml`).

## Scope

Core wiring only. CCSaaS access control, the Elasticsearch session store, token bridges, logout, and
the frontend are separate Phase 1 sub-issues under the epic.

## Testing

- `CslSecurityChainSelectionTest` — `ApplicationContextRunner` test asserting chain selection for
  both flag states across both CCSM and CCSaaS editions (4 cases).
- `mvn -pl optimize/backend test -Dtest=CslSecurityChainSelectionTest` → 4/4 pass.
- Full `io.camunda.optimize.rest.security.**` regression → 37/37 pass.

## Docs

No user-facing docs change yet: the flag defaults off and is not documented until Phase 3 flips the
default. The docs update lands with that phase.

Closes #58469
Part of #58403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
