### PR TITLE
feat: expose update metadata in REST responses

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverride.java
@@ -42,8 +42,24 @@ public class GatewayRestPropertiesOverride {
   public GatewayRestProperties gatewayRestProperties() {
     final GatewayRestProperties override = new GatewayRestProperties();
     BeanUtils.copyProperties(legacyGatewayRestProperties, override);
+    copyReadOnlyNestedProperties(legacyGatewayRestProperties, override);
     new Converter(unifiedConfiguration.getCamunda()).applyTo(override);
     return override;
+  }
+
+  /**
+   * Copies nested configuration that {@link BeanUtils#copyProperties} cannot reach.
+   *
+   * <p>{@code copyProperties} only writes properties that are writable on the target. Nested
+   * configuration objects are exposed as read-only bean properties (a getter over a {@code final}
+   * field), so their values are silently dropped. Anything bound only under the legacy {@code
+   * camunda.rest} prefix — i.e. not re-applied by {@link Converter} from the unified configuration
+   * — must therefore be propagated explicitly here, or it would stay at its default in the {@link
+   * Primary} bean that consumers are injected with.
+   */
+  static void copyReadOnlyNestedProperties(
+      final GatewayRestConfiguration source, final GatewayRestConfiguration target) {
+    target.getUpdateMetadata().setEnabled(source.getUpdateMetadata().isEnabled());
   }
 
   /** Maps a {@link Camunda} configuration into a {@link GatewayRestConfiguration}. */

--- a/configuration/src/test/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverrideTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/beanoverrides/GatewayRestPropertiesOverrideTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.beanoverrides;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.configuration.beans.GatewayRestProperties;
+import io.camunda.configuration.beans.LegacyGatewayRestProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
+
+class GatewayRestPropertiesOverrideTest {
+
+  @BeforeAll
+  @AfterAll
+  static void clearStaticEnvironment() {
+    // The Camunda config getters delegate to UnifiedConfigurationHelper, which short-circuits
+    // when its static environment is null. Clear it so a previous Spring-based test in the
+    // same JVM doesn't leak its environment into these plain unit tests.
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  /**
+   * Reproduces the copy performed by {@code gatewayRestProperties()}: consumers are injected with
+   * the {@code @Primary} {@link GatewayRestProperties} bean, so anything that fails to survive this
+   * copy is invisible at runtime even when configured.
+   */
+  private static GatewayRestProperties copyOf(final LegacyGatewayRestProperties legacy) {
+    final GatewayRestProperties override = new GatewayRestProperties();
+    BeanUtils.copyProperties(legacy, override);
+    GatewayRestPropertiesOverride.copyReadOnlyNestedProperties(legacy, override);
+    return override;
+  }
+
+  @Test
+  void shouldPropagateEnabledUpdateMetadataFlag() {
+    // given - as bound from camunda.rest.update-metadata.enabled=true
+    final LegacyGatewayRestProperties legacy = new LegacyGatewayRestProperties();
+    legacy.getUpdateMetadata().setEnabled(true);
+
+    // when
+    final GatewayRestProperties override = copyOf(legacy);
+
+    // then - BeanUtils.copyProperties cannot write this read-only nested property on its own
+    assertThat(override.getUpdateMetadata().isEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldKeepUpdateMetadataDisabledByDefault() {
+    // given
+    final LegacyGatewayRestProperties legacy = new LegacyGatewayRestProperties();
+
+    // when
+    final GatewayRestProperties override = copyOf(legacy);
+
+    // then
+    assertThat(override.getUpdateMetadata().isEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldStillCopyWritableScalarProperties() {
+    // given
+    final LegacyGatewayRestProperties legacy = new LegacyGatewayRestProperties();
+    legacy.setMaxNameFieldLength(4242);
+
+    // when
+    final GatewayRestProperties override = copyOf(legacy);
+
+    // then
+    assertThat(override.getMaxNameFieldLength()).isEqualTo(4242);
+  }
+}

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1409,11 +1409,10 @@ camunda: # Type: io.camunda.configuration.Camunda
       max-unique-keys: null # Type: Integer, Env: CAMUNDA_REST_JOBMETRICS_MAXUNIQUEKEYS
       max-worker-name-length: null # Type: Integer, Env: CAMUNDA_REST_JOBMETRICS_MAXWORKERNAMELENGTH
     
-    update-metadata: # Type: io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration$UpdateMetadataConfiguration  
-      enabled: null # Type: Boolean, Env: CAMUNDA_REST_UPDATEMETADATA_ENABLED
-    
     max-cluster-variable-metadata-size: null # Type: Integer, Env: CAMUNDA_REST_MAXCLUSTERVARIABLEMETADATASIZE
     max-name-field-length: null # Type: Integer, Env: CAMUNDA_REST_MAXNAMEFIELDLENGTH
+    update-metadata: # Type: io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration$UpdateMetadataConfiguration  
+      enabled: null # Type: Boolean, Env: CAMUNDA_REST_UPDATEMETADATA_ENABLED
   
   secrets: # Type: io.camunda.configuration.Secrets  
     stores: # Type: io.camunda.configuration.Secrets$Stores  

--- a/dist/src/main/config/defaults.yaml
+++ b/dist/src/main/config/defaults.yaml
@@ -1409,6 +1409,9 @@ camunda: # Type: io.camunda.configuration.Camunda
       max-unique-keys: null # Type: Integer, Env: CAMUNDA_REST_JOBMETRICS_MAXUNIQUEKEYS
       max-worker-name-length: null # Type: Integer, Env: CAMUNDA_REST_JOBMETRICS_MAXWORKERNAMELENGTH
     
+    update-metadata: # Type: io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration$UpdateMetadataConfiguration  
+      enabled: null # Type: Boolean, Env: CAMUNDA_REST_UPDATEMETADATA_ENABLED
+    
     max-cluster-variable-metadata-size: null # Type: Integer, Env: CAMUNDA_REST_MAXCLUSTERVARIABLEMETADATASIZE
     max-name-field-length: null # Type: Integer, Env: CAMUNDA_REST_MAXNAMEFIELDLENGTH
   

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -251,7 +251,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
@@ -511,20 +510,6 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
-  public static ProcessInstanceSearchQueryResult toProcessInstanceSearchQueryResponse(
-      final SearchQueryResult<ProcessInstanceEntity> result,
-      final Function<ProcessInstanceEntity, String> updatedByFn,
-      final Function<ProcessInstanceEntity, String> updatedAtFn) {
-    final var page = toSearchQueryPageResponse(result);
-    return ProcessInstanceSearchQueryResult.Builder.create()
-        .page(page)
-        .items(
-            ofNullable(result.items())
-                .map(items -> toProcessInstances(items, updatedByFn, updatedAtFn))
-                .orElseGet(Collections::emptyList))
-        .build();
-  }
-
   public static JobSearchQueryResult toJobSearchQueryResponse(
       final SearchQueryResult<JobEntity> result) {
     final var page = toSearchQueryPageResponse(result);
@@ -683,20 +668,6 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
-  public static DecisionDefinitionSearchQueryResult toDecisionDefinitionSearchQueryResponse(
-      final SearchQueryResult<DecisionDefinitionEntity> result,
-      final Function<DecisionDefinitionEntity, String> updatedByFn,
-      final Function<DecisionDefinitionEntity, String> updatedAtFn) {
-    final var page = toSearchQueryPageResponse(result);
-    return DecisionDefinitionSearchQueryResult.Builder.create()
-        .page(page)
-        .items(
-            ofNullable(result.items())
-                .map(items -> toDecisionDefinitions(items, updatedByFn, updatedAtFn))
-                .orElseGet(Collections::emptyList))
-        .build();
-  }
-
   public static DecisionRequirementsSearchQueryResult toDecisionRequirementsSearchQueryResponse(
       final SearchQueryResult<DecisionRequirementsEntity> result) {
     final var page = toSearchQueryPageResponse(result);
@@ -845,20 +816,6 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
-  public static UserTaskSearchQueryResult toUserTaskSearchQueryResponse(
-      final SearchQueryResult<UserTaskEntity> result,
-      final Function<UserTaskEntity, String> updatedByFn,
-      final Function<UserTaskEntity, String> updatedAtFn) {
-    final var page = toSearchQueryPageResponse(result);
-    return UserTaskSearchQueryResult.Builder.create()
-        .page(page)
-        .items(
-            ofNullable(result.items())
-                .map(tasks -> toUserTasks(tasks, updatedByFn, updatedAtFn))
-                .orElseGet(Collections::emptyList))
-        .build();
-  }
-
   public static UserSearchResult toUserSearchQueryResponse(
       final SearchQueryResult<UserEntity> result) {
     return UserSearchResult.Builder.create()
@@ -902,20 +859,6 @@ public final class SearchQueryResponseMapper {
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toIncidents)
-                .orElseGet(Collections::emptyList))
-        .build();
-  }
-
-  public static IncidentSearchQueryResult toIncidentSearchQueryResponse(
-      final SearchQueryResult<IncidentEntity> result,
-      final Function<IncidentEntity, String> updatedByFn,
-      final Function<IncidentEntity, String> updatedAtFn) {
-    final var page = toSearchQueryPageResponse(result);
-    return IncidentSearchQueryResult.Builder.create()
-        .page(page)
-        .items(
-            ofNullable(result.items())
-                .map(items -> toIncidents(items, updatedByFn, updatedAtFn))
                 .orElseGet(Collections::emptyList))
         .build();
   }
@@ -984,15 +927,6 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toProcessInstance).toList();
   }
 
-  private static List<ProcessInstanceResult> toProcessInstances(
-      final List<ProcessInstanceEntity> instances,
-      final Function<ProcessInstanceEntity, String> updatedByFn,
-      final Function<ProcessInstanceEntity, String> updatedAtFn) {
-    return instances.stream()
-        .map(p -> toProcessInstance(p, updatedByFn.apply(p), updatedAtFn.apply(p)))
-        .toList();
-  }
-
   private static List<JobSearchResult> toJobs(final List<JobEntity> jobs) {
     return jobs.stream().map(SearchQueryResponseMapper::toJob).toList();
   }
@@ -1029,11 +963,6 @@ public final class SearchQueryResponseMapper {
   }
 
   public static ProcessInstanceResult toProcessInstance(final ProcessInstanceEntity p) {
-    return toProcessInstance(p, null, null);
-  }
-
-  public static ProcessInstanceResult toProcessInstance(
-      final ProcessInstanceEntity p, final String updatedBy, final String updatedAt) {
     // processDefinitionId/Version/Key are @Nullable on the entity due to the onlyKeys(true)
     // source projection in ProcessInstanceItemProvider#fetchItemPage; that path doesn't reach
     // this mapper, but the contract has to admit the null so we fall back to spec-compliant
@@ -1057,8 +986,6 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(p.rootProcessInstanceKey()))
         .tags(p.tags())
         .businessId(emptyToNull(p.businessId()))
-        .updatedBy(updatedBy)
-        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1261,15 +1188,6 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionDefinition).toList();
   }
 
-  private static List<DecisionDefinitionResult> toDecisionDefinitions(
-      final List<DecisionDefinitionEntity> instances,
-      final Function<DecisionDefinitionEntity, String> updatedByFn,
-      final Function<DecisionDefinitionEntity, String> updatedAtFn) {
-    return instances.stream()
-        .map(d -> toDecisionDefinition(d, updatedByFn.apply(d), updatedAtFn.apply(d)))
-        .toList();
-  }
-
   private static List<DecisionRequirementsResult> toDecisionRequirements(
       final List<DecisionRequirementsEntity> instances) {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionRequirements).toList();
@@ -1305,11 +1223,6 @@ public final class SearchQueryResponseMapper {
   }
 
   public static DecisionDefinitionResult toDecisionDefinition(final DecisionDefinitionEntity d) {
-    return toDecisionDefinition(d, null, null);
-  }
-
-  public static DecisionDefinitionResult toDecisionDefinition(
-      final DecisionDefinitionEntity d, final String updatedBy, final String updatedAt) {
     return DecisionDefinitionResult.Builder.create()
         .decisionDefinitionId(d.decisionDefinitionId())
         .decisionDefinitionKey(keyToString(d.decisionDefinitionKey()))
@@ -1320,8 +1233,6 @@ public final class SearchQueryResponseMapper {
         .name(d.name())
         .tenantId(d.tenantId())
         .version(d.version())
-        .updatedBy(updatedBy)
-        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1346,34 +1257,11 @@ public final class SearchQueryResponseMapper {
         .toList();
   }
 
-  private static List<UserTaskResult> toUserTasks(
-      final List<UserTaskEntity> tasks,
-      final Function<UserTaskEntity, String> updatedByFn,
-      final Function<UserTaskEntity, String> updatedAtFn) {
-    return tasks.stream()
-        .map(t -> toUserTask(t, updatedByFn.apply(t), updatedAtFn.apply(t)))
-        .toList();
-  }
-
   public static List<IncidentResult> toIncidents(final List<IncidentEntity> incidents) {
     return incidents.stream().map(SearchQueryResponseMapper::toIncident).toList();
   }
 
-  private static List<IncidentResult> toIncidents(
-      final List<IncidentEntity> incidents,
-      final Function<IncidentEntity, String> updatedByFn,
-      final Function<IncidentEntity, String> updatedAtFn) {
-    return incidents.stream()
-        .map(t -> toIncident(t, updatedByFn.apply(t), updatedAtFn.apply(t)))
-        .toList();
-  }
-
   public static IncidentResult toIncident(final IncidentEntity t) {
-    return toIncident(t, null, null);
-  }
-
-  public static IncidentResult toIncident(
-      final IncidentEntity t, final String updatedBy, final String updatedAt) {
     return IncidentResult.Builder.create()
         .incidentKey(keyToString(t.incidentKey()))
         .processDefinitionKey(keyToString(t.processDefinitionKey()))
@@ -1396,8 +1284,6 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(t.rootProcessInstanceKey()))
         .jobKey(keyToStringOrNull(t.jobKey()))
         .tenantId(t.tenantId())
-        .updatedBy(updatedBy)
-        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1469,11 +1355,6 @@ public final class SearchQueryResponseMapper {
   }
 
   public static UserTaskResult toUserTask(final UserTaskEntity t) {
-    return toUserTask(t, null, null);
-  }
-
-  public static UserTaskResult toUserTask(
-      final UserTaskEntity t, final String updatedBy, final String updatedAt) {
     return UserTaskResult.Builder.create()
         .tenantId(t.tenantId())
         .userTaskKey(keyToString(t.userTaskKey()))
@@ -1502,8 +1383,6 @@ public final class SearchQueryResponseMapper {
         .followUpDate(formatDateOrNull(t.followUpDate()))
         .processDefinitionVersion(t.processDefinitionVersion())
         .formKey(keyToStringOrNull(t.formKey()))
-        .updatedBy(updatedBy)
-        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1690,49 +1569,13 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
-  public static VariableSearchQueryResult toVariableSearchQueryResponse(
-      final SearchQueryResult<VariableEntity> result,
-      final boolean truncateValues,
-      final Function<VariableEntity, String> updatedByFn,
-      final Function<VariableEntity, String> updatedAtFn) {
-    final var page = toSearchQueryPageResponse(result);
-    return VariableSearchQueryResult.Builder.create()
-        .page(page)
-        .items(
-            ofNullable(result.items())
-                .map(entity -> toVariables(entity, truncateValues, updatedByFn, updatedAtFn))
-                .orElseGet(Collections::emptyList))
-        .build();
-  }
-
   private static List<VariableSearchResult> toVariables(
       final List<VariableEntity> variableEntities, final boolean truncateValues) {
     return variableEntities.stream().map(entity -> toVariable(entity, truncateValues)).toList();
   }
 
-  private static List<VariableSearchResult> toVariables(
-      final List<VariableEntity> variableEntities,
-      final boolean truncateValues,
-      final Function<VariableEntity, String> updatedByFn,
-      final Function<VariableEntity, String> updatedAtFn) {
-    return variableEntities.stream()
-        .map(
-            entity ->
-                toVariable(
-                    entity, truncateValues, updatedByFn.apply(entity), updatedAtFn.apply(entity)))
-        .toList();
-  }
-
   private static VariableSearchResult toVariable(
       final VariableEntity variableEntity, final boolean truncateValues) {
-    return toVariable(variableEntity, truncateValues, null, null);
-  }
-
-  private static VariableSearchResult toVariable(
-      final VariableEntity variableEntity,
-      final boolean truncateValues,
-      final String updatedBy,
-      final String updatedAt) {
     return VariableSearchResult.Builder.create()
         .name(variableEntity.name())
         .processInstanceKey(keyToString(variableEntity.processInstanceKey()))
@@ -1740,8 +1583,6 @@ public final class SearchQueryResponseMapper {
         .variableKey(keyToString(variableEntity.variableKey()))
         .scopeKey(keyToString(variableEntity.scopeKey()))
         .rootProcessInstanceKey(keyToStringOrNull(variableEntity.rootProcessInstanceKey()))
-        .updatedBy(updatedBy)
-        .updatedAt(updatedAt)
         .isTruncated(truncateValues && variableEntity.isPreview())
         .value(!truncateValues ? getFullValueIfPresent(variableEntity) : variableEntity.value())
         .build();
@@ -1766,11 +1607,6 @@ public final class SearchQueryResponseMapper {
   }
 
   public static VariableResult toVariableItem(final VariableEntity variableEntity) {
-    return toVariableItem(variableEntity, null, null);
-  }
-
-  public static VariableResult toVariableItem(
-      final VariableEntity variableEntity, final String updatedBy, final String updatedAt) {
     return VariableResult.Builder.create()
         .name(variableEntity.name())
         .processInstanceKey(keyToString(variableEntity.processInstanceKey()))
@@ -1778,8 +1614,6 @@ public final class SearchQueryResponseMapper {
         .variableKey(keyToString(variableEntity.variableKey()))
         .scopeKey(keyToString(variableEntity.scopeKey()))
         .rootProcessInstanceKey(keyToStringOrNull(variableEntity.rootProcessInstanceKey()))
-        .updatedBy(updatedBy)
-        .updatedAt(updatedAt)
         .value(getFullValueIfPresent(variableEntity))
         .build();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -251,6 +251,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
@@ -510,6 +511,20 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
+  public static ProcessInstanceSearchQueryResult toProcessInstanceSearchQueryResponse(
+      final SearchQueryResult<ProcessInstanceEntity> result,
+      final Function<ProcessInstanceEntity, String> updatedByFn,
+      final Function<ProcessInstanceEntity, String> updatedAtFn) {
+    final var page = toSearchQueryPageResponse(result);
+    return ProcessInstanceSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(items -> toProcessInstances(items, updatedByFn, updatedAtFn))
+                .orElseGet(Collections::emptyList))
+        .build();
+  }
+
   public static JobSearchQueryResult toJobSearchQueryResponse(
       final SearchQueryResult<JobEntity> result) {
     final var page = toSearchQueryPageResponse(result);
@@ -668,6 +683,20 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
+  public static DecisionDefinitionSearchQueryResult toDecisionDefinitionSearchQueryResponse(
+      final SearchQueryResult<DecisionDefinitionEntity> result,
+      final Function<DecisionDefinitionEntity, String> updatedByFn,
+      final Function<DecisionDefinitionEntity, String> updatedAtFn) {
+    final var page = toSearchQueryPageResponse(result);
+    return DecisionDefinitionSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(items -> toDecisionDefinitions(items, updatedByFn, updatedAtFn))
+                .orElseGet(Collections::emptyList))
+        .build();
+  }
+
   public static DecisionRequirementsSearchQueryResult toDecisionRequirementsSearchQueryResponse(
       final SearchQueryResult<DecisionRequirementsEntity> result) {
     final var page = toSearchQueryPageResponse(result);
@@ -816,6 +845,20 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
+  public static UserTaskSearchQueryResult toUserTaskSearchQueryResponse(
+      final SearchQueryResult<UserTaskEntity> result,
+      final Function<UserTaskEntity, String> updatedByFn,
+      final Function<UserTaskEntity, String> updatedAtFn) {
+    final var page = toSearchQueryPageResponse(result);
+    return UserTaskSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(tasks -> toUserTasks(tasks, updatedByFn, updatedAtFn))
+                .orElseGet(Collections::emptyList))
+        .build();
+  }
+
   public static UserSearchResult toUserSearchQueryResponse(
       final SearchQueryResult<UserEntity> result) {
     return UserSearchResult.Builder.create()
@@ -859,6 +902,20 @@ public final class SearchQueryResponseMapper {
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toIncidents)
+                .orElseGet(Collections::emptyList))
+        .build();
+  }
+
+  public static IncidentSearchQueryResult toIncidentSearchQueryResponse(
+      final SearchQueryResult<IncidentEntity> result,
+      final Function<IncidentEntity, String> updatedByFn,
+      final Function<IncidentEntity, String> updatedAtFn) {
+    final var page = toSearchQueryPageResponse(result);
+    return IncidentSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(items -> toIncidents(items, updatedByFn, updatedAtFn))
                 .orElseGet(Collections::emptyList))
         .build();
   }
@@ -927,6 +984,15 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toProcessInstance).toList();
   }
 
+  private static List<ProcessInstanceResult> toProcessInstances(
+      final List<ProcessInstanceEntity> instances,
+      final Function<ProcessInstanceEntity, String> updatedByFn,
+      final Function<ProcessInstanceEntity, String> updatedAtFn) {
+    return instances.stream()
+        .map(p -> toProcessInstance(p, updatedByFn.apply(p), updatedAtFn.apply(p)))
+        .toList();
+  }
+
   private static List<JobSearchResult> toJobs(final List<JobEntity> jobs) {
     return jobs.stream().map(SearchQueryResponseMapper::toJob).toList();
   }
@@ -963,6 +1029,11 @@ public final class SearchQueryResponseMapper {
   }
 
   public static ProcessInstanceResult toProcessInstance(final ProcessInstanceEntity p) {
+    return toProcessInstance(p, null, null);
+  }
+
+  public static ProcessInstanceResult toProcessInstance(
+      final ProcessInstanceEntity p, final String updatedBy, final String updatedAt) {
     // processDefinitionId/Version/Key are @Nullable on the entity due to the onlyKeys(true)
     // source projection in ProcessInstanceItemProvider#fetchItemPage; that path doesn't reach
     // this mapper, but the contract has to admit the null so we fall back to spec-compliant
@@ -986,6 +1057,8 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(p.rootProcessInstanceKey()))
         .tags(p.tags())
         .businessId(emptyToNull(p.businessId()))
+        .updatedBy(updatedBy)
+        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1188,6 +1261,15 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionDefinition).toList();
   }
 
+  private static List<DecisionDefinitionResult> toDecisionDefinitions(
+      final List<DecisionDefinitionEntity> instances,
+      final Function<DecisionDefinitionEntity, String> updatedByFn,
+      final Function<DecisionDefinitionEntity, String> updatedAtFn) {
+    return instances.stream()
+        .map(d -> toDecisionDefinition(d, updatedByFn.apply(d), updatedAtFn.apply(d)))
+        .toList();
+  }
+
   private static List<DecisionRequirementsResult> toDecisionRequirements(
       final List<DecisionRequirementsEntity> instances) {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionRequirements).toList();
@@ -1223,6 +1305,11 @@ public final class SearchQueryResponseMapper {
   }
 
   public static DecisionDefinitionResult toDecisionDefinition(final DecisionDefinitionEntity d) {
+    return toDecisionDefinition(d, null, null);
+  }
+
+  public static DecisionDefinitionResult toDecisionDefinition(
+      final DecisionDefinitionEntity d, final String updatedBy, final String updatedAt) {
     return DecisionDefinitionResult.Builder.create()
         .decisionDefinitionId(d.decisionDefinitionId())
         .decisionDefinitionKey(keyToString(d.decisionDefinitionKey()))
@@ -1233,6 +1320,8 @@ public final class SearchQueryResponseMapper {
         .name(d.name())
         .tenantId(d.tenantId())
         .version(d.version())
+        .updatedBy(updatedBy)
+        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1257,11 +1346,34 @@ public final class SearchQueryResponseMapper {
         .toList();
   }
 
+  private static List<UserTaskResult> toUserTasks(
+      final List<UserTaskEntity> tasks,
+      final Function<UserTaskEntity, String> updatedByFn,
+      final Function<UserTaskEntity, String> updatedAtFn) {
+    return tasks.stream()
+        .map(t -> toUserTask(t, updatedByFn.apply(t), updatedAtFn.apply(t)))
+        .toList();
+  }
+
   public static List<IncidentResult> toIncidents(final List<IncidentEntity> incidents) {
     return incidents.stream().map(SearchQueryResponseMapper::toIncident).toList();
   }
 
+  private static List<IncidentResult> toIncidents(
+      final List<IncidentEntity> incidents,
+      final Function<IncidentEntity, String> updatedByFn,
+      final Function<IncidentEntity, String> updatedAtFn) {
+    return incidents.stream()
+        .map(t -> toIncident(t, updatedByFn.apply(t), updatedAtFn.apply(t)))
+        .toList();
+  }
+
   public static IncidentResult toIncident(final IncidentEntity t) {
+    return toIncident(t, null, null);
+  }
+
+  public static IncidentResult toIncident(
+      final IncidentEntity t, final String updatedBy, final String updatedAt) {
     return IncidentResult.Builder.create()
         .incidentKey(keyToString(t.incidentKey()))
         .processDefinitionKey(keyToString(t.processDefinitionKey()))
@@ -1284,6 +1396,8 @@ public final class SearchQueryResponseMapper {
         .rootProcessInstanceKey(keyToStringOrNull(t.rootProcessInstanceKey()))
         .jobKey(keyToStringOrNull(t.jobKey()))
         .tenantId(t.tenantId())
+        .updatedBy(updatedBy)
+        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1355,6 +1469,11 @@ public final class SearchQueryResponseMapper {
   }
 
   public static UserTaskResult toUserTask(final UserTaskEntity t) {
+    return toUserTask(t, null, null);
+  }
+
+  public static UserTaskResult toUserTask(
+      final UserTaskEntity t, final String updatedBy, final String updatedAt) {
     return UserTaskResult.Builder.create()
         .tenantId(t.tenantId())
         .userTaskKey(keyToString(t.userTaskKey()))
@@ -1383,6 +1502,8 @@ public final class SearchQueryResponseMapper {
         .followUpDate(formatDateOrNull(t.followUpDate()))
         .processDefinitionVersion(t.processDefinitionVersion())
         .formKey(keyToStringOrNull(t.formKey()))
+        .updatedBy(updatedBy)
+        .updatedAt(updatedAt)
         .build();
   }
 
@@ -1569,13 +1690,49 @@ public final class SearchQueryResponseMapper {
         .build();
   }
 
+  public static VariableSearchQueryResult toVariableSearchQueryResponse(
+      final SearchQueryResult<VariableEntity> result,
+      final boolean truncateValues,
+      final Function<VariableEntity, String> updatedByFn,
+      final Function<VariableEntity, String> updatedAtFn) {
+    final var page = toSearchQueryPageResponse(result);
+    return VariableSearchQueryResult.Builder.create()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(entity -> toVariables(entity, truncateValues, updatedByFn, updatedAtFn))
+                .orElseGet(Collections::emptyList))
+        .build();
+  }
+
   private static List<VariableSearchResult> toVariables(
       final List<VariableEntity> variableEntities, final boolean truncateValues) {
     return variableEntities.stream().map(entity -> toVariable(entity, truncateValues)).toList();
   }
 
+  private static List<VariableSearchResult> toVariables(
+      final List<VariableEntity> variableEntities,
+      final boolean truncateValues,
+      final Function<VariableEntity, String> updatedByFn,
+      final Function<VariableEntity, String> updatedAtFn) {
+    return variableEntities.stream()
+        .map(
+            entity ->
+                toVariable(
+                    entity, truncateValues, updatedByFn.apply(entity), updatedAtFn.apply(entity)))
+        .toList();
+  }
+
   private static VariableSearchResult toVariable(
       final VariableEntity variableEntity, final boolean truncateValues) {
+    return toVariable(variableEntity, truncateValues, null, null);
+  }
+
+  private static VariableSearchResult toVariable(
+      final VariableEntity variableEntity,
+      final boolean truncateValues,
+      final String updatedBy,
+      final String updatedAt) {
     return VariableSearchResult.Builder.create()
         .name(variableEntity.name())
         .processInstanceKey(keyToString(variableEntity.processInstanceKey()))
@@ -1583,6 +1740,8 @@ public final class SearchQueryResponseMapper {
         .variableKey(keyToString(variableEntity.variableKey()))
         .scopeKey(keyToString(variableEntity.scopeKey()))
         .rootProcessInstanceKey(keyToStringOrNull(variableEntity.rootProcessInstanceKey()))
+        .updatedBy(updatedBy)
+        .updatedAt(updatedAt)
         .isTruncated(truncateValues && variableEntity.isPreview())
         .value(!truncateValues ? getFullValueIfPresent(variableEntity) : variableEntity.value())
         .build();
@@ -1607,6 +1766,11 @@ public final class SearchQueryResponseMapper {
   }
 
   public static VariableResult toVariableItem(final VariableEntity variableEntity) {
+    return toVariableItem(variableEntity, null, null);
+  }
+
+  public static VariableResult toVariableItem(
+      final VariableEntity variableEntity, final String updatedBy, final String updatedAt) {
     return VariableResult.Builder.create()
         .name(variableEntity.name())
         .processInstanceKey(keyToString(variableEntity.processInstanceKey()))
@@ -1614,6 +1778,8 @@ public final class SearchQueryResponseMapper {
         .variableKey(keyToString(variableEntity.variableKey()))
         .scopeKey(keyToString(variableEntity.scopeKey()))
         .rootProcessInstanceKey(keyToStringOrNull(variableEntity.rootProcessInstanceKey()))
+        .updatedBy(updatedBy)
+        .updatedAt(updatedAt)
         .value(getFullValueIfPresent(variableEntity))
         .build();
   }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -2815,6 +2815,16 @@
                 {
                   "name": "version",
                   "type": "number"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -2892,6 +2902,16 @@
           {
             "name": "version",
             "type": "number"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []
@@ -4276,6 +4296,16 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -5032,6 +5062,16 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -5153,6 +5193,16 @@
           {
             "name": "tenantId",
             "type": "string"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []
@@ -7327,6 +7377,16 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "schema",
                   "wrapper": true
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -7487,6 +7547,16 @@
             "underlyingPrimitive": "string",
             "rawRefName": "schema",
             "wrapper": true
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []
@@ -7624,6 +7694,16 @@
                 {
                   "name": "tenantId",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -9369,6 +9449,16 @@
                 {
                   "name": "userTaskKey",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -9535,6 +9625,16 @@
           {
             "name": "userTaskKey",
             "type": "string"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []
@@ -9835,6 +9935,16 @@
                 {
                   "name": "variableKey",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -9944,6 +10054,16 @@
                 {
                   "name": "variableKey",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -10023,6 +10143,16 @@
                 {
                   "name": "variableKey",
                   "type": "string"
+                },
+                {
+                  "name": "updatedAt",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "updatedBy",
+                  "type": "string",
+                  "nullable": true
                 }
               ],
               "optional": []
@@ -10093,6 +10223,16 @@
           {
             "name": "variableKey",
             "type": "string"
+          },
+          {
+            "name": "updatedAt",
+            "type": "string",
+            "nullable": true
+          },
+          {
+            "name": "updatedBy",
+            "type": "string",
+            "nullable": true
           }
         ],
         "optional": []

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -2815,7 +2815,9 @@
                 {
                   "name": "version",
                   "type": "number"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -2826,8 +2828,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -2902,7 +2903,9 @@
           {
             "name": "version",
             "type": "number"
-          },
+          }
+        ],
+        "optional": [
           {
             "name": "updatedAt",
             "type": "string",
@@ -2913,8 +2916,7 @@
             "type": "string",
             "nullable": true
           }
-        ],
-        "optional": []
+        ]
       }
     },
     {
@@ -4296,7 +4298,9 @@
                 {
                   "name": "tenantId",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -4307,8 +4311,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -5062,7 +5065,9 @@
                 {
                   "name": "tenantId",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -5073,8 +5078,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -5193,7 +5197,9 @@
           {
             "name": "tenantId",
             "type": "string"
-          },
+          }
+        ],
+        "optional": [
           {
             "name": "updatedAt",
             "type": "string",
@@ -5204,8 +5210,7 @@
             "type": "string",
             "nullable": true
           }
-        ],
-        "optional": []
+        ]
       }
     },
     {
@@ -7377,7 +7382,9 @@
                   "underlyingPrimitive": "string",
                   "rawRefName": "schema",
                   "wrapper": true
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -7388,8 +7395,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -7547,7 +7553,9 @@
             "underlyingPrimitive": "string",
             "rawRefName": "schema",
             "wrapper": true
-          },
+          }
+        ],
+        "optional": [
           {
             "name": "updatedAt",
             "type": "string",
@@ -7558,8 +7566,7 @@
             "type": "string",
             "nullable": true
           }
-        ],
-        "optional": []
+        ]
       }
     },
     {
@@ -7694,7 +7701,9 @@
                 {
                   "name": "tenantId",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -7705,8 +7714,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -9449,7 +9457,9 @@
                 {
                   "name": "userTaskKey",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -9460,8 +9470,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -9625,7 +9634,9 @@
           {
             "name": "userTaskKey",
             "type": "string"
-          },
+          }
+        ],
+        "optional": [
           {
             "name": "updatedAt",
             "type": "string",
@@ -9636,8 +9647,7 @@
             "type": "string",
             "nullable": true
           }
-        ],
-        "optional": []
+        ]
       }
     },
     {
@@ -9935,7 +9945,9 @@
                 {
                   "name": "variableKey",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -9946,8 +9958,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -10054,7 +10065,9 @@
                 {
                   "name": "variableKey",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -10065,8 +10078,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -10143,7 +10155,9 @@
                 {
                   "name": "variableKey",
                   "type": "string"
-                },
+                }
+              ],
+              "optional": [
                 {
                   "name": "updatedAt",
                   "type": "string",
@@ -10154,8 +10168,7 @@
                   "type": "string",
                   "nullable": true
                 }
-              ],
-              "optional": []
+              ]
             }
           },
           {
@@ -10223,7 +10236,9 @@
           {
             "name": "variableKey",
             "type": "string"
-          },
+          }
+        ],
+        "optional": [
           {
             "name": "updatedAt",
             "type": "string",
@@ -10234,8 +10249,7 @@
             "type": "string",
             "nullable": true
           }
-        ],
-        "optional": []
+        ]
       }
     }
   ]

--- a/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
+++ b/zeebe/gateway-protocol/spectral-functions/verifyResponsePropertiesRequired.js
@@ -15,8 +15,16 @@
 // types (e.g. `string | undefined`), which complicates consumer code and
 // obscures the actual API contract. The convention is to list every response
 // field in the `required` array.
+//
+// EXCEPTION: a property marked `x-feature-gated: true` is omitted from the
+// response entirely while its feature flag is disabled, so it cannot be
+// declared `required` without breaking the schema contract for the default
+// configuration. Such properties are skipped by this rule. Use this only for
+// properties whose presence is controlled by a configuration flag — not to
+// avoid declaring a genuinely optional field.
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'];
+const FEATURE_GATED = 'x-feature-gated';
 
 module.exports = (input, _opts, context) => {
   if (!input || typeof input !== 'object') {
@@ -118,7 +126,7 @@ function checkSchema(
   for (const { name, schema: propSchema, path: propPath } of propertyEntries) {
     if (!propSchema || typeof propSchema !== 'object') continue;
 
-    if (!requiredSet.has(name)) {
+    if (!requiredSet.has(name) && propSchema[FEATURE_GATED] !== true) {
       const renderedPath = propPath.join('/');
       errors.push({
         message: `Response property \`${name}\` at \`${schemaLocation}/${renderedPath}\` must be listed in \`required\`.`,

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/rest-api.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/rest-api.yaml
@@ -29,6 +29,10 @@ paths:
   /valid-empty/get:
     $ref: 'things.yaml#/paths/~1valid-empty~1get'
 
+  # Non-required property explicitly opted out via x-feature-gated
+  /valid-feature-gated/get:
+    $ref: 'things.yaml#/paths/~1valid-feature-gated~1get'
+
   # ── Invalid cases ───────────────────────────────────────────
   # One property not in required
   /invalid-missing-one/get:

--- a/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/things.yaml
+++ b/zeebe/gateway-protocol/spectral-tests/fixtures/response-properties-required/things.yaml
@@ -80,6 +80,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmptyResult'
 
+  # ── Valid: non-required property opted out via x-feature-gated ────
+  /valid-feature-gated/get:
+    get:
+      tags: [Test]
+      operationId: validFeatureGated
+      summary: Get a feature-gated thing (valid)
+      description: The non-required property is marked x-feature-gated.
+      responses:
+        "200":
+          description: The thing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidFeatureGatedResult'
+
   # ── Invalid: one property not in required ─────────────────────────
   /invalid-missing-one/get:
     get:
@@ -162,6 +177,20 @@ components:
   schemas:
 
     # ── Valid: flat object, all required ──────────────────────────────
+    ValidFeatureGatedResult:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: The name.
+        gatedField:
+          type: string
+          nullable: true
+          description: Absent unless its feature flag is enabled, so it cannot be required.
+          x-feature-gated: true
+
     ValidFlatResult:
       type: object
       required:

--- a/zeebe/gateway-protocol/spectral-tests/verifyResponsePropertiesRequired.test.js
+++ b/zeebe/gateway-protocol/spectral-tests/verifyResponsePropertiesRequired.test.js
@@ -63,6 +63,13 @@ describe('verifyResponsePropertiesRequired', () => {
     });
   });
 
+  describe('valid: non-required property marked x-feature-gated', () => {
+    it('produces no violations', () => {
+      const v = filterByApiPath(violations, '/valid-feature-gated/get');
+      assert.equal(v.length, 0);
+    });
+  });
+
   // ── Invalid cases ────────────────────────────────────────────────
 
   describe('invalid: one property not in required', () => {

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -301,6 +301,8 @@ components:
         - name
         - tenantId
         - version
+        - updatedBy
+        - updatedAt
       properties:
         decisionDefinitionId:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -301,6 +301,8 @@ components:
         - name
         - tenantId
         - version
+        - updatedBy
+        - updatedAt
       properties:
         decisionDefinitionId:
           allOf:
@@ -333,6 +335,15 @@ components:
         version:
           description: The assigned version of the decision definition.
           type: integer
+        updatedBy:
+          description: The actor ID from the latest accessible successful audit log entry for this decision definition.
+          type: string
+          nullable: true
+        updatedAt:
+          description: The timestamp of the latest accessible successful audit log entry for this decision definition.
+          type: string
+          format: date-time
+          nullable: true
       x-properties-added-in-version:
         - propertyName: decisionDefinitionId
           addedInVersion: "8.6"
@@ -352,6 +363,10 @@ components:
           addedInVersion: "8.6"
         - propertyName: version
           addedInVersion: "8.6"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     DecisionEvaluationInstruction:
       x-polymorphic-schema: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -301,8 +301,6 @@ components:
         - name
         - tenantId
         - version
-        - updatedBy
-        - updatedAt
       properties:
         decisionDefinitionId:
           allOf:
@@ -336,14 +334,20 @@ components:
           description: The assigned version of the decision definition.
           type: integer
         updatedBy:
-          description: The actor ID from the latest accessible successful audit log entry for this decision definition.
+          description: |
+            The actor ID from the latest accessible successful audit log entry for this decision definition.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           nullable: true
+          x-feature-gated: true
         updatedAt:
-          description: The timestamp of the latest accessible successful audit log entry for this decision definition.
+          description: |
+            The timestamp of the latest accessible successful audit log entry for this decision definition.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           format: date-time
           nullable: true
+          x-feature-gated: true
       x-properties-added-in-version:
         - propertyName: decisionDefinitionId
           addedInVersion: "8.6"

--- a/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/decision-definitions.yaml
@@ -301,8 +301,6 @@ components:
         - name
         - tenantId
         - version
-        - updatedBy
-        - updatedAt
       properties:
         decisionDefinitionId:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -493,8 +493,6 @@ components:
         - rootProcessInstanceKey
         - jobKey
         - tenantId
-        - updatedBy
-        - updatedAt
       properties:
         processDefinitionId:
           allOf:
@@ -553,14 +551,20 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
         updatedBy:
-          description: The actor ID from the latest accessible successful audit log entry for this incident.
+          description: |
+            The actor ID from the latest accessible successful audit log entry for this incident.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           nullable: true
+          x-feature-gated: true
         updatedAt:
-          description: The timestamp of the latest accessible successful audit log entry for this incident.
+          description: |
+            The timestamp of the latest accessible successful audit log entry for this incident.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           format: date-time
           nullable: true
+          x-feature-gated: true
       x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.6"

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -493,6 +493,8 @@ components:
         - rootProcessInstanceKey
         - jobKey
         - tenantId
+        - updatedBy
+        - updatedAt
       properties:
         processDefinitionId:
           allOf:
@@ -550,6 +552,15 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKey'
+        updatedBy:
+          description: The actor ID from the latest accessible successful audit log entry for this incident.
+          type: string
+          nullable: true
+        updatedAt:
+          description: The timestamp of the latest accessible successful audit log entry for this incident.
+          type: string
+          format: date-time
+          nullable: true
       x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.6"
@@ -577,6 +588,10 @@ components:
           addedInVersion: "8.8"
         - propertyName: jobKey
           addedInVersion: "8.6"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     IncidentResolutionRequest:
       type: object
@@ -740,5 +755,3 @@ components:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
       required:
         - field
-
-

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -493,8 +493,6 @@ components:
         - rootProcessInstanceKey
         - jobKey
         - tenantId
-        - updatedBy
-        - updatedAt
       properties:
         processDefinitionId:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/incidents.yaml
@@ -493,6 +493,8 @@ components:
         - rootProcessInstanceKey
         - jobKey
         - tenantId
+        - updatedBy
+        - updatedAt
       properties:
         processDefinitionId:
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1746,8 +1746,6 @@ components:
         - rootProcessInstanceKey
         - tags
         - businessId
-        - updatedBy
-        - updatedAt
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
@@ -1820,14 +1818,20 @@ components:
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
         updatedBy:
-          description: The actor ID from the latest accessible successful audit log entry for this process instance.
+          description: |
+            The actor ID from the latest accessible successful audit log entry for this process instance.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           nullable: true
+          x-feature-gated: true
         updatedAt:
-          description: The timestamp of the latest accessible successful audit log entry for this process instance.
+          description: |
+            The timestamp of the latest accessible successful audit log entry for this process instance.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           format: date-time
           nullable: true
+          x-feature-gated: true
       x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1746,8 +1746,6 @@ components:
         - rootProcessInstanceKey
         - tags
         - businessId
-        - updatedBy
-        - updatedAt
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1746,6 +1746,8 @@ components:
         - rootProcessInstanceKey
         - tags
         - businessId
+        - updatedBy
+        - updatedAt
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'
@@ -1817,6 +1819,15 @@ components:
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
+        updatedBy:
+          description: The actor ID from the latest accessible successful audit log entry for this process instance.
+          type: string
+          nullable: true
+        updatedAt:
+          description: The timestamp of the latest accessible successful audit log entry for this process instance.
+          type: string
+          format: date-time
+          nullable: true
       x-properties-added-in-version:
         - propertyName: processDefinitionId
           addedInVersion: "8.8"
@@ -1852,6 +1863,10 @@ components:
           addedInVersion: "8.8"
         - propertyName: businessId
           addedInVersion: "8.9"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     CancelProcessInstanceRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -1746,6 +1746,8 @@ components:
         - rootProcessInstanceKey
         - tags
         - businessId
+        - updatedBy
+        - updatedAt
       properties:
         processDefinitionId:
           $ref: 'identifiers.yaml#/components/schemas/ProcessDefinitionId'

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -714,6 +714,8 @@ components:
         - followUpDate
         - processDefinitionVersion
         - formKey
+        - updatedBy
+        - updatedAt
       properties:
         name:
           nullable: true
@@ -828,6 +830,15 @@ components:
             - $ref: 'keys.yaml#/components/schemas/FormKey'
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
+        updatedBy:
+          description: The actor ID from the latest accessible successful audit log entry for this user task.
+          type: string
+          nullable: true
+        updatedAt:
+          description: The timestamp of the latest accessible successful audit log entry for this user task.
+          type: string
+          format: date-time
+          nullable: true
       x-properties-added-in-version:
         - propertyName: name
           addedInVersion: "8.8"
@@ -879,6 +890,10 @@ components:
           addedInVersion: "8.6"
         - propertyName: tags
           addedInVersion: "8.9"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     UserTaskCompletionRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -714,8 +714,6 @@ components:
         - followUpDate
         - processDefinitionVersion
         - formKey
-        - updatedBy
-        - updatedAt
       properties:
         name:
           nullable: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -714,8 +714,6 @@ components:
         - followUpDate
         - processDefinitionVersion
         - formKey
-        - updatedBy
-        - updatedAt
       properties:
         name:
           nullable: true
@@ -831,14 +829,20 @@ components:
         tags:
           $ref: 'identifiers.yaml#/components/schemas/TagSet'
         updatedBy:
-          description: The actor ID from the latest accessible successful audit log entry for this user task.
+          description: |
+            The actor ID from the latest accessible successful audit log entry for this user task.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           nullable: true
+          x-feature-gated: true
         updatedAt:
-          description: The timestamp of the latest accessible successful audit log entry for this user task.
+          description: |
+            The timestamp of the latest accessible successful audit log entry for this user task.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           format: date-time
           nullable: true
+          x-feature-gated: true
       x-properties-added-in-version:
         - propertyName: name
           addedInVersion: "8.8"

--- a/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/user-tasks.yaml
@@ -714,6 +714,8 @@ components:
         - followUpDate
         - processDefinitionVersion
         - formKey
+        - updatedBy
+        - updatedAt
       properties:
         name:
           nullable: true

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -234,6 +234,8 @@ components:
         - variableKey
         - scopeKey
         - rootProcessInstanceKey
+        - updatedBy
+        - updatedAt
       properties:
         name:
           description: Name of this variable.

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -234,6 +234,8 @@ components:
         - variableKey
         - scopeKey
         - rootProcessInstanceKey
+        - updatedBy
+        - updatedAt
       properties:
         name:
           description: Name of this variable.
@@ -266,9 +268,22 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+        updatedBy:
+          description: The actor ID from the latest accessible successful audit log entry for this variable.
+          type: string
+          nullable: true
+        updatedAt:
+          description: The timestamp of the latest accessible successful audit log entry for this variable.
+          type: string
+          format: date-time
+          nullable: true
       x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
+        - propertyName: updatedBy
+          addedInVersion: "8.10"
+        - propertyName: updatedAt
+          addedInVersion: "8.10"
 
     VariableValueFilterProperty:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -234,8 +234,6 @@ components:
         - variableKey
         - scopeKey
         - rootProcessInstanceKey
-        - updatedBy
-        - updatedAt
       properties:
         name:
           description: Name of this variable.

--- a/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/variables.yaml
@@ -234,8 +234,6 @@ components:
         - variableKey
         - scopeKey
         - rootProcessInstanceKey
-        - updatedBy
-        - updatedAt
       properties:
         name:
           description: Name of this variable.
@@ -269,14 +267,20 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
         updatedBy:
-          description: The actor ID from the latest accessible successful audit log entry for this variable.
+          description: |
+            The actor ID from the latest accessible successful audit log entry for this variable.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           nullable: true
+          x-feature-gated: true
         updatedAt:
-          description: The timestamp of the latest accessible successful audit log entry for this variable.
+          description: |
+            The timestamp of the latest accessible successful audit log entry for this variable.
+            Only present when `camunda.rest.update-metadata.enabled` is `true`.
           type: string
           format: date-time
           nullable: true
+          x-feature-gated: true
       x-properties-added-in-version:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -147,7 +147,13 @@ public class GatewayRestConfiguration {
 
     private static final boolean DEFAULT_ENABLED = false;
 
-    /** Whether {@code updatedBy}/{@code updatedAt} are populated in REST responses. */
+    /**
+     * Whether {@code updatedBy}/{@code updatedAt} are populated in REST responses. Disabled by
+     * default: while disabled the properties are omitted from responses and no audit log is
+     * queried, so there is no effect on behaviour or latency. Enabling it adds one audit log query
+     * per returned item, so a search endpoint returning the default page of 100 items issues 100
+     * additional queries; treat it as opt-in and size the audit log accordingly.
+     */
     private boolean enabled = DEFAULT_ENABLED;
 
     public boolean isEnabled() {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/GatewayRestConfiguration.java
@@ -26,11 +26,16 @@ public class GatewayRestConfiguration {
       MAX_CLUSTER_VARIABLE_METADATA_ENTRIES * MAX_CLUSTER_VARIABLE_METADATA_ENTRY_LENGTH;
 
   private final JobMetricsConfiguration jobMetrics = new JobMetricsConfiguration();
+  private final UpdateMetadataConfiguration updateMetadata = new UpdateMetadataConfiguration();
   private int maxNameFieldLength = DEFAULT_MAX_NAME_FIELD_LENGTH;
   private int maxClusterVariableMetadataSize = DEFAULT_MAX_CLUSTER_VARIABLE_METADATA_SIZE;
 
   public JobMetricsConfiguration getJobMetrics() {
     return jobMetrics;
+  }
+
+  public UpdateMetadataConfiguration getUpdateMetadata() {
+    return updateMetadata;
   }
 
   /**
@@ -127,6 +132,23 @@ public class GatewayRestConfiguration {
     public void setMaxUniqueKeys(final int maxUniqueKeys) {
       this.maxUniqueKeys = maxUniqueKeys;
     }
+
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+      this.enabled = enabled;
+    }
+  }
+
+  /** Configuration for exposing {@code updatedBy}/{@code updatedAt} in REST responses. */
+  public static class UpdateMetadataConfiguration {
+
+    private static final boolean DEFAULT_ENABLED = false;
+
+    /** Whether {@code updatedBy}/{@code updatedAt} are populated in REST responses. */
+    private boolean enabled = DEFAULT_ENABLED;
 
     public boolean isEnabled() {
       return enabled;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,11 +31,13 @@ import io.camunda.gateway.protocol.model.CategoryFilterProperty;
 import io.camunda.gateway.protocol.model.ClusterVariableKindFilterProperty;
 import io.camunda.gateway.protocol.model.ClusterVariableScopeFilterProperty;
 import io.camunda.gateway.protocol.model.DateTimeFilterProperty;
+import io.camunda.gateway.protocol.model.DecisionDefinitionResult;
 import io.camunda.gateway.protocol.model.DecisionEvaluationInstruction;
 import io.camunda.gateway.protocol.model.DecisionInstanceStateFilterProperty;
 import io.camunda.gateway.protocol.model.ElementInstanceStateFilterProperty;
 import io.camunda.gateway.protocol.model.EntityTypeFilterProperty;
 import io.camunda.gateway.protocol.model.IncidentErrorTypeFilterProperty;
+import io.camunda.gateway.protocol.model.IncidentResult;
 import io.camunda.gateway.protocol.model.IncidentStateFilterProperty;
 import io.camunda.gateway.protocol.model.IntegerFilterProperty;
 import io.camunda.gateway.protocol.model.JobKindFilterProperty;
@@ -45,10 +48,13 @@ import io.camunda.gateway.protocol.model.MessageSubscriptionTypeFilterProperty;
 import io.camunda.gateway.protocol.model.OperationTypeFilterProperty;
 import io.camunda.gateway.protocol.model.ProcessInstanceCreationInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceModificationTerminateInstruction;
+import io.camunda.gateway.protocol.model.ProcessInstanceResult;
 import io.camunda.gateway.protocol.model.ProcessInstanceStateFilterProperty;
 import io.camunda.gateway.protocol.model.SearchQueryPageRequest;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
+import io.camunda.gateway.protocol.model.UserTaskResult;
 import io.camunda.gateway.protocol.model.UserTaskStateFilterProperty;
+import io.camunda.gateway.protocol.model.VariableResultBase;
 import io.camunda.gateway.protocol.model.WaitStateElementTypeFilterProperty;
 import io.camunda.gateway.protocol.model.WaitStateTypeFilterProperty;
 import io.camunda.zeebe.gateway.rest.deserializer.AgentInstanceHistoryCommitStatusFilterPropertyDeserializer;
@@ -86,6 +92,7 @@ import io.camunda.zeebe.gateway.rest.deserializer.StringFilterPropertyDeserializ
 import io.camunda.zeebe.gateway.rest.deserializer.UserTaskStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.WaitStateElementTypeFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.WaitStateTypeFilterPropertyDeserializer;
+import java.util.List;
 import java.util.function.Consumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -93,6 +100,19 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 @Configuration
 public class JacksonConfig {
+
+  /**
+   * Response models carrying the feature-gated {@code updatedBy}/{@code updatedAt} properties.
+   * {@code VariableResult} and {@code VariableSearchResult} inherit them from {@code
+   * VariableResultBase}, so registering the base type covers both.
+   */
+  private static final List<Class<?>> UPDATE_METADATA_TYPES =
+      List.of(
+          ProcessInstanceResult.class,
+          UserTaskResult.class,
+          IncidentResult.class,
+          DecisionDefinitionResult.class,
+          VariableResultBase.class);
 
   @Bean("gatewayRestObjectMapperCustomizer")
   public Consumer<Jackson2ObjectMapperBuilder> gatewayRestObjectMapperCustomizer() {
@@ -176,6 +196,8 @@ public class JacksonConfig {
         new WaitStateElementTypeFilterPropertyDeserializer());
     module.addDeserializer(
         WaitStateTypeFilterProperty.class, new WaitStateTypeFilterPropertyDeserializer());
+    UPDATE_METADATA_TYPES.forEach(
+        type -> module.setMixInAnnotation(type, UpdateMetadataMixin.class));
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 
@@ -198,5 +220,23 @@ public class JacksonConfig {
             });
     gatewayRestObjectMapperCustomizer().accept(builder);
     return builder.build();
+  }
+
+  /**
+   * Omits {@code updatedBy}/{@code updatedAt} from serialized responses when they carry no value.
+   *
+   * <p>The generated response models are annotated {@code @JsonInclude(ALWAYS)} at class level, so
+   * without this mix-in these properties would be emitted as explicit nulls even while {@code
+   * camunda.rest.update-metadata.enabled} is {@code false}. Property-level inclusion declared on a
+   * mix-in takes precedence over the class-level default, so the keys are absent unless a value was
+   * resolved.
+   */
+  abstract static class UpdateMetadataMixin {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    abstract String getUpdatedBy();
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    abstract String getUpdatedAt();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.DECISION;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
@@ -80,12 +82,21 @@ public class DecisionDefinitionController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey) {
     try {
-      return ResponseEntity.ok(
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var response =
           SearchQueryResponseMapper.toDecisionDefinition(
               serviceRegistry
                   .decisionDefinitionServices(physicalTenantId)
-                  .getByKey(
-                      decisionDefinitionKey, authenticationProvider.getCamundaAuthentication())));
+                  .getByKey(decisionDefinitionKey, authentication));
+      UpdateMetadataMapper.addUpdateMetadata(
+          response,
+          DecisionDefinitionResult::getDecisionDefinitionKey,
+          DECISION,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          DecisionDefinitionResult::setUpdatedBy,
+          DecisionDefinitionResult::setUpdatedAt);
+      return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -116,11 +127,19 @@ public class DecisionDefinitionController {
     final var decisionDefinitionServices =
         serviceRegistry.decisionDefinitionServices(physicalTenantId);
     try {
-      final var result =
-          decisionDefinitionServices.search(
-              query, authenticationProvider.getCamundaAuthentication());
-      return ResponseEntity.ok(
-          SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result));
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var result = decisionDefinitionServices.search(query, authentication);
+      final var response =
+          SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result);
+      UpdateMetadataMapper.addUpdateMetadata(
+          response.getItems(),
+          DecisionDefinitionResult::getDecisionDefinitionKey,
+          DECISION,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          DecisionDefinitionResult::setUpdatedBy,
+          DecisionDefinitionResult::setUpdatedAt);
+      return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
@@ -46,14 +47,17 @@ public class DecisionDefinitionController {
   private final ServiceRegistry serviceRegistry;
   private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public DecisionDefinitionController(
       final ServiceRegistry serviceRegistry,
       final MultiTenancyConfiguration multiTenancyCfg,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.serviceRegistry = serviceRegistry;
     this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
   @CamundaPostMapping(path = "/evaluation")
@@ -88,14 +92,16 @@ public class DecisionDefinitionController {
               serviceRegistry
                   .decisionDefinitionServices(physicalTenantId)
                   .getByKey(decisionDefinitionKey, authentication));
-      UpdateMetadataMapper.addUpdateMetadata(
-          response,
-          DecisionDefinitionResult::getDecisionDefinitionKey,
-          DECISION,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          DecisionDefinitionResult::setUpdatedBy,
-          DecisionDefinitionResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            DecisionDefinitionResult::getDecisionDefinitionKey,
+            DECISION,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            DecisionDefinitionResult::setUpdatedBy,
+            DecisionDefinitionResult::setUpdatedAt);
+      }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -131,14 +137,16 @@ public class DecisionDefinitionController {
       final var result = decisionDefinitionServices.search(query, authentication);
       final var response =
           SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result);
-      UpdateMetadataMapper.addUpdateMetadata(
-          response.getItems(),
-          DecisionDefinitionResult::getDecisionDefinitionKey,
-          DECISION,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          DecisionDefinitionResult::setUpdatedBy,
-          DecisionDefinitionResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            DecisionDefinitionResult::getDecisionDefinitionKey,
+            DECISION,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            DecisionDefinitionResult::setUpdatedBy,
+            DecisionDefinitionResult::setUpdatedAt);
+      }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -31,8 +31,10 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -87,20 +89,24 @@ public class DecisionDefinitionController {
       @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var response =
-          SearchQueryResponseMapper.toDecisionDefinition(
-              serviceRegistry
-                  .decisionDefinitionServices(physicalTenantId)
-                  .getByKey(decisionDefinitionKey, authentication));
+      final var entity =
+          serviceRegistry
+              .decisionDefinitionServices(physicalTenantId)
+              .getByKey(decisionDefinitionKey, authentication);
+      final DecisionDefinitionResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response,
-            DecisionDefinitionResult::getDecisionDefinitionKey,
-            DECISION,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            DecisionDefinitionResult::setUpdatedBy,
-            DecisionDefinitionResult::setUpdatedAt);
+        final var metadata =
+            UpdateMetadataMapper.resolve(
+                entity,
+                d -> String.valueOf(d.decisionDefinitionKey()),
+                DECISION,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication);
+        response =
+            SearchQueryResponseMapper.toDecisionDefinition(
+                entity, metadata.updatedBy(), metadata.updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toDecisionDefinition(entity);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
@@ -135,17 +141,24 @@ public class DecisionDefinitionController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = decisionDefinitionServices.search(query, authentication);
-      final var response =
-          SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result);
+      final DecisionDefinitionSearchQueryResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response.getItems(),
-            DecisionDefinitionResult::getDecisionDefinitionKey,
-            DECISION,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            DecisionDefinitionResult::setUpdatedBy,
-            DecisionDefinitionResult::setUpdatedAt);
+        final Function<io.camunda.search.entities.DecisionDefinitionEntity, String> keyFn =
+            d -> String.valueOf(d.decisionDefinitionKey());
+        final var metadata =
+            UpdateMetadataMapper.resolveAll(
+                result.items(),
+                keyFn,
+                DECISION,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication);
+        response =
+            SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(
+                result,
+                d -> metadata.getOrDefault(keyFn.apply(d), ResolvedMetadata.EMPTY).updatedBy(),
+                d -> metadata.getOrDefault(keyFn.apply(d), ResolvedMetadata.EMPTY).updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -31,10 +31,8 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
-import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -89,24 +87,20 @@ public class DecisionDefinitionController {
       @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var entity =
-          serviceRegistry
-              .decisionDefinitionServices(physicalTenantId)
-              .getByKey(decisionDefinitionKey, authentication);
-      final DecisionDefinitionResult response;
+      final var response =
+          SearchQueryResponseMapper.toDecisionDefinition(
+              serviceRegistry
+                  .decisionDefinitionServices(physicalTenantId)
+                  .getByKey(decisionDefinitionKey, authentication));
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final var metadata =
-            UpdateMetadataMapper.resolve(
-                entity,
-                d -> String.valueOf(d.decisionDefinitionKey()),
-                DECISION,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication);
-        response =
-            SearchQueryResponseMapper.toDecisionDefinition(
-                entity, metadata.updatedBy(), metadata.updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toDecisionDefinition(entity);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            DecisionDefinitionResult::getDecisionDefinitionKey,
+            DECISION,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            DecisionDefinitionResult::setUpdatedBy,
+            DecisionDefinitionResult::setUpdatedAt);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
@@ -141,24 +135,17 @@ public class DecisionDefinitionController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = decisionDefinitionServices.search(query, authentication);
-      final DecisionDefinitionSearchQueryResult response;
+      final var response =
+          SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result);
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final Function<io.camunda.search.entities.DecisionDefinitionEntity, String> keyFn =
-            d -> String.valueOf(d.decisionDefinitionKey());
-        final var metadata =
-            UpdateMetadataMapper.resolveAll(
-                result.items(),
-                keyFn,
-                DECISION,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication);
-        response =
-            SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(
-                result,
-                d -> metadata.getOrDefault(keyFn.apply(d), ResolvedMetadata.EMPTY).updatedBy(),
-                d -> metadata.getOrDefault(keyFn.apply(d), ResolvedMetadata.EMPTY).updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toDecisionDefinitionSearchQueryResponse(result);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            DecisionDefinitionResult::getDecisionDefinitionKey,
+            DECISION,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            DecisionDefinitionResult::setUpdatedBy,
+            DecisionDefinitionResult::setUpdatedAt);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.INCIDENT;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
 import jakarta.validation.ValidationException;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
@@ -85,12 +87,21 @@ public class IncidentController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable("incidentKey") final Long incidentKey) {
     try {
-      return ResponseEntity.ok()
-          .body(
-              SearchQueryResponseMapper.toIncident(
-                  serviceRegistry
-                      .incidentServices(physicalTenantId)
-                      .getByKey(incidentKey, authenticationProvider.getCamundaAuthentication())));
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var response =
+          SearchQueryResponseMapper.toIncident(
+              serviceRegistry
+                  .incidentServices(physicalTenantId)
+                  .getByKey(incidentKey, authentication));
+      UpdateMetadataMapper.addUpdateMetadata(
+          response,
+          IncidentResult::getIncidentKey,
+          INCIDENT,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          IncidentResult::setUpdatedBy,
+          IncidentResult::setUpdatedAt);
+      return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -125,9 +136,18 @@ public class IncidentController {
       final String physicalTenantId, final IncidentQuery query) {
     final var incidentServices = serviceRegistry.incidentServices(physicalTenantId);
     try {
-      final var result =
-          incidentServices.search(query, authenticationProvider.getCamundaAuthentication());
-      return ResponseEntity.ok(SearchQueryResponseMapper.toIncidentSearchQueryResponse(result));
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var result = incidentServices.search(query, authentication);
+      final var response = SearchQueryResponseMapper.toIncidentSearchQueryResponse(result);
+      UpdateMetadataMapper.addUpdateMetadata(
+          response.getItems(),
+          IncidentResult::getIncidentKey,
+          INCIDENT,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          IncidentResult::setUpdatedBy,
+          IncidentResult::setUpdatedAt);
+      return ResponseEntity.ok(response);
     } catch (final ValidationException e) {
       final var problemDetail =
           GatewayErrorMapper.createProblemDetail(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
@@ -11,7 +11,6 @@ import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.INCID
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
-import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -33,10 +32,8 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
-import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import jakarta.validation.ValidationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -95,23 +92,21 @@ public class IncidentController {
       @PathVariable("incidentKey") final Long incidentKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var entity =
-          serviceRegistry.incidentServices(physicalTenantId).getByKey(incidentKey, authentication);
-      final IncidentResult response;
+      final var response =
+          SearchQueryResponseMapper.toIncident(
+              serviceRegistry
+                  .incidentServices(physicalTenantId)
+                  .getByKey(incidentKey, authentication));
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final var metadata =
-            UpdateMetadataMapper.resolve(
-                entity,
-                t -> String.valueOf(t.incidentKey()),
-                INCIDENT,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication,
-                t -> ResponseMapper.formatDate(t.creationTime()));
-        response =
-            SearchQueryResponseMapper.toIncident(
-                entity, metadata.updatedBy(), metadata.updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toIncident(entity);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            IncidentResult::getIncidentKey,
+            INCIDENT,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            IncidentResult::setUpdatedBy,
+            IncidentResult::setUpdatedAt,
+            IncidentResult::getCreationTime);
       }
       return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
@@ -150,25 +145,17 @@ public class IncidentController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = incidentServices.search(query, authentication);
-      final IncidentSearchQueryResult response;
+      final var response = SearchQueryResponseMapper.toIncidentSearchQueryResponse(result);
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final Function<io.camunda.search.entities.IncidentEntity, String> keyFn =
-            t -> String.valueOf(t.incidentKey());
-        final var metadata =
-            UpdateMetadataMapper.resolveAll(
-                result.items(),
-                keyFn,
-                INCIDENT,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication,
-                t -> ResponseMapper.formatDate(t.creationTime()));
-        response =
-            SearchQueryResponseMapper.toIncidentSearchQueryResponse(
-                result,
-                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedBy(),
-                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toIncidentSearchQueryResponse(result);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            IncidentResult::getIncidentKey,
+            INCIDENT,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            IncidentResult::setUpdatedBy,
+            IncidentResult::setUpdatedAt,
+            IncidentResult::getCreationTime);
       }
       return ResponseEntity.ok(response);
     } catch (final ValidationException e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
@@ -45,12 +46,15 @@ public class IncidentController {
 
   private final ServiceRegistry serviceRegistry;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public IncidentController(
       final ServiceRegistry serviceRegistry,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
   @CamundaPostMapping(path = "/{incidentKey}/resolution")
@@ -93,14 +97,17 @@ public class IncidentController {
               serviceRegistry
                   .incidentServices(physicalTenantId)
                   .getByKey(incidentKey, authentication));
-      UpdateMetadataMapper.addUpdateMetadata(
-          response,
-          IncidentResult::getIncidentKey,
-          INCIDENT,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          IncidentResult::setUpdatedBy,
-          IncidentResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            IncidentResult::getIncidentKey,
+            INCIDENT,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            IncidentResult::setUpdatedBy,
+            IncidentResult::setUpdatedAt,
+            IncidentResult::getCreationTime);
+      }
       return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -139,14 +146,17 @@ public class IncidentController {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = incidentServices.search(query, authentication);
       final var response = SearchQueryResponseMapper.toIncidentSearchQueryResponse(result);
-      UpdateMetadataMapper.addUpdateMetadata(
-          response.getItems(),
-          IncidentResult::getIncidentKey,
-          INCIDENT,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          IncidentResult::setUpdatedBy,
-          IncidentResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            IncidentResult::getIncidentKey,
+            INCIDENT,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            IncidentResult::setUpdatedBy,
+            IncidentResult::setUpdatedAt,
+            IncidentResult::getCreationTime);
+      }
       return ResponseEntity.ok(response);
     } catch (final ValidationException e) {
       final var problemDetail =

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
@@ -11,6 +11,7 @@ import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.INCID
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.GatewayErrorMapper;
+import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByDefinitionQuery;
@@ -32,8 +33,10 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import jakarta.validation.ValidationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -92,21 +95,23 @@ public class IncidentController {
       @PathVariable("incidentKey") final Long incidentKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var response =
-          SearchQueryResponseMapper.toIncident(
-              serviceRegistry
-                  .incidentServices(physicalTenantId)
-                  .getByKey(incidentKey, authentication));
+      final var entity =
+          serviceRegistry.incidentServices(physicalTenantId).getByKey(incidentKey, authentication);
+      final IncidentResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response,
-            IncidentResult::getIncidentKey,
-            INCIDENT,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            IncidentResult::setUpdatedBy,
-            IncidentResult::setUpdatedAt,
-            IncidentResult::getCreationTime);
+        final var metadata =
+            UpdateMetadataMapper.resolve(
+                entity,
+                t -> String.valueOf(t.incidentKey()),
+                INCIDENT,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication,
+                t -> ResponseMapper.formatDate(t.creationTime()));
+        response =
+            SearchQueryResponseMapper.toIncident(
+                entity, metadata.updatedBy(), metadata.updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toIncident(entity);
       }
       return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
@@ -145,17 +150,25 @@ public class IncidentController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = incidentServices.search(query, authentication);
-      final var response = SearchQueryResponseMapper.toIncidentSearchQueryResponse(result);
+      final IncidentSearchQueryResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response.getItems(),
-            IncidentResult::getIncidentKey,
-            INCIDENT,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            IncidentResult::setUpdatedBy,
-            IncidentResult::setUpdatedAt,
-            IncidentResult::getCreationTime);
+        final Function<io.camunda.search.entities.IncidentEntity, String> keyFn =
+            t -> String.valueOf(t.incidentKey());
+        final var metadata =
+            UpdateMetadataMapper.resolveAll(
+                result.items(),
+                keyFn,
+                INCIDENT,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication,
+                t -> ResponseMapper.formatDate(t.creationTime()));
+        response =
+            SearchQueryResponseMapper.toIncidentSearchQueryResponse(
+                result,
+                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedBy(),
+                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toIncidentSearchQueryResponse(result);
       }
       return ResponseEntity.ok(response);
     } catch (final ValidationException e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.PROCESS_INSTANCE;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.ResponseMapper;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
@@ -192,14 +194,22 @@ public class ProcessInstanceController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable("processInstanceKey") final Long processInstanceKey) {
     try {
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var response =
+          SearchQueryResponseMapper.toProcessInstance(
+              serviceRegistry
+                  .processInstanceServices(physicalTenantId)
+                  .getByKey(processInstanceKey, authentication));
+      UpdateMetadataMapper.addUpdateMetadata(
+          response,
+          io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
+          PROCESS_INSTANCE,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
+          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
       // Success case: Return the left side with the ProcessInstanceItem wrapped in ResponseEntity
-      return ResponseEntity.ok()
-          .body(
-              SearchQueryResponseMapper.toProcessInstance(
-                  serviceRegistry
-                      .processInstanceServices(physicalTenantId)
-                      .getByKey(
-                          processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+      return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -394,10 +404,18 @@ public class ProcessInstanceController {
       final String physicalTenantId, final ProcessInstanceQuery query) {
     final var processInstanceServices = serviceRegistry.processInstanceServices(physicalTenantId);
     try {
-      final var result =
-          processInstanceServices.search(query, authenticationProvider.getCamundaAuthentication());
-      return ResponseEntity.ok(
-          SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result));
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var result = processInstanceServices.search(query, authentication);
+      final var response = SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result);
+      UpdateMetadataMapper.addUpdateMetadata(
+          response.getItems(),
+          io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
+          PROCESS_INSTANCE,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
+          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+      return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
@@ -70,14 +71,17 @@ public class ProcessInstanceController {
   private final MultiTenancyConfiguration multiTenancyCfg;
   private final CamundaAuthenticationProvider authenticationProvider;
   private final ProcessInstanceMapper processInstanceMapper;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public ProcessInstanceController(
       final ServiceRegistry serviceRegistry,
       final MultiTenancyConfiguration multiTenancyCfg,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.serviceRegistry = serviceRegistry;
     this.multiTenancyCfg = multiTenancyCfg;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
     processInstanceMapper = new ProcessInstanceMapper();
   }
 
@@ -200,14 +204,16 @@ public class ProcessInstanceController {
               serviceRegistry
                   .processInstanceServices(physicalTenantId)
                   .getByKey(processInstanceKey, authentication));
-      UpdateMetadataMapper.addUpdateMetadata(
-          response,
-          io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
-          PROCESS_INSTANCE,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
-          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
+            PROCESS_INSTANCE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+      }
       // Success case: Return the left side with the ProcessInstanceItem wrapped in ResponseEntity
       return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
@@ -407,14 +413,16 @@ public class ProcessInstanceController {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = processInstanceServices.search(query, authentication);
       final var response = SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result);
-      UpdateMetadataMapper.addUpdateMetadata(
-          response.getItems(),
-          io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
-          PROCESS_INSTANCE,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
-          io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
+            PROCESS_INSTANCE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+      }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -55,8 +55,10 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -199,20 +201,24 @@ public class ProcessInstanceController {
       @PathVariable("processInstanceKey") final Long processInstanceKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var response =
-          SearchQueryResponseMapper.toProcessInstance(
-              serviceRegistry
-                  .processInstanceServices(physicalTenantId)
-                  .getByKey(processInstanceKey, authentication));
+      final var entity =
+          serviceRegistry
+              .processInstanceServices(physicalTenantId)
+              .getByKey(processInstanceKey, authentication);
+      final Object response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response,
-            io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
-            PROCESS_INSTANCE,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
-            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+        final var metadata =
+            UpdateMetadataMapper.resolve(
+                entity,
+                p -> String.valueOf(p.processInstanceKey()),
+                PROCESS_INSTANCE,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication);
+        response =
+            SearchQueryResponseMapper.toProcessInstance(
+                entity, metadata.updatedBy(), metadata.updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toProcessInstance(entity);
       }
       // Success case: Return the left side with the ProcessInstanceItem wrapped in ResponseEntity
       return ResponseEntity.ok().body(response);
@@ -412,16 +418,24 @@ public class ProcessInstanceController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = processInstanceServices.search(query, authentication);
-      final var response = SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result);
+      final ProcessInstanceSearchQueryResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response.getItems(),
-            io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
-            PROCESS_INSTANCE,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
-            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt);
+        final Function<io.camunda.search.entities.ProcessInstanceEntity, String> keyFn =
+            p -> String.valueOf(p.processInstanceKey());
+        final var metadata =
+            UpdateMetadataMapper.resolveAll(
+                result.items(),
+                keyFn,
+                PROCESS_INSTANCE,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication);
+        response =
+            SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(
+                result,
+                p -> metadata.getOrDefault(keyFn.apply(p), ResolvedMetadata.EMPTY).updatedBy(),
+                p -> metadata.getOrDefault(keyFn.apply(p), ResolvedMetadata.EMPTY).updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -55,10 +55,8 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
-import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -201,24 +199,21 @@ public class ProcessInstanceController {
       @PathVariable("processInstanceKey") final Long processInstanceKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var entity =
-          serviceRegistry
-              .processInstanceServices(physicalTenantId)
-              .getByKey(processInstanceKey, authentication);
-      final Object response;
+      final var response =
+          SearchQueryResponseMapper.toProcessInstance(
+              serviceRegistry
+                  .processInstanceServices(physicalTenantId)
+                  .getByKey(processInstanceKey, authentication));
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final var metadata =
-            UpdateMetadataMapper.resolve(
-                entity,
-                p -> String.valueOf(p.processInstanceKey()),
-                PROCESS_INSTANCE,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication);
-        response =
-            SearchQueryResponseMapper.toProcessInstance(
-                entity, metadata.updatedBy(), metadata.updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toProcessInstance(entity);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
+            PROCESS_INSTANCE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::getStartDate);
       }
       // Success case: Return the left side with the ProcessInstanceItem wrapped in ResponseEntity
       return ResponseEntity.ok().body(response);
@@ -418,24 +413,17 @@ public class ProcessInstanceController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = processInstanceServices.search(query, authentication);
-      final ProcessInstanceSearchQueryResult response;
+      final var response = SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result);
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final Function<io.camunda.search.entities.ProcessInstanceEntity, String> keyFn =
-            p -> String.valueOf(p.processInstanceKey());
-        final var metadata =
-            UpdateMetadataMapper.resolveAll(
-                result.items(),
-                keyFn,
-                PROCESS_INSTANCE,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication);
-        response =
-            SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(
-                result,
-                p -> metadata.getOrDefault(keyFn.apply(p), ResolvedMetadata.EMPTY).updatedBy(),
-                p -> metadata.getOrDefault(keyFn.apply(p), ResolvedMetadata.EMPTY).updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::getProcessInstanceKey,
+            PROCESS_INSTANCE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedBy,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::setUpdatedAt,
+            io.camunda.gateway.protocol.model.ProcessInstanceResult::getStartDate);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.USER_TASK;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.RequestMapper;
@@ -40,6 +41,7 @@ import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -119,12 +121,20 @@ public class UserTaskController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable("userTaskKey") final Long userTaskKey) {
     try {
+      final var authentication = authenticationProvider.getCamundaAuthentication();
       final var userTask =
-          serviceRegistry
-              .userTaskServices(physicalTenantId)
-              .getByKey(userTaskKey, authenticationProvider.getCamundaAuthentication());
+          serviceRegistry.userTaskServices(physicalTenantId).getByKey(userTaskKey, authentication);
+      final var response = SearchQueryResponseMapper.toUserTask(userTask);
+      UpdateMetadataMapper.addUpdateMetadata(
+          response,
+          UserTaskResult::getUserTaskKey,
+          USER_TASK,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          UserTaskResult::setUpdatedBy,
+          UserTaskResult::setUpdatedAt);
 
-      return ResponseEntity.ok().body(SearchQueryResponseMapper.toUserTask(userTask));
+      return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -199,10 +209,19 @@ public class UserTaskController {
       final String physicalTenantId, final UserTaskQuery query) {
     final var userTaskServices = serviceRegistry.userTaskServices(physicalTenantId);
     try {
-      final var result =
-          userTaskServices.search(query, authenticationProvider.getCamundaAuthentication());
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var result = userTaskServices.search(query, authentication);
+      final var response = SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result);
+      UpdateMetadataMapper.addUpdateMetadata(
+          response.getItems(),
+          UserTaskResult::getUserTaskKey,
+          USER_TASK,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          UserTaskResult::setUpdatedBy,
+          UserTaskResult::setUpdatedAt);
 
-      return ResponseEntity.ok(SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result));
+      return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
@@ -55,12 +56,15 @@ public class UserTaskController {
 
   private final ServiceRegistry serviceRegistry;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public UserTaskController(
       final ServiceRegistry serviceRegistry,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
   @CamundaPostMapping(path = "/{userTaskKey}/completion")
@@ -125,14 +129,17 @@ public class UserTaskController {
       final var userTask =
           serviceRegistry.userTaskServices(physicalTenantId).getByKey(userTaskKey, authentication);
       final var response = SearchQueryResponseMapper.toUserTask(userTask);
-      UpdateMetadataMapper.addUpdateMetadata(
-          response,
-          UserTaskResult::getUserTaskKey,
-          USER_TASK,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          UserTaskResult::setUpdatedBy,
-          UserTaskResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            UserTaskResult::getUserTaskKey,
+            USER_TASK,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            UserTaskResult::setUpdatedBy,
+            UserTaskResult::setUpdatedAt,
+            UserTaskResult::getCreationDate);
+      }
 
       return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
@@ -212,14 +219,17 @@ public class UserTaskController {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = userTaskServices.search(query, authentication);
       final var response = SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result);
-      UpdateMetadataMapper.addUpdateMetadata(
-          response.getItems(),
-          UserTaskResult::getUserTaskKey,
-          USER_TASK,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          UserTaskResult::setUpdatedBy,
-          UserTaskResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            UserTaskResult::getUserTaskKey,
+            USER_TASK,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            UserTaskResult::setUpdatedBy,
+            UserTaskResult::setUpdatedAt,
+            UserTaskResult::getCreationDate);
+      }
 
       return ResponseEntity.ok(response);
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -14,7 +14,6 @@ import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.RequestMapper.AssignUserTaskRequest;
 import io.camunda.gateway.mapping.http.RequestMapper.CompleteUserTaskRequest;
 import io.camunda.gateway.mapping.http.RequestMapper.UpdateUserTaskRequest;
-import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.AuditLogSearchQueryResult;
@@ -44,9 +43,7 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
-import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -131,21 +128,17 @@ public class UserTaskController {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var userTask =
           serviceRegistry.userTaskServices(physicalTenantId).getByKey(userTaskKey, authentication);
-      final UserTaskResult response;
+      final var response = SearchQueryResponseMapper.toUserTask(userTask);
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final var metadata =
-            UpdateMetadataMapper.resolve(
-                userTask,
-                t -> String.valueOf(t.userTaskKey()),
-                USER_TASK,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication,
-                t -> ResponseMapper.formatDate(t.creationDate()));
-        response =
-            SearchQueryResponseMapper.toUserTask(
-                userTask, metadata.updatedBy(), metadata.updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toUserTask(userTask);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            UserTaskResult::getUserTaskKey,
+            USER_TASK,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            UserTaskResult::setUpdatedBy,
+            UserTaskResult::setUpdatedAt,
+            UserTaskResult::getCreationDate);
       }
 
       return ResponseEntity.ok().body(response);
@@ -225,25 +218,17 @@ public class UserTaskController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = userTaskServices.search(query, authentication);
-      final UserTaskSearchQueryResult response;
+      final var response = SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result);
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final Function<io.camunda.search.entities.UserTaskEntity, String> keyFn =
-            t -> String.valueOf(t.userTaskKey());
-        final var metadata =
-            UpdateMetadataMapper.resolveAll(
-                result.items(),
-                keyFn,
-                USER_TASK,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication,
-                t -> ResponseMapper.formatDate(t.creationDate()));
-        response =
-            SearchQueryResponseMapper.toUserTaskSearchQueryResponse(
-                result,
-                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedBy(),
-                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            UserTaskResult::getUserTaskKey,
+            USER_TASK,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            UserTaskResult::setUpdatedBy,
+            UserTaskResult::setUpdatedAt,
+            UserTaskResult::getCreationDate);
       }
 
       return ResponseEntity.ok(response);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -14,6 +14,7 @@ import io.camunda.gateway.mapping.http.RequestMapper;
 import io.camunda.gateway.mapping.http.RequestMapper.AssignUserTaskRequest;
 import io.camunda.gateway.mapping.http.RequestMapper.CompleteUserTaskRequest;
 import io.camunda.gateway.mapping.http.RequestMapper.UpdateUserTaskRequest;
+import io.camunda.gateway.mapping.http.ResponseMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
 import io.camunda.gateway.protocol.model.AuditLogSearchQueryResult;
@@ -43,7 +44,9 @@ import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -128,17 +131,21 @@ public class UserTaskController {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var userTask =
           serviceRegistry.userTaskServices(physicalTenantId).getByKey(userTaskKey, authentication);
-      final var response = SearchQueryResponseMapper.toUserTask(userTask);
+      final UserTaskResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response,
-            UserTaskResult::getUserTaskKey,
-            USER_TASK,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            UserTaskResult::setUpdatedBy,
-            UserTaskResult::setUpdatedAt,
-            UserTaskResult::getCreationDate);
+        final var metadata =
+            UpdateMetadataMapper.resolve(
+                userTask,
+                t -> String.valueOf(t.userTaskKey()),
+                USER_TASK,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication,
+                t -> ResponseMapper.formatDate(t.creationDate()));
+        response =
+            SearchQueryResponseMapper.toUserTask(
+                userTask, metadata.updatedBy(), metadata.updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toUserTask(userTask);
       }
 
       return ResponseEntity.ok().body(response);
@@ -218,17 +225,25 @@ public class UserTaskController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = userTaskServices.search(query, authentication);
-      final var response = SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result);
+      final UserTaskSearchQueryResult response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response.getItems(),
-            UserTaskResult::getUserTaskKey,
-            USER_TASK,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            UserTaskResult::setUpdatedBy,
-            UserTaskResult::setUpdatedAt,
-            UserTaskResult::getCreationDate);
+        final Function<io.camunda.search.entities.UserTaskEntity, String> keyFn =
+            t -> String.valueOf(t.userTaskKey());
+        final var metadata =
+            UpdateMetadataMapper.resolveAll(
+                result.items(),
+                keyFn,
+                USER_TASK,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication,
+                t -> ResponseMapper.formatDate(t.creationDate()));
+        response =
+            SearchQueryResponseMapper.toUserTaskSearchQueryResponse(
+                result,
+                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedBy(),
+                t -> metadata.getOrDefault(keyFn.apply(t), ResolvedMetadata.EMPTY).updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result);
       }
 
       return ResponseEntity.ok(response);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.VARIABLE;
 import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.protocol.model.VariableResult;
 import io.camunda.gateway.protocol.model.VariableSearchQuery;
+import io.camunda.gateway.protocol.model.VariableSearchResult;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
@@ -20,6 +23,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,10 +61,19 @@ public class VariableController {
       final String physicalTenantId, final VariableQuery query, final boolean truncateValues) {
     final var variableServices = serviceRegistry.variableServices(physicalTenantId);
     try {
-      final var result =
-          variableServices.search(query, authenticationProvider.getCamundaAuthentication());
-      return ResponseEntity.ok(
-          SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues));
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var result = variableServices.search(query, authentication);
+      final var response =
+          SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues);
+      UpdateMetadataMapper.addUpdateMetadata(
+          response.getItems(),
+          VariableSearchResult::getVariableKey,
+          VARIABLE,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          VariableSearchResult::setUpdatedBy,
+          VariableSearchResult::setUpdatedAt);
+      return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -71,13 +84,22 @@ public class VariableController {
       @PhysicalTenantId final String physicalTenantId,
       @PathVariable("variableKey") final Long variableKey) {
     try {
+      final var authentication = authenticationProvider.getCamundaAuthentication();
+      final var response =
+          SearchQueryResponseMapper.toVariableItem(
+              serviceRegistry
+                  .variableServices(physicalTenantId)
+                  .getByKey(variableKey, authentication));
+      UpdateMetadataMapper.addUpdateMetadata(
+          response,
+          VariableResult::getVariableKey,
+          VARIABLE,
+          serviceRegistry.auditLogServices(physicalTenantId),
+          authentication,
+          VariableResult::setUpdatedBy,
+          VariableResult::setUpdatedAt);
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
-      return ResponseEntity.ok()
-          .body(
-              SearchQueryResponseMapper.toVariableItem(
-                  serviceRegistry
-                      .variableServices(physicalTenantId)
-                      .getByKey(variableKey, authenticationProvider.getCamundaAuthentication())));
+      return ResponseEntity.ok().body(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
 import org.springframework.http.ResponseEntity;
@@ -37,12 +38,15 @@ public class VariableController {
 
   private final ServiceRegistry serviceRegistry;
   private final CamundaAuthenticationProvider authenticationProvider;
+  private final GatewayRestConfiguration gatewayRestConfiguration;
 
   public VariableController(
       final ServiceRegistry serviceRegistry,
-      final CamundaAuthenticationProvider authenticationProvider) {
+      final CamundaAuthenticationProvider authenticationProvider,
+      final GatewayRestConfiguration gatewayRestConfiguration) {
     this.serviceRegistry = serviceRegistry;
     this.authenticationProvider = authenticationProvider;
+    this.gatewayRestConfiguration = gatewayRestConfiguration;
   }
 
   @CamundaPostMapping(path = "/search")
@@ -65,14 +69,16 @@ public class VariableController {
       final var result = variableServices.search(query, authentication);
       final var response =
           SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues);
-      UpdateMetadataMapper.addUpdateMetadata(
-          response.getItems(),
-          VariableSearchResult::getVariableKey,
-          VARIABLE,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          VariableSearchResult::setUpdatedBy,
-          VariableSearchResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            VariableSearchResult::getVariableKey,
+            VARIABLE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            VariableSearchResult::setUpdatedBy,
+            VariableSearchResult::setUpdatedAt);
+      }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
       return mapErrorToResponse(e);
@@ -90,14 +96,16 @@ public class VariableController {
               serviceRegistry
                   .variableServices(physicalTenantId)
                   .getByKey(variableKey, authentication));
-      UpdateMetadataMapper.addUpdateMetadata(
-          response,
-          VariableResult::getVariableKey,
-          VARIABLE,
-          serviceRegistry.auditLogServices(physicalTenantId),
-          authentication,
-          VariableResult::setUpdatedBy,
-          VariableResult::setUpdatedAt);
+      if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            VariableResult::getVariableKey,
+            VARIABLE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            VariableResult::setUpdatedBy,
+            VariableResult::setUpdatedAt);
+      }
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
       return ResponseEntity.ok().body(response);
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -12,8 +12,9 @@ import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToRes
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
+import io.camunda.gateway.protocol.model.VariableResult;
 import io.camunda.gateway.protocol.model.VariableSearchQuery;
-import io.camunda.search.entities.VariableEntity;
+import io.camunda.gateway.protocol.model.VariableSearchResult;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
@@ -24,8 +25,6 @@ import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
-import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
-import java.util.function.Function;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -68,24 +67,17 @@ public class VariableController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = variableServices.search(query, authentication);
-      final Object response;
+      final var response =
+          SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues);
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final Function<VariableEntity, String> keyFn = v -> String.valueOf(v.variableKey());
-        final var metadata =
-            UpdateMetadataMapper.resolveAll(
-                result.items(),
-                keyFn,
-                VARIABLE,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication);
-        response =
-            SearchQueryResponseMapper.toVariableSearchQueryResponse(
-                result,
-                truncateValues,
-                v -> metadata.getOrDefault(keyFn.apply(v), ResolvedMetadata.EMPTY).updatedBy(),
-                v -> metadata.getOrDefault(keyFn.apply(v), ResolvedMetadata.EMPTY).updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response.getItems(),
+            VariableSearchResult::getVariableKey,
+            VARIABLE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            VariableSearchResult::setUpdatedBy,
+            VariableSearchResult::setUpdatedAt);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
@@ -99,22 +91,20 @@ public class VariableController {
       @PathVariable("variableKey") final Long variableKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var entity =
-          serviceRegistry.variableServices(physicalTenantId).getByKey(variableKey, authentication);
-      final Object response;
+      final var response =
+          SearchQueryResponseMapper.toVariableItem(
+              serviceRegistry
+                  .variableServices(physicalTenantId)
+                  .getByKey(variableKey, authentication));
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        final var metadata =
-            UpdateMetadataMapper.resolve(
-                entity,
-                v -> String.valueOf(v.variableKey()),
-                VARIABLE,
-                serviceRegistry.auditLogServices(physicalTenantId),
-                authentication);
-        response =
-            SearchQueryResponseMapper.toVariableItem(
-                entity, metadata.updatedBy(), metadata.updatedAt());
-      } else {
-        response = SearchQueryResponseMapper.toVariableItem(entity);
+        UpdateMetadataMapper.addUpdateMetadata(
+            response,
+            VariableResult::getVariableKey,
+            VARIABLE,
+            serviceRegistry.auditLogServices(physicalTenantId),
+            authentication,
+            VariableResult::setUpdatedBy,
+            VariableResult::setUpdatedAt);
       }
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
       return ResponseEntity.ok().body(response);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -12,9 +12,8 @@ import static io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper.mapErrorToRes
 
 import io.camunda.gateway.mapping.http.search.SearchQueryRequestMapper;
 import io.camunda.gateway.mapping.http.search.SearchQueryResponseMapper;
-import io.camunda.gateway.protocol.model.VariableResult;
 import io.camunda.gateway.protocol.model.VariableSearchQuery;
-import io.camunda.gateway.protocol.model.VariableSearchResult;
+import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
@@ -25,6 +24,8 @@ import io.camunda.zeebe.gateway.rest.annotation.RequiresSecondaryStorage;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.mapper.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper;
+import io.camunda.zeebe.gateway.rest.mapper.UpdateMetadataMapper.ResolvedMetadata;
+import java.util.function.Function;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -67,17 +68,24 @@ public class VariableController {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
       final var result = variableServices.search(query, authentication);
-      final var response =
-          SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues);
+      final Object response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response.getItems(),
-            VariableSearchResult::getVariableKey,
-            VARIABLE,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            VariableSearchResult::setUpdatedBy,
-            VariableSearchResult::setUpdatedAt);
+        final Function<VariableEntity, String> keyFn = v -> String.valueOf(v.variableKey());
+        final var metadata =
+            UpdateMetadataMapper.resolveAll(
+                result.items(),
+                keyFn,
+                VARIABLE,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication);
+        response =
+            SearchQueryResponseMapper.toVariableSearchQueryResponse(
+                result,
+                truncateValues,
+                v -> metadata.getOrDefault(keyFn.apply(v), ResolvedMetadata.EMPTY).updatedBy(),
+                v -> metadata.getOrDefault(keyFn.apply(v), ResolvedMetadata.EMPTY).updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toVariableSearchQueryResponse(result, truncateValues);
       }
       return ResponseEntity.ok(response);
     } catch (final Exception e) {
@@ -91,20 +99,22 @@ public class VariableController {
       @PathVariable("variableKey") final Long variableKey) {
     try {
       final var authentication = authenticationProvider.getCamundaAuthentication();
-      final var response =
-          SearchQueryResponseMapper.toVariableItem(
-              serviceRegistry
-                  .variableServices(physicalTenantId)
-                  .getByKey(variableKey, authentication));
+      final var entity =
+          serviceRegistry.variableServices(physicalTenantId).getByKey(variableKey, authentication);
+      final Object response;
       if (gatewayRestConfiguration.getUpdateMetadata().isEnabled()) {
-        UpdateMetadataMapper.addUpdateMetadata(
-            response,
-            VariableResult::getVariableKey,
-            VARIABLE,
-            serviceRegistry.auditLogServices(physicalTenantId),
-            authentication,
-            VariableResult::setUpdatedBy,
-            VariableResult::setUpdatedAt);
+        final var metadata =
+            UpdateMetadataMapper.resolve(
+                entity,
+                v -> String.valueOf(v.variableKey()),
+                VARIABLE,
+                serviceRegistry.auditLogServices(physicalTenantId),
+                authentication);
+        response =
+            SearchQueryResponseMapper.toVariableItem(
+                entity, metadata.updatedBy(), metadata.updatedAt());
+      } else {
+        response = SearchQueryResponseMapper.toVariableItem(entity);
       }
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
       return ResponseEntity.ok().body(response);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.mapper;
+
+import static io.camunda.gateway.mapping.http.ResponseMapper.formatDate;
+import static io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS;
+
+import io.camunda.search.entities.AuditLogEntity.AuditLogEntityType;
+import io.camunda.search.query.AuditLogQuery;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.AuditLogServices;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public final class UpdateMetadataMapper {
+
+  private UpdateMetadataMapper() {}
+
+  public static <T> void addUpdateMetadata(
+      final T item,
+      final Function<T, String> entityKeyExtractor,
+      final AuditLogEntityType entityType,
+      final AuditLogServices auditLogServices,
+      final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter) {
+    addUpdateMetadata(
+        List.of(item),
+        entityKeyExtractor,
+        entityType,
+        auditLogServices,
+        authentication,
+        updatedBySetter,
+        updatedAtSetter);
+  }
+
+  public static <T> void addUpdateMetadata(
+      final Collection<T> items,
+      final Function<T, String> entityKeyExtractor,
+      final AuditLogEntityType entityType,
+      final AuditLogServices auditLogServices,
+      final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter) {
+    for (final T item : items) {
+      try {
+        final var entityKey = entityKeyExtractor.apply(item);
+        final var query =
+            AuditLogQuery.of(
+                q ->
+                    q.filter(
+                            f ->
+                                f.entityKeys(entityKey)
+                                    .entityTypes(entityType.name())
+                                    .results(SUCCESS.name()))
+                        .sort(s -> s.timestamp().desc())
+                        .page(p -> p.size(1)));
+        auditLogServices.search(query, authentication).items().stream()
+            .findFirst()
+            .ifPresent(
+                auditLog -> {
+                  if (auditLog.actorId() != null) {
+                    updatedBySetter.accept(item, auditLog.actorId());
+                  }
+                  updatedAtSetter.accept(item, formatDate(auditLog.timestamp()));
+                });
+      } catch (final RuntimeException ignored) {
+        // Update metadata is supplemental and must not fail the entity response.
+      }
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
@@ -88,6 +88,21 @@ public final class UpdateMetadataMapper {
         null);
   }
 
+  /**
+   * Resolves the metadata for a whole page of items.
+   *
+   * <p>KNOWN COST: this issues <em>one audit log query per item</em>, so a search endpoint
+   * returning the default page of 100 items performs 100 additional queries. Callers must therefore
+   * only invoke this while {@code camunda.rest.update-metadata.enabled} is set, which is off by
+   * default.
+   *
+   * <p>The queries are not batched even though {@code AuditLogFilter#entityKeys} accepts several
+   * keys, because selecting the <em>latest</em> entry per key relies on {@code sort(timestamp
+   * desc)} combined with {@code size(1)}. The audit log search exposes no per-group top-hits or
+   * aggregation, so a single bounded query cannot guarantee one row per key: an entity with many
+   * entries can crowd every other key out of the page. Batching correctly would mean paging until
+   * every key is resolved, which is deliberately left out of scope here.
+   */
   public static <T> void addUpdateMetadata(
       final Collection<T> items,
       final Function<T, String> entityKeyExtractor,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
@@ -38,7 +38,35 @@ public final class UpdateMetadataMapper {
         auditLogServices,
         authentication,
         updatedBySetter,
-        updatedAtSetter);
+        updatedAtSetter,
+        null);
+  }
+
+  /**
+   * Same as {@link #addUpdateMetadata(Object, Function, AuditLogEntityType, AuditLogServices,
+   * CamundaAuthentication, BiConsumer, BiConsumer)}, but falls back to {@code
+   * creationTimestampFallback} for {@code updatedAt} when the entity has no audit log entry at all
+   * (e.g. it was never explicitly updated after creation, and its creation is not itself an audited
+   * action).
+   */
+  public static <T> void addUpdateMetadata(
+      final T item,
+      final Function<T, String> entityKeyExtractor,
+      final AuditLogEntityType entityType,
+      final AuditLogServices auditLogServices,
+      final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter,
+      final Function<T, String> creationTimestampFallback) {
+    addUpdateMetadata(
+        List.of(item),
+        entityKeyExtractor,
+        entityType,
+        auditLogServices,
+        authentication,
+        updatedBySetter,
+        updatedAtSetter,
+        creationTimestampFallback);
   }
 
   public static <T> void addUpdateMetadata(
@@ -49,6 +77,26 @@ public final class UpdateMetadataMapper {
       final CamundaAuthentication authentication,
       final BiConsumer<T, String> updatedBySetter,
       final BiConsumer<T, String> updatedAtSetter) {
+    addUpdateMetadata(
+        items,
+        entityKeyExtractor,
+        entityType,
+        auditLogServices,
+        authentication,
+        updatedBySetter,
+        updatedAtSetter,
+        null);
+  }
+
+  public static <T> void addUpdateMetadata(
+      final Collection<T> items,
+      final Function<T, String> entityKeyExtractor,
+      final AuditLogEntityType entityType,
+      final AuditLogServices auditLogServices,
+      final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter,
+      final Function<T, String> creationTimestampFallback) {
     for (final T item : items) {
       try {
         final var entityKey = entityKeyExtractor.apply(item);
@@ -62,15 +110,20 @@ public final class UpdateMetadataMapper {
                                     .results(SUCCESS.name()))
                         .sort(s -> s.timestamp().desc())
                         .page(p -> p.size(1)));
-        auditLogServices.search(query, authentication).items().stream()
-            .findFirst()
-            .ifPresent(
-                auditLog -> {
-                  if (auditLog.actorId() != null) {
-                    updatedBySetter.accept(item, auditLog.actorId());
-                  }
-                  updatedAtSetter.accept(item, formatDate(auditLog.timestamp()));
-                });
+        final var latestAuditLog =
+            auditLogServices.search(query, authentication).items().stream().findFirst();
+        if (latestAuditLog.isPresent()) {
+          final var auditLog = latestAuditLog.get();
+          if (auditLog.actorId() != null) {
+            updatedBySetter.accept(item, auditLog.actorId());
+          }
+          updatedAtSetter.accept(item, formatDate(auditLog.timestamp()));
+        } else if (creationTimestampFallback != null) {
+          // No audit log entry exists (e.g. creation itself is not an audited action for this
+          // entity type). Initialize updatedAt to the entity's own creation time instead of
+          // leaving it null, mirroring how Job#lastUpdateTime is set at creation.
+          updatedAtSetter.accept(item, creationTimestampFallback.apply(item));
+        }
       } catch (final RuntimeException ignored) {
         // Update metadata is supplemental and must not fail the entity response.
       }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
@@ -15,72 +15,91 @@ import io.camunda.search.query.AuditLogQuery;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.service.AuditLogServices;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-/**
- * Resolves the {@code updatedBy}/{@code updatedAt} REST response metadata from the audit log, ahead
- * of constructing the (immutable, required-field) response objects.
- */
 public final class UpdateMetadataMapper {
 
   private UpdateMetadataMapper() {}
 
-  public static <T> ResolvedMetadata resolve(
+  public static <T> void addUpdateMetadata(
       final T item,
       final Function<T, String> entityKeyExtractor,
       final AuditLogEntityType entityType,
       final AuditLogServices auditLogServices,
-      final CamundaAuthentication authentication) {
-    return resolve(item, entityKeyExtractor, entityType, auditLogServices, authentication, null);
+      final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter) {
+    addUpdateMetadata(
+        List.of(item),
+        entityKeyExtractor,
+        entityType,
+        auditLogServices,
+        authentication,
+        updatedBySetter,
+        updatedAtSetter,
+        null);
   }
 
   /**
-   * Same as {@link #resolve(Object, Function, AuditLogEntityType, AuditLogServices,
-   * CamundaAuthentication)}, but falls back to {@code creationTimestampFallback} for {@code
-   * updatedAt} when the entity has no audit log entry at all (e.g. it was never explicitly updated
-   * after creation, and its creation is not itself an audited action).
+   * Same as {@link #addUpdateMetadata(Object, Function, AuditLogEntityType, AuditLogServices,
+   * CamundaAuthentication, BiConsumer, BiConsumer)}, but falls back to {@code
+   * creationTimestampFallback} for {@code updatedAt} when the entity has no audit log entry at all
+   * (e.g. it was never explicitly updated after creation, and its creation is not itself an audited
+   * action).
    */
-  public static <T> ResolvedMetadata resolve(
+  public static <T> void addUpdateMetadata(
       final T item,
       final Function<T, String> entityKeyExtractor,
       final AuditLogEntityType entityType,
       final AuditLogServices auditLogServices,
       final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter,
       final Function<T, String> creationTimestampFallback) {
-    return resolveAll(
-            List.of(item),
-            entityKeyExtractor,
-            entityType,
-            auditLogServices,
-            authentication,
-            creationTimestampFallback)
-        .getOrDefault(entityKeyExtractor.apply(item), ResolvedMetadata.EMPTY);
+    addUpdateMetadata(
+        List.of(item),
+        entityKeyExtractor,
+        entityType,
+        auditLogServices,
+        authentication,
+        updatedBySetter,
+        updatedAtSetter,
+        creationTimestampFallback);
   }
 
-  public static <T> Map<String, ResolvedMetadata> resolveAll(
-      final Collection<T> items,
-      final Function<T, String> entityKeyExtractor,
-      final AuditLogEntityType entityType,
-      final AuditLogServices auditLogServices,
-      final CamundaAuthentication authentication) {
-    return resolveAll(
-        items, entityKeyExtractor, entityType, auditLogServices, authentication, null);
-  }
-
-  public static <T> Map<String, ResolvedMetadata> resolveAll(
+  public static <T> void addUpdateMetadata(
       final Collection<T> items,
       final Function<T, String> entityKeyExtractor,
       final AuditLogEntityType entityType,
       final AuditLogServices auditLogServices,
       final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter) {
+    addUpdateMetadata(
+        items,
+        entityKeyExtractor,
+        entityType,
+        auditLogServices,
+        authentication,
+        updatedBySetter,
+        updatedAtSetter,
+        null);
+  }
+
+  public static <T> void addUpdateMetadata(
+      final Collection<T> items,
+      final Function<T, String> entityKeyExtractor,
+      final AuditLogEntityType entityType,
+      final AuditLogServices auditLogServices,
+      final CamundaAuthentication authentication,
+      final BiConsumer<T, String> updatedBySetter,
+      final BiConsumer<T, String> updatedAtSetter,
       final Function<T, String> creationTimestampFallback) {
-    final Map<String, ResolvedMetadata> resolved = new HashMap<>();
     for (final T item : items) {
-      final var entityKey = entityKeyExtractor.apply(item);
       try {
+        final var entityKey = entityKeyExtractor.apply(item);
         final var query =
             AuditLogQuery.of(
                 q ->
@@ -95,24 +114,19 @@ public final class UpdateMetadataMapper {
             auditLogServices.search(query, authentication).items().stream().findFirst();
         if (latestAuditLog.isPresent()) {
           final var auditLog = latestAuditLog.get();
-          resolved.put(
-              entityKey,
-              new ResolvedMetadata(auditLog.actorId(), formatDate(auditLog.timestamp())));
+          if (auditLog.actorId() != null) {
+            updatedBySetter.accept(item, auditLog.actorId());
+          }
+          updatedAtSetter.accept(item, formatDate(auditLog.timestamp()));
         } else if (creationTimestampFallback != null) {
           // No audit log entry exists (e.g. creation itself is not an audited action for this
           // entity type). Initialize updatedAt to the entity's own creation time instead of
           // leaving it null, mirroring how Job#lastUpdateTime is set at creation.
-          resolved.put(
-              entityKey, new ResolvedMetadata(null, creationTimestampFallback.apply(item)));
+          updatedAtSetter.accept(item, creationTimestampFallback.apply(item));
         }
       } catch (final RuntimeException ignored) {
         // Update metadata is supplemental and must not fail the entity response.
       }
     }
-    return resolved;
-  }
-
-  public record ResolvedMetadata(String updatedBy, String updatedAt) {
-    public static final ResolvedMetadata EMPTY = new ResolvedMetadata(null, null);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapper.java
@@ -15,91 +15,72 @@ import io.camunda.search.query.AuditLogQuery;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.service.AuditLogServices;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
-import java.util.function.BiConsumer;
+import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * Resolves the {@code updatedBy}/{@code updatedAt} REST response metadata from the audit log, ahead
+ * of constructing the (immutable, required-field) response objects.
+ */
 public final class UpdateMetadataMapper {
 
   private UpdateMetadataMapper() {}
 
-  public static <T> void addUpdateMetadata(
+  public static <T> ResolvedMetadata resolve(
       final T item,
       final Function<T, String> entityKeyExtractor,
       final AuditLogEntityType entityType,
       final AuditLogServices auditLogServices,
-      final CamundaAuthentication authentication,
-      final BiConsumer<T, String> updatedBySetter,
-      final BiConsumer<T, String> updatedAtSetter) {
-    addUpdateMetadata(
-        List.of(item),
-        entityKeyExtractor,
-        entityType,
-        auditLogServices,
-        authentication,
-        updatedBySetter,
-        updatedAtSetter,
-        null);
+      final CamundaAuthentication authentication) {
+    return resolve(item, entityKeyExtractor, entityType, auditLogServices, authentication, null);
   }
 
   /**
-   * Same as {@link #addUpdateMetadata(Object, Function, AuditLogEntityType, AuditLogServices,
-   * CamundaAuthentication, BiConsumer, BiConsumer)}, but falls back to {@code
-   * creationTimestampFallback} for {@code updatedAt} when the entity has no audit log entry at all
-   * (e.g. it was never explicitly updated after creation, and its creation is not itself an audited
-   * action).
+   * Same as {@link #resolve(Object, Function, AuditLogEntityType, AuditLogServices,
+   * CamundaAuthentication)}, but falls back to {@code creationTimestampFallback} for {@code
+   * updatedAt} when the entity has no audit log entry at all (e.g. it was never explicitly updated
+   * after creation, and its creation is not itself an audited action).
    */
-  public static <T> void addUpdateMetadata(
+  public static <T> ResolvedMetadata resolve(
       final T item,
       final Function<T, String> entityKeyExtractor,
       final AuditLogEntityType entityType,
       final AuditLogServices auditLogServices,
       final CamundaAuthentication authentication,
-      final BiConsumer<T, String> updatedBySetter,
-      final BiConsumer<T, String> updatedAtSetter,
       final Function<T, String> creationTimestampFallback) {
-    addUpdateMetadata(
-        List.of(item),
-        entityKeyExtractor,
-        entityType,
-        auditLogServices,
-        authentication,
-        updatedBySetter,
-        updatedAtSetter,
-        creationTimestampFallback);
+    return resolveAll(
+            List.of(item),
+            entityKeyExtractor,
+            entityType,
+            auditLogServices,
+            authentication,
+            creationTimestampFallback)
+        .getOrDefault(entityKeyExtractor.apply(item), ResolvedMetadata.EMPTY);
   }
 
-  public static <T> void addUpdateMetadata(
+  public static <T> Map<String, ResolvedMetadata> resolveAll(
+      final Collection<T> items,
+      final Function<T, String> entityKeyExtractor,
+      final AuditLogEntityType entityType,
+      final AuditLogServices auditLogServices,
+      final CamundaAuthentication authentication) {
+    return resolveAll(
+        items, entityKeyExtractor, entityType, auditLogServices, authentication, null);
+  }
+
+  public static <T> Map<String, ResolvedMetadata> resolveAll(
       final Collection<T> items,
       final Function<T, String> entityKeyExtractor,
       final AuditLogEntityType entityType,
       final AuditLogServices auditLogServices,
       final CamundaAuthentication authentication,
-      final BiConsumer<T, String> updatedBySetter,
-      final BiConsumer<T, String> updatedAtSetter) {
-    addUpdateMetadata(
-        items,
-        entityKeyExtractor,
-        entityType,
-        auditLogServices,
-        authentication,
-        updatedBySetter,
-        updatedAtSetter,
-        null);
-  }
-
-  public static <T> void addUpdateMetadata(
-      final Collection<T> items,
-      final Function<T, String> entityKeyExtractor,
-      final AuditLogEntityType entityType,
-      final AuditLogServices auditLogServices,
-      final CamundaAuthentication authentication,
-      final BiConsumer<T, String> updatedBySetter,
-      final BiConsumer<T, String> updatedAtSetter,
       final Function<T, String> creationTimestampFallback) {
+    final Map<String, ResolvedMetadata> resolved = new HashMap<>();
     for (final T item : items) {
+      final var entityKey = entityKeyExtractor.apply(item);
       try {
-        final var entityKey = entityKeyExtractor.apply(item);
         final var query =
             AuditLogQuery.of(
                 q ->
@@ -114,19 +95,24 @@ public final class UpdateMetadataMapper {
             auditLogServices.search(query, authentication).items().stream().findFirst();
         if (latestAuditLog.isPresent()) {
           final var auditLog = latestAuditLog.get();
-          if (auditLog.actorId() != null) {
-            updatedBySetter.accept(item, auditLog.actorId());
-          }
-          updatedAtSetter.accept(item, formatDate(auditLog.timestamp()));
+          resolved.put(
+              entityKey,
+              new ResolvedMetadata(auditLog.actorId(), formatDate(auditLog.timestamp())));
         } else if (creationTimestampFallback != null) {
           // No audit log entry exists (e.g. creation itself is not an audited action for this
           // entity type). Initialize updatedAt to the entity's own creation time instead of
           // leaving it null, mirroring how Job#lastUpdateTime is set at creation.
-          updatedAtSetter.accept(item, creationTimestampFallback.apply(item));
+          resolved.put(
+              entityKey, new ResolvedMetadata(null, creationTimestampFallback.apply(item)));
         }
       } catch (final RuntimeException ignored) {
         // Update metadata is supplemental and must not fail the entity response.
       }
     }
+    return resolved;
+  }
+
+  public record ResolvedMetadata(String updatedBy, String updatedAt) {
+    public static final ResolvedMetadata EMPTY = new ResolvedMetadata(null, null);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
@@ -13,11 +13,14 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceController;
 import io.camunda.zeebe.gateway.rest.controller.TopologyController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = {ProcessInstanceController.class, TopologyController.class})
@@ -57,5 +60,13 @@ public class RestApiDefaultConfigurationTest extends RestApiConfigurationTest {
         .isOk();
 
     verify(topologyServices).getTopology();
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiJacksonConfigTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiJacksonConfigTest.java
@@ -14,11 +14,14 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceController;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -114,5 +117,13 @@ public class RestApiJacksonConfigTest extends RestApiConfigurationTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -29,7 +30,9 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -292,5 +295,13 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
         .setTenantId(tenantId);
 
     return CompletableFuture.completedFuture(new BrokerResponse<>(record, 1, 123));
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -57,7 +57,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                       "decisionRequirementsId": "drId",
                       "decisionRequirementsKey": "2",
                       "decisionRequirementsName": "drN",
-                      "decisionRequirementsVersion": 2
+                      "decisionRequirementsVersion": 2,
+                      "updatedBy": null,
+                      "updatedAt": null
                   }
               ],
               "page": {
@@ -454,7 +456,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "decisionRequirementsId": "drId",
               "decisionRequirementsKey": "2",
               "decisionRequirementsName": "drN",
-              "decisionRequirementsVersion": 2
+              "decisionRequirementsVersion": 2,
+              "updatedBy": null,
+              "updatedAt": null
             }""";
     // when/then
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.DecisionDefinitionFilter;
@@ -23,20 +24,27 @@ import io.camunda.search.sort.DecisionDefinitionSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.service.AuditLogServices;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -88,12 +96,19 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean ServiceRegistry serviceRegistry;
+  @MockitoBean AuditLogServices auditLogServices;
+  @Autowired GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setupServices() {
     when(serviceRegistry.decisionDefinitionServices(any())).thenReturn(decisionDefinitionServices);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @AfterEach
+  void resetUpdateMetadataFlag() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(false);
   }
 
   @Test
@@ -471,6 +486,45 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
         .json(expectedResponse, JsonCompareMode.STRICT);
+
+    verify(serviceRegistry, never()).auditLogServices(any());
+  }
+
+  @Test
+  public void shouldPopulateUpdateMetadataWhenFlagEnabled() {
+    // given
+    final Long decisionDefinitionKey = 1L;
+    final DecisionDefinitionEntity decisionDefinitionEntity =
+        new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "drN", 2, "t");
+    when(decisionDefinitionServices.getByKey(eq(decisionDefinitionKey), any()))
+        .thenReturn(decisionDefinitionEntity);
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("0")
+            .entityType(io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.DECISION)
+            .operationType(io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.CREATE)
+            .timestamp(OffsetDateTime.parse("2026-01-05T10:00:00Z"))
+            .actorId("demo")
+            .result(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS)
+            .category(io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory.ADMIN)
+            .build();
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+
+    // when/then
+    webClient
+        .get()
+        .uri("/v2/decision-definitions/%d".formatted(decisionDefinitionKey))
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo("demo")
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2026-01-05T10:00:00.000Z");
   }
 
   @Test
@@ -580,5 +634,13 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         Pair.of(
             DECISION_DEFINITIONS_GET_XML_URL,
             (service, key) -> service.getDecisionDefinitionXml(eq(key), any())));
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -65,9 +65,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                       "decisionRequirementsId": "drId",
                       "decisionRequirementsKey": "2",
                       "decisionRequirementsName": "drN",
-                      "decisionRequirementsVersion": 2,
-                      "updatedBy": null,
-                      "updatedAt": null
+                      "decisionRequirementsVersion": 2
                   }
               ],
               "page": {
@@ -471,9 +469,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "decisionRequirementsId": "drId",
               "decisionRequirementsKey": "2",
               "decisionRequirementsName": "drN",
-              "decisionRequirementsVersion": 2,
-              "updatedBy": null,
-              "updatedAt": null
+              "decisionRequirementsVersion": 2
             }""";
     // when/then
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -188,7 +188,9 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
             "creationTime": "2023-05-17T00:00:00.000Z",
             "state": "ACTIVE",
             "jobKey": "99",
-            "tenantId": "tenant1"
+            "tenantId": "tenant1",
+            "updatedBy": null,
+            "updatedAt": null
           }
         ],
         "page": {
@@ -221,7 +223,9 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                   "creationTime": "2024-01-02T00:00:00.000Z",
                   "state": "ACTIVE",
                   "jobKey": "567",
-                  "tenantId": "tenantId"
+                  "tenantId": "tenantId",
+                  "updatedBy": null,
+                  "updatedAt": null
                 }
               ],
               "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceQueryControllerTest.java
@@ -188,9 +188,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
             "creationTime": "2023-05-17T00:00:00.000Z",
             "state": "ACTIVE",
             "jobKey": "99",
-            "tenantId": "tenant1",
-            "updatedBy": null,
-            "updatedAt": null
+            "tenantId": "tenant1"
           }
         ],
         "page": {
@@ -223,9 +221,7 @@ public class ElementInstanceQueryControllerTest extends RestControllerTest {
                   "creationTime": "2024-01-02T00:00:00.000Z",
                   "state": "ACTIVE",
                   "jobKey": "567",
-                  "tenantId": "tenantId",
-                  "updatedBy": null,
-                  "updatedAt": null
+                  "tenantId": "tenantId"
                 }
               ],
               "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.msgpack.spec.MsgpackException;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -50,7 +51,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -690,5 +693,13 @@ public class ErrorMapperTest extends RestControllerTest {
         .isEqualTo(HttpStatus.BAD_REQUEST)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FaultyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FaultyControllerTest.java
@@ -14,9 +14,12 @@ import io.camunda.security.api.model.config.MultiTenancyConfiguration;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -73,5 +76,13 @@ public class FaultyControllerTest extends RestControllerTest {
              """
                 .formatted("Request property [test] cannot be parsed", PROCESS_INSTANCES_START_URL),
             JsonCompareMode.STRICT);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -27,7 +28,9 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -114,5 +117,13 @@ public class IncidentControllerTest extends RestControllerTest {
         .json(expectedBody, JsonCompareMode.STRICT);
 
     verify(incidentServices).resolveIncident(eq(1L), isNull(), any());
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -69,7 +69,9 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                       "creationTime": "2024-05-23T23:05:00.000Z",
                       "state": "ACTIVE",
                       "jobKey": "101",
-                      "tenantId": "tenantId"
+                      "tenantId": "tenantId",
+                      "updatedBy": null,
+                      "updatedAt": null
                   }
               ],
               "page": {
@@ -116,9 +118,11 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                           "elementId": "elementId",
                           "elementInstanceKey": "17",
                           "creationTime": "2024-05-23T23:05:00.000Z",
-                          "state": "ACTIVE",
-                          "jobKey": "101",
-                          "tenantId": "tenantId"
+                           "state": "ACTIVE",
+                           "jobKey": "101",
+                           "tenantId": "tenantId",
+                           "updatedBy": null,
+                           "updatedAt": null
                       }
           """;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
@@ -26,16 +27,22 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.IncidentSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AuditLogServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -213,12 +220,19 @@ public class IncidentQueryControllerTest extends RestControllerTest {
   @MockitoBean IncidentServices incidentServices;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean ServiceRegistry serviceRegistry;
+  @MockitoBean AuditLogServices auditLogServices;
+  @Autowired GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setupIncidentServices() {
     when(serviceRegistry.incidentServices(any())).thenReturn(incidentServices);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @AfterEach
+  void resetUpdateMetadataFlag() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(false);
   }
 
   @Test
@@ -380,6 +394,58 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_GET_RESPONSE, JsonCompareMode.STRICT);
 
     verify(incidentServices).getByKey(eq(23L), any());
+    verify(serviceRegistry, org.mockito.Mockito.never()).auditLogServices(any());
+  }
+
+  @Test
+  void shouldPopulateUpdateMetadataWhenFlagEnabled() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(incidentServices.getByKey(any(Long.class), any())).thenReturn(GET_QUERY_RESULT);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("5")
+            .entityType(io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.INCIDENT)
+            .operationType(io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.RESOLVE)
+            .timestamp(OffsetDateTime.parse("2026-01-05T10:00:00Z"))
+            .actorId("demo")
+            .result(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS)
+            .category(io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory.ADMIN)
+            .build();
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+
+    webClient
+        .get()
+        .uri(INCIDENT_URL + "23")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo("demo")
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2026-01-05T10:00:00.000Z");
+  }
+
+  @Test
+  void shouldFallBackToCreationTimeWhenFlagEnabledAndNoAuditLogEntry() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(incidentServices.getByKey(any(Long.class), any())).thenReturn(GET_QUERY_RESULT);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.empty());
+
+    webClient
+        .get()
+        .uri(INCIDENT_URL + "23")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo(null)
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2024-05-23T23:05:00.000Z");
   }
 
   @Test
@@ -811,5 +877,13 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                 """
                 .formatted(INCIDENT_PROCESS_INSTANCE_STATISTICS_BY_ERROR_URL),
             JsonCompareMode.LENIENT);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -76,9 +76,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                       "creationTime": "2024-05-23T23:05:00.000Z",
                       "state": "ACTIVE",
                       "jobKey": "101",
-                      "tenantId": "tenantId",
-                      "updatedBy": null,
-                      "updatedAt": null
+                      "tenantId": "tenantId"
                   }
               ],
               "page": {
@@ -127,9 +125,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                           "creationTime": "2024-05-23T23:05:00.000Z",
                            "state": "ACTIVE",
                            "jobKey": "101",
-                           "tenantId": "tenantId",
-                           "updatedBy": null,
-                           "updatedAt": null
+                           "tenantId": "tenantId"
                       }
           """;
 
@@ -442,8 +438,9 @@ public class IncidentQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
+        // no actor is known without an audit log entry, so the key stays absent
         .jsonPath("$.updatedBy")
-        .isEqualTo(null)
+        .doesNotExist()
         .jsonPath("$.updatedAt")
         .isEqualTo("2024-05-23T23:05:00.000Z");
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -3008,7 +3008,9 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                 "processInstanceKey": "2251799814751255",
                 "rootProcessInstanceKey": "3751799814751237",
                 "elementInstanceKey": "2251799814751258",
-                "jobKey": "1"
+                "jobKey": "1",
+                "updatedBy": null,
+                "updatedAt": null
             }
         ],
         "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -39,6 +39,7 @@ import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.history.HistoryDeletionRecord;
@@ -68,7 +69,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -4102,5 +4105,13 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody, JsonCompareMode.STRICT);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -3011,9 +3011,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
                 "processInstanceKey": "2251799814751255",
                 "rootProcessInstanceKey": "3751799814751237",
                 "elementInstanceKey": "2251799814751258",
-                "jobKey": "1",
-                "updatedBy": null,
-                "updatedAt": null
+                "jobKey": "1"
             }
         ],
         "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -113,7 +113,9 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             "hasIncident": false,
             "tenantId": "tenant",
             "tags": ["tag1", "tag2"],
-            "businessId": "biz-id"
+            "businessId": "biz-id",
+            "updatedBy": null,
+            "updatedAt": null
           }
           """;
   private static final String EXPECTED_SEARCH_RESPONSE =
@@ -137,7 +139,9 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "hasIncident": false,
                   "tenantId": "tenant",
                   "tags": ["tag1", "tag2"],
-                  "businessId": "biz-id"
+                  "businessId": "biz-id",
+                  "updatedBy": null,
+                  "updatedAt": null
                 }
               ],
               "page": {
@@ -187,7 +191,9 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "creationTime": "2024-01-02T00:00:00.000Z",
                   "state": "ACTIVE",
                   "jobKey": "567",
-                  "tenantId": "tenantId"
+                  "tenantId": "tenantId",
+                  "updatedBy": null,
+                  "updatedAt": null
                 }
               ],
               "page": {
@@ -795,7 +801,9 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               "hasIncident": false,
               "tenantId": "tenant",
               "tags": [],
-              "businessId": null
+              "businessId": null,
+              "updatedBy": null,
+              "updatedAt": null
             }
             """;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.gateway.mapping.http.converters.ProcessInstanceStateConverter;
 import io.camunda.gateway.protocol.model.IncidentErrorTypeEnum;
 import io.camunda.gateway.protocol.model.IncidentStateEnum;
 import io.camunda.gateway.protocol.model.ProcessInstanceStateEnum;
+import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
@@ -36,16 +37,19 @@ import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.config.MultiTenancyConfiguration;
+import io.camunda.service.AuditLogServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,7 +62,10 @@ import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -238,6 +245,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
   @MockitoBean ServiceRegistry serviceRegistry;
   @MockitoBean MultiTenancyConfiguration multiTenancyCfg;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
+  @MockitoBean AuditLogServices auditLogServices;
+  @Autowired GatewayRestConfiguration gatewayRestConfiguration;
   @Captor ArgumentCaptor<ProcessInstanceQuery> queryCaptor;
   @Captor ArgumentCaptor<IncidentQuery> incidentQueryCaptor;
 
@@ -248,6 +257,11 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .thenReturn(processInstanceServices);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
+  }
+
+  @AfterEach
+  void resetUpdateMetadataFlag() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(false);
   }
 
   private static void assertJsonNonExtensible(final String expected, final byte[] actualBytes) {
@@ -753,6 +767,45 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
     // Verify that the service was called with the valid key
     verify(processInstanceServices)
         .getByKey(eq(validProcesInstanceKey), any(CamundaAuthentication.class));
+    verify(serviceRegistry, never()).auditLogServices(any());
+  }
+
+  @Test
+  public void shouldPopulateUpdateMetadataWhenFlagEnabled() {
+    // given
+    final var validProcesInstanceKey = 123L;
+    when(processInstanceServices.getByKey(
+            eq(validProcesInstanceKey), any(CamundaAuthentication.class)))
+        .thenReturn(PROCESS_INSTANCE_ENTITY);
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey(String.valueOf(validProcesInstanceKey))
+            .entityType(
+                io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.PROCESS_INSTANCE)
+            .operationType(io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.CANCEL)
+            .timestamp(OffsetDateTime.parse("2026-01-05T10:00:00Z"))
+            .actorId("demo")
+            .result(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS)
+            .category(io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory.ADMIN)
+            .build();
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+
+    // when / then
+    webClient
+        .get()
+        .uri(PROCESS_INSTANCES_BY_KEY_URL, validProcesInstanceKey)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo("demo")
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2026-01-05T10:00:00.000Z");
   }
 
   @Test
@@ -1358,5 +1411,13 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class), any());
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -120,9 +120,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             "hasIncident": false,
             "tenantId": "tenant",
             "tags": ["tag1", "tag2"],
-            "businessId": "biz-id",
-            "updatedBy": null,
-            "updatedAt": null
+            "businessId": "biz-id"
           }
           """;
   private static final String EXPECTED_SEARCH_RESPONSE =
@@ -146,9 +144,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "hasIncident": false,
                   "tenantId": "tenant",
                   "tags": ["tag1", "tag2"],
-                  "businessId": "biz-id",
-                  "updatedBy": null,
-                  "updatedAt": null
+                  "businessId": "biz-id"
                 }
               ],
               "page": {
@@ -198,9 +194,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
                   "creationTime": "2024-01-02T00:00:00.000Z",
                   "state": "ACTIVE",
                   "jobKey": "567",
-                  "tenantId": "tenantId",
-                  "updatedBy": null,
-                  "updatedAt": null
+                  "tenantId": "tenantId"
                 }
               ],
               "page": {
@@ -771,6 +765,31 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
   }
 
   @Test
+  public void shouldOmitUpdateMetadataKeysEntirelyWhenFlagDisabled() {
+    // given - the flag defaults to disabled
+    final var validProcesInstanceKey = 123L;
+    when(processInstanceServices.getByKey(
+            eq(validProcesInstanceKey), any(CamundaAuthentication.class)))
+        .thenReturn(PROCESS_INSTANCE_ENTITY);
+
+    // when / then - the properties must be absent, not serialized as null
+    webClient
+        .get()
+        .uri(PROCESS_INSTANCES_BY_KEY_URL, validProcesInstanceKey)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .doesNotExist()
+        .jsonPath("$.updatedAt")
+        .doesNotExist();
+
+    verify(serviceRegistry, never()).auditLogServices(any());
+  }
+
+  @Test
   public void shouldPopulateUpdateMetadataWhenFlagEnabled() {
     // given
     final var validProcesInstanceKey = 123L;
@@ -854,9 +873,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               "hasIncident": false,
               "tenantId": "tenant",
               "tags": [],
-              "businessId": null,
-              "updatedBy": null,
-              "updatedAt": null
+              "businessId": null
             }
             """;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -37,7 +38,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -1339,5 +1342,13 @@ public class UserTaskControllerTest extends RestControllerTest {
         .isEqualTo("Expected to handle request, but request timed out between gateway and broker")
         .jsonPath("$.status")
         .isEqualTo(504);
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -87,7 +87,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                         "processDefinitionVersion": 1,
                         "customHeaders": {},
                         "priority": 50,
-                        "tags": []
+                        "tags": [],
+                        "updatedBy": null,
+                        "updatedAt": null
                     }
                 ],
                 "page": {
@@ -110,7 +112,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                     "processInstanceKey":"2",
                     "rootProcessInstanceKey":"3",
                     "tenantId":"<default>",
-                    "isTruncated":false
+                    "isTruncated":false,
+                    "updatedBy": null,
+                    "updatedAt": null
                 },
                 {
                     "variableKey":"1",
@@ -120,7 +124,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                     "processInstanceKey":"2",
                     "rootProcessInstanceKey":"3",
                     "tenantId":"<default>",
-                    "isTruncated":true
+                    "isTruncated":true,
+                    "updatedBy": null,
+                    "updatedAt": null
                 }
               ],
               "page": {
@@ -144,7 +150,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":false
+              "isTruncated":false,
+              "updatedBy": null,
+              "updatedAt": null
           },
           {
               "variableKey":"1",
@@ -154,7 +162,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":false
+              "isTruncated":false,
+              "updatedBy": null,
+              "updatedAt": null
           }
         ],
         "page": {
@@ -178,7 +188,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":false
+              "isTruncated":false,
+              "updatedBy": null,
+              "updatedAt": null
           },
           {
               "variableKey":"1",
@@ -188,7 +200,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":true
+              "isTruncated":true,
+              "updatedBy": null,
+              "updatedAt": null
           }
         ],
         "page": {
@@ -311,7 +325,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                         "processDefinitionVersion": 1,
                         "customHeaders": {},
                         "priority": 50,
-                        "tags": []
+                        "tags": [],
+                        "updatedBy": null,
+                        "updatedAt": null
             }
             """;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -29,10 +29,12 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.sort.UserTaskSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AuditLogServices;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -42,12 +44,16 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -436,6 +442,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
   @MockitoBean UserTaskServices userTaskServices;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean ServiceRegistry serviceRegistry;
+  @MockitoBean AuditLogServices auditLogServices;
+  @Autowired GatewayRestConfiguration gatewayRestConfiguration;
 
   @BeforeEach
   void setupServices() throws IOException {
@@ -479,6 +487,11 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 new CamundaSearchException(
                     String.format("User Task with key %d not found", INVALID_USER_TASK_KEY),
                     CamundaSearchException.Reason.NOT_FOUND)));
+  }
+
+  @AfterEach
+  void resetUpdateMetadataFlag() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(false);
   }
 
   @Test
@@ -963,6 +976,59 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
     // Verify that the service was called with the invalid userTaskKey
     verify(userTaskServices).getByKey(eq(VALID_USER_TASK_KEY), any());
+    verify(serviceRegistry, never()).auditLogServices(any());
+  }
+
+  @Test
+  public void shouldPopulateUpdateMetadataWhenFlagEnabled() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("0")
+            .entityType(io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.USER_TASK)
+            .operationType(io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.ASSIGN)
+            .timestamp(OffsetDateTime.parse("2026-01-05T10:00:00Z"))
+            .actorId("demo")
+            .result(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS)
+            .category(
+                io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory.USER_TASKS)
+            .build();
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+
+    webClient
+        .get()
+        .uri("/v2/user-tasks/{userTaskKey}", VALID_USER_TASK_KEY)
+        .accept(APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo("demo")
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2026-01-05T10:00:00.000Z");
+  }
+
+  @Test
+  public void shouldFallBackToCreationDateWhenFlagEnabledAndNoAuditLogEntry() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.empty());
+
+    webClient
+        .get()
+        .uri("/v2/user-tasks/{userTaskKey}", VALID_USER_TASK_KEY)
+        .accept(APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo(null)
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2020-11-11T00:00:00.000Z");
   }
 
   @Test
@@ -1298,5 +1364,13 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
             eq(VALID_USER_TASK_KEY),
             eq(auditLogSearchQuery().filter(f -> f.actorIds("1")).build()),
             any());
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -93,9 +93,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                         "processDefinitionVersion": 1,
                         "customHeaders": {},
                         "priority": 50,
-                        "tags": [],
-                        "updatedBy": null,
-                        "updatedAt": null
+                        "tags": []
                     }
                 ],
                 "page": {
@@ -118,9 +116,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                     "processInstanceKey":"2",
                     "rootProcessInstanceKey":"3",
                     "tenantId":"<default>",
-                    "isTruncated":false,
-                    "updatedBy": null,
-                    "updatedAt": null
+                    "isTruncated":false
                 },
                 {
                     "variableKey":"1",
@@ -130,9 +126,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                     "processInstanceKey":"2",
                     "rootProcessInstanceKey":"3",
                     "tenantId":"<default>",
-                    "isTruncated":true,
-                    "updatedBy": null,
-                    "updatedAt": null
+                    "isTruncated":true
                 }
               ],
               "page": {
@@ -156,9 +150,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":false,
-              "updatedBy": null,
-              "updatedAt": null
+              "isTruncated":false
           },
           {
               "variableKey":"1",
@@ -168,9 +160,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":false,
-              "updatedBy": null,
-              "updatedAt": null
+              "isTruncated":false
           }
         ],
         "page": {
@@ -194,9 +184,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":false,
-              "updatedBy": null,
-              "updatedAt": null
+              "isTruncated":false
           },
           {
               "variableKey":"1",
@@ -206,9 +194,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "processInstanceKey":"2",
               "rootProcessInstanceKey":"3",
               "tenantId":"<default>",
-              "isTruncated":true,
-              "updatedBy": null,
-              "updatedAt": null
+              "isTruncated":true
           }
         ],
         "page": {
@@ -331,9 +317,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                         "processDefinitionVersion": 1,
                         "customHeaders": {},
                         "priority": 50,
-                        "tags": [],
-                        "updatedBy": null,
-                        "updatedAt": null
+                        "tags": []
             }
             """;
 
@@ -1025,8 +1009,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .expectStatus()
         .isOk()
         .expectBody()
+        // no actor is known without an audit log entry, so the key stays absent
         .jsonPath("$.updatedBy")
-        .isEqualTo(null)
+        .doesNotExist()
         .jsonPath("$.updatedAt")
         .isEqualTo("2020-11-11T00:00:00.000Z");
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -60,7 +60,9 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               "scopeKey": "2",
               "processInstanceKey": "3",
               "rootProcessInstanceKey": "4",
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "updatedBy": null,
+              "updatedAt": null
           }""";
   private static final String EXPECT_SINGLE_TRUNCATED_VARIABLE_RESPONSE =
       """
@@ -71,7 +73,9 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               "scopeKey": "2",
               "processInstanceKey": "3",
               "rootProcessInstanceKey": "4",
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "updatedBy": null,
+              "updatedAt": null
           }""";
   private static final String EXPECTED_SEARCH_RESPONSE =
       """
@@ -85,7 +89,9 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": false
+                        "isTruncated": false,
+                        "updatedBy": null,
+                        "updatedAt": null
                   },
                   {
                         "variableKey": "1",
@@ -95,7 +101,9 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": true
+                        "isTruncated": true,
+                        "updatedBy": null,
+                        "updatedAt": null
                   }
               ],
               "page": {
@@ -118,7 +126,9 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": false
+                        "isTruncated": false,
+                        "updatedBy": null,
+                        "updatedAt": null
                   },
                   {
                         "variableKey": "1",
@@ -128,7 +138,9 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": false
+                        "isTruncated": false,
+                        "updatedBy": null,
+                        "updatedAt": null
                   }
               ],
               "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
+import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.filter.VariableFilter;
@@ -23,12 +24,16 @@ import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.service.AuditLogServices;
 import io.camunda.service.VariableServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +43,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
@@ -165,7 +173,14 @@ public class VariablesQueryControllerTest extends RestControllerTest {
   @MockitoBean VariableServices variableServices;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean ServiceRegistry serviceRegistry;
+  @MockitoBean AuditLogServices auditLogServices;
+  @Autowired GatewayRestConfiguration gatewayRestConfiguration;
   @Captor ArgumentCaptor<VariableQuery> variableQueryCaptor;
+
+  @AfterEach
+  void resetUpdateMetadataFlag() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(false);
+  }
 
   @BeforeEach
   void setupServices() {
@@ -462,6 +477,37 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .json(EXPECT_SINGLE_VARIABLE_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).getByKey(eq(VALID_VARIABLE_KEY), any());
+    verify(serviceRegistry, never()).auditLogServices(any());
+  }
+
+  @Test
+  void shouldPopulateUpdateMetadataWhenFlagEnabled() {
+    gatewayRestConfiguration.getUpdateMetadata().setEnabled(true);
+    when(serviceRegistry.auditLogServices(any())).thenReturn(auditLogServices);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("0")
+            .entityType(io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.VARIABLE)
+            .operationType(io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.UPDATE)
+            .timestamp(OffsetDateTime.parse("2026-01-05T10:00:00Z"))
+            .actorId("demo")
+            .result(io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS)
+            .category(io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory.ADMIN)
+            .build();
+    when(auditLogServices.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+
+    webClient
+        .get()
+        .uri("/v2/variables/" + VALID_VARIABLE_KEY)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.updatedBy")
+        .isEqualTo("demo")
+        .jsonPath("$.updatedAt")
+        .isEqualTo("2026-01-05T10:00:00.000Z");
   }
 
   @Test
@@ -557,5 +603,13 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE, JsonCompareMode.STRICT);
 
     verify(variableServices).search(eq(new VariableQuery.Builder().filter(filter).build()), any());
+  }
+
+  @TestConfiguration
+  static class TestConfig {
+    @Bean
+    GatewayRestConfiguration gatewayRestConfiguration() {
+      return new GatewayRestConfiguration();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -68,9 +68,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               "scopeKey": "2",
               "processInstanceKey": "3",
               "rootProcessInstanceKey": "4",
-              "tenantId": "<default>",
-              "updatedBy": null,
-              "updatedAt": null
+              "tenantId": "<default>"
           }""";
   private static final String EXPECT_SINGLE_TRUNCATED_VARIABLE_RESPONSE =
       """
@@ -81,9 +79,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               "scopeKey": "2",
               "processInstanceKey": "3",
               "rootProcessInstanceKey": "4",
-              "tenantId": "<default>",
-              "updatedBy": null,
-              "updatedAt": null
+              "tenantId": "<default>"
           }""";
   private static final String EXPECTED_SEARCH_RESPONSE =
       """
@@ -97,9 +93,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": false,
-                        "updatedBy": null,
-                        "updatedAt": null
+                        "isTruncated": false
                   },
                   {
                         "variableKey": "1",
@@ -109,9 +103,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": true,
-                        "updatedBy": null,
-                        "updatedAt": null
+                        "isTruncated": true
                   }
               ],
               "page": {
@@ -134,9 +126,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": false,
-                        "updatedBy": null,
-                        "updatedAt": null
+                        "isTruncated": false
                   },
                   {
                         "variableKey": "1",
@@ -146,9 +136,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
                         "processInstanceKey": "3",
                         "rootProcessInstanceKey": "4",
                         "tenantId": "<default>",
-                        "isTruncated": false,
-                        "updatedBy": null,
-                        "updatedAt": null
+                        "isTruncated": false
                   }
               ],
               "page": {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.mapper;
+
+import static io.camunda.search.entities.AuditLogEntity.AuditLogEntityType.USER_TASK;
+import static io.camunda.search.entities.AuditLogEntity.AuditLogOperationCategory.USER_TASKS;
+import static io.camunda.search.entities.AuditLogEntity.AuditLogOperationResult.SUCCESS;
+import static io.camunda.search.entities.AuditLogEntity.AuditLogOperationType.UPDATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.query.AuditLogQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.service.AuditLogServices;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class UpdateMetadataMapperTest {
+
+  @Test
+  void shouldMapLatestSuccessfulAuditLog() {
+    final var services = mock(AuditLogServices.class);
+    final var authentication = mock(CamundaAuthentication.class);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("123")
+            .entityType(USER_TASK)
+            .operationType(UPDATE)
+            .timestamp(OffsetDateTime.parse("2026-07-22T10:15:30Z"))
+            .actorId("demo")
+            .result(SUCCESS)
+            .category(USER_TASKS)
+            .build();
+    when(services.search(any(), same(authentication))).thenReturn(SearchQueryResult.of(auditLog));
+    final var item = new Item("123");
+
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        authentication,
+        Item::setUpdatedBy,
+        Item::setUpdatedAt);
+
+    assertThat(item.updatedBy).isEqualTo("demo");
+    assertThat(item.updatedAt).isEqualTo("2026-07-22T10:15:30.000Z");
+    final var queryCaptor = ArgumentCaptor.forClass(AuditLogQuery.class);
+    verify(services).search(queryCaptor.capture(), same(authentication));
+    final var query = queryCaptor.getValue();
+    assertThat(query.filter().entityKeyOperations())
+        .containsExactly(io.camunda.search.filter.Operation.eq("123"));
+    assertThat(query.filter().entityTypeOperations())
+        .containsExactly(io.camunda.search.filter.Operation.eq("USER_TASK"));
+    assertThat(query.filter().resultOperations())
+        .containsExactly(io.camunda.search.filter.Operation.eq("SUCCESS"));
+    assertThat(query.sort().orderings())
+        .containsExactly(
+            new io.camunda.search.sort.SortOption.FieldSorting(
+                "timestamp", io.camunda.search.sort.SortOrder.DESC));
+    assertThat(query.page().size()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldLeaveMetadataNullWhenAuditLookupFails() {
+    final var services = mock(AuditLogServices.class);
+    when(services.search(any(), any())).thenThrow(new RuntimeException("unavailable"));
+    final var item = new Item("123");
+
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        mock(CamundaAuthentication.class),
+        Item::setUpdatedBy,
+        Item::setUpdatedAt);
+
+    assertThat(item.updatedBy).isNull();
+    assertThat(item.updatedAt).isNull();
+  }
+
+  private static final class Item {
+    private final String key;
+    private String updatedBy;
+    private String updatedAt;
+
+    private Item(final String key) {
+      this.key = key;
+    }
+
+    private String key() {
+      return key;
+    }
+
+    private void setUpdatedBy(final String updatedBy) {
+      this.updatedBy = updatedBy;
+    }
+
+    private void setUpdatedAt(final String updatedAt) {
+      this.updatedAt = updatedAt;
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
@@ -24,14 +24,13 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.service.AuditLogServices;
 import java.time.OffsetDateTime;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class UpdateMetadataMapperTest {
 
   @Test
-  void shouldResolveLatestSuccessfulAuditLog() {
+  void shouldMapLatestSuccessfulAuditLog() {
     final var services = mock(AuditLogServices.class);
     final var authentication = mock(CamundaAuthentication.class);
     final var auditLog =
@@ -46,12 +45,19 @@ class UpdateMetadataMapperTest {
             .category(USER_TASKS)
             .build();
     when(services.search(any(), same(authentication))).thenReturn(SearchQueryResult.of(auditLog));
+    final var item = new Item("123");
 
-    final var metadata =
-        UpdateMetadataMapper.resolve("123", key -> key, USER_TASK, services, authentication);
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        authentication,
+        Item::setUpdatedBy,
+        Item::setUpdatedAt);
 
-    assertThat(metadata.updatedBy()).isEqualTo("demo");
-    assertThat(metadata.updatedAt()).isEqualTo("2026-07-22T10:15:30.000Z");
+    assertThat(item.updatedBy).isEqualTo("demo");
+    assertThat(item.updatedAt).isEqualTo("2026-07-22T10:15:30.000Z");
     final var queryCaptor = ArgumentCaptor.forClass(AuditLogQuery.class);
     verify(services).search(queryCaptor.capture(), same(authentication));
     final var query = queryCaptor.getValue();
@@ -69,34 +75,43 @@ class UpdateMetadataMapperTest {
   }
 
   @Test
-  void shouldReturnEmptyMetadataWhenAuditLookupFails() {
+  void shouldLeaveMetadataNullWhenAuditLookupFails() {
     final var services = mock(AuditLogServices.class);
     when(services.search(any(), any())).thenThrow(new RuntimeException("unavailable"));
+    final var item = new Item("123");
 
-    final var metadata =
-        UpdateMetadataMapper.resolve(
-            "123", key -> key, USER_TASK, services, mock(CamundaAuthentication.class));
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        mock(CamundaAuthentication.class),
+        Item::setUpdatedBy,
+        Item::setUpdatedAt);
 
-    assertThat(metadata.updatedBy()).isNull();
-    assertThat(metadata.updatedAt()).isNull();
+    assertThat(item.updatedBy).isNull();
+    assertThat(item.updatedAt).isNull();
   }
 
   @Test
   void shouldFallBackToCreationTimestampWhenNoAuditLogEntryExists() {
     final var services = mock(AuditLogServices.class);
     when(services.search(any(), any())).thenReturn(SearchQueryResult.empty());
+    final var item = new Item("123");
+    item.creationDate = "2026-01-01T00:00:00.000Z";
 
-    final var metadata =
-        UpdateMetadataMapper.resolve(
-            "123",
-            key -> key,
-            USER_TASK,
-            services,
-            mock(CamundaAuthentication.class),
-            key -> "2026-01-01T00:00:00.000Z");
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        mock(CamundaAuthentication.class),
+        Item::setUpdatedBy,
+        Item::setUpdatedAt,
+        Item::creationDate);
 
-    assertThat(metadata.updatedBy()).isNull();
-    assertThat(metadata.updatedAt()).isEqualTo("2026-01-01T00:00:00.000Z");
+    assertThat(item.updatedBy).isNull();
+    assertThat(item.updatedAt).isEqualTo("2026-01-01T00:00:00.000Z");
   }
 
   @Test
@@ -114,44 +129,47 @@ class UpdateMetadataMapperTest {
             .category(USER_TASKS)
             .build();
     when(services.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+    final var item = new Item("123");
+    item.creationDate = "2026-01-01T00:00:00.000Z";
 
-    final var metadata =
-        UpdateMetadataMapper.resolve(
-            "123",
-            key -> key,
-            USER_TASK,
-            services,
-            mock(CamundaAuthentication.class),
-            key -> "2026-01-01T00:00:00.000Z");
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        mock(CamundaAuthentication.class),
+        Item::setUpdatedBy,
+        Item::setUpdatedAt,
+        Item::creationDate);
 
-    assertThat(metadata.updatedBy()).isEqualTo("demo");
-    assertThat(metadata.updatedAt()).isEqualTo("2026-07-22T10:15:30.000Z");
+    assertThat(item.updatedBy).isEqualTo("demo");
+    assertThat(item.updatedAt).isEqualTo("2026-07-22T10:15:30.000Z");
   }
 
-  @Test
-  void shouldResolveAllForMultipleItems() {
-    final var services = mock(AuditLogServices.class);
-    final var authentication = mock(CamundaAuthentication.class);
-    final var auditLogFor1 =
-        new AuditLogEntity.Builder()
-            .auditLogKey("1-2")
-            .entityKey("1")
-            .entityType(USER_TASK)
-            .operationType(UPDATE)
-            .timestamp(OffsetDateTime.parse("2026-07-22T10:15:30Z"))
-            .actorId("demo")
-            .result(SUCCESS)
-            .category(USER_TASKS)
-            .build();
-    when(services.search(any(), same(authentication)))
-        .thenReturn(SearchQueryResult.of(auditLogFor1))
-        .thenReturn(SearchQueryResult.empty());
+  private static final class Item {
+    private final String key;
+    private String updatedBy;
+    private String updatedAt;
+    private String creationDate;
 
-    final var metadataByKey =
-        UpdateMetadataMapper.resolveAll(
-            List.of("1", "2"), key -> key, USER_TASK, services, authentication);
+    private Item(final String key) {
+      this.key = key;
+    }
 
-    assertThat(metadataByKey.get("1").updatedBy()).isEqualTo("demo");
-    assertThat(metadataByKey).doesNotContainKey("2");
+    private String key() {
+      return key;
+    }
+
+    private void setUpdatedBy(final String updatedBy) {
+      this.updatedBy = updatedBy;
+    }
+
+    private void setUpdatedAt(final String updatedAt) {
+      this.updatedAt = updatedAt;
+    }
+
+    private String creationDate() {
+      return creationDate;
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
@@ -24,13 +24,14 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.service.AuditLogServices;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class UpdateMetadataMapperTest {
 
   @Test
-  void shouldMapLatestSuccessfulAuditLog() {
+  void shouldResolveLatestSuccessfulAuditLog() {
     final var services = mock(AuditLogServices.class);
     final var authentication = mock(CamundaAuthentication.class);
     final var auditLog =
@@ -45,19 +46,12 @@ class UpdateMetadataMapperTest {
             .category(USER_TASKS)
             .build();
     when(services.search(any(), same(authentication))).thenReturn(SearchQueryResult.of(auditLog));
-    final var item = new Item("123");
 
-    UpdateMetadataMapper.addUpdateMetadata(
-        item,
-        Item::key,
-        USER_TASK,
-        services,
-        authentication,
-        Item::setUpdatedBy,
-        Item::setUpdatedAt);
+    final var metadata =
+        UpdateMetadataMapper.resolve("123", key -> key, USER_TASK, services, authentication);
 
-    assertThat(item.updatedBy).isEqualTo("demo");
-    assertThat(item.updatedAt).isEqualTo("2026-07-22T10:15:30.000Z");
+    assertThat(metadata.updatedBy()).isEqualTo("demo");
+    assertThat(metadata.updatedAt()).isEqualTo("2026-07-22T10:15:30.000Z");
     final var queryCaptor = ArgumentCaptor.forClass(AuditLogQuery.class);
     verify(services).search(queryCaptor.capture(), same(authentication));
     final var query = queryCaptor.getValue();
@@ -75,43 +69,34 @@ class UpdateMetadataMapperTest {
   }
 
   @Test
-  void shouldLeaveMetadataNullWhenAuditLookupFails() {
+  void shouldReturnEmptyMetadataWhenAuditLookupFails() {
     final var services = mock(AuditLogServices.class);
     when(services.search(any(), any())).thenThrow(new RuntimeException("unavailable"));
-    final var item = new Item("123");
 
-    UpdateMetadataMapper.addUpdateMetadata(
-        item,
-        Item::key,
-        USER_TASK,
-        services,
-        mock(CamundaAuthentication.class),
-        Item::setUpdatedBy,
-        Item::setUpdatedAt);
+    final var metadata =
+        UpdateMetadataMapper.resolve(
+            "123", key -> key, USER_TASK, services, mock(CamundaAuthentication.class));
 
-    assertThat(item.updatedBy).isNull();
-    assertThat(item.updatedAt).isNull();
+    assertThat(metadata.updatedBy()).isNull();
+    assertThat(metadata.updatedAt()).isNull();
   }
 
   @Test
   void shouldFallBackToCreationTimestampWhenNoAuditLogEntryExists() {
     final var services = mock(AuditLogServices.class);
     when(services.search(any(), any())).thenReturn(SearchQueryResult.empty());
-    final var item = new Item("123");
-    item.creationDate = "2026-01-01T00:00:00.000Z";
 
-    UpdateMetadataMapper.addUpdateMetadata(
-        item,
-        Item::key,
-        USER_TASK,
-        services,
-        mock(CamundaAuthentication.class),
-        Item::setUpdatedBy,
-        Item::setUpdatedAt,
-        Item::creationDate);
+    final var metadata =
+        UpdateMetadataMapper.resolve(
+            "123",
+            key -> key,
+            USER_TASK,
+            services,
+            mock(CamundaAuthentication.class),
+            key -> "2026-01-01T00:00:00.000Z");
 
-    assertThat(item.updatedBy).isNull();
-    assertThat(item.updatedAt).isEqualTo("2026-01-01T00:00:00.000Z");
+    assertThat(metadata.updatedBy()).isNull();
+    assertThat(metadata.updatedAt()).isEqualTo("2026-01-01T00:00:00.000Z");
   }
 
   @Test
@@ -129,47 +114,44 @@ class UpdateMetadataMapperTest {
             .category(USER_TASKS)
             .build();
     when(services.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
-    final var item = new Item("123");
-    item.creationDate = "2026-01-01T00:00:00.000Z";
 
-    UpdateMetadataMapper.addUpdateMetadata(
-        item,
-        Item::key,
-        USER_TASK,
-        services,
-        mock(CamundaAuthentication.class),
-        Item::setUpdatedBy,
-        Item::setUpdatedAt,
-        Item::creationDate);
+    final var metadata =
+        UpdateMetadataMapper.resolve(
+            "123",
+            key -> key,
+            USER_TASK,
+            services,
+            mock(CamundaAuthentication.class),
+            key -> "2026-01-01T00:00:00.000Z");
 
-    assertThat(item.updatedBy).isEqualTo("demo");
-    assertThat(item.updatedAt).isEqualTo("2026-07-22T10:15:30.000Z");
+    assertThat(metadata.updatedBy()).isEqualTo("demo");
+    assertThat(metadata.updatedAt()).isEqualTo("2026-07-22T10:15:30.000Z");
   }
 
-  private static final class Item {
-    private final String key;
-    private String updatedBy;
-    private String updatedAt;
-    private String creationDate;
+  @Test
+  void shouldResolveAllForMultipleItems() {
+    final var services = mock(AuditLogServices.class);
+    final var authentication = mock(CamundaAuthentication.class);
+    final var auditLogFor1 =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("1")
+            .entityType(USER_TASK)
+            .operationType(UPDATE)
+            .timestamp(OffsetDateTime.parse("2026-07-22T10:15:30Z"))
+            .actorId("demo")
+            .result(SUCCESS)
+            .category(USER_TASKS)
+            .build();
+    when(services.search(any(), same(authentication)))
+        .thenReturn(SearchQueryResult.of(auditLogFor1))
+        .thenReturn(SearchQueryResult.empty());
 
-    private Item(final String key) {
-      this.key = key;
-    }
+    final var metadataByKey =
+        UpdateMetadataMapper.resolveAll(
+            List.of("1", "2"), key -> key, USER_TASK, services, authentication);
 
-    private String key() {
-      return key;
-    }
-
-    private void setUpdatedBy(final String updatedBy) {
-      this.updatedBy = updatedBy;
-    }
-
-    private void setUpdatedAt(final String updatedAt) {
-      this.updatedAt = updatedAt;
-    }
-
-    private String creationDate() {
-      return creationDate;
-    }
+    assertThat(metadataByKey.get("1").updatedBy()).isEqualTo("demo");
+    assertThat(metadataByKey).doesNotContainKey("2");
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/UpdateMetadataMapperTest.java
@@ -93,10 +93,64 @@ class UpdateMetadataMapperTest {
     assertThat(item.updatedAt).isNull();
   }
 
+  @Test
+  void shouldFallBackToCreationTimestampWhenNoAuditLogEntryExists() {
+    final var services = mock(AuditLogServices.class);
+    when(services.search(any(), any())).thenReturn(SearchQueryResult.empty());
+    final var item = new Item("123");
+    item.creationDate = "2026-01-01T00:00:00.000Z";
+
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        mock(CamundaAuthentication.class),
+        Item::setUpdatedBy,
+        Item::setUpdatedAt,
+        Item::creationDate);
+
+    assertThat(item.updatedBy).isNull();
+    assertThat(item.updatedAt).isEqualTo("2026-01-01T00:00:00.000Z");
+  }
+
+  @Test
+  void shouldPreferAuditLogEntryOverFallbackWhenBothAvailable() {
+    final var services = mock(AuditLogServices.class);
+    final var auditLog =
+        new AuditLogEntity.Builder()
+            .auditLogKey("1-2")
+            .entityKey("123")
+            .entityType(USER_TASK)
+            .operationType(UPDATE)
+            .timestamp(OffsetDateTime.parse("2026-07-22T10:15:30Z"))
+            .actorId("demo")
+            .result(SUCCESS)
+            .category(USER_TASKS)
+            .build();
+    when(services.search(any(), any())).thenReturn(SearchQueryResult.of(auditLog));
+    final var item = new Item("123");
+    item.creationDate = "2026-01-01T00:00:00.000Z";
+
+    UpdateMetadataMapper.addUpdateMetadata(
+        item,
+        Item::key,
+        USER_TASK,
+        services,
+        mock(CamundaAuthentication.class),
+        Item::setUpdatedBy,
+        Item::setUpdatedAt,
+        Item::creationDate);
+
+    assertThat(item.updatedBy).isEqualTo("demo");
+    assertThat(item.updatedAt).isEqualTo("2026-07-22T10:15:30.000Z");
+  }
+
   private static final class Item {
     private final String key;
     private String updatedBy;
     private String updatedAt;
+    private String creationDate;
 
     private Item(final String key) {
       this.key = key;
@@ -112,6 +166,10 @@ class UpdateMetadataMapperTest {
 
     private void setUpdatedAt(final String updatedAt) {
       this.updatedAt = updatedAt;
+    }
+
+    private String creationDate() {
+      return creationDate;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `updatedBy`/`updatedAt` to the process instance, user task, variable, incident, and decision definition REST responses (get-by-key and search endpoints).
- Gate them behind a new feature flag, `camunda.rest.update-metadata.enabled`, **default `false`**.
- While the flag is off, the properties are **absent from the response body entirely** — not serialized as `null` — and no audit-log lookups are performed.

## Response shape

| `camunda.rest.update-metadata.enabled` | Response |
|---|---|
| `false` (default) | keys absent; zero audit-log queries |
| `true` | keys present for every value that could be resolved |

`updatedBy` also stays absent on the fallback path below, where a timestamp is known but no actor is.

Two things had to change to make omission possible:

- The properties are declared **non-required** and marked `x-feature-gated: true`. This repo's `response-properties-must-be-required` rule requires every response property to be listed in `required`; it now skips properties carrying that marker, on the grounds that a property whose presence is controlled by configuration cannot be required. The marker is intentionally narrow — it documents flag-controlled presence, it is not a general opt-out — and is covered by a new fixture and case in the rule's own test suite, which still reports the same seven violations for the genuinely non-compliant fixtures.
- The generated models carry `@JsonInclude(ALWAYS)` at class level, so a null property is written anyway. A Jackson **mix-in** applies `@JsonInclude(NON_NULL)` to just these two properties on the five affected types. Property-level inclusion from a mix-in overrides the generated class-level default, so the shared model generator is untouched.

## updatedAt initialization

Intent is to mirror `Job#lastUpdateTime`, which is initialized to the creation timestamp rather than left unset. Creation is not an audited action for every entity type, so coverage differs:

| Entity | Behaviour when no audit-log entry exists |
|---|---|
| process instance | falls back to `startDate` |
| user task | falls back to `creationDate` |
| incident | falls back to `creationTime` |
| variable, decision definition | **`updatedAt` absent** — these entities expose no creation timestamp, so no fallback is available |

In normal operation all five are covered, since process instance, variable and decision definition creation *is* audit-logged; user task and incident creation is not (only later `UPDATE`/`ASSIGN`/`COMPLETE`, resp. `RESOLVE`), which is why those two need the entity-level fallback. The remaining gap is variables and decision definitions whose audit row is missing, e.g. after history cleanup.

## Implementation

- `UpdateMetadataMapper` queries `AuditLogServices` for the latest `SUCCESS` entry by entity key/type (timestamp descending, size 1), with an optional creation-timestamp fallback.
- The five controllers invoke it only when the flag is enabled, so the disabled path performs no additional queries.
- `SearchQueryResponseMapper` is unchanged from `main`.
- No persistence, search-domain, service, or Java client changes.
- `GatewayRestPropertiesOverride` copies the flag explicitly after `BeanUtils.copyProperties`. Consumers are injected with the `@Primary` `GatewayRestProperties` bean, and `copyProperties` cannot write a read-only nested property (a getter over a `final` field), so the value bound from `camunda.rest.update-metadata.enabled` was previously dropped and the flag could not be enabled at all. Covered by a test that reproduces the bean's copy. Raised by Copilot in review.
- The generated e2e response assertions move these properties from `required` to `optional`. They were not regenerated wholesale because that pulls in unrelated drift already present between `main`'s spec and its committed output.

## Known limitation: audit-log query volume when enabled

Enabling the flag costs **one audit-log query per returned item**. A search endpoint returning the default page of 100 items therefore issues 100 additional queries, and the page size has no declared maximum.

While the flag is off — the default, and the state this PR ships in — no audit-log query is issued at all and the properties are absent from responses, so there is no latency or load impact.

The queries are deliberately not batched. `AuditLogFilter#entityKeys` does accept multiple keys, but selecting the *latest* entry per key relies on `sort(timestamp desc)` combined with `size(1)`, and the audit-log search exposes no per-group top-hits or aggregation. A single bounded query therefore cannot guarantee one row per key — an entity with many entries can crowd every other key out of the page. Batching correctly would require paging until every key is resolved, which is out of scope here.

Documented on `UpdateMetadataMapper#addUpdateMetadata(Collection, ...)` and on the `camunda.rest.update-metadata.enabled` property. Raised by Copilot in review.

## Verification

- `zeebe/gateway-rest`: 1972 tests pass, including a test asserting both keys are absent by default and that `auditLogServices` is never invoked.
- `response-properties-must-be-required` rule suite: 17 tests pass.
- Both CI Spectral passes (structural and file-level) clean locally against the same invocation CI uses.
- Full monorepo `./mvnw install -Dquickly`: green.
