### PR TITLE
fix: stop identity setup INITIALIZED event from duplicating full setup record

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -61,8 +61,14 @@ public final class IdentitySetupInitializeProcessor
     createRoleMembers(initializationKey, setupRecord.getRoleMembers());
     createGroupMembers(initializationKey, setupRecord.getGroupMembers());
 
+    // the setup record's data is intentionally not included here: it was already written via the
+    // follow-up commands above, and nothing consumes this event's payload, so re-serializing the
+    // entire record would only make this already large batch grow further. The default tenant's
+    // tenantId must still be set explicitly, as it has no default value.
     stateWriter.appendFollowUpEvent(
-        initializationKey, IdentitySetupIntent.INITIALIZED, setupRecord);
+        initializationKey,
+        IdentitySetupIntent.INITIALIZED,
+        new IdentitySetupRecord().setDefaultTenant(setupRecord.getDefaultTenant()));
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -694,8 +694,10 @@ public final class EngineRule extends ExternalResource {
   }
 
   public void awaitIdentitySetup() {
+    // The INITIALIZED event payload is intentionally empty (see IdentitySetupInitializeProcessor).
+    // Authorization count is read from the INITIALIZE command instead, which still carries it.
     final var identitySetup =
-        RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).getFirst();
+        RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZE).getFirst();
 
     /*
      * We'll need to await for the identity setup to be completed before proceeding, but it's not

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/startup/IdentitySetupOnStartupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/startup/IdentitySetupOnStartupTest.java
@@ -42,7 +42,7 @@ final class IdentitySetupOnStartupTest {
                       cfg.unifiedConfig()
                           .getCluster()
                           .getNetwork()
-                          .setMaxMessageSize(DataSize.ofKilobytes(64));
+                          .setMaxMessageSize(DataSize.ofKilobytes(32));
                       cfg.unifiedConfig().getProcessing().setMaxCommandsInBatch(100);
                     })
                 .build()


### PR DESCRIPTION
## Description

On broker startup, `IdentitySetupInitializeProcessor` emits a terminal `IdentitySetup.INITIALIZED` event that re-serialized the **entire `IdentitySetupRecord`** into a single atomic append. The `admin` and `readonly-admin` roles each get one authorization per `AuthorizationResourceType`, so this event grows unboundedly as resource types are added — eventually breaching `maxMessageSize` and rolling setup back.

Nothing consumes this event's payload. This change appends it with a minimal record (only the default tenant, which has no default value) instead of the full setup record. The follow-up entity commands already carry the real data.

It also reverts the temporary 64 KB `maxMessageSize` bump (#58494) back to 32 KB, keeping the regression guard meaningful, and updates `EngineRule` to read the authorization count from the `INITIALIZE` command instead of the now-empty `INITIALIZED` event.

Closes #58499

🤖 Generated with [Claude Code](https://claude.com/claude-code)