### PR TITLE
feat: rebalance leadership across all partition groups

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/RebalancingService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/RebalancingService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.admin.BrokerAdminRequest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,23 +17,30 @@ import org.springframework.stereotype.Component;
 public final class RebalancingService {
 
   private final BrokerClient client;
+  private final PhysicalTenantIds physicalTenantIds;
 
   @Autowired
-  public RebalancingService(final BrokerClient client) {
+  public RebalancingService(final BrokerClient client, final PhysicalTenantIds physicalTenantIds) {
     this.client = client;
+    this.physicalTenantIds = physicalTenantIds;
   }
 
   public void rebalanceCluster() {
-    client
-        .getTopologyManager()
-        .getTopology()
-        .getPartitions()
+    physicalTenantIds
+        .known()
         .forEach(
-            (partition) -> {
-              final var request = new BrokerAdminRequest();
-              request.setPartitionId(partition);
-              request.stepDownIfNotPrimary();
-              client.sendRequest(request);
-            });
+            physicalTenantId ->
+                client
+                    .getTopologyManager()
+                    .getTopology(physicalTenantId)
+                    .getPartitions()
+                    .forEach(
+                        (partition) -> {
+                          final var request = new BrokerAdminRequest();
+                          request.setPartitionGroup(physicalTenantId);
+                          request.setPartitionId(partition);
+                          request.stepDownIfNotPrimary();
+                          client.sendRequest(request);
+                        }));
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/RebalancingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/RebalancingEndpointTest.java
@@ -7,17 +7,21 @@
  */
 package io.camunda.zeebe.shared.management;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 final class RebalancingEndpointTest {
 
@@ -25,25 +29,67 @@ final class RebalancingEndpointTest {
   void shouldRebalance() {
     // given
     final var partitions = List.of(1, 2, 3, 4, 5);
-    final var client = setupBrokerClient(partitions);
+    final var client =
+        setupBrokerClient(partitions, Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
 
-    final var service = new RebalancingService(client);
+    final var service =
+        new RebalancingService(client, () -> Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
     final var endpoint = new RebalancingEndpoint(service);
 
     // when
     endpoint.rebalance();
 
     // then
-    verify(client, times(partitions.size())).sendRequest(any());
+    final var requestCaptor = ArgumentCaptor.forClass(BrokerRequest.class);
+    verify(client, times(partitions.size())).sendRequest(requestCaptor.capture());
+    assertThat(requestCaptor.getAllValues())
+        .allSatisfy(
+            request ->
+                assertThat(request.getPartitionGroup())
+                    .isEqualTo(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID));
   }
 
-  private BrokerClient setupBrokerClient(final List<Integer> partitions) {
+  @Test
+  void shouldRebalanceAllPartitionGroups() {
+    // given
+    final var partitions = List.of(1, 2, 3);
+    final var physicalTenantIds = Set.of("default", "tenant-a", "tenant-b");
+    final var client = setupBrokerClient(partitions, physicalTenantIds);
+
+    final var service = new RebalancingService(client, () -> physicalTenantIds);
+    final var endpoint = new RebalancingEndpoint(service);
+
+    // when
+    endpoint.rebalance();
+
+    // then
+    final var requestCaptor = ArgumentCaptor.forClass(BrokerRequest.class);
+    verify(client, times(partitions.size() * physicalTenantIds.size()))
+        .sendRequest(requestCaptor.capture());
+    assertThat(requestCaptor.getAllValues())
+        .extracting(BrokerRequest::getPartitionGroup)
+        .containsExactlyInAnyOrder(
+            "default",
+            "default",
+            "default",
+            "tenant-a",
+            "tenant-a",
+            "tenant-a",
+            "tenant-b",
+            "tenant-b",
+            "tenant-b");
+  }
+
+  private BrokerClient setupBrokerClient(
+      final List<Integer> partitions, final Set<String> physicalTenantIds) {
     final var client = mock(BrokerClient.class);
     final var topology = mock(BrokerClusterState.class);
     final var topologyManager = mock(BrokerTopologyManager.class);
 
     when(topology.getPartitions()).thenReturn(partitions);
-    when(topologyManager.getTopology()).thenReturn(topology);
+    physicalTenantIds.forEach(
+        physicalTenantId ->
+            when(topologyManager.getTopology(physicalTenantId)).thenReturn(topology));
     when(client.getTopologyManager()).thenReturn(topologyManager);
     return client;
   }


### PR DESCRIPTION
## Description

RebalancingService previously derived partitions from only the default partition group's topology, so POST /actuator/rebalance never rebalanced non-default physical tenants. Iterate all known physical tenants and stamp each step-down request with its partition group so rebalancing reaches every partition group in the cluster.

## Related issues

closes #57018 
