### PR TITLE
fix: attach missing index aliases during schema init

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -182,6 +182,8 @@ public class SchemaManager implements CloseableSilently {
       }
       // Store the current version as schema version after successful initialization
       schemaMetadataStore.storeSchemaVersion(currentVersion);
+    } else {
+      ensureIndexAliases();
     }
     updateSchemaSettings();
     createLifecyclePolicies();
@@ -319,6 +321,47 @@ public class SchemaManager implements CloseableSilently {
     // We need to wait for the completion, to make sure all indices has been created successfully
     // Doing this in parallel is still speeding up the bootstrap time
     joinOnFutures(futures);
+    ensureIndexAliases();
+  }
+
+  /**
+   * Attaches the expected alias to any existing concrete index that is missing it (e.g.
+   * auto-created by a write before schema init).
+   */
+  @VisibleForTesting
+  void ensureIndexAliases() {
+    if (allIndexDescriptors.isEmpty()) {
+      return;
+    }
+
+    final var existingIndexNames = existingIndexNames(allIndexDescriptors);
+    if (existingIndexNames.isEmpty()) {
+      return;
+    }
+
+    final var existingDescriptors =
+        allIndexDescriptors.stream()
+            .filter(descriptor -> existingIndexNames.contains(descriptor.getFullQualifiedName()))
+            .toList();
+    if (existingDescriptors.isEmpty()) {
+      return;
+    }
+
+    final List<String> existingNames =
+        existingDescriptors.stream().map(IndexDescriptor::getFullQualifiedName).toList();
+    final Map<String, Set<String>> aliasByIndex = searchEngineClient.getAliases(existingNames);
+
+    for (final IndexDescriptor descriptor : existingDescriptors) {
+      final Set<String> aliases =
+          aliasByIndex.getOrDefault(descriptor.getFullQualifiedName(), Set.of());
+      if (!aliases.contains(descriptor.getAlias())) {
+        LOG.info(
+            "Index '{}' is missing expected alias '{}'; attaching it",
+            descriptor.getFullQualifiedName(),
+            descriptor.getAlias());
+        searchEngineClient.putIndexAlias(descriptor);
+      }
+    }
   }
 
   private List<IndexDescriptor> getMissingIndices(

--- a/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SearchEngineClient.java
@@ -47,6 +47,9 @@ public interface SearchEngineClient extends CloseableSilently {
    */
   Map<String, Set<String>> getAliases(Collection<String> indexNames);
 
+  /** Attach the descriptor's expected alias to its concrete full-qualified index. */
+  void putIndexAlias(final IndexDescriptor indexDescriptor);
+
   void putSettings(
       final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings);
 

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -98,13 +98,13 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       throw new SearchEngineException(errMsg, ioe);
     } catch (final ElasticsearchException elsEx) {
       if ("resource_already_exists_exception".equals(elsEx.error().type())) {
-        // we can ignore already exists exceptions
-        // as this means the index was created by another instance
+        // Index may exist without our alias (e.g. auto-created by a concurrent write).
         final var warnMsg =
             String.format(
-                "Expected to create index [%s], but already exist. Will continue, likely was created by a different instance.",
+                "Expected to create index [%s], but already exist. Will ensure alias and continue, likely was created by a different instance.",
                 indexDescriptor.getFullQualifiedName());
         LOG.debug(warnMsg, elsEx);
+        putIndexAlias(indexDescriptor);
         return;
       }
 
@@ -207,6 +207,30 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
           .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().aliases().keySet()));
     } catch (final IOException | ElasticsearchException e) {
       final var errMsg = String.format("Failed to retrieve aliases for indexes '%s'", indexNames);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
+  public void putIndexAlias(final IndexDescriptor indexDescriptor) {
+    try {
+      client
+          .indices()
+          .putAlias(
+              req ->
+                  req.index(indexDescriptor.getFullQualifiedName())
+                      .name(indexDescriptor.getAlias())
+                      .isWriteIndex(false));
+      LOG.debug(
+          "Alias [{}] was successfully attached to index [{}]",
+          indexDescriptor.getAlias(),
+          indexDescriptor.getFullQualifiedName());
+    } catch (final IOException | ElasticsearchException e) {
+      final var errMsg =
+          String.format(
+              "Failed to attach alias [%s] to index [%s]",
+              indexDescriptor.getAlias(), indexDescriptor.getFullQualifiedName());
       LOG.error(errMsg, e);
       throw new SearchEngineException(errMsg, e);
     }

--- a/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -101,7 +101,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
         // Index may exist without our alias (e.g. auto-created by a concurrent write).
         final var warnMsg =
             String.format(
-                "Expected to create index [%s], but already exist. Will ensure alias and continue, likely was created by a different instance.",
+                "Expected to create index [%s], but already exists. Will ensure alias and continue, likely was created by a different instance.",
                 indexDescriptor.getFullQualifiedName());
         LOG.debug(warnMsg, elsEx);
         putIndexAlias(indexDescriptor);

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -113,13 +113,13 @@ public class OpensearchEngineClient implements SearchEngineClient {
       throw new SearchEngineException(errMsg, ioe);
     } catch (final OpenSearchException ose) {
       if ("resource_already_exists_exception".equals(ose.error().type())) {
-        // we can ignore already exists exceptions
-        // as this means the index was created by another instance
+        // Index may exist without our alias (e.g. auto-created by a concurrent write).
         final var warnMsg =
             String.format(
-                "Expected to create index [%s], but already exist. Will continue, likely was created by a different instance.",
+                "Expected to create index [%s], but already exist. Will ensure alias and continue, likely was created by a different instance.",
                 indexDescriptor.getFullQualifiedName());
         LOG.debug(warnMsg, ose);
+        putIndexAlias(indexDescriptor);
         return;
       }
 
@@ -222,6 +222,30 @@ public class OpensearchEngineClient implements SearchEngineClient {
           .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().aliases().keySet()));
     } catch (final IOException | OpenSearchException e) {
       final var errMsg = String.format("Failed to retrieve aliases for index '%s'", indexNames);
+      LOG.error(errMsg, e);
+      throw new SearchEngineException(errMsg, e);
+    }
+  }
+
+  @Override
+  public void putIndexAlias(final IndexDescriptor indexDescriptor) {
+    try {
+      client
+          .indices()
+          .putAlias(
+              req ->
+                  req.index(indexDescriptor.getFullQualifiedName())
+                      .name(indexDescriptor.getAlias())
+                      .isWriteIndex(false));
+      LOG.debug(
+          "Alias [{}] was successfully attached to index [{}]",
+          indexDescriptor.getAlias(),
+          indexDescriptor.getFullQualifiedName());
+    } catch (final IOException | OpenSearchException e) {
+      final var errMsg =
+          String.format(
+              "Failed to attach alias [%s] to index [%s]",
+              indexDescriptor.getAlias(), indexDescriptor.getFullQualifiedName());
       LOG.error(errMsg, e);
       throw new SearchEngineException(errMsg, e);
     }

--- a/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/opensearch/OpensearchEngineClient.java
@@ -116,7 +116,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
         // Index may exist without our alias (e.g. auto-created by a concurrent write).
         final var warnMsg =
             String.format(
-                "Expected to create index [%s], but already exist. Will ensure alias and continue, likely was created by a different instance.",
+                "Expected to create index [%s], but already exists. Will ensure alias and continue, likely was created by a different instance.",
                 indexDescriptor.getFullQualifiedName());
         LOG.debug(warnMsg, ose);
         putIndexAlias(indexDescriptor);

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -788,6 +788,32 @@ public class SchemaManagerIT {
     assertThatNoException().isThrownBy(schemaManager::startup);
   }
 
+  @RegressionTestTemplate("https://github.com/camunda/camunda/issues/58509")
+  void shouldAttachMissingAliasToExistingIndexOnStartup(
+      final SearchEngineConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given
+    searchClientAdapter.createIndex(index.getFullQualifiedName(), 0);
+    final var bareIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    assertThat(bareIndex.get("aliases").fieldNames().hasNext()).isFalse();
+
+    final var schemaManager =
+        new SchemaManager(
+            searchEngineClientFromConfig(config),
+            Set.of(index, metadataIndex),
+            Set.of(),
+            config,
+            objectMapper);
+
+    // when
+    assertThatNoException().isThrownBy(schemaManager::startup);
+
+    // then
+    final var repairedIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    assertThat(repairedIndex.get("aliases").fieldNames().next()).isEqualTo(index.getAlias());
+    assertThat(schemaManager.isAliasIntegrityValid(false)).isTrue();
+  }
+
   @TestTemplate
   void shouldStartDifferentSchemaManagersWithRetention(
       final SearchEngineConfiguration config, final SearchClientAdapter ignored) {

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +75,8 @@ class SchemaManagerTest {
 
     // Mock search engine client operations
     when(searchEngineClient.indexExists(metadataIndex.getFullQualifiedName())).thenReturn(true);
+    when(searchEngineClient.getMappings(anyString(), any())).thenReturn(Map.of());
+    when(searchEngineClient.getAliases(any())).thenReturn(Map.of());
   }
 
   @AfterEach
@@ -369,6 +372,8 @@ class SchemaManagerTest {
               client, indices, templates, cfg, mock(IndexSchemaValidator.class), "8.9.0", null);
       when(client.getDocument(metaIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID))
           .thenReturn(null);
+      when(client.getMappings(anyString(), any())).thenReturn(Map.of());
+      when(client.getAliases(any())).thenReturn(Map.of());
       return mgr;
     }
 
@@ -435,6 +440,51 @@ class SchemaManagerTest {
       final var captor = ArgumentCaptor.forClass(IndexConfiguration.class);
       verify(client).createIndex(eq(index), captor.capture());
       assertThat(captor.getValue().getNumberOfShards()).isEqualTo(7);
+    }
+  }
+
+  @Nested
+  class EnsureIndexAliasesTest {
+
+    @Test
+    void shouldAttachMissingAliasToExistingIndexOnStartup() {
+      // given
+      schemaManager = createSpySchemaManager("8.8.0");
+      mockSchemaVersionInMetadata("8.8.0");
+
+      final var indexName = testIndexDescriptor.getFullQualifiedName();
+      final var dummyMapping =
+          new IndexMapping.Builder().indexName(indexName).dynamic("strict").build();
+      when(searchEngineClient.getMappings(anyString(), any()))
+          .thenReturn(Map.of(indexName, dummyMapping));
+      when(searchEngineClient.getAliases(any())).thenReturn(Map.of(indexName, Set.of()));
+
+      // when
+      schemaManager.startup();
+
+      // then
+      verify(searchEngineClient).putIndexAlias(testIndexDescriptor);
+    }
+
+    @Test
+    void shouldNotPutAliasWhenAlreadyPresent() {
+      // given
+      schemaManager = createSpySchemaManager("8.8.0");
+      mockSchemaVersionInMetadata("8.8.0");
+
+      final var indexName = testIndexDescriptor.getFullQualifiedName();
+      final var dummyMapping =
+          new IndexMapping.Builder().indexName(indexName).dynamic("strict").build();
+      when(searchEngineClient.getMappings(anyString(), any()))
+          .thenReturn(Map.of(indexName, dummyMapping));
+      when(searchEngineClient.getAliases(any()))
+          .thenReturn(Map.of(indexName, Set.of(testIndexDescriptor.getAlias())));
+
+      // when
+      schemaManager.startup();
+
+      // then
+      verify(searchEngineClient, never()).putIndexAlias(any());
     }
   }
 


### PR DESCRIPTION
## Description

Schema initialization could fail with `index_not_found_exception` on a `*_alias` when the concrete index already existed without that alias (observed for `camunda-web-session`). That happens if a write to the full-qualified index name auto-creates a bare index before schema init; `putMapping` / `putSettings` then address the missing alias.

This change:

- Attaches the expected alias to existing concrete indices during schema init (`ensureIndexAliases`)
- Runs that ensure on both the upgrade path (after index creation) and the non-upgrade path (before settings update)
- When `createIndex` hits `resource_already_exists`, still attaches the alias

## Related issues

Closes #58509

## Configuration

N/A

## Definition of Ready

- [x] The changes are tested
- [x] The title of PR follows [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The description of the PR explains how the changes can be verified
- [x] If the PR includes UI changes, the description of the PR contains screenshots
- [x] If the PR is related to a GitHub issue, the description of the PR contains a [GitHub keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link the PR to the issue
- [x] If the PR is related to a Zendesk ticket, the description of the PR contains a [Zendesk keyword](https://camunda.zendesk.com/hc/en-us/articles/8782011074716-Linking-GitHub-pull-requests-and-Zendesk-tickets) to link the PR to the ticket

## Workflow (to be filled by the bot)

- [ ]  Regression tests are added
- [ ]  All tasks are completed
- [ ]  Reviewers are assigned
- [ ]  The PR is labeled
- [ ]  CI checks are green
- [ ]  Review comments are resolved