### PR TITLE
fix: init routing state from topology partition count

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -152,7 +152,7 @@ public final class ClusterConfigurationManagerService
                 staticConfiguration.localMemberId(),
                 managerActor,
                 false))
-        .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
+        .andThen(new RoutingStateInitializer())
         // Must be initialized by the coordinator only. However, we still define it here because the
         // actual coordinator might be different from what is provided in the static configuration.
         // These initializers will be skipped if they are not running on the latest coordinator
@@ -180,7 +180,7 @@ public final class ClusterConfigurationManagerService
                 staticConfiguration.localMemberId(),
                 managerActor,
                 true))
-        .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
+        .andThen(new RoutingStateInitializer())
         // Must be initialized by the coordinator only
         .andThen(new PartitionDistributorInitializer(staticConfiguration))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -13,17 +13,12 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
 /**
- * Initializes the routing state of the cluster configuration if the partition scaling feature is
- * enabled. All members will initialize the same routing state (as long as their statically
- * configured partition counts match).
+ * Initializes a missing {@link RoutingState} from the partitions already present in the cluster
+ * configuration. Used on upgrades from versions that did not persist routing state. New clusters
+ * already get a routing state from {@link
+ * io.camunda.zeebe.dynamic.config.util.ConfigurationUtil#getClusterConfigFrom}.
  */
 public class RoutingStateInitializer implements ClusterConfigurationModifier {
-
-  private final int staticPartitionCount;
-
-  public RoutingStateInitializer(final int staticPartitionCount) {
-    this.staticPartitionCount = staticPartitionCount;
-  }
 
   @Override
   public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
@@ -31,8 +26,12 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier {
       return CompletableActorFuture.completed(configuration);
     }
 
-    final var routingState = RoutingState.initializeWithPartitionCount(staticPartitionCount);
-    final var withRoutingState = configuration.setRoutingState(routingState);
-    return CompletableActorFuture.completed(withRoutingState);
+    final int partitionCount = configuration.partitionCount();
+    if (partitionCount < 1) {
+      return CompletableActorFuture.completed(configuration);
+    }
+
+    final var routingState = RoutingState.initializeWithPartitionCount(partitionCount);
+    return CompletableActorFuture.completed(configuration.setRoutingState(routingState));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -13,17 +13,12 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
 /**
- * Initializes the routing state of the cluster configuration if the partition scaling feature is
- * enabled. All members will initialize the same routing state (as long as their statically
- * configured partition counts match).
+ * Initializes a missing {@link RoutingState} from the partitions already present in the cluster
+ * configuration. Used on upgrades from versions that did not persist routing state. New clusters
+ * already get a routing state from {@link
+ * io.camunda.zeebe.dynamic.config.util.ConfigurationUtil#getClusterConfigFrom}.
  */
 public class RoutingStateInitializer implements ClusterConfigurationModifier<ClusterConfiguration> {
-
-  private final int staticPartitionCount;
-
-  public RoutingStateInitializer(final int staticPartitionCount) {
-    this.staticPartitionCount = staticPartitionCount;
-  }
 
   @Override
   public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
@@ -31,8 +26,12 @@ public class RoutingStateInitializer implements ClusterConfigurationModifier<Clu
       return CompletableActorFuture.completed(configuration);
     }
 
-    final var routingState = RoutingState.initializeWithPartitionCount(staticPartitionCount);
-    final var withRoutingState = configuration.setRoutingState(routingState);
-    return CompletableActorFuture.completed(withRoutingState);
+    final int partitionCount = configuration.partitionCount();
+    if (partitionCount < 1) {
+      return CompletableActorFuture.completed(configuration);
+    }
+
+    final var routingState = RoutingState.initializeWithPartitionCount(partitionCount);
+    return CompletableActorFuture.completed(configuration.setRoutingState(routingState));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ExportingState;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.util.List;
@@ -42,34 +43,72 @@ final class ClusterConfigurationModifierTest {
   @Nested
   final class RoutingStateInitializerTest {
 
+    private static final DynamicPartitionConfig PARTITION_CONFIG =
+        new DynamicPartitionConfig(new ExportingConfig(ExportingState.EXPORTING, Map.of()));
+
     private final MemberId localMemberId = MemberId.from("0");
-    private final ClusterConfiguration currentConfiguration =
-        ClusterConfiguration.init()
-            .addMember(
-                localMemberId,
-                MemberState.initializeAsActive(
-                    Map.of(
-                        1,
-                        PartitionState.active(
-                            1,
-                            new DynamicPartitionConfig(
-                                new ExportingConfig(ExportingState.EXPORTING, Map.of()))))));
+    private final RoutingStateInitializer routingStateInitializer = new RoutingStateInitializer();
 
     @Test
-    void shouldInitializeRoutingStateIfPartitionScalingIsEnabled() {
+    void shouldInitializeRoutingStateFromClusterConfigurationPartitionCount() {
       // given
-      final var routingStateInitializer = new RoutingStateInitializer(5);
+      final var configurationWithThreePartitions =
+          ClusterConfiguration.init()
+              .addMember(
+                  localMemberId,
+                  MemberState.initializeAsActive(
+                      Map.of(
+                          1, PartitionState.active(1, PARTITION_CONFIG),
+                          2, PartitionState.active(1, PARTITION_CONFIG),
+                          3, PartitionState.active(1, PARTITION_CONFIG))));
 
       // when
-      final var newConfiguration = routingStateInitializer.modify(currentConfiguration).join();
+      final var newConfiguration =
+          routingStateInitializer.modify(configurationWithThreePartitions).join();
 
       // then
       ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration).hasRoutingState();
       ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration)
           .routingState()
           .hasVersion(1)
-          .hasActivatedPartitions(5)
-          .correlatesMessagesToPartitions(5);
+          .hasActivatedPartitions(3)
+          .correlatesMessagesToPartitions(3);
+    }
+
+    @Test
+    void shouldPreserveExistingRoutingState() {
+      // given
+      final var existingRoutingState = RoutingState.initializeWithPartitionCount(3);
+      final var configurationWithRoutingState =
+          ClusterConfiguration.init()
+              .addMember(
+                  localMemberId,
+                  MemberState.initializeAsActive(
+                      Map.of(
+                          1, PartitionState.active(1, PARTITION_CONFIG),
+                          2, PartitionState.active(1, PARTITION_CONFIG),
+                          3, PartitionState.active(1, PARTITION_CONFIG))))
+              .setRoutingState(existingRoutingState);
+
+      // when
+      final var newConfiguration =
+          routingStateInitializer.modify(configurationWithRoutingState).join();
+
+      // then
+      assertThat(newConfiguration).isEqualTo(configurationWithRoutingState);
+    }
+
+    @Test
+    void shouldNotInventRoutingStateWhenConfigurationHasNoPartitions() {
+      // given
+      final var emptyConfiguration = ClusterConfiguration.init();
+
+      // when
+      final var newConfiguration = routingStateInitializer.modify(emptyConfiguration).join();
+
+      // then
+      assertThat(newConfiguration).isEqualTo(emptyConfiguration);
+      ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration).hasNoRoutingState();
     }
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -166,7 +166,7 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(2).modify(currentTopology).join();
+    currentTopology = new RoutingStateInitializer().modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;
@@ -197,7 +197,7 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(2).modify(currentTopology).join();
+    currentTopology = new RoutingStateInitializer().modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -189,7 +189,7 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(2).modify(currentTopology).join();
+    currentTopology = new RoutingStateInitializer().modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;
@@ -220,7 +220,7 @@ final class ClusterPatchRequestTransformerTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
-    currentTopology = new RoutingStateInitializer(2).modify(currentTopology).join();
+    currentTopology = new RoutingStateInitializer().modify(currentTopology).join();
 
     // when
     final int newPartitionCount = 4;


### PR DESCRIPTION
## Description

Upgrading from 8.7 to 8.8 with a different static `partitionCount` could persist a routing state whose `HashMod` did not match the partitions that actually exist. Message publish then failed with `INVALID_STATE` (message not routed to the right partition).

`RoutingStateInitializer` filled a missing routing state from static config. On upgrade the topology already has the real partitions, so that value is wrong if config was changed.

This change derives the initial routing state from the partition count in the cluster configuration instead. Existing routing state is left as-is. New clusters are unchanged (they already get routing state from `ConfigurationUtil`).

## Related issues

Closes #58444

## Configuration

N/A

## Definition of Ready

- [x] The changes are tested
- [x] The title of PR follows [conventional commit style](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The description of the PR explains how the changes can be verified
- [x] If the PR includes UI changes, the description of the PR contains screenshots
- [x] If the PR is related to a GitHub issue, the description of the PR contains a [GitHub keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) to link the PR to the issue
- [x] If the PR is related to a Zendesk ticket, the description of the PR contains a [Zendesk keyword](https://camunda.zendesk.com/hc/en-us/articles/8782011074716-Linking-GitHub-pull-requests-and-Zendesk-tickets) to link the PR to the ticket

## Workflow (to be filled by the bot)

- [ ]  Regression tests are added
- [ ]  All tasks are completed
- [ ]  Reviewers are assigned
- [ ]  The PR is labeled
- [ ]  CI checks are green
- [ ]  Review comments are resolved