### PR TITLE
feat: wire AddZone/ForceRemoveZone  requests through management RPC chain

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -19,6 +20,14 @@ public interface ClusterConfigurationCoordinatorSupplier {
   MemberId getNextCoordinator(Collection<MemberId> members);
 
   MemberId getNextCoordinatorExcluding(Set<MemberId> memberIds);
+
+  /**
+   * Returns a coordinator that is not a member of the given zone, or empty if no such member
+   * exists. Used by zone force-removal, where the zone's brokers (including the default
+   * coordinator) may be down and unreachable. An empty result means every member is in the zone,
+   * i.e. it is the only remaining zone and removing it is invalid.
+   */
+  Optional<MemberId> getNextCoordinatorExcludingZone(String zone);
 
   static ClusterConfigurationCoordinatorSupplier ofMembers(final Set<MemberId> members) {
     return ofMembers(() -> members);
@@ -51,6 +60,13 @@ public interface ClusterConfigurationCoordinatorSupplier {
         final var currentMembers = memberSupplier.get();
         final var newMembers = currentMembers.stream().filter(m -> !memberIds.contains(m)).toList();
         return lowestMemberId(newMembers);
+      }
+
+      @Override
+      public Optional<MemberId> getNextCoordinatorExcludingZone(final String zone) {
+        final var newMembers =
+            memberSupplier.get().stream().filter(m -> !m.isInZone(zone)).toList();
+        return newMembers.isEmpty() ? Optional.empty() : Optional.of(lowestMemberId(newMembers));
       }
     };
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
@@ -76,6 +78,11 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> forceRemoveBrokers(
       ForceRemoveBrokersRequest forceRemoveBrokersRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> forceRemoveZone(
+      ForceZoneRemoveRequest forceZoneRemoveRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> addZone(AddZoneRequest addZoneRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
       ExporterDisableRequest exporterDisableRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -122,6 +122,21 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ForceRemoveBrokersRequest(Set<MemberId> membersToRemove, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
+  /**
+   * Force-evicts a failed zone's brokers from the member set and drops the zone from the persisted
+   * {@code ZoneAwareConfig}, in one atomic change.
+   */
+  record ForceZoneRemoveRequest(String zoneId, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
+  /**
+   * Restores a previously failed-over zone: re-adds the operator-supplied brokers and re-includes
+   * the zone in the persisted {@code ZoneAwareConfig}, in one atomic change.
+   */
+  record AddZoneRequest(
+      String zoneId, int numberOfReplicas, int priority, Set<MemberId> brokers, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record ExporterDisableRequest(String exporterId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -262,12 +262,23 @@ public final class ClusterConfigurationManagementRequestSender {
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
       forceRemoveZone(final ForceZoneRemoveRequest request) {
+    final var coordinator = coordinatorSupplier.getNextCoordinatorExcludingZone(request.zoneId());
+    if (coordinator.isEmpty()) {
+      // No member outside the zone means it is the only remaining zone; removing it is invalid and
+      // there is no live coordinator to reject it, so short-circuit here.
+      return CompletableFuture.completedFuture(
+          Either.left(
+              new ErrorResponse(
+                  ErrorResponse.ErrorCode.INVALID_REQUEST,
+                  "Cannot force remove zone '%s' because it is the last remaining zone."
+                      .formatted(request.zoneId()))));
+    }
     return communicationService.send(
         ClusterConfigurationRequestTopics.FORCE_REMOVE_ZONE.topic(),
         request,
         serializer::encodeForceRemoveZoneRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinatorSupplier.getDefaultCoordinator(),
+        coordinator.get(),
         TIMEOUT);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
@@ -253,6 +255,28 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.ZONE_MIGRATION.topic(),
         request,
         serializer::encodeClusterZoneMigrationRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      forceRemoveZone(final ForceZoneRemoveRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.FORCE_REMOVE_ZONE.topic(),
+        request,
+        serializer::encodeForceRemoveZoneRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> addZone(
+      final AddZoneRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.ADD_ZONE.topic(),
+        request,
+        serializer::encodeForceRemoveZoneRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -287,7 +287,7 @@ public final class ClusterConfigurationManagementRequestSender {
     return communicationService.send(
         ClusterConfigurationRequestTopics.ADD_ZONE.topic(),
         request,
-        serializer::encodeForceRemoveZoneRequest,
+        serializer::encodeAddZoneRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
@@ -201,6 +203,26 @@ public final class ClusterConfigurationManagementRequestsHandler
         forceRemoveBrokersRequest.dryRun(),
         new ForceRemoveBrokersRequestTransformer(
             forceRemoveBrokersRequest.membersToRemove(), localMemberId));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> forceRemoveZone(
+      final ForceZoneRemoveRequest forceZoneRemoveRequest) {
+    return handleRequest(
+        forceZoneRemoveRequest.dryRun(),
+        new ForceRemoveZoneTransformer(forceZoneRemoveRequest.zoneId()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> addZone(
+      final AddZoneRequest addZoneRequest) {
+    return handleRequest(
+        addZoneRequest.dryRun(),
+        new AddZoneTransformer(
+            addZoneRequest.zoneId(),
+            addZoneRequest.numberOfReplicas(),
+            addZoneRequest.priority(),
+            addZoneRequest.brokers()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -56,6 +56,8 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerPurgeRequestHandler();
     registerModeChangeHandler();
     registerRestoreHandler();
+    registerForceRemoveZoneHandler();
+    registerAddZoneHandler();
   }
 
   @Override
@@ -249,6 +251,22 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.RESTORE.topic(),
         serializer::decodeRestoreRequest,
         request -> mapResponse(clusterConfigurationManagementApi.restore(request)),
+        this::encodeResponse);
+  }
+
+  private void registerForceRemoveZoneHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.FORCE_REMOVE_ZONE.topic(),
+        serializer::decodeForceRemoveZoneRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.forceRemoveZone(request)),
+        this::encodeResponse);
+  }
+
+  private void registerAddZoneHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.ADD_ZONE.topic(),
+        serializer::decodeAddZoneRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.addZone(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -20,7 +20,6 @@ public enum ClusterConfigurationRequestTopics {
   DISABLE_EXPORTER("topology-exporter-disable"),
   ENABLE_EXPORTER("topology-exporter-enable"),
   DELETE_EXPORTER("topology-exporter-delete"),
-
   SCALE_CLUSTER("topology-cluster-scale"),
   PATCH_CLUSTER("topology-cluster-patch"),
   PURGE("topology-cluster-purge"),
@@ -29,7 +28,9 @@ public enum ClusterConfigurationRequestTopics {
   UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution"),
   MODE_CHANGE("topology-mode-change"),
   RESTORE("cluster-restore"),
-  ZONE_MIGRATION("topology-cluster-zone-migration");
+  ZONE_MIGRATION("topology-cluster-zone-migration"),
+  ADD_ZONE("topology-add-zone"),
+  FORCE_REMOVE_ZONE("topology-force-remove-zone");
 
   private final String topic;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.dynamic.config.serializer;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
@@ -66,6 +68,10 @@ public interface ClusterConfigurationRequestsSerializer {
       UpdatePartitionDistributorConfigRequest request);
 
   byte[] encodeClusterZoneMigrationRequest(ClusterZoneMigrationRequest request);
+
+  byte[] encodeForceRemoveZoneRequest(ForceZoneRemoveRequest request);
+
+  byte[] encodeForceRemoveZoneRequest(AddZoneRequest request);
 
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
@@ -124,6 +130,10 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] bytes);
 
   ClusterZoneMigrationRequest decodeClusterZoneMigrationRequest(byte[] bytes);
+
+  ForceZoneRemoveRequest decodeForceRemoveZoneRequest(byte[] bytes);
+
+  AddZoneRequest decodeAddZoneRequest(byte[] bytes);
 
   byte[] encodeModeChangeRequest(ModeChangeRequest modeChangeRequest);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -71,7 +71,7 @@ public interface ClusterConfigurationRequestsSerializer {
 
   byte[] encodeForceRemoveZoneRequest(ForceZoneRemoveRequest request);
 
-  byte[] encodeForceRemoveZoneRequest(AddZoneRequest request);
+  byte[] encodeAddZoneRequest(AddZoneRequest request);
 
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -12,6 +12,7 @@ import com.google.protobuf.Timestamp;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
@@ -1109,6 +1111,27 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodeForceRemoveZoneRequest(final ForceZoneRemoveRequest request) {
+    return Requests.ForceRemoveZoneRequest.newBuilder()
+        .setZoneId(request.zoneId())
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
+  public byte[] encodeForceRemoveZoneRequest(final AddZoneRequest request) {
+    return Requests.AddZoneRequest.newBuilder()
+        .setZoneId(request.zoneId())
+        .setNumberOfReplicas(request.numberOfReplicas())
+        .setPriority(request.priority())
+        .addAllBrokers(request.brokers().stream().map(MemberId::id).toList())
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -1436,6 +1459,33 @@ public class ProtoBufSerializer
       throw new DecodingFailed(e);
     }
     return new ClusterZoneMigrationRequest(proto.getZone(), proto.getDryRun());
+  }
+
+  @Override
+  public ForceZoneRemoveRequest decodeForceRemoveZoneRequest(final byte[] bytes) {
+    final Requests.ForceRemoveZoneRequest proto;
+    try {
+      proto = Requests.ForceRemoveZoneRequest.parseFrom(bytes);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+    return new ForceZoneRemoveRequest(proto.getZoneId(), proto.getDryRun());
+  }
+
+  @Override
+  public AddZoneRequest decodeAddZoneRequest(final byte[] bytes) {
+    final Requests.AddZoneRequest proto;
+    try {
+      proto = Requests.AddZoneRequest.parseFrom(bytes);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+    return new AddZoneRequest(
+        proto.getZoneId(),
+        proto.getNumberOfReplicas(),
+        proto.getPriority(),
+        proto.getBrokersList().stream().map(MemberId::from).collect(Collectors.toSet()),
+        proto.getDryRun());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1120,7 +1120,7 @@ public class ProtoBufSerializer
   }
 
   @Override
-  public byte[] encodeForceRemoveZoneRequest(final AddZoneRequest request) {
+  public byte[] encodeAddZoneRequest(final AddZoneRequest request) {
     return Requests.AddZoneRequest.newBuilder()
         .setZoneId(request.zoneId())
         .setNumberOfReplicas(request.numberOfReplicas())

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -74,6 +74,19 @@ message ForceRemoveBrokersRequest {
   bool dryRun = 2;
 }
 
+message ForceRemoveZoneRequest {
+  string zoneId = 1;
+  bool dryRun = 2;
+}
+
+message AddZoneRequest {
+  string zoneId = 1;
+  int32 numberOfReplicas = 2;
+  int32 priority = 3;
+  repeated string brokers = 4;
+  bool dryRun = 5;
+}
+
 message ReassignAllPartitionsRequest {
   // The ids of the brokers to which all partitions should be re-distributed
   repeated string memberIds = 1;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/BareClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/BareClusterConfigurationManagementApiTest.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+
+/** Runs the inherited suite against a plain, non-zone-aware coordinator ({@code "0"}). */
+final class BareClusterConfigurationManagementApiTest
+    extends ClusterConfigurationManagementApiTestBase {
+
+  BareClusterConfigurationManagementApiTest() {
+    super(MemberId::from);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplierTest.java
@@ -102,4 +102,33 @@ class ClusterConfigurationCoordinatorSupplierTest {
     // then
     assertThat(nextCoordinator).isEqualTo(MemberId.from("1"));
   }
+
+  @Test
+  void shouldSelectCoordinatorOutsideZone() {
+    // given — two-zone cluster; the zone to remove (eu) contains the default coordinator
+    final var euZone0 = MemberId.from("eu", 0);
+    final var euZone1 = MemberId.from("eu", 1);
+    final var usZone0 = MemberId.from("us", 0);
+    final var members = Set.of(euZone0, euZone1, usZone0);
+    final var supplier = ClusterConfigurationCoordinatorSupplier.ofMembers(members);
+
+    // when
+    final var coordinator = supplier.getNextCoordinatorExcludingZone("eu");
+
+    // then — us_0 is the only member outside the removed zone
+    assertThat(coordinator).contains(usZone0);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenExcludingTheOnlyZone() {
+    // given — every member is in the zone being removed, i.e. it is the last remaining zone
+    final var members = Set.of(MemberId.from("eu", 0), MemberId.from("eu", 1));
+    final var supplier = ClusterConfigurationCoordinatorSupplier.ofMembers(members);
+
+    // when
+    final var coordinator = supplier.getNextCoordinatorExcludingZone("eu");
+
+    // then
+    assertThat(coordinator).isEmpty();
+  }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -15,10 +15,12 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
@@ -35,7 +37,10 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOp
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDeleteExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
@@ -461,6 +466,78 @@ final class ClusterConfigurationManagementApiTest {
             new PartitionForceReconfigureOperation(id2, 2, Set.of(id2)),
             new MemberRemoveOperation(id0, id1),
             new MemberRemoveOperation(id0, id3));
+  }
+
+  @Test
+  void shouldForceRemoveZone() {
+    // given
+    // id0 is a bare (non-zoned) member so that the request is routed to the coordinator that the
+    // test's real communicationService actually knows about; the zone members below are the ones
+    // exercised by the force-remove-zone logic itself.
+    final var zoneA0 = MemberId.from("zone-a", 0);
+    final var zoneA1 = MemberId.from("zone-a", 1);
+    final var zoneB0 = MemberId.from("zone-b", 0);
+    final var zoneB1 = MemberId.from("zone-b", 1);
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(zoneA0, MemberState.initializeAsActive(Map.of()))
+            .addMember(zoneA1, MemberState.initializeAsActive(Map.of()))
+            .addMember(zoneB0, MemberState.initializeAsActive(Map.of()))
+            .addMember(zoneB1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(zoneB0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(zoneA0, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(zoneB1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(zoneA1, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)))
+            .setPartitionDistributorConfig(
+                new ZoneAwareConfig(
+                    List.of(new ZoneSpec("zone-a", 2, 1), new ZoneSpec("zone-b", 2, 2))));
+    recordingCoordinator.setCurrentTopology(currentTopology);
+    final var request = new ForceZoneRemoveRequest("zone-a", false);
+
+    // when
+    final var changeStatus = clientApi.forceRemoveZone(request).join().get();
+
+    // then
+    assertThat(changeStatus.plannedChanges())
+        .containsExactlyInAnyOrder(
+            new PartitionForceReconfigureOperation(zoneB0, 1, Set.of(zoneB0)),
+            new PartitionForceReconfigureOperation(zoneB1, 2, Set.of(zoneB1)),
+            new MemberRemoveOperation(id0, zoneA0),
+            new MemberRemoveOperation(id0, zoneA1),
+            new UpdatePartitionDistributorConfigOperation(
+                id0, new ZoneAwareConfig(List.of(new ZoneSpec("zone-b", 2, 2)))));
+  }
+
+  @Test
+  void shouldAddZone() {
+    // given
+    // id0 and id1 are bare (non-zoned) members so that the request is routed to the coordinator
+    // that the test's real communicationService actually knows about; the cluster is mid zone
+    // migration, with a zone-aware distribution config persisted but brokers not yet re-tagged.
+    final var zoneB0 = MemberId.from("zone-b", 0);
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .setPartitionDistributorConfig(
+                new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1))));
+    recordingCoordinator.setCurrentTopology(currentTopology);
+    final var request = new AddZoneRequest("zone-b", 1, 2, Set.of(zoneB0), false);
+
+    // when
+    final var changeStatus = clientApi.addZone(request).join().get();
+
+    // then
+    assertThat(changeStatus.plannedChanges()).contains(new MemberJoinOperation(zoneB0));
+    assertThat(changeStatus.plannedChanges())
+        .filteredOn(UpdatePartitionDistributorConfigOperation.class::isInstance)
+        .extracting(op -> ((UpdatePartitionDistributorConfigOperation) op).config())
+        .containsExactly(
+            new ZoneAwareConfig(
+                List.of(new ZoneSpec("zone-a", 1, 1), new ZoneSpec("zone-b", 1, 2))));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTestBase.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.ClusterConfig;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
@@ -67,43 +68,91 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-// Test to verify that server handles requests from the clients. This test uses the actual
-// communicationService to ensure that request subscription and handling is done correctly.
-final class ClusterConfigurationManagementApiTest {
-  private ClusterConfigurationManagementRequestSender clientApi;
-  private final RecordingChangeCoordinator recordingCoordinator = new RecordingChangeCoordinator();
+abstract class ClusterConfigurationManagementApiTestBase {
+  protected final MemberId coordinatorId;
+  protected ClusterConfigurationManagementRequestSender clientApi;
+  protected final RecordingChangeCoordinator recordingCoordinator =
+      new RecordingChangeCoordinator();
+  protected final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final ClusterConfiguration initialTopology;
   private ClusterConfigurationRequestServer requestServer;
+  private List<ClusterConfigurationRequestServer> extraRequestServers = List.of();
   private AtomixCluster gateway;
   private AtomixCluster coordinator;
-  private final MemberId id0 = MemberId.from("0");
-  private final MemberId id1 = MemberId.from("1");
-  private final MemberId id2 = MemberId.from("2");
-  private final MemberId id3 = MemberId.from("3");
-  private final ClusterConfiguration initialTopology =
-      ClusterConfiguration.init().addMember(id0, MemberState.initializeAsActive(Map.of()));
+  private List<AtomixCluster> extraNodes = List.of();
   @AutoClose private final MeterRegistry registry = new SimpleMeterRegistry();
+  private final Function<Integer, MemberId> memberFactory;
 
-  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  ClusterConfigurationManagementApiTestBase(final Function<Integer, MemberId> memberFactory) {
+    this.memberFactory = memberFactory;
+    coordinatorId = memberFactory.apply(0);
+    // the physical coordinator node is always coordinatorId, so the recorded topology's
+    // coordinator member must be the same id for requests to route to the started node
+    initialTopology =
+        ClusterConfiguration.init()
+            .addMember(coordinatorId, MemberState.initializeAsActive(Map.of()));
+  }
 
   @BeforeEach
   void setup() {
-    final var gatewayNode =
-        Node.builder().withId("gateway").withPort(SocketUtil.getNextAddress().getPort()).build();
-    final var coordinatorNode =
-        Node.builder().withId("0").withPort(SocketUtil.getNextAddress().getPort()).build();
+    // seed the coordinator so that the "no topology yet" default still resolves to the physical
+    // coordinator node, rather than falling back to member "0"
+    recordingCoordinator.setCurrentTopology(initialTopology);
 
-    gateway = createClusterNode(gatewayNode, List.of(gatewayNode, coordinatorNode));
-    coordinator = createClusterNode(coordinatorNode, List.of(gatewayNode, coordinatorNode));
+    final var gatewayId = MemberId.from("gateway");
+    final var gatewayNode =
+        Node.builder()
+            .withId(gatewayId.id())
+            .withPort(SocketUtil.getNextAddress().getPort())
+            .build();
+    final var coordinatorNode =
+        Node.builder()
+            .withId(coordinatorId.id())
+            .withPort(SocketUtil.getNextAddress().getPort())
+            .build();
+    final var extraNodeEntries =
+        extraPhysicalMembers().stream()
+            .map(
+                id ->
+                    Map.entry(
+                        id,
+                        Node.builder()
+                            .withId(id.id())
+                            .withPort(SocketUtil.getNextAddress().getPort())
+                            .build()))
+            .toList();
+    final var nodes =
+        Stream.concat(
+                Stream.of(gatewayNode, coordinatorNode),
+                extraNodeEntries.stream().map(Map.Entry::getValue))
+            .toList();
+
+    gateway = createClusterNode(gatewayId, gatewayNode, nodes);
+    coordinator = createClusterNode(coordinatorId, coordinatorNode, nodes);
+    final var extraClusters =
+        extraNodeEntries.stream()
+            .map(
+                entry ->
+                    Map.entry(
+                        entry.getKey(), createClusterNode(entry.getKey(), entry.getValue(), nodes)))
+            .toList();
+    extraNodes = extraClusters.stream().map(Map.Entry::getValue).toList();
 
     final var gatewayStarted = gateway.start();
     final var coordinatorStarted = coordinator.start();
-    CompletableFuture.allOf(gatewayStarted, coordinatorStarted).join();
+    final var extraStarted = extraNodes.stream().map(AtomixCluster::start).toList();
+    CompletableFuture.allOf(
+            Stream.concat(Stream.of(gatewayStarted, coordinatorStarted), extraStarted.stream())
+                .toArray(CompletableFuture[]::new))
+        .join();
 
     clientApi =
         new ClusterConfigurationManagementRequestSender(
@@ -132,22 +181,62 @@ final class ClusterConfigurationManagementApiTest {
             coordinator.getCommunicationService(),
             new ProtoBufSerializer(),
             new ClusterConfigurationManagementRequestsHandler(
-                recordingCoordinator, id0, new TestConcurrencyControl(), validatorRegistry));
-
+                recordingCoordinator,
+                coordinatorId,
+                new TestConcurrencyControl(),
+                validatorRegistry));
     requestServer.start();
+
+    // extra nodes may be resolved as the coordinator for a given request (see
+    // extraPhysicalMembers), so they need their own request server too
+    extraRequestServers =
+        extraClusters.stream()
+            .map(
+                entry ->
+                    new ClusterConfigurationRequestServer(
+                        entry.getValue().getCommunicationService(),
+                        new ProtoBufSerializer(),
+                        new ClusterConfigurationManagementRequestsHandler(
+                            recordingCoordinator,
+                            entry.getKey(),
+                            new TestConcurrencyControl(),
+                            validatorRegistry)))
+            .toList();
+    extraRequestServers.forEach(ClusterConfigurationRequestServer::start);
   }
 
   @AfterEach
   void tearDown() {
     requestServer.close();
+    extraRequestServers.forEach(ClusterConfigurationRequestServer::close);
     gateway.stop();
     coordinator.stop();
+    extraNodes.forEach(AtomixCluster::stop);
   }
 
-  private AtomixCluster createClusterNode(final Node localNode, final Collection<Node> nodes) {
-    return AtomixCluster.builder(registry)
+  /**
+   * Extra physical broker nodes to start alongside the coordinator, so that {@code
+   * communicationService} can route requests to a member other than {@link #coordinatorId}. Used by
+   * tests where the coordinator resolved at request time (e.g. force-remove-zone routing around the
+   * removed zone) differs from the physical coordinator node.
+   */
+  protected List<MemberId> extraPhysicalMembers() {
+    return List.of();
+  }
+
+  /**
+   * Builds the physical cluster member for {@code localId}. Atomix's own {@link
+   * io.atomix.cluster.Member} validates that the zone it was configured with matches the zone
+   * embedded in the {@link MemberId}, so a zone-aware {@code localId} (e.g. {@code zone-a_0})
+   * requires setting the zone explicitly on the {@link ClusterConfig}; {@code AtomixClusterBuilder}
+   * has no public setter for it.
+   */
+  private AtomixCluster createClusterNode(
+      final MemberId localId, final Node localNode, final Collection<Node> nodes) {
+    final var clusterConfig = new ClusterConfig();
+    clusterConfig.getNodeConfig().setId(localId).setZoneId(localId.zone());
+    return AtomixCluster.builder(clusterConfig, registry)
         .withAddress(localNode.address())
-        .withMemberId(localNode.id().id())
         .withMembershipProvider(new BootstrapDiscoveryProvider(nodes))
         .withMembershipProtocol(new DiscoveryMembershipProtocol())
         .build();
@@ -157,7 +246,7 @@ final class ClusterConfigurationManagementApiTest {
   void shouldGetCurrentTopology() {
     // given
     final var expectedTopology =
-        initialTopology.addMember(id1, MemberState.initializeAsActive(Map.of()));
+        initialTopology.addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()));
     recordingCoordinator.setCurrentTopology(expectedTopology);
 
     // when
@@ -171,13 +260,14 @@ final class ClusterConfigurationManagementApiTest {
   void shouldAddMembers() {
     // given
     final var request =
-        new ClusterConfigurationManagementRequest.AddMembersRequest(Set.of(id1), false);
+        new ClusterConfigurationManagementRequest.AddMembersRequest(
+            Set.of(memberFactory.apply(1)), false);
 
     // when
     final var changeStatus = clientApi.addMembers(request).join().get();
 
     // then
-    final var expected = new MemberJoinOperation(id1);
+    final var expected = new MemberJoinOperation(memberFactory.apply(1));
     assertThat(changeStatus.plannedChanges()).containsExactly(expected);
   }
 
@@ -186,17 +276,20 @@ final class ClusterConfigurationManagementApiTest {
     // given
     recordingCoordinator.setCurrentTopology(
         initialTopology
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .addMember(id2, MemberState.initializeAsActive(Map.of())));
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(2), MemberState.initializeAsActive(Map.of())));
     final var request =
-        new ClusterConfigurationManagementRequest.RemoveMembersRequest(Set.of(id1, id2), false);
+        new ClusterConfigurationManagementRequest.RemoveMembersRequest(
+            Set.of(memberFactory.apply(1), memberFactory.apply(2)), false);
 
     // when
     final var changeStatus = clientApi.removeMembers(request).join().get();
 
     // then
     final List<ClusterConfigurationChangeOperation> expected =
-        List.of(new MemberLeaveOperation(id1), new MemberLeaveOperation(id2));
+        List.of(
+            new MemberLeaveOperation(memberFactory.apply(1)),
+            new MemberLeaveOperation(memberFactory.apply(2)));
     assertThat(changeStatus.plannedChanges()).containsExactlyElementsOf(expected);
   }
 
@@ -204,28 +297,30 @@ final class ClusterConfigurationManagementApiTest {
   void shouldJoinPartition() {
     // given
     final var request =
-        new ClusterConfigurationManagementRequest.JoinPartitionRequest(id1, 1, 3, false);
+        new ClusterConfigurationManagementRequest.JoinPartitionRequest(
+            memberFactory.apply(1), 1, 3, false);
 
     // when
     final var changeStatus = clientApi.joinPartition(request).join().get();
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .containsExactly(new PartitionJoinOperation(id1, 1, 3));
+        .containsExactly(new PartitionJoinOperation(memberFactory.apply(1), 1, 3));
   }
 
   @Test
   void shouldLeavePartition() {
     // given
     final var request =
-        new ClusterConfigurationManagementRequest.LeavePartitionRequest(id1, 1, false);
+        new ClusterConfigurationManagementRequest.LeavePartitionRequest(
+            memberFactory.apply(1), 1, false);
 
     // when
     final var changeStatus = clientApi.leavePartition(request).join().get();
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .containsExactly(new PartitionLeaveOperation(id1, 1, 1));
+        .containsExactly(new PartitionLeaveOperation(memberFactory.apply(1), 1, 1));
   }
 
   @Test
@@ -233,18 +328,18 @@ final class ClusterConfigurationManagementApiTest {
     // given
     final var request =
         new ClusterConfigurationManagementRequest.ReassignPartitionsRequest(
-            Set.of(id1, id2), false);
+            Set.of(memberFactory.apply(1), memberFactory.apply(2)), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .addMember(
-                id1,
+                memberFactory.apply(1),
                 MemberState.initializeAsActive(
                     Map.of(
                         1,
                         PartitionState.active(1, partitionConfig),
                         2,
                         PartitionState.active(1, partitionConfig))))
-            .addMember(id2, MemberState.initializeAsActive(Map.of()));
+            .addMember(memberFactory.apply(2), MemberState.initializeAsActive(Map.of()));
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when
@@ -253,17 +348,23 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
-            new PartitionJoinOperation(id2, 2, 1), new PartitionLeaveOperation(id1, 2, 1));
+            new PartitionJoinOperation(memberFactory.apply(2), 2, 1),
+            new PartitionLeaveOperation(memberFactory.apply(1), 2, 1));
   }
 
   @Test
   void shouldScaleBrokers() {
     // given
-    final var request = new BrokerScaleRequest(Set.of(id0, id1), false);
+    final var request =
+        new BrokerScaleRequest(Set.of(memberFactory.apply(0), memberFactory.apply(1)), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -273,21 +374,29 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
-            new PreScalingOperation(id0, Set.of(id0, id1)),
-            new MemberJoinOperation(id1),
-            new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2, 1),
-            new PostScalingOperation(id0, Set.of(id0, id1)));
+            new PreScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))),
+            new MemberJoinOperation(memberFactory.apply(1)),
+            new PartitionJoinOperation(memberFactory.apply(1), 2, 1),
+            new PartitionLeaveOperation(memberFactory.apply(0), 2, 1),
+            new PostScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))));
   }
 
   @Test
   void shouldScaleBrokersWithNewReplicationFactor() {
     // given
-    final var request = new BrokerScaleRequest(Set.of(id0, id1), Optional.of(2), false);
+    final var request =
+        new BrokerScaleRequest(
+            Set.of(memberFactory.apply(0), memberFactory.apply(1)), Optional.of(2), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -297,22 +406,34 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .hasSize(6)
-        .startsWith(new PreScalingOperation(id0, Set.of(id0, id1)))
-        .endsWith(new PostScalingOperation(id0, Set.of(id0, id1)))
-        .contains(new MemberJoinOperation(id1), new PartitionJoinOperation(id1, 2, 2))
+        .startsWith(
+            new PreScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))))
+        .endsWith(
+            new PostScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))))
+        .contains(
+            new MemberJoinOperation(memberFactory.apply(1)),
+            new PartitionJoinOperation(memberFactory.apply(1), 2, 2))
         .containsSequence(
-            new PartitionJoinOperation(id1, 1, 1),
-            new PartitionReconfigurePriorityOperation(id0, 1, 2));
+            new PartitionJoinOperation(memberFactory.apply(1), 1, 1),
+            new PartitionReconfigurePriorityOperation(memberFactory.apply(0), 1, 2));
   }
 
   @Test
   void shouldRejectScaleRequestWithInvalidReplicationFactor() {
     // given
-    final var request = new BrokerScaleRequest(Set.of(id0, id1), Optional.of(0), false);
+    final var request =
+        new BrokerScaleRequest(
+            Set.of(memberFactory.apply(0), memberFactory.apply(1)), Optional.of(0), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -330,14 +451,24 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldReduceReplicationFactorWithoutScalingDown() {
     // given
-    final var request = new BrokerScaleRequest(Set.of(id0, id1), Optional.of(1), false);
+    final var request =
+        new BrokerScaleRequest(
+            Set.of(memberFactory.apply(0), memberFactory.apply(1)), Optional.of(1), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -347,26 +478,35 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactlyInAnyOrder(
-            new PartitionLeaveOperation(id0, 2, 1),
-            new PartitionLeaveOperation(id1, 1, 1),
-            new PartitionReconfigurePriorityOperation(id0, 1, 1),
-            new PartitionReconfigurePriorityOperation(id1, 2, 1));
+            new PartitionLeaveOperation(memberFactory.apply(0), 2, 1),
+            new PartitionLeaveOperation(memberFactory.apply(1), 1, 1),
+            new PartitionReconfigurePriorityOperation(memberFactory.apply(0), 1, 1),
+            new PartitionReconfigurePriorityOperation(memberFactory.apply(1), 2, 1));
   }
 
   @Test
   void shouldForceScaleDown() {
     // given
-    final var request = new BrokerScaleRequest(Set.of(id0, id2), false);
+    final var request =
+        new BrokerScaleRequest(Set.of(memberFactory.apply(0), memberFactory.apply(2)), false);
     final ClusterConfiguration currentTopology =
         ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .addMember(id2, MemberState.initializeAsActive(Map.of()))
-            .addMember(id3, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-            .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
-            .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+            .addMember(memberFactory.apply(0), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(2), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(3), MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(2),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(3),
+                m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when
@@ -375,10 +515,12 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactlyInAnyOrder(
-            new PartitionForceReconfigureOperation(id0, 1, Set.of(id0)),
-            new PartitionForceReconfigureOperation(id2, 2, Set.of(id2)),
-            new MemberRemoveOperation(id0, id1),
-            new MemberRemoveOperation(id0, id3));
+            new PartitionForceReconfigureOperation(
+                memberFactory.apply(0), 1, Set.of(memberFactory.apply(0))),
+            new PartitionForceReconfigureOperation(
+                memberFactory.apply(2), 2, Set.of(memberFactory.apply(2))),
+            new MemberRemoveOperation(memberFactory.apply(0), memberFactory.apply(1)),
+            new MemberRemoveOperation(memberFactory.apply(0), memberFactory.apply(3)));
   }
 
   @Test
@@ -386,40 +528,63 @@ final class ClusterConfigurationManagementApiTest {
     // given
     final var request =
         new ClusterScaleRequest(
-            Optional.of(2), Optional.of(3), Optional.empty(), Optional.empty(), false);
-    final ClusterConfiguration currentTopology =
+            Optional.of(2),
+            Optional.of(3),
+            Optional.empty(),
+            Optional.ofNullable(coordinatorId.zone()),
+            false);
+    final var topologyWithPartitions =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+    final ClusterConfiguration currentTopology =
+        Optional.ofNullable(coordinatorId.zone())
+            .map(
+                zone ->
+                    topologyWithPartitions.setPartitionDistributorConfig(
+                        new ZoneAwareConfig(List.of(new ZoneSpec(zone, 1, 1)))))
+            .orElse(topologyWithPartitions);
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when
-    final var changeStatus = clientApi.scaleCluster(request).join().get();
+    final var changeStatus = clientApi.scaleCluster(request).join();
+    EitherAssert.assertThat(changeStatus).isRight();
 
     // then
-    assertThat(changeStatus.plannedChanges())
+    assertThat(changeStatus.get().plannedChanges())
         .containsExactly(
-            new PreScalingOperation(id0, Set.of(id0, id1)),
-            new MemberJoinOperation(id1),
-            new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2, 1),
-            new StartPartitionScaleUp(id0, 3),
-            new PartitionBootstrapOperation(id0, 3, 1, true),
-            new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
-            new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))),
-            new PostScalingOperation(id0, Set.of(id0, id1)));
+            new PreScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))),
+            new MemberJoinOperation(memberFactory.apply(1)),
+            new PartitionJoinOperation(memberFactory.apply(1), 2, 1),
+            new PartitionLeaveOperation(memberFactory.apply(0), 2, 1),
+            new StartPartitionScaleUp(memberFactory.apply(0), 3),
+            new PartitionBootstrapOperation(memberFactory.apply(0), 3, 1, true),
+            new AwaitRedistributionCompletion(memberFactory.apply(0), 3, new TreeSet<>(List.of(3))),
+            new AwaitRelocationCompletion(memberFactory.apply(0), 3, new TreeSet<>(List.of(3))),
+            new PostScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))));
   }
 
   @Test
   void shouldPatchCluster() {
     // given
     final var request =
-        new ClusterPatchRequest(Set.of(id1), Set.of(), Optional.of(3), Optional.empty(), false);
+        new ClusterPatchRequest(
+            Set.of(memberFactory.apply(1)), Set.of(), Optional.of(3), Optional.empty(), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -429,31 +594,43 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
-            new PreScalingOperation(id0, Set.of(id0, id1)),
-            new MemberJoinOperation(id1),
-            new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2, 1),
-            new StartPartitionScaleUp(id0, 3),
-            new PartitionBootstrapOperation(id0, 3, 1, true),
-            new AwaitRedistributionCompletion(id0, 3, new TreeSet<>(List.of(3))),
-            new AwaitRelocationCompletion(id0, 3, new TreeSet<>(List.of(3))),
-            new PostScalingOperation(id0, Set.of(id0, id1)));
+            new PreScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))),
+            new MemberJoinOperation(memberFactory.apply(1)),
+            new PartitionJoinOperation(memberFactory.apply(1), 2, 1),
+            new PartitionLeaveOperation(memberFactory.apply(0), 2, 1),
+            new StartPartitionScaleUp(memberFactory.apply(0), 3),
+            new PartitionBootstrapOperation(memberFactory.apply(0), 3, 1, true),
+            new AwaitRedistributionCompletion(memberFactory.apply(0), 3, new TreeSet<>(List.of(3))),
+            new AwaitRelocationCompletion(memberFactory.apply(0), 3, new TreeSet<>(List.of(3))),
+            new PostScalingOperation(
+                memberFactory.apply(0), Set.of(memberFactory.apply(0), memberFactory.apply(1))));
   }
 
   @Test
   void shouldForceRemoveBrokers() {
     // given
-    final var request = new ForceRemoveBrokersRequest(Set.of(id1, id3), false);
+    final var request =
+        new ForceRemoveBrokersRequest(
+            Set.of(memberFactory.apply(1), memberFactory.apply(3)), false);
     final ClusterConfiguration currentTopology =
         ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .addMember(id2, MemberState.initializeAsActive(Map.of()))
-            .addMember(id3, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-            .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
-            .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+            .addMember(memberFactory.apply(0), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(2), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(3), MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(2),
+                m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(3),
+                m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when
@@ -462,16 +639,19 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactlyInAnyOrder(
-            new PartitionForceReconfigureOperation(id0, 1, Set.of(id0)),
-            new PartitionForceReconfigureOperation(id2, 2, Set.of(id2)),
-            new MemberRemoveOperation(id0, id1),
-            new MemberRemoveOperation(id0, id3));
+            new PartitionForceReconfigureOperation(
+                memberFactory.apply(0), 1, Set.of(memberFactory.apply(0))),
+            new PartitionForceReconfigureOperation(
+                memberFactory.apply(2), 2, Set.of(memberFactory.apply(2))),
+            new MemberRemoveOperation(memberFactory.apply(0), memberFactory.apply(1)),
+            new MemberRemoveOperation(memberFactory.apply(0), memberFactory.apply(3)));
   }
 
   @Test
   void shouldForceRemoveZone() {
     // given
-    // id0 is a bare (non-zoned) member so that the request is routed to the coordinator that the
+    // memberFactory.apply(0) is a bare (non-zoned) member so that the request is routed to the
+    // coordinator that the
     // test's real communicationService actually knows about; the zone members below are the ones
     // exercised by the force-remove-zone logic itself.
     final var zoneA0 = MemberId.from("zone-a", 0);
@@ -480,7 +660,7 @@ final class ClusterConfigurationManagementApiTest {
     final var zoneB1 = MemberId.from("zone-b", 1);
     final var currentTopology =
         ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(0), MemberState.initializeAsActive(Map.of()))
             .addMember(zoneA0, MemberState.initializeAsActive(Map.of()))
             .addMember(zoneA1, MemberState.initializeAsActive(Map.of()))
             .addMember(zoneB0, MemberState.initializeAsActive(Map.of()))
@@ -503,25 +683,31 @@ final class ClusterConfigurationManagementApiTest {
         .containsExactlyInAnyOrder(
             new PartitionForceReconfigureOperation(zoneB0, 1, Set.of(zoneB0)),
             new PartitionForceReconfigureOperation(zoneB1, 2, Set.of(zoneB1)),
-            new MemberRemoveOperation(id0, zoneA0),
-            new MemberRemoveOperation(id0, zoneA1),
+            new MemberRemoveOperation(memberFactory.apply(0), zoneA0),
+            new MemberRemoveOperation(memberFactory.apply(0), zoneA1),
             new UpdatePartitionDistributorConfigOperation(
-                id0, new ZoneAwareConfig(List.of(new ZoneSpec("zone-b", 2, 2)))));
+                memberFactory.apply(0),
+                new ZoneAwareConfig(List.of(new ZoneSpec("zone-b", 2, 2)))));
   }
 
   @Test
   void shouldAddZone() {
     // given
-    // id0 and id1 are bare (non-zoned) members so that the request is routed to the coordinator
+    // memberFactory.apply(0) and memberFactory.apply(1) are bare (non-zoned) members so that the
+    // request is routed to the coordinator
     // that the test's real communicationService actually knows about; the cluster is mid zone
     // migration, with a zone-aware distribution config persisted but brokers not yet re-tagged.
     final var zoneB0 = MemberId.from("zone-b", 0);
     final var currentTopology =
         ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()))
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .addMember(memberFactory.apply(0), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
             .setPartitionDistributorConfig(
                 new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1))));
     recordingCoordinator.setCurrentTopology(currentTopology);
@@ -553,7 +739,8 @@ final class ClusterConfigurationManagementApiTest {
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
-            id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));
+            memberFactory.apply(0),
+            m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));
     recordingCoordinator.setCurrentTopology(configurationWithExporter);
 
     // when
@@ -561,7 +748,8 @@ final class ClusterConfigurationManagementApiTest {
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .containsExactly(new PartitionDisableExporterOperation(id0, 1, exporterId));
+        .containsExactly(
+            new PartitionDisableExporterOperation(memberFactory.apply(0), 1, exporterId));
   }
 
   @Test
@@ -577,7 +765,8 @@ final class ClusterConfigurationManagementApiTest {
                 Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
-            id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));
+            memberFactory.apply(0),
+            m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));
     recordingCoordinator.setCurrentTopology(configurationWithExporter);
 
     // when
@@ -585,7 +774,8 @@ final class ClusterConfigurationManagementApiTest {
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .containsExactly(new PartitionDeleteExporterOperation(id0, 1, exporterId));
+        .containsExactly(
+            new PartitionDeleteExporterOperation(memberFactory.apply(0), 1, exporterId));
   }
 
   @Test
@@ -602,7 +792,8 @@ final class ClusterConfigurationManagementApiTest {
                 Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
-            id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));
+            memberFactory.apply(0),
+            m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));
     recordingCoordinator.setCurrentTopology(configurationWithExporter);
 
     // when
@@ -611,7 +802,8 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
-            new PartitionEnableExporterOperation(id0, 1, exporterId, Optional.empty()));
+            new PartitionEnableExporterOperation(
+                memberFactory.apply(0), 1, exporterId, Optional.empty()));
   }
 
   @Test
@@ -636,7 +828,8 @@ final class ClusterConfigurationManagementApiTest {
     // given
     recordingCoordinator.setCurrentTopology(
         ClusterConfiguration.init()
-            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
+            .addMember(
+                memberFactory.apply(0), MemberState.initializeAsActive(Map.of()).toRecovering()));
     final var request =
         new RestoreRequest(
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
@@ -688,14 +881,26 @@ final class ClusterConfigurationManagementApiTest {
     // given
     recordingCoordinator.setCurrentTopology(
         initialTopology
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .addMember(id2, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(0, PartitionState.active(2, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
-            .updateMember(id2, m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
-            .updateMember(id2, m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
+            .addMember(memberFactory.apply(1), MemberState.initializeAsActive(Map.of()))
+            .addMember(memberFactory.apply(2), MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(0, PartitionState.active(2, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(2),
+                m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(0),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(1),
+                m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(
+                memberFactory.apply(2),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
     final var request = new PurgeRequest(false);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneAwareClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneAwareClusterConfigurationManagementApiTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.util.ZoneFixtures;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@code forceRemoveZone} and {@code addZone}, which only make sense for an already
+ * zone-aware cluster. The coordinator's physical id is {@link ZoneFixtures.ZONE_A_0} so that a
+ * fully zone-aware topology (whose lowest member is always zone-a's first broker) routes correctly
+ * through the real {@code communicationService}.
+ */
+final class ZoneAwareClusterConfigurationManagementApiTest
+    extends ClusterConfigurationManagementApiTestBase {
+
+  ZoneAwareClusterConfigurationManagementApiTest() {
+    super(idx -> MemberId.from(ZONE_A, idx));
+  }
+
+  @Override
+  protected List<MemberId> extraPhysicalMembers() {
+    // shouldForceRemoveZone removes zone-a, so the coordinator resolved at request time is
+    // zone-b_0 (lowest member outside the removed zone), not the physical coordinator node
+    // (zone-a_0); start it so communicationService can route to it.
+    return List.of(ZONE_B_0);
+  }
+
+  @Override
+  @Test
+  void shouldForceRemoveZone() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(ZONE_A_0, MemberState.initializeAsActive(Map.of()))
+            .addMember(ZONE_A_1, MemberState.initializeAsActive(Map.of()))
+            .addMember(ZONE_B_0, MemberState.initializeAsActive(Map.of()))
+            .addMember(ZONE_B_1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                ZONE_B_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                ZONE_A_0, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(
+                ZONE_B_1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                ZONE_A_1, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)))
+            .setPartitionDistributorConfig(new ZoneAwareConfig(DUAL_REGION));
+    recordingCoordinator.setCurrentTopology(currentTopology);
+    final var request = new ForceZoneRemoveRequest(ZONE_A, false);
+
+    // when
+    final var changeStatus = clientApi.forceRemoveZone(request).join().get();
+
+    // then
+    assertThat(changeStatus.plannedChanges())
+        .containsExactlyInAnyOrder(
+            new PartitionForceReconfigureOperation(ZONE_B_0, 1, Set.of(ZONE_B_0)),
+            new PartitionForceReconfigureOperation(ZONE_B_1, 2, Set.of(ZONE_B_1)),
+            new MemberRemoveOperation(ZONE_B_0, ZONE_A_0),
+            new MemberRemoveOperation(ZONE_B_0, ZONE_A_1),
+            new UpdatePartitionDistributorConfigOperation(
+                ZONE_B_0, new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_B, 2, 100)))));
+  }
+
+  @Override
+  @Test
+  void shouldAddZone() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(ZONE_A_0, MemberState.initializeAsActive(Map.of()))
+            .addMember(ZONE_A_1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                ZONE_A_0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(
+                ZONE_A_1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .setPartitionDistributorConfig(
+                new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1))));
+    recordingCoordinator.setCurrentTopology(currentTopology);
+    final var request = new AddZoneRequest(ZONE_B, 1, 2, Set.of(ZONE_B_0), false);
+
+    // when
+    final var changeStatus = clientApi.addZone(request).join().get();
+
+    // then
+    assertThat(changeStatus.plannedChanges())
+        .containsExactly(
+            new MemberJoinOperation(ZONE_B_0),
+            new UpdatePartitionDistributorConfigOperation(
+                ZONE_A_0,
+                new ZoneAwareConfig(
+                    List.of(new ZoneSpec(ZONE_A, 1, 1), new ZoneSpec(ZONE_B, 1, 2)))),
+            new PartitionJoinOperation(ZONE_B_0, 1, 2),
+            new PartitionLeaveOperation(ZONE_A_1, 1, 1));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -13,6 +13,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExportingStateChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
@@ -65,6 +67,34 @@ final class ProtoBufSerializerTest {
 
     // then
     final var decodedRequest = protoBufSerializer.decodeClusterZoneMigrationRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeForceRemoveZoneRequest() {
+    // given
+    final var request = new ForceZoneRemoveRequest("us-west-1", true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeForceRemoveZoneRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeForceRemoveZoneRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeAddZoneRequest() {
+    // given
+    final var request =
+        new AddZoneRequest(
+            "us-west-1", 3, 1, Set.of(MemberId.from("1"), MemberId.from("2")), false);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeAddZoneRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeAddZoneRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(request);
   }
 


### PR DESCRIPTION
Add AddZoneRequest and ForceRemoveZone records and thread them through every layer of the cluster-configuration management RPC: topics, serializer interface and protobuf implementation, requests.proto schema, management API, handler sender, and RPC server.

REST api changes are implemented as a followup

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #51593
