### PR TITLE
fix: build zeebe-protocol reactor deps from source in optimize snapshot deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2709,10 +2709,11 @@ jobs:
         with:
           name: fe-optimize-${{ github.run_id }}
           path: optimize/client/dist
+      # -am fixes a race with deploy-snapshots by building reactor deps from source instead of Nexus
       - name: Build zeebe-protocol from source
         uses: ./.github/actions/run-maven
         with:
-          parameters: install -pl zeebe/protocol -Dquickly
+          parameters: install -pl zeebe/protocol -am -Dquickly
       - name: Generate Optimize production .tar.gz
         uses: ./.github/actions/run-maven
         with:


### PR DESCRIPTION
## Description

The `deploy-optimize-docker-snapshot` job builds `zeebe-protocol` from source with `install -pl zeebe/protocol -Dquickly`, but `-pl` alone does not build zeebe-protocol's own reactor dependencies (`camunda-security-protocol`, `zeebe-build-tools`). Those are instead resolved from Nexus, which races the `deploy-snapshots` job that publishes them.

On the **first push after a release version bump**, the freshly-bumped `X.Y.Z-SNAPSHOT` has no artifacts in Nexus yet, so the race is guaranteed to lose and the build fails with:

```
Could not find artifact io.camunda:camunda-security-protocol:jar:8.8.33-SNAPSHOT
Could not find artifact io.camunda:zeebe-build-tools:jar:8.8.33-SNAPSHOT
```

On other pushes the failure is masked by stale artifacts left in Nexus from earlier same-day builds, which is why this only surfaces once per release cut. Observed on `stable/8.8`: [run 29992362892](https://github.com/camunda/camunda/actions/runs/29992362892/job/89167338975).

Adding `-am` builds those dependencies from source into the local repository, matching the intent of the step (build what Optimize needs from source rather than depending on Nexus) and removing the race entirely. The sibling `deploy-camunda-docker-snapshot` job never hit this because its `build-zeebe` action does a full-reactor `install`.

The identical buggy step exists on `stable/8.8` and `stable/8.9`; since `push` runs the workflow on the pushed branch, both need the fix directly (backport labels added). `stable/8.7` has no such step.

Related incident: [#inc-6627-unsuccessful-job-ci-deploy-optimize-docker-snapshot-on-stable8-8](https://camunda.slack.com/archives/C0BKC31M9PB)

## Checklist

- [x] Enable backports when necessary — `backport stable/8.8` and `backport stable/8.9` labels added.

## Related issues

closes #
