### PR TITLE
test: gate backport hop inherits original

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -207,6 +207,15 @@ outputs:
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.rdbms-change == 'true'
       }}
+  release-notes-action:
+    description: Output whether the release-notes action's tests and bundle-drift guards should be run
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-common.outputs.release-notes-action-change == 'true'
+      }}
   renovate-config-changes:
     description: Output whether renovate config validator needs to be run
     value: >-
@@ -288,6 +297,22 @@ runs:
 
         renovate-config-change:
           - '**/renovate.json'
+
+        # The gate workflow is included so a change to it still runs the action's
+        # tests and the bundle-drift guard that back it.
+        #
+        # The first two globs overlap `ci-relevant` (which already covers
+        # .github/actions/** and .github/workflows/**) and are kept on purpose:
+        # ci-relevant additionally requires check.sh to judge the change
+        # CI-relevant, so an excluded path there would otherwise skip the
+        # action's own tests. The last two are not GitHub Actions files at all,
+        # so only this filter catches them — and both are drift-guarded by the
+        # action's CI, which is exactly what must run when they change.
+        release-notes-action-change:
+          - '.github/actions/release-notes/**'
+          - '.github/workflows/release-notes*'
+          - '.github/pull_request_template.md'
+          - 'commitlint.config.cjs'
 
         # We use specific src/main and src/test path to:
         #  * react on java code (production + test) changes

--- a/.github/actions/release-notes/.gitignore
+++ b/.github/actions/release-notes/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -70,6 +70,16 @@ PR** and validates *its* attribution (`deliveryPath: backportHop`). The backport
 inherits the original's linked issue (C7); the `Backport of #N` marker is never
 removed (the stale-backport tracker depends on it).
 
+The hop only fires when the link is otherwise **undeclared** — a section that
+links a pull request is a hard error and is *not* rescued by an unrelated
+`Backport of #N`. A **cross-repo** marker (`owner/other#N`) cannot inherit
+attribution (this action only validates its own repo), and a marker whose target
+PR does not resolve is surfaced explicitly rather than folded into the generic
+"no linked issue" message.
+
+HTML comments are stripped before parsing, so the PR template's own instructional
+`<!-- … closes #1234 … -->` boilerplate is never mistaken for a real ref.
+
 ### Title lint
 
 The title check reimplements the **active** `commitlint.config.cjs` rules

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -5,7 +5,8 @@ Shared tooling for the release-notes pipeline (epic
 package with two entrypoints that import **one** reference parser:
 
 - `lint/` — the **PR-gate** ([#53593](https://github.com/camunda/camunda/issues/53593)):
-  validates that a PR links a tracked issue (or opts out). Live now, **warn-only**.
+  validates that a PR links a tracked issue (or opts out) and lints its title;
+  syncs a sticky comment and a `no-issue` label. Live now, **warn-only**.
 - `generate/` — the **release-notes generator**
   ([#57713](https://github.com/camunda/camunda/issues/57713)): builds the changelog
   from the PRs shipped in a release range. **Not built yet.**
@@ -43,7 +44,9 @@ The gate runs two checks (`gate.evaluateGate`) and reports a combined outcome.
 header ≤ length. Skipped for bot authors (D16); their link/marker is still
 validated. See [Title lint](#title-lint).
 
-Then it reconciles a single sticky PR comment (`comment`) covering both checks.
+Then it reconciles a single sticky PR comment (`comment`) covering both checks,
+and syncs the display-only `no-issue` label (`labels`) to the PR-issue-link
+check alone.
 
 ### Decision table (PR-issue link)
 
@@ -91,6 +94,22 @@ Comment sync is best-effort: an API failure is logged and never fails the gate.
 It posts under the app identity (not `GITHUB_TOKEN`) so it triggers the same
 downstream automations a human comment would.
 
+### `no-issue` label
+
+The gate also syncs a single label, `no-issue` (`src/labels`), mirroring the
+**PR-issue-link check only** — a title-only failure never touches it:
+
+- link check **fails** and the label is absent → add it.
+- link check **passes** and the label is present → remove it.
+- otherwise → no-op.
+
+This runs during warn-only rollout too (it's informational, not the
+enforcement mechanism), so the label is already accurate across the backlog
+by the time `enforce` mode ships. Label sync is best-effort like the comment;
+a sync failure never fails the gate. If the repo doesn't have the `no-issue`
+label defined yet, the first add creates it (color/description in
+`src/labels/index.ts`) and retries — no manual setup required.
+
 ## Architecture — pure core + injected IO
 
 ```
@@ -117,6 +136,7 @@ ParsedRef  ──►  ResolvedRef  ──►  PolicyDecision
 | `src/title/`    | Pure title lint (commitlint active rules) + bot-author exemption               |
 | `src/gate/`     | Orchestrates link (+ backport hop) + title into one `GateOutcome`              |
 | `src/comment/`  | Sticky-comment render + idempotent upsert (pure logic + `fetch` adapter)       |
+| `src/labels/`   | `no-issue` label sync, mirroring the PR-issue-link check (pure logic + `fetch` adapter) |
 | `src/gha.ts`    | Minimal `@actions/core` replacement                                            |
 | `src/lint.ts`   | The gate entrypoint (warn-only)                                                |
 
@@ -127,7 +147,7 @@ The gate runs on **`pull_request_target`, metadata-only**
 
 - The PR body is read from the event payload — the workflow **never checks out
   the PR head**. The only checkout takes the base ref (to load this action).
-- A privileged token (reused `MONOREPO_RELEASE_APP`) lets later versions post a
+- A privileged token (reused `MONOREPO_RELEASE_APP`) lets the gate post a
   sticky comment and sync the display-only `no-issue` label, including on fork
   PRs. `GITHUB_TOKEN` on plain `pull_request` cannot do that for forks.
 

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -38,12 +38,12 @@ Given a PR body:
 
 ### Decision table
 
-| Situation | Result |
-|---|---|
-| Section links a **live issue** via a closing or contributor ref | ✅ pass |
+|                            Situation                             | Result |
+|------------------------------------------------------------------|--------|
+| Section links a **live issue** via a closing or contributor ref  | ✅ pass |
 | Opt-out checkbox ticked (`This PR does not need a linked issue`) | ✅ pass |
-| Section links a **pull request** (message names it) | ❌ fail |
-| No satisfying ref **and** no opt-out | ❌ fail |
+| Section links a **pull request** (message names it)              | ❌ fail |
+| No satisfying ref **and** no opt-out                             | ❌ fail |
 
 Cross-repo refs (`owner/repo#N`) and the `Backport of #N` marker never satisfy
 the requirement on their own. A bare `#N` **does** count (contributor ref).
@@ -65,14 +65,14 @@ ParsedRef  ──►  ResolvedRef  ──►  PolicyDecision
   action ships with **zero runtime dependencies** — the committed bundle is
   entirely our own code.
 
-| File | Role |
-|---|---|
-| `src/types.ts` | The `ParsedRef → ResolvedRef → PolicyDecision` contract + `Resolver` interface |
-| `src/parser/` | Pure section-scoped reference extraction (shared with the generator) |
-| `src/policy/` | Pure PASS/FAIL decision from resolved refs + opt-out state |
-| `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo) |
-| `src/gha.ts` | Minimal `@actions/core` replacement |
-| `src/lint.ts` | The gate entrypoint (warn-only) |
+|      File       |                                      Role                                      |
+|-----------------|--------------------------------------------------------------------------------|
+| `src/types.ts`  | The `ParsedRef → ResolvedRef → PolicyDecision` contract + `Resolver` interface |
+| `src/parser/`   | Pure section-scoped reference extraction (shared with the generator)           |
+| `src/policy/`   | Pure PASS/FAIL decision from resolved refs + opt-out state                     |
+| `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo)                        |
+| `src/gha.ts`    | Minimal `@actions/core` replacement                                            |
+| `src/lint.ts`   | The gate entrypoint (warn-only)                                                |
 
 ## Security model
 

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -1,0 +1,110 @@
+# release-notes action
+
+Shared tooling for the release-notes pipeline (epic
+[#53605](https://github.com/camunda/camunda/issues/53605)). One TypeScript
+package with two entrypoints that import **one** reference parser:
+
+- `lint/` — the **PR-gate** ([#53593](https://github.com/camunda/camunda/issues/53593)):
+  validates that a PR links a tracked issue (or opts out). Live now, **warn-only**.
+- `generate/` — the **release-notes generator**
+  ([#57713](https://github.com/camunda/camunda/issues/57713)): builds the changelog
+  from the PRs shipped in a release range. **Not built yet.**
+
+## Why this exists
+
+Linking a PR to a tracked issue is currently optional and unvalidated, so
+features and fixes silently vanish from release notes (epic #53605, root
+cause 4). The fix is to enforce the link at PR time using the **exact same
+parser** the generator later uses to attribute PRs.
+
+That shared parser is the whole point: if the gate and the generator parsed
+differently, a PR could pass the gate and still be mis-attributed by the
+generator. Because they import the same module, **a green gate becomes a
+structural guarantee** that the generator will attribute the PR correctly.
+Do not fork the parser logic — extend it in `src/` and both consumers benefit.
+
+## What the gate does
+
+Given a PR body:
+
+1. Slice the `## Related issues` section (`extractSection`).
+2. Extract every reference in it (`parseRefs`): closing keywords
+   (`close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`),
+   the custom `completes #N`, the `Backport of #N` marker, `relates to #N`,
+   bare `#N`, `owner/repo#N`, and full GitHub URLs.
+3. Resolve each ref against the API (`resolver`): is it an issue, a PR, or
+   missing? Is it cross-repo?
+4. Decide PASS/FAIL (`policy`).
+
+### Decision table
+
+| Situation | Result |
+|---|---|
+| Section links a **live issue** via a closing or contributor ref | ✅ pass |
+| Opt-out checkbox ticked (`This PR does not need a linked issue`) | ✅ pass |
+| Section links a **pull request** (message names it) | ❌ fail |
+| No satisfying ref **and** no opt-out | ❌ fail |
+
+Cross-repo refs (`owner/repo#N`) and the `Backport of #N` marker never satisfy
+the requirement on their own. A bare `#N` **does** count (contributor ref).
+
+## Architecture — pure core + injected IO
+
+```
+ParsedRef  ──►  ResolvedRef  ──►  PolicyDecision
+(parser)       (resolver)        (policy)
+ pure, no IO    the one API call  pure, no IO
+```
+
+- `src/parser` and `src/policy` are pure functions — fully unit-tested, no
+  network (see `test/`).
+- `src/resolver` is the only part that touches the network (one `fetch` to the
+  issues API), behind the `Resolver` interface in `src/types.ts`, so the core
+  stays testable without mocking everything.
+- `src/gha.ts` is a ~40-line shim of the GitHub Actions calls we use, so the
+  action ships with **zero runtime dependencies** — the committed bundle is
+  entirely our own code.
+
+| File | Role |
+|---|---|
+| `src/types.ts` | The `ParsedRef → ResolvedRef → PolicyDecision` contract + `Resolver` interface |
+| `src/parser/` | Pure section-scoped reference extraction (shared with the generator) |
+| `src/policy/` | Pure PASS/FAIL decision from resolved refs + opt-out state |
+| `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo) |
+| `src/gha.ts` | Minimal `@actions/core` replacement |
+| `src/lint.ts` | The gate entrypoint (warn-only) |
+
+## Security model
+
+The gate runs on **`pull_request_target`, metadata-only**
+(`.github/workflows/release-notes-pr-gate.yml`):
+
+- The PR body is read from the event payload — the workflow **never checks out
+  the PR head**. The only checkout takes the base ref (to load this action).
+- A privileged token (reused `MONOREPO_RELEASE_APP`) lets later versions post a
+  sticky comment and sync the display-only `no-issue` label, including on fork
+  PRs. `GITHUB_TOKEN` on plain `pull_request` cannot do that for forks.
+
+Note: because `pull_request_target` uses the workflow definition from the
+**base** branch, this workflow only runs once it has landed on the target
+branch — the required-check spike can only be verified after merge to `main`.
+
+## Build & test
+
+Node 24. The `dist/` bundle is **committed** (Actions runs it directly, no
+runtime install) and kept fresh by CI (`release-notes-action-ci.yml` rebuilds
+and diffs it).
+
+```bash
+npm ci
+npm test        # parser + policy unit tests (node --test via tsx)
+npm run typecheck
+npm run build   # ncc -> lint/dist/index.js  (commit the result)
+```
+
+## Shared constants
+
+`SECTION_HEADING` and `OPT_OUT_PHRASE` in `src/parser/index.ts` are the single
+source of truth for the PR template wording. CI greps the template for
+`OPT_OUT_PHRASE`, so the parser and `.github/pull_request_template.md` cannot
+drift apart.

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -35,6 +35,7 @@ Given a PR body:
 3. Resolve each ref against the API (`resolver`): is it an issue, a PR, or
    missing? Is it cross-repo?
 4. Decide PASS/FAIL (`policy`).
+5. Reconcile a single sticky PR comment (`comment`) explaining the decision.
 
 ### Decision table
 
@@ -47,6 +48,21 @@ Given a PR body:
 
 Cross-repo refs (`owner/repo#N`) and the `Backport of #N` marker never satisfy
 the requirement on their own. A bare `#N` **does** count (contributor ref).
+
+### Sticky comment
+
+The gate keeps **one** sticky comment per PR, identified by a hidden marker so
+re-runs never stack duplicates (`src/comment`):
+
+- **fail** → create the comment (or update the existing one) with the reasons
+  and the fix.
+- **fixed** (fail → pass) → flip that same comment to a resolved note.
+- **never failed** → no comment at all, so the gate stays silent on the ~800
+  PRs that already link correctly.
+
+Comment sync is best-effort: an API failure is logged and never fails the gate.
+It posts under the app identity (not `GITHUB_TOKEN`) so it triggers the same
+downstream automations a human comment would.
 
 ## Architecture — pure core + injected IO
 
@@ -71,6 +87,7 @@ ParsedRef  ──►  ResolvedRef  ──►  PolicyDecision
 | `src/parser/`   | Pure section-scoped reference extraction (shared with the generator)           |
 | `src/policy/`   | Pure PASS/FAIL decision from resolved refs + opt-out state                     |
 | `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo)                        |
+| `src/comment/`  | Sticky-comment render + idempotent upsert (pure logic + `fetch` adapter)       |
 | `src/gha.ts`    | Minimal `@actions/core` replacement                                            |
 | `src/lint.ts`   | The gate entrypoint (warn-only)                                                |
 

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -25,7 +25,9 @@ Do not fork the parser logic — extend it in `src/` and both consumers benefit.
 
 ## What the gate does
 
-Given a PR body:
+The gate runs two checks (`gate.evaluateGate`) and reports a combined outcome.
+
+**PR-issue link** — given a PR body:
 
 1. Slice the `## Related issues` section (`extractSection`).
 2. Extract every reference in it (`parseRefs`): closing keywords
@@ -35,19 +37,44 @@ Given a PR body:
 3. Resolve each ref against the API (`resolver`): is it an issue, a PR, or
    missing? Is it cross-repo?
 4. Decide PASS/FAIL (`policy`).
-5. Reconcile a single sticky PR comment (`comment`) explaining the decision.
 
-### Decision table
+**Title** — lint the PR title against the active `commitlint.config.cjs` rules
+(`title`): `type: subject` shape, `type` in the enum, lower-case, no scope,
+header ≤ length. Skipped for bot authors (D16); their link/marker is still
+validated. See [Title lint](#title-lint).
+
+Then it reconciles a single sticky PR comment (`comment`) covering both checks.
+
+### Decision table (PR-issue link)
 
 |                            Situation                             | Result |
 |------------------------------------------------------------------|--------|
 | Section links a **live issue** via a closing or contributor ref  | ✅ pass |
 | Opt-out checkbox ticked (`This PR does not need a linked issue`) | ✅ pass |
+| **Backport** whose original PR is properly attributed (hop)      | ✅ pass |
 | Section links a **pull request** (message names it)              | ❌ fail |
 | No satisfying ref **and** no opt-out                             | ❌ fail |
 
-Cross-repo refs (`owner/repo#N`) and the `Backport of #N` marker never satisfy
-the requirement on their own. A bare `#N` **does** count (contributor ref).
+Cross-repo refs (`owner/repo#N`) never satisfy on their own. A bare `#N` **does**
+count (contributor ref).
+
+### Backport hop
+
+A backport PR passes on its own `## Related issues` section if it has one
+(manual backport template). Otherwise — the backport **bot** body carries only
+`⤵️ Backport of #N`, no section — the gate follows that marker to the **original
+PR** and validates *its* attribution (`deliveryPath: backportHop`). The backport
+inherits the original's linked issue (C7); the `Backport of #N` marker is never
+removed (the stale-backport tracker depends on it).
+
+### Title lint
+
+The title check reimplements the **active** `commitlint.config.cjs` rules
+(`type-empty`, `type-case`, `type-enum`, `scope-empty`, `header-max-length`) as
+a pure regex, so the action keeps **zero runtime dependencies** rather than
+vendoring `@commitlint` into the committed bundle. `TITLE_TYPES` and `HEADER_MAX`
+in `src/title` are the source of truth, and the action CI greps
+`commitlint.config.cjs` to fail if they ever drift.
 
 ### Sticky comment
 
@@ -85,8 +112,10 @@ ParsedRef  ──►  ResolvedRef  ──►  PolicyDecision
 |-----------------|--------------------------------------------------------------------------------|
 | `src/types.ts`  | The `ParsedRef → ResolvedRef → PolicyDecision` contract + `Resolver` interface |
 | `src/parser/`   | Pure section-scoped reference extraction (shared with the generator)           |
+| `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo, backport-hop PR fetch) |
 | `src/policy/`   | Pure PASS/FAIL decision from resolved refs + opt-out state                     |
-| `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo)                        |
+| `src/title/`    | Pure title lint (commitlint active rules) + bot-author exemption               |
+| `src/gate/`     | Orchestrates link (+ backport hop) + title into one `GateOutcome`              |
 | `src/comment/`  | Sticky-comment render + idempotent upsert (pure logic + `fetch` adapter)       |
 | `src/gha.ts`    | Minimal `@actions/core` replacement                                            |
 | `src/lint.ts`   | The gate entrypoint (warn-only)                                                |

--- a/.github/actions/release-notes/README.md
+++ b/.github/actions/release-notes/README.md
@@ -1,0 +1,254 @@
+# release-notes action
+
+Shared tooling for the release-notes pipeline (epic
+[#53605](https://github.com/camunda/camunda/issues/53605)). One TypeScript
+package with two entrypoints that import **one** reference parser:
+
+- `lint/` — the **PR-gate** ([#53593](https://github.com/camunda/camunda/issues/53593)):
+  validates that a PR links a tracked issue (or opts out) and lints its title;
+  syncs a sticky comment and a `no-issue` label. Live now, **warn-only**.
+- `generate/` — the **release-notes generator**
+  ([#57713](https://github.com/camunda/camunda/issues/57713)): builds the changelog
+  from the PRs shipped in a release range. **Not built yet.**
+
+## Why this exists
+
+Linking a PR to a tracked issue is currently optional and unvalidated, so
+features and fixes silently vanish from release notes (epic #53605, root
+cause 4). The fix is to enforce the link at PR time using the **exact same
+parser** the generator later uses to attribute PRs.
+
+That shared parser is the whole point: if the gate and the generator parsed
+differently, a PR could pass the gate and still be mis-attributed by the
+generator. Because they import the same module, **a green gate becomes a
+structural guarantee** that the generator will attribute the PR correctly.
+Do not fork the parser logic — extend it in `src/` and both consumers benefit.
+
+## What the gate does
+
+The gate runs two checks (`gate.evaluateGate`) and reports a combined outcome.
+
+**PR-issue link** — given a PR body:
+
+1. Slice the `## Related issues` section (`extractSection`).
+2. Extract every reference in it (`parseRefs`): closing keywords
+   (`close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`),
+   the custom `completes #N`, the `Backport of #N` marker, `relates to #N`,
+   bare `#N`, `owner/repo#N`, and full GitHub URLs.
+3. Resolve each ref against the API (`resolver`): is it an issue, a PR, or
+   missing? Is it cross-repo?
+4. Decide PASS/FAIL (`policy`).
+
+**Title** — lint the PR title against the active `commitlint.config.cjs` rules
+(`title`): `type: subject` shape, `type` in the enum, lower-case, no scope,
+header ≤ length. Skipped for bot authors (D16); their link/marker is still
+validated. See [Title lint](#title-lint) and [Bot exemptions](#bot-exemptions).
+
+Then it reconciles a single sticky PR comment (`comment`) covering both checks,
+and syncs the display-only `no-issue` label (`labels`) to the PR-issue-link
+check alone.
+
+### Decision table (PR-issue link)
+
+|                             Situation                             | Result |
+|-------------------------------------------------------------------|--------|
+| Section links a **live issue** via a closing or contributor ref   | ✅ pass |
+| Opt-out checkbox ticked (`This PR does not need a linked issue`)  | ✅ pass |
+| **Backport** whose original PR is properly attributed (hop)       | ✅ pass |
+| Author is an exempt bot (`renovate[bot]`) and nothing else passed | ✅ pass |
+| Section links a **pull request** (message names it)               | ❌ fail |
+| No satisfying ref **and** no opt-out                              | ❌ fail |
+
+Cross-repo refs (`owner/repo#N`) never satisfy on their own. A bare `#N` **does**
+count (contributor ref).
+
+### Bot exemptions
+
+Two separate sets in `src/title`, and they must stay separate:
+
+- `BOT_TITLE_EXEMPT` — skips the **title** check for bots whose titles are
+  machine-generated (D16). Their link/marker is still validated.
+- `BOT_LINK_EXEMPT` — skips the **link** check. Currently `renovate[bot]` only:
+  it opens PRs from its own template and will never tick the opt-out, and
+  dependency bumps are not release-notes material.
+
+`BOT_LINK_EXEMPT` must **never** be replaced by `BOT_TITLE_EXEMPT`. That set
+contains `monorepo-devops-automation[bot]`, the author of every backport PR;
+exempting it from the link check would skip the [backport hop](#backport-hop), so
+backports would stop inheriting their original's issue and silently drop out of
+the release notes — the exact failure this gate exists to prevent.
+
+The link exemption is applied **after** the hop and only to a still-failing
+link, so it is a fallback and never a bypass: a bot PR that does link an issue
+keeps its real policy code (`section-closing`, not `bot-exempt`).
+
+### Backport hop
+
+A backport PR passes on its own `## Related issues` section if it has one
+(manual backport template). Otherwise — the backport **bot** body carries only
+`⤵️ Backport of #N`, no section — the gate follows that marker to the **original
+PR** and validates *its* attribution (`deliveryPath: backportHop`). The backport
+inherits the original's linked issue (C7); the `Backport of #N` marker is never
+removed (the stale-backport tracker depends on it).
+
+The hop only fires when the link is otherwise **undeclared** — a section that
+links a pull request is a hard error and is *not* rescued by an unrelated
+`Backport of #N`. When the marker cannot be followed to an original PR the
+message names why: it points at an **issue** (not a PR), it **doesn't resolve**
+to anything in this repo, or it's **cross-repo** (`owner/other#N`, which this
+action can't validate) — rather than folding into the generic "no linked issue"
+message.
+
+HTML comments are stripped before parsing, so the PR template's own instructional
+`<!-- … closes #1234 … -->` boilerplate is never mistaken for a real ref.
+
+### Title lint
+
+The title check reimplements the **active** `commitlint.config.cjs` rules
+(`type-empty`, `type-case`, `type-enum`, `scope-empty`, `header-max-length`) as
+a pure regex, so the action keeps **zero runtime dependencies** rather than
+vendoring `@commitlint` into the committed bundle. `TITLE_TYPES` and `HEADER_MAX`
+in `src/title` are the source of truth, and the action CI greps
+`commitlint.config.cjs` to fail if they ever drift.
+
+### Sticky comment
+
+The gate keeps **one** sticky comment per PR, identified by a hidden marker so
+re-runs never stack duplicates (`src/comment`):
+
+- **fail** → create the comment (or update the existing one) with the reasons
+  and the fix.
+- **fixed** (fail → pass) → flip that same comment to a resolved note.
+- **never failed** → no comment at all, so the gate stays silent on the ~800
+  PRs that already link correctly.
+
+The body is deliberately terse — the failing reasons and a link to
+[Causes and fixes](https://camunda.github.io/camunda/ci/#release-notes-pr-gate).
+Everything else (why the rule exists, the full cause list, the rollout state)
+lives in the docs rather than being restated on every failing PR.
+
+Comment sync is best-effort: an API failure is logged and never fails the gate.
+It posts with `GITHUB_TOKEN` as `github-actions[bot]` — nothing reacts to this
+comment as an event, so no App identity (and therefore no Vault secret) is
+needed. Skipped on fork PRs; see [Fork pull requests](#fork-pull-requests).
+
+### `no-issue` label
+
+The gate also syncs a single label, `no-issue` (`src/labels`), mirroring the
+**PR-issue-link check only** — a title-only failure never touches it:
+
+- link check **fails** and the label is absent → add it.
+- link check **passes** and the label is present → remove it.
+- otherwise → no-op.
+
+This runs during warn-only rollout too (it's informational, not the
+enforcement mechanism), so the label is already accurate across the backlog
+by the time `enforce` mode ships. Label sync is best-effort like the comment;
+a sync failure never fails the gate. Skipped on fork PRs; see
+[Fork pull requests](#fork-pull-requests).
+
+The label already exists in this repo. If it is ever deleted, the next add
+recreates it and retries, so an accidental deletion degrades to a self-heal
+instead of a failing sync. The constants in `src/labels/index.ts` therefore
+mirror the live label (colour `ededed`) — otherwise a delete-then-heal cycle
+would silently reskin it.
+
+The label is a projection for humans (PR-list filtering and search), not a
+signal to build on: it is skipped on fork PRs and anyone can add or remove it by
+hand. The generator (#57713) must read the ticked opt-out checkbox and the
+shared bot-exemption sets in `src/`, never this label.
+
+## Architecture — pure core + injected IO
+
+```
+ParsedRef  ──►  ResolvedRef  ──►  PolicyDecision
+(parser)       (resolver)        (policy)
+ pure, no IO    the one API call  pure, no IO
+```
+
+- `src/parser` and `src/policy` are pure functions — fully unit-tested, no
+  network (see `test/`).
+- `src/resolver` is the only part that touches the network (one `fetch` to the
+  issues API), behind the `Resolver` interface in `src/types.ts`, so the core
+  stays testable without mocking everything.
+- `src/gha.ts` is a ~40-line shim of the GitHub Actions calls we use, so the
+  action ships with **zero runtime dependencies** — the committed bundle is
+  entirely our own code.
+
+|      File       |                                          Role                                           |
+|-----------------|-----------------------------------------------------------------------------------------|
+| `src/types.ts`  | The `ParsedRef → ResolvedRef → PolicyDecision` contract + `Resolver` interface          |
+| `src/parser/`   | Pure section-scoped reference extraction (shared with the generator)                    |
+| `src/resolver/` | GitHub-API adapter (issue vs PR vs missing, cross-repo, backport-hop PR fetch)          |
+| `src/policy/`   | Pure PASS/FAIL decision from resolved refs + opt-out state                              |
+| `src/title/`    | Pure title lint (commitlint active rules) + bot-author exemption                        |
+| `src/gate/`     | Orchestrates link (+ backport hop) + title into one `GateOutcome`                       |
+| `src/comment/`  | Sticky-comment render + idempotent upsert (pure logic + `fetch` adapter)                |
+| `src/labels/`   | `no-issue` label sync, mirroring the PR-issue-link check (pure logic + `fetch` adapter) |
+| `src/gha.ts`    | Minimal `@actions/core` replacement                                                     |
+| `src/lint.ts`   | The gate entrypoint (warn-only)                                                         |
+
+## Security model
+
+The gate is one workflow, `release-notes-pr-gate.yml`, on plain **`pull_request`**
+(`opened, edited, synchronize, reopened`; base `main` and `stable/**`).
+`pull_request_target` is **not** used and cannot be — it is denied repo-wide by
+`.github/conftest-gha-best-practices.rego`.
+
+- **Metadata-only.** The action reads the PR through the API and never checks out
+  or executes PR code.
+- **No privileged token.** `GITHUB_TOKEN` only, with `pull-requests: write` (the
+  comment and label) and `issues: write` (recreating a deleted `no-issue` label).
+  No Vault, no App token.
+- **The check is the job's own conclusion.** GitHub renders it on the PR
+  natively, so the gate publishes nothing itself — and it works on fork PRs
+  without any token.
+- **Accepted trade-off:** on `pull_request` the workflow and this action resolve
+  from the PR head, so a PR can edit the code that judges it. That is the same
+  trust model as every other lint in `ci.yml` (actionlint, spotless, commitlint),
+  and it is acceptable while this check is **advisory** — it is not a required
+  status check, so it is not a security boundary. `.github/**` is
+  CODEOWNERS-gated, so a tampering diff still needs review.
+  ⚠ **This must be resolved before the check is made required**, at which point a
+  PR could pass itself by editing the action. See epic #53605.
+
+### Fork pull requests
+
+GitHub gives a fork PR a **read-only** `GITHUB_TOKEN` and withholds secrets, no
+matter what `permissions:` asks for. The workflow therefore passes
+`can-write: false` for forks (derived from
+`github.event.pull_request.head.repo.full_name == github.repository`), and:
+
+|                          Capability                          | Internal PR |  Fork PR  |
+|--------------------------------------------------------------|-------------|-----------|
+| Parse the body/title, resolve refs, backport hop (API reads) | ✅           | ✅         |
+| Job summary + job log                                        | ✅           | ✅         |
+| Red/green check row on the PR (the job's conclusion)         | ✅           | ✅         |
+| Sticky comment                                               | ✅           | ❌ skipped |
+| `no-issue` label                                             | ✅           | ❌ skipped |
+
+So a fork PR is **fully evaluated** and its verdict is fully visible — only the
+two writes are skipped, and the job log says so explicitly rather than surfacing
+a 403. This is a hard GitHub limitation, not a gap in the action: posting to a
+fork PR requires a privileged token, which is precisely what must not be exposed
+to PR-head code.
+
+## Build & test
+
+Node 24. The `dist/` bundle is **committed** (Actions runs it directly, no
+runtime install) and kept fresh by CI (`release-notes-action-ci.yml` rebuilds
+and diffs it).
+
+```bash
+npm ci
+npm test        # parser + policy unit tests (node --test via tsx)
+npm run typecheck
+npm run build   # ncc -> lint/dist/index.js  (commit the result)
+```
+
+## Shared constants
+
+`SECTION_HEADING` and `OPT_OUT_PHRASE` in `src/parser/index.ts` are the single
+source of truth for the PR template wording. CI greps the template for
+`OPT_OUT_PHRASE`, so the parser and `.github/pull_request_template.md` cannot
+drift apart.

--- a/.github/actions/release-notes/lint/action.yml
+++ b/.github/actions/release-notes/lint/action.yml
@@ -7,8 +7,8 @@ description: >
 inputs:
   token:
     description: >
-      Token used to read issue/PR metadata and to post the sticky comment (and,
-      in later versions, sync the no-issue label). Reuses MONOREPO_RELEASE_APP.
+      Token used to read issue/PR metadata, post the sticky comment, and sync
+      the no-issue label. Reuses MONOREPO_RELEASE_APP.
     required: true
   enforce:
     description: When 'true', a failing check exits non-zero. Warn-only otherwise.
@@ -21,6 +21,8 @@ outputs:
     description: direct | backportHop — how the PR-issue link was satisfied.
   failed-checks:
     description: Comma-separated labels of the checks that failed (empty on pass).
+  label-action:
+    description: added | removed | noop — what the no-issue label sync did.
 runs:
   using: node24
   main: dist/index.js

--- a/.github/actions/release-notes/lint/action.yml
+++ b/.github/actions/release-notes/lint/action.yml
@@ -1,0 +1,23 @@
+name: Release-notes PR-gate lint
+description: >
+  Validates that a PR links a tracked issue (or ticks the opt-out) using the
+  shared release-notes reference parser. Metadata-only; must run on
+  pull_request_target and must never check out the PR head.
+inputs:
+  token:
+    description: >
+      Token used to read issue/PR metadata (and, in later versions, to post the
+      sticky comment and sync the no-issue label). Reuses MONOREPO_RELEASE_APP.
+    required: true
+  enforce:
+    description: When 'true', a failing check exits non-zero. Warn-only otherwise.
+    required: false
+    default: 'false'
+outputs:
+  outcome:
+    description: pass | fail
+  code:
+    description: The PolicyCode explaining the outcome.
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/release-notes/lint/action.yml
+++ b/.github/actions/release-notes/lint/action.yml
@@ -1,13 +1,14 @@
 name: Release-notes PR-gate lint
 description: >
-  Validates that a PR links a tracked issue (or ticks the opt-out) using the
-  shared release-notes reference parser. Metadata-only; must run on
-  pull_request_target and must never check out the PR head.
+  Validates that a PR links a tracked issue (or ticks the opt-out) and that its
+  title is a conventional commit, using the shared release-notes reference
+  parser. Metadata-only; must run on pull_request_target and must never check
+  out the PR head.
 inputs:
   token:
     description: >
-      Token used to read issue/PR metadata (and, in later versions, to post the
-      sticky comment and sync the no-issue label). Reuses MONOREPO_RELEASE_APP.
+      Token used to read issue/PR metadata and to post the sticky comment (and,
+      in later versions, sync the no-issue label). Reuses MONOREPO_RELEASE_APP.
     required: true
   enforce:
     description: When 'true', a failing check exits non-zero. Warn-only otherwise.
@@ -15,9 +16,11 @@ inputs:
     default: 'false'
 outputs:
   outcome:
-    description: pass | fail
-  code:
-    description: The PolicyCode explaining the outcome.
+    description: pass | fail (combined across all checks)
+  delivery-path:
+    description: direct | backportHop — how the PR-issue link was satisfied.
+  failed-checks:
+    description: Comma-separated labels of the checks that failed (empty on pass).
 runs:
   using: node24
   main: dist/index.js

--- a/.github/actions/release-notes/lint/action.yml
+++ b/.github/actions/release-notes/lint/action.yml
@@ -1,0 +1,42 @@
+name: Release-notes PR-gate lint
+description: >
+  Validates that a PR links a tracked issue (or ticks the opt-out) and that its
+  title is a conventional commit, using the shared release-notes reference
+  parser. Metadata-only — it reads the PR through the API and never checks out or
+  executes PR code.
+inputs:
+  token:
+    description: >
+      Token used to read issue/PR metadata and — when can-write is true — post
+      the sticky comment and sync the no-issue label. Pass GITHUB_TOKEN; the job
+      needs `pull-requests: write` for the comment and label, plus `issues:
+      write` so a deleted no-issue label can be recreated.
+    required: true
+  pr-number:
+    description: The pull request to evaluate, e.g. github.event.pull_request.number.
+    required: true
+  can-write:
+    description: >
+      Whether the token can write to this PR. Pass false for fork PRs, where
+      GitHub issues a read-only token regardless of the requested permissions:
+      the gate still evaluates and reports to the job summary, but skips the
+      comment and label instead of failing on a 403. Defaults to false so a
+      caller that forgets it degrades to read-only rather than erroring.
+    required: false
+    default: 'false'
+  enforce:
+    description: When 'true', a failing check exits non-zero. Warn-only otherwise.
+    required: false
+    default: 'false'
+outputs:
+  outcome:
+    description: pass | fail (combined across all checks)
+  delivery-path:
+    description: direct | backportHop — how the PR-issue link was satisfied.
+  failed-checks:
+    description: Comma-separated labels of the checks that failed (empty on pass).
+  label-action:
+    description: added | removed | noop — what the no-issue label sync did.
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -1,0 +1,422 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 93:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.summary = exports.setFailed = exports.warning = exports.info = exports.setOutput = exports.getBooleanInput = exports.getInput = void 0;
+const node_fs_1 = __nccwpck_require__(24);
+/**
+ * ponytail: the ~7 GitHub Actions toolkit calls we actually use, inlined.
+ * @actions/core drags in @actions/exec + http-client + io (~400kB) for OIDC and
+ * command features this action never touches. These are the documented Actions
+ * command/file protocols — nothing clever.
+ */
+const escape = (s) => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+const appendEnvFile = (envVar, content) => {
+    const file = process.env[envVar];
+    if (file)
+        (0, node_fs_1.appendFileSync)(file, content);
+};
+const getInput = (name, opts = {}) => {
+    const value = (process.env[`INPUT_${name.toUpperCase().replace(/ /g, '_')}`] ?? '').trim();
+    if (opts.required && !value)
+        throw new Error(`Input required and not supplied: ${name}`);
+    return value;
+};
+exports.getInput = getInput;
+const getBooleanInput = (name) => (0, exports.getInput)(name).toLowerCase() === 'true';
+exports.getBooleanInput = getBooleanInput;
+// GITHUB_OUTPUT file protocol with a heredoc delimiter (safe for multiline values).
+const setOutput = (name, value) => appendEnvFile('GITHUB_OUTPUT', `${name}<<_GHA_EOF_\n${value}\n_GHA_EOF_\n`);
+exports.setOutput = setOutput;
+const info = (msg) => {
+    process.stdout.write(`${msg}\n`);
+};
+exports.info = info;
+const warning = (msg) => {
+    process.stdout.write(`::warning::${escape(msg)}\n`);
+};
+exports.warning = warning;
+const setFailed = (msg) => {
+    process.stdout.write(`::error::${escape(msg)}\n`);
+    process.exitCode = 1;
+};
+exports.setFailed = setFailed;
+class Summary {
+    buf = '';
+    addHeading(text, level = 1) {
+        this.buf += `<h${level}>${text}</h${level}>\n`;
+        return this;
+    }
+    addList(items) {
+        this.buf += `<ul>${items.map((i) => `<li>${i}</li>`).join('')}</ul>\n`;
+        return this;
+    }
+    async write() {
+        appendEnvFile('GITHUB_STEP_SUMMARY', this.buf);
+        this.buf = '';
+    }
+}
+exports.summary = new Summary();
+
+
+/***/ }),
+
+/***/ 554:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const node_fs_1 = __nccwpck_require__(24);
+const core = __importStar(__nccwpck_require__(93));
+const parser_1 = __nccwpck_require__(883);
+const policy_1 = __nccwpck_require__(86);
+const resolver_1 = __nccwpck_require__(306);
+/**
+ * PR-gate lint entrypoint (spike / warn-only).
+ *
+ * Security: runs on pull_request_target, metadata-only. The PR body is read
+ * from the event payload — never by checking out the PR head. The privileged
+ * token comes in as an input (reused MONOREPO_RELEASE_APP).
+ *
+ * ponytail: warn-only for now — reports the decision to the job summary and
+ * outputs; the sticky comment, label sync, and enforce mode ship in follow-up
+ * PRs. `enforce=true` flips a fail into a non-zero exit.
+ */
+async function run() {
+    const token = core.getInput('token', { required: true });
+    const enforce = core.getBooleanInput('enforce');
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    const event = eventPath ? JSON.parse((0, node_fs_1.readFileSync)(eventPath, 'utf8')) : {};
+    const pr = event.pull_request;
+    if (!pr) {
+        core.info('No pull_request in payload; nothing to lint.');
+        return;
+    }
+    const body = pr.body ?? '';
+    const section = (0, parser_1.extractSection)(body);
+    const optOut = (0, parser_1.isOptOutTicked)(body);
+    const refs = section ? (0, parser_1.parseRefs)(section) : [];
+    const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
+    const resolver = new resolver_1.GithubResolver(token, owner ?? '', repo ?? '');
+    const resolved = await resolver.resolve(refs);
+    const decision = (0, policy_1.decide)(resolved, optOut);
+    core.setOutput('outcome', decision.outcome);
+    core.setOutput('code', decision.code);
+    const heading = decision.outcome === 'pass' ? '✅ PR-issue link check passed' : '❌ PR-issue link check failed';
+    await core.summary
+        .addHeading(heading, 3)
+        .addList(decision.reasons.slice())
+        .write();
+    if (decision.outcome === 'fail') {
+        const msg = decision.reasons.join(' ');
+        if (enforce)
+            core.setFailed(msg);
+        else
+            core.warning(`[warn-only] ${msg}`);
+    }
+    else {
+        core.info(decision.reasons.join(' '));
+    }
+}
+run().catch((err) => core.setFailed(err instanceof Error ? err.message : String(err)));
+
+
+/***/ }),
+
+/***/ 883:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.SECTION_HEADING = exports.OPT_OUT_PHRASE = void 0;
+exports.parseRefs = parseRefs;
+exports.extractSection = extractSection;
+exports.isOptOutTicked = isOptOutTicked;
+/**
+ * Pure, section-scoped reference parser. Shared verbatim with the generator
+ * (#57713) — no IO, no repo awareness. Cross-repo detection and issue-vs-PR
+ * classification belong to the Resolver, not here.
+ */
+/** The template's opt-out phrase. Kept as an exported constant so the PR template
+ *  and the parser cannot drift (enforced by the repo-constant grep in CI). */
+exports.OPT_OUT_PHRASE = 'this pr does not need a linked issue';
+/** The section whose refs the gate evaluates. */
+exports.SECTION_HEADING = 'Related issues';
+// GitHub's closing keywords + our custom "completes". Case-insensitive.
+const CLOSING = /^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?)$/i;
+const RELATES = /^relates?\s+to$/i;
+const BACKPORT = /^backport\s+of$/i;
+// Optional keyword prefix shared by both ref shapes.
+const KW = String.raw `(?:\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?|relates?\s+to|backport\s+of)\b[\s:]+)?`;
+const OWNER_REPO = String.raw `([A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*)`;
+// "closes #12", "camunda/other#7", bare "#12".
+const SHORTHAND = new RegExp(KW + `(?:${OWNER_REPO})?#(\\d+)`, 'gi');
+// Full GitHub URLs: ".../owner/repo/issues/12" or ".../pull/12".
+const URL = new RegExp(KW + String.raw `https?:\/\/github\.com\/${OWNER_REPO}\/(?:issues|pull)\/(\d+)`, 'gi');
+function kindOf(keyword) {
+    if (keyword && BACKPORT.test(keyword))
+        return 'backport';
+    if (keyword && RELATES.test(keyword))
+        return 'contributor';
+    if (keyword && CLOSING.test(keyword))
+        return 'closing';
+    return 'contributor'; // bare "#N"
+}
+/** Extract every reference from the given text (already scoped by the caller). */
+function parseRefs(text) {
+    const refs = [];
+    const seen = new Set(); // dedupe by match offset
+    const push = (m, repo, num) => {
+        if (seen.has(m.index))
+            return;
+        seen.add(m.index);
+        const keyword = m[1] ? m[1].toLowerCase().replace(/\s+/g, ' ') : null;
+        refs.push({
+            raw: m[0].trim(),
+            number: Number(num),
+            repo: repo ?? null,
+            keyword,
+            kind: kindOf(keyword),
+            index: m.index,
+        });
+    };
+    for (const m of text.matchAll(URL))
+        push(m, m[2] ?? null, m[3]);
+    for (const m of text.matchAll(SHORTHAND))
+        push(m, m[2] ?? null, m[3]);
+    return refs.sort((a, b) => a.index - b.index);
+}
+/**
+ * Slice out a markdown section body: everything after the matching heading up
+ * to the next heading of any level (or EOF). Returns null if absent.
+ */
+function extractSection(body, heading = exports.SECTION_HEADING) {
+    const lines = body.split(/\r?\n/);
+    const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
+    const start = lines.findIndex((l) => headingRe.test(l.trim()));
+    if (start < 0)
+        return null;
+    const rest = lines.slice(start + 1);
+    const end = rest.findIndex((l) => /^#{1,6}\s+\S/.test(l));
+    return (end < 0 ? rest : rest.slice(0, end)).join('\n');
+}
+/** True when the opt-out checkbox is present and ticked. */
+function isOptOutTicked(body) {
+    const re = new RegExp(String.raw `^\s*[-*]\s*\[x\]\s*.*${escapeRe(exports.OPT_OUT_PHRASE)}`, 'im');
+    return re.test(body);
+}
+function escapeRe(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+
+/***/ }),
+
+/***/ 86:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.decide = decide;
+/**
+ * Pure PR-gate decision. Given the resolved refs found inside the section and
+ * whether the opt-out checkbox is ticked, decide PASS/FAIL with reasons that
+ * name the offending ref and the exact fix.
+ *
+ * Precedence (a PR ref is always an error, even alongside a valid issue ref):
+ *   1. any same-repo ref resolves to a PR      -> FAIL pr-ref-in-section
+ *   2. opt-out ticked                          -> PASS opt-out
+ *   3. a same-repo ref resolves to a live issue -> PASS section-(closing|contributor)
+ *   4. otherwise                               -> FAIL unlinked-undeclared
+ *
+ * Cross-repo refs and backport markers never satisfy the requirement on their own.
+ */
+function decide(refs, optOut) {
+    const sameRepo = refs.filter((r) => !r.crossRepo && r.kind !== 'backport');
+    const prRefs = sameRepo.filter((r) => r.target === 'pullRequest');
+    if (prRefs.length > 0) {
+        const list = prRefs.map((r) => `#${r.number}`).join(', ');
+        return {
+            outcome: 'fail',
+            code: 'pr-ref-in-section',
+            reasons: [
+                `The "Related issues" section links a pull request (${list}), not an issue.`,
+                'Link the tracked issue this PR resolves (e.g. "closes #1234"), or tick the opt-out checkbox.',
+            ],
+        };
+    }
+    if (optOut) {
+        return { outcome: 'pass', code: 'opt-out', reasons: ['Opt-out checkbox ticked: no linked issue required.'] };
+    }
+    const liveIssues = sameRepo.filter((r) => r.target === 'issue');
+    if (liveIssues.length > 0) {
+        const closing = liveIssues.some((r) => r.kind === 'closing');
+        const list = liveIssues.map((r) => `#${r.number}`).join(', ');
+        return {
+            outcome: 'pass',
+            code: closing ? 'section-closing' : 'section-contributor',
+            reasons: [`Linked to issue ${list} in the "Related issues" section.`],
+        };
+    }
+    const dead = sameRepo.filter((r) => r.target === 'missing').map((r) => `#${r.number}`);
+    const crossRepo = refs.filter((r) => r.crossRepo).map((r) => r.raw);
+    const reasons = [
+        'No linked issue found in the "Related issues" section, and the opt-out checkbox is not ticked.',
+        'Add a closing keyword with the tracked issue (e.g. "closes #1234"), or tick the opt-out checkbox.',
+    ];
+    if (dead.length)
+        reasons.push(`These refs do not resolve to an existing issue: ${dead.join(', ')}.`);
+    if (crossRepo.length)
+        reasons.push(`Cross-repo refs do not count toward this repo's release notes: ${crossRepo.join(', ')}.`);
+    return { outcome: 'fail', code: 'unlinked-undeclared', reasons };
+}
+
+
+/***/ }),
+
+/***/ 306:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GithubResolver = void 0;
+/**
+ * GitHub-API resolver: the only part of the pipeline that touches the network.
+ * Classifies each ref as issue vs PR vs missing and flags cross-repo refs.
+ *
+ * GitHub's issues API returns PRs too (a PR is an issue with a `pull_request`
+ * field), so one lookup per number classifies both. Cross-repo refs are not
+ * queried — they never satisfy the gate, so their target stays "missing".
+ *
+ * ponytail: plain fetch (Node 24 global) over octokit — we hit exactly one
+ * endpoint; octokit would inline the whole REST client into the bundle.
+ */
+class GithubResolver {
+    token;
+    owner;
+    repo;
+    constructor(token, owner, repo) {
+        this.token = token;
+        this.owner = owner;
+        this.repo = repo;
+    }
+    async resolve(refs) {
+        return Promise.all(refs.map((ref) => this.resolveOne(ref)));
+    }
+    async resolveOne(ref) {
+        const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+        if (crossRepo)
+            return { ...ref, target: 'missing', crossRepo: true };
+        const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${ref.number}`, {
+            headers: {
+                authorization: `Bearer ${this.token}`,
+                accept: 'application/vnd.github+json',
+                'x-github-api-version': '2022-11-28',
+                'user-agent': 'camunda-release-notes-gate',
+            },
+        });
+        if (res.status === 404)
+            return { ...ref, target: 'missing', crossRepo: false };
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);
+        const data = (await res.json());
+        return { ...ref, target: data.pull_request ? 'pullRequest' : 'issue', crossRepo: false };
+    }
+}
+exports.GithubResolver = GithubResolver;
+
+
+/***/ }),
+
+/***/ 24:
+/***/ ((module) => {
+
+module.exports = require("node:fs");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(554);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -243,6 +243,133 @@ exports.summary = new Summary();
 
 /***/ }),
 
+/***/ 855:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GithubLabelApi = exports.NO_ISSUE_LABEL_DESCRIPTION = exports.NO_ISSUE_LABEL_COLOR = exports.NO_ISSUE_LABEL = void 0;
+exports.decideLabelAction = decideLabelAction;
+exports.syncNoIssueLabel = syncNoIssueLabel;
+/**
+ * Syncs the display-only `no-issue` label to mirror the PR-issue-link check
+ * only (not the title check — the label answers one question: "does this PR
+ * link a tracked issue?"). Best-effort like the sticky comment: a sync
+ * failure never fails the gate, and it runs regardless of `enforce` — the
+ * label is informational, not a blocking mechanism.
+ */
+/** The label the gate syncs. Single source of truth — do not rename without
+ *  updating any saved searches/dashboards that filter on it. */
+exports.NO_ISSUE_LABEL = 'no-issue';
+/** Created on demand (see GithubLabelApi.ensureLabelExists) if the repo does
+ *  not already have this label — keeps rollout self-contained. */
+exports.NO_ISSUE_LABEL_COLOR = 'e4e669';
+exports.NO_ISSUE_LABEL_DESCRIPTION = 'Release-notes gate: this PR does not link a tracked issue (warn-only).';
+/** Pure decision: given the PR's current labels and the link check's
+ * outcome, decide whether to add/remove the no-issue label. */
+function decideLabelAction(currentLabels, linkOutcome) {
+    const has = currentLabels.includes(exports.NO_ISSUE_LABEL);
+    if (linkOutcome === 'fail')
+        return has ? 'noop' : 'added';
+    return has ? 'removed' : 'noop';
+}
+/**
+ * Reconcile the no-issue label against the gate's PR-issue-link check.
+ * Reads the check by label rather than gate.outcome so a title-only failure
+ * never adds a label whose name specifically means "no linked issue".
+ */
+async function syncNoIssueLabel(api, gate) {
+    const link = gate.checks.find((check) => check.label === 'PR-issue link');
+    if (!link)
+        return 'noop'; // defensive — the link check is always present today
+    const current = await api.list();
+    const action = decideLabelAction(current, link.outcome);
+    if (action === 'added')
+        await api.add(exports.NO_ISSUE_LABEL);
+    if (action === 'removed')
+        await api.remove(exports.NO_ISSUE_LABEL);
+    return action;
+}
+/**
+ * issue-labels API over plain fetch. Same rationale as GithubCommentApi /
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost isn't
+ * worth paying.
+ */
+class GithubLabelApi {
+    token;
+    issueNumber;
+    repoUrl;
+    constructor(token, owner, repo, issueNumber) {
+        this.token = token;
+        this.issueNumber = issueNumber;
+        this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+    }
+    headers() {
+        return {
+            authorization: `Bearer ${this.token}`,
+            accept: 'application/vnd.github+json',
+            'content-type': 'application/json',
+            'x-github-api-version': '2022-11-28',
+            'user-agent': 'camunda-release-notes-gate',
+        };
+    }
+    async list() {
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
+            headers: this.headers(),
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} listing labels on #${this.issueNumber}`);
+        const data = (await res.json());
+        return data.map((label) => label.name);
+    }
+    async add(label) {
+        const res = await this.postLabel(label);
+        if (res.status === 404) {
+            // Repo doesn't have this label defined yet — create it once, then retry.
+            await this.ensureLabelExists(label);
+            const retry = await this.postLabel(label);
+            if (!retry.ok) {
+                throw new Error(`GitHub API ${retry.status} adding label "${label}" to #${this.issueNumber} after creating it`);
+            }
+            return;
+        }
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} adding label "${label}" to #${this.issueNumber}`);
+    }
+    async remove(label) {
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels/${encodeURIComponent(label)}`, {
+            method: 'DELETE',
+            headers: this.headers(),
+        });
+        // 404 means the label is already gone (e.g. a concurrent run removed it) — not an error.
+        if (!res.ok && res.status !== 404) {
+            throw new Error(`GitHub API ${res.status} removing label "${label}" from #${this.issueNumber}`);
+        }
+    }
+    postLabel(label) {
+        return fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels`, {
+            method: 'POST',
+            headers: this.headers(),
+            body: JSON.stringify({ labels: [label] }),
+        });
+    }
+    async ensureLabelExists(label) {
+        const res = await fetch(`${this.repoUrl}/labels`, {
+            method: 'POST',
+            headers: this.headers(),
+            body: JSON.stringify({ name: label, color: exports.NO_ISSUE_LABEL_COLOR, description: exports.NO_ISSUE_LABEL_DESCRIPTION }),
+        });
+        // 422 means another concurrent run already created it — not an error.
+        if (!res.ok && res.status !== 422) {
+            throw new Error(`GitHub API ${res.status} creating label "${label}"`);
+        }
+    }
+}
+exports.GithubLabelApi = GithubLabelApi;
+
+
+/***/ }),
+
 /***/ 554:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -285,6 +412,7 @@ const node_fs_1 = __nccwpck_require__(24);
 const comment_1 = __nccwpck_require__(573);
 const gate_1 = __nccwpck_require__(155);
 const core = __importStar(__nccwpck_require__(93));
+const labels_1 = __nccwpck_require__(855);
 const resolver_1 = __nccwpck_require__(306);
 /**
  * PR-gate lint entrypoint (warn-only rollout).
@@ -294,9 +422,11 @@ const resolver_1 = __nccwpck_require__(306);
  * privileged token comes in as an input (reused MONOREPO_RELEASE_APP).
  *
  * ponytail: warn-only for now — reports the combined gate outcome (PR-issue
- * link + title lint, with a backport hop) to the job summary, the outputs, and
- * a single sticky PR comment (created only on failure, flipped to resolved once
- * fixed). Label sync and enforce mode ship in follow-up PRs. `enforce=true`
+ * link + title lint, with a backport hop) to the job summary, the outputs, a
+ * single sticky PR comment (created only on failure, flipped to resolved once
+ * fixed), and the display-only `no-issue` label. Both the comment and the
+ * label sync regardless of `enforce` — they're informational, not the
+ * enforcement mechanism. Enforce mode ships in a follow-up PR. `enforce=true`
  * flips a fail into a non-zero exit.
  */
 async function run() {
@@ -336,6 +466,18 @@ async function run() {
         }
         catch (err) {
             core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+        }
+        // Display-only `no-issue` label, mirroring the PR-issue-link check. Runs
+        // during warn-only rollout too, so the label is already trustworthy by the
+        // time enforce mode lands — a sync failure never fails the gate.
+        try {
+            const labels = new labels_1.GithubLabelApi(token, owner ?? '', repo ?? '', pr.number);
+            const action = await (0, labels_1.syncNoIssueLabel)(labels, gate);
+            core.setOutput('label-action', action);
+            core.info(`no-issue label: ${action}.`);
+        }
+        catch (err) {
+            core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
         }
     }
     if (gate.outcome === 'fail') {

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -22,28 +22,30 @@ exports.syncStickyComment = syncStickyComment;
  * every future run finds the comment it already posted. */
 exports.STICKY_MARKER = '<!-- release-notes-pr-gate -->';
 /** Build the comment body (pure). Always carries the marker on the first line. */
-function renderStickyComment(decision) {
-    const title = decision.outcome === 'pass'
-        ? '### ✅ Release-notes: PR-issue link resolved'
-        : '### ❌ Release-notes: PR-issue link check';
-    const reasons = decision.reasons.map((reason) => `- ${reason}`).join('\n');
-    const footer = decision.outcome === 'pass'
-        ? '_This check now passes — no action needed._'
-        : '_Warn-only during rollout: this does not block merge yet. Fix the link (or tick the opt-out) so release notes attribute this change._';
-    return `${exports.STICKY_MARKER}\n${title}\n\n${reasons}\n\n${footer}\n`;
+function renderStickyComment(gate) {
+    if (gate.outcome === 'pass') {
+        return `${exports.STICKY_MARKER}\n### ✅ Release-notes checks passed\n\n_These checks now pass — no action needed._\n`;
+    }
+    // One block per failing check, each naming the reasons and the fix.
+    const blocks = gate.checks
+        .filter((check) => check.outcome === 'fail')
+        .map((check) => `**${check.label}**\n${check.reasons.map((reason) => `- ${reason}`).join('\n')}`)
+        .join('\n\n');
+    const footer = '_Warn-only during rollout: this does not block merge yet. Addressing it keeps release notes accurate._';
+    return `${exports.STICKY_MARKER}\n### ❌ Release-notes checks\n\n${blocks}\n\n${footer}\n`;
 }
 /**
- * Idempotently reconcile the PR's single sticky comment against the decision.
+ * Idempotently reconcile the PR's single sticky comment against the outcome.
  *
  *  - fail: update the existing comment, or create one if none exists.
  *  - pass: if a comment exists (the PR failed earlier), update it to the
  *          resolved body; if none exists, do nothing — a PR that never failed
  *          stays comment-free, so the gate adds no noise across ~800 PRs.
  */
-async function syncStickyComment(api, decision) {
+async function syncStickyComment(api, gate) {
     const existing = (await api.list()).find((comment) => comment.body.includes(exports.STICKY_MARKER));
-    const body = renderStickyComment(decision);
-    if (decision.outcome === 'fail') {
+    const body = renderStickyComment(gate);
+    if (gate.outcome === 'fail') {
         if (existing) {
             await api.update(existing.id, body);
             return 'updated';
@@ -111,6 +113,68 @@ class GithubCommentApi {
     }
 }
 exports.GithubCommentApi = GithubCommentApi;
+
+
+/***/ }),
+
+/***/ 155:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.evaluateGate = evaluateGate;
+const parser_1 = __nccwpck_require__(883);
+const policy_1 = __nccwpck_require__(86);
+const title_1 = __nccwpck_require__(150);
+/** Evaluate the PR-issue link for one PR body: section refs + opt-out. */
+async function evaluateLink(resolver, body) {
+    const section = (0, parser_1.extractSection)(body);
+    const optOut = (0, parser_1.isOptOutTicked)(body);
+    const refs = section ? (0, parser_1.parseRefs)(section) : [];
+    const resolved = await resolver.resolve(refs);
+    return (0, policy_1.decide)(resolved, optOut);
+}
+async function evaluateGate(resolver, input) {
+    // --- PR-issue link, with a backport-hop fallback (C7/V2) ---
+    // A backport PR passes on its own section if it has one (manual template);
+    // otherwise (bot backports carry only `Backport of #N`, no section) it passes
+    // by inheriting the ORIGINAL PR's attribution.
+    let deliveryPath = 'direct';
+    let link = await evaluateLink(resolver, input.body);
+    if (link.outcome === 'fail') {
+        const backport = (0, parser_1.parseRefs)(input.body).find((ref) => ref.kind === 'backport');
+        if (backport) {
+            const originalBody = await resolver.fetchPullBody(backport.number);
+            if (originalBody !== null) {
+                const original = await evaluateLink(resolver, originalBody);
+                deliveryPath = 'backportHop';
+                link =
+                    original.outcome === 'pass'
+                        ? {
+                            outcome: 'pass',
+                            code: original.code,
+                            reasons: [`Backport of #${backport.number} — inherits that PR's attribution (${original.code}).`],
+                        }
+                        : {
+                            outcome: 'fail',
+                            code: 'unlinked-undeclared',
+                            reasons: [
+                                `Backport of #${backport.number}, but that PR does not link a tracked issue either.`,
+                                ...original.reasons,
+                            ],
+                        };
+            }
+        }
+    }
+    const checks = [{ label: 'PR-issue link', outcome: link.outcome, reasons: [...link.reasons] }];
+    // --- Title lint (D16: skipped for bot authors; link/marker still checked) ---
+    if (!(0, title_1.isTitleExemptAuthor)(input.authorLogin)) {
+        const title = (0, title_1.lintTitle)(input.title);
+        checks.push({ label: 'Title', outcome: title.outcome, reasons: [...title.reasons] });
+    }
+    const outcome = checks.every((check) => check.outcome === 'pass') ? 'pass' : 'fail';
+    return { outcome, checks, deliveryPath };
+}
 
 
 /***/ }),
@@ -219,21 +283,21 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const node_fs_1 = __nccwpck_require__(24);
 const comment_1 = __nccwpck_require__(573);
+const gate_1 = __nccwpck_require__(155);
 const core = __importStar(__nccwpck_require__(93));
-const parser_1 = __nccwpck_require__(883);
-const policy_1 = __nccwpck_require__(86);
 const resolver_1 = __nccwpck_require__(306);
 /**
  * PR-gate lint entrypoint (warn-only rollout).
  *
- * Security: runs on pull_request_target, metadata-only. The PR body is read
- * from the event payload — never by checking out the PR head. The privileged
- * token comes in as an input (reused MONOREPO_RELEASE_APP).
+ * Security: runs on pull_request_target, metadata-only. The PR body/title are
+ * read from the event payload — never by checking out the PR head. The
+ * privileged token comes in as an input (reused MONOREPO_RELEASE_APP).
  *
- * ponytail: warn-only for now — reports the decision to the job summary, the
- * outputs, and a single sticky PR comment (created only when the check fails,
- * flipped to resolved once fixed). Label sync and enforce mode ship in
- * follow-up PRs. `enforce=true` flips a fail into a non-zero exit.
+ * ponytail: warn-only for now — reports the combined gate outcome (PR-issue
+ * link + title lint, with a backport hop) to the job summary, the outputs, and
+ * a single sticky PR comment (created only on failure, flipped to resolved once
+ * fixed). Label sync and enforce mode ship in follow-up PRs. `enforce=true`
+ * flips a fail into a non-zero exit.
  */
 async function run() {
     const token = core.getInput('token', { required: true });
@@ -247,42 +311,42 @@ async function run() {
         core.info('No pull_request in payload; nothing to lint.');
         return;
     }
-    const body = pr.body ?? '';
-    const section = (0, parser_1.extractSection)(body);
-    const optOut = (0, parser_1.isOptOutTicked)(body);
-    const refs = section ? (0, parser_1.parseRefs)(section) : [];
     const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
     const resolver = new resolver_1.GithubResolver(token, owner ?? '', repo ?? '');
-    const resolved = await resolver.resolve(refs);
-    const decision = (0, policy_1.decide)(resolved, optOut);
-    core.setOutput('outcome', decision.outcome);
-    core.setOutput('code', decision.code);
-    const heading = decision.outcome === 'pass' ? '✅ PR-issue link check passed' : '❌ PR-issue link check failed';
-    await core.summary
-        .addHeading(heading, 3)
-        .addList(decision.reasons.slice())
-        .write();
+    const gate = await (0, gate_1.evaluateGate)(resolver, {
+        body: pr.body ?? '',
+        title: pr.title ?? '',
+        authorLogin: pr.user?.login,
+    });
+    const failed = gate.checks.filter((check) => check.outcome === 'fail');
+    const reasons = failed.flatMap((check) => check.reasons.map((reason) => `${check.label}: ${reason}`));
+    core.setOutput('outcome', gate.outcome);
+    core.setOutput('delivery-path', gate.deliveryPath);
+    core.setOutput('failed-checks', failed.map((check) => check.label).join(','));
+    const heading = gate.outcome === 'pass' ? '✅ Release-notes checks passed' : '❌ Release-notes checks failed';
+    const summaryLines = gate.checks.map((check) => `${check.outcome === 'pass' ? '✅' : '❌'} ${check.label}: ${check.reasons.join(' ')}`);
+    await core.summary.addHeading(heading, 3).addList(summaryLines).write();
     // Sticky PR comment (D24: comments from day one). A comment sync failure must
-    // never fail the gate — warn or not, the decision above stands.
+    // never fail the gate — warn or not, the outcome above stands.
     if (pr.number) {
         try {
             const comments = new comment_1.GithubCommentApi(token, owner ?? '', repo ?? '', pr.number);
-            const action = await (0, comment_1.syncStickyComment)(comments, decision);
+            const action = await (0, comment_1.syncStickyComment)(comments, gate);
             core.info(`Sticky comment: ${action}.`);
         }
         catch (err) {
             core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
         }
     }
-    if (decision.outcome === 'fail') {
-        const msg = decision.reasons.join(' ');
+    if (gate.outcome === 'fail') {
+        const msg = reasons.join(' ');
         if (enforce)
             core.setFailed(msg);
         else
             core.warning(`[warn-only] ${msg}`);
     }
     else {
-        core.info(decision.reasons.join(' '));
+        core.info('All release-notes checks passed.');
     }
 }
 run().catch((err) => core.setFailed(err instanceof Error ? err.message : String(err)));
@@ -470,17 +534,36 @@ class GithubResolver {
     async resolve(refs) {
         return Promise.all(refs.map((ref) => this.resolveOne(ref)));
     }
+    /**
+     * Fetch a same-repo pull request's body for backport-hop validation, or null
+     * if it does not exist. Used to follow `Backport of #N` to the original PR and
+     * validate that PR's attribution (the backport inherits it — C7).
+     */
+    async fetchPullBody(number) {
+        const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/pulls/${number}`, {
+            headers: this.headers(),
+        });
+        if (res.status === 404)
+            return null;
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} fetching PR #${number}`);
+        const data = (await res.json());
+        return data.body ?? '';
+    }
+    headers() {
+        return {
+            authorization: `Bearer ${this.token}`,
+            accept: 'application/vnd.github+json',
+            'x-github-api-version': '2022-11-28',
+            'user-agent': 'camunda-release-notes-gate',
+        };
+    }
     async resolveOne(ref) {
         const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
         if (crossRepo)
             return { ...ref, target: 'missing', crossRepo: true };
         const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${ref.number}`, {
-            headers: {
-                authorization: `Bearer ${this.token}`,
-                accept: 'application/vnd.github+json',
-                'x-github-api-version': '2022-11-28',
-                'user-agent': 'camunda-release-notes-gate',
-            },
+            headers: this.headers(),
         });
         if (res.status === 404)
             return { ...ref, target: 'missing', crossRepo: false };
@@ -491,6 +574,106 @@ class GithubResolver {
     }
 }
 exports.GithubResolver = GithubResolver;
+
+
+/***/ }),
+
+/***/ 150:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.BOT_TITLE_EXEMPT = exports.HEADER_MAX = exports.TITLE_TYPES = void 0;
+exports.lintTitle = lintTitle;
+exports.isTitleExemptAuthor = isTitleExemptAuthor;
+/**
+ * PR-title lint — the active rules of `commitlint.config.cjs`, reimplemented as
+ * a pure check so the action keeps zero runtime deps (pulling @commitlint +
+ * config-conventional would vendor hundreds of kB into the committed bundle for
+ * a handful of trivial rules). The config's other rules are disabled ([0,...]).
+ *
+ * DRIFT GUARD: TITLE_TYPES and HEADER_MAX are the single source of truth here,
+ * and the action CI greps commitlint.config.cjs to assert they still match —
+ * so a change to the repo's commit rules fails CI until this is updated.
+ *
+ * Active rules mirrored (see commitlint.config.cjs):
+ *   type-empty:never · type-case:lower-case · type-enum · scope-empty:always ·
+ *   header-max-length:120. Subject/body/footer rules are disabled there.
+ */
+/** commitlint.config.cjs `type-enum`. Keep in sync — CI enforces it. */
+exports.TITLE_TYPES = [
+    'build',
+    'ci',
+    'deps',
+    'docs',
+    'feat',
+    'fix',
+    'merge',
+    'perf',
+    'refactor',
+    'revert',
+    'style',
+    'test',
+];
+/** commitlint.config.cjs `header-max-length`. Keep in sync — CI enforces it. */
+exports.HEADER_MAX = 120;
+// `type` + optional `(scope)` + optional `!` + `: ` + subject. Mirrors the
+// conventional-commit header shape config-conventional parses.
+const HEADER = /^(?<type>[^\s():!]+)(?<scope>\([^)]*\))?!?:[ ](?<subject>.+)$/;
+/** Lint a PR title. Pure — no IO, no bot logic (the caller decides bot skips). */
+function lintTitle(title) {
+    if (title.length > exports.HEADER_MAX) {
+        return {
+            outcome: 'fail',
+            code: 'title-length',
+            reasons: [`The title is ${title.length} characters; keep it within ${exports.HEADER_MAX}.`],
+        };
+    }
+    const match = HEADER.exec(title);
+    if (!match?.groups) {
+        return {
+            outcome: 'fail',
+            code: 'title-format',
+            reasons: [
+                'The title must follow Conventional Commits: `type: summary` (e.g. "fix: correct retry backoff").',
+                `Allowed types: ${exports.TITLE_TYPES.join(', ')}.`,
+            ],
+        };
+    }
+    const { type, scope } = match.groups;
+    if (scope) {
+        return {
+            outcome: 'fail',
+            code: 'title-scope',
+            reasons: [`Scopes are not used in this repo — drop "${scope}" and write "${type}: …".`],
+        };
+    }
+    if (type !== type?.toLowerCase()) {
+        return { outcome: 'fail', code: 'title-type', reasons: [`The type "${type}" must be lower-case.`] };
+    }
+    if (!exports.TITLE_TYPES.includes(type)) {
+        return {
+            outcome: 'fail',
+            code: 'title-type',
+            reasons: [`"${type}" is not an allowed type. Use one of: ${exports.TITLE_TYPES.join(', ')}.`],
+        };
+    }
+    return { outcome: 'pass', code: 'title-ok', reasons: [`Title type "${type}" is valid.`] };
+}
+/**
+ * Bot authors whose titles are machine-generated and exempt from title lint
+ * (D16). Their PR-issue link / backport marker is still validated — only the
+ * title check is skipped.
+ */
+exports.BOT_TITLE_EXEMPT = new Set([
+    'backport-action',
+    'monorepo-devops-automation[bot]',
+    'renovate[bot]',
+    'dependabot[bot]',
+]);
+function isTitleExemptAuthor(login) {
+    return login !== undefined && exports.BOT_TITLE_EXEMPT.has(login);
+}
 
 
 /***/ }),

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -15,7 +15,7 @@ const node_fs_1 = __nccwpck_require__(24);
  * command features this action never touches. These are the documented Actions
  * command/file protocols — nothing clever.
  */
-const escape = (s) => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+const escape = (msg) => msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 const appendEnvFile = (envVar, content) => {
     const file = process.env[envVar];
     if (file)
@@ -53,7 +53,7 @@ class Summary {
         return this;
     }
     addList(items) {
-        this.buf += `<ul>${items.map((i) => `<li>${i}</li>`).join('')}</ul>\n`;
+        this.buf += `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>\n`;
         return this;
     }
     async write() {
@@ -204,25 +204,25 @@ function kindOf(keyword) {
 function parseRefs(text) {
     const refs = [];
     const seen = new Set(); // dedupe by match offset
-    const push = (m, repo, num) => {
-        if (seen.has(m.index))
+    const push = (match, repo, num) => {
+        if (seen.has(match.index))
             return;
-        seen.add(m.index);
-        const keyword = m[1] ? m[1].toLowerCase().replace(/\s+/g, ' ') : null;
+        seen.add(match.index);
+        const keyword = match[1] ? match[1].toLowerCase().replace(/\s+/g, ' ') : null;
         refs.push({
-            raw: m[0].trim(),
+            raw: match[0].trim(),
             number: Number(num),
             repo: repo ?? null,
             keyword,
             kind: kindOf(keyword),
-            index: m.index,
+            index: match.index,
         });
     };
-    for (const m of text.matchAll(URL))
-        push(m, m[2] ?? null, m[3]);
-    for (const m of text.matchAll(SHORTHAND))
-        push(m, m[2] ?? null, m[3]);
-    return refs.sort((a, b) => a.index - b.index);
+    for (const match of text.matchAll(URL))
+        push(match, match[2] ?? null, match[3]);
+    for (const match of text.matchAll(SHORTHAND))
+        push(match, match[2] ?? null, match[3]);
+    return refs.sort((first, second) => first.index - second.index);
 }
 /**
  * Slice out a markdown section body: everything after the matching heading up
@@ -231,11 +231,11 @@ function parseRefs(text) {
 function extractSection(body, heading = exports.SECTION_HEADING) {
     const lines = body.split(/\r?\n/);
     const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
-    const start = lines.findIndex((l) => headingRe.test(l.trim()));
+    const start = lines.findIndex((line) => headingRe.test(line.trim()));
     if (start < 0)
         return null;
     const rest = lines.slice(start + 1);
-    const end = rest.findIndex((l) => /^#{1,6}\s+\S/.test(l));
+    const end = rest.findIndex((line) => /^#{1,6}\s+\S/.test(line));
     return (end < 0 ? rest : rest.slice(0, end)).join('\n');
 }
 /** True when the opt-out checkbox is present and ticked. */
@@ -243,8 +243,8 @@ function isOptOutTicked(body) {
     const re = new RegExp(String.raw `^\s*[-*]\s*\[x\]\s*.*${escapeRe(exports.OPT_OUT_PHRASE)}`, 'im');
     return re.test(body);
 }
-function escapeRe(s) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function escapeRe(literal) {
+    return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 
@@ -270,10 +270,10 @@ exports.decide = decide;
  * Cross-repo refs and backport markers never satisfy the requirement on their own.
  */
 function decide(refs, optOut) {
-    const sameRepo = refs.filter((r) => !r.crossRepo && r.kind !== 'backport');
-    const prRefs = sameRepo.filter((r) => r.target === 'pullRequest');
+    const sameRepo = refs.filter((ref) => !ref.crossRepo && ref.kind !== 'backport');
+    const prRefs = sameRepo.filter((ref) => ref.target === 'pullRequest');
     if (prRefs.length > 0) {
-        const list = prRefs.map((r) => `#${r.number}`).join(', ');
+        const list = prRefs.map((ref) => `#${ref.number}`).join(', ');
         return {
             outcome: 'fail',
             code: 'pr-ref-in-section',
@@ -286,18 +286,18 @@ function decide(refs, optOut) {
     if (optOut) {
         return { outcome: 'pass', code: 'opt-out', reasons: ['Opt-out checkbox ticked: no linked issue required.'] };
     }
-    const liveIssues = sameRepo.filter((r) => r.target === 'issue');
+    const liveIssues = sameRepo.filter((ref) => ref.target === 'issue');
     if (liveIssues.length > 0) {
-        const closing = liveIssues.some((r) => r.kind === 'closing');
-        const list = liveIssues.map((r) => `#${r.number}`).join(', ');
+        const closing = liveIssues.some((ref) => ref.kind === 'closing');
+        const list = liveIssues.map((ref) => `#${ref.number}`).join(', ');
         return {
             outcome: 'pass',
             code: closing ? 'section-closing' : 'section-contributor',
             reasons: [`Linked to issue ${list} in the "Related issues" section.`],
         };
     }
-    const dead = sameRepo.filter((r) => r.target === 'missing').map((r) => `#${r.number}`);
-    const crossRepo = refs.filter((r) => r.crossRepo).map((r) => r.raw);
+    const dead = sameRepo.filter((ref) => ref.target === 'missing').map((ref) => `#${ref.number}`);
+    const crossRepo = refs.filter((ref) => ref.crossRepo).map((ref) => ref.raw);
     const reasons = [
         'No linked issue found in the "Related issues" section, and the opt-out checkbox is not ticked.',
         'Add a closing keyword with the tracked issue (e.g. "closes #1234"), or tick the opt-out checkbox.',

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -3,13 +3,14 @@
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 573:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GithubCommentApi = exports.STICKY_MARKER = void 0;
 exports.renderStickyComment = renderStickyComment;
 exports.syncStickyComment = syncStickyComment;
+const github_1 = __nccwpck_require__(631);
 /**
  * The single sticky PR comment the gate maintains. One marked comment per PR,
  * upserted by a hidden marker so re-runs never stack duplicates.
@@ -72,26 +73,28 @@ class GithubCommentApi {
     constructor(token, owner, repo, issueNumber) {
         this.token = token;
         this.issueNumber = issueNumber;
-        this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+        this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
     }
     headers() {
-        return {
-            authorization: `Bearer ${this.token}`,
-            accept: 'application/vnd.github+json',
-            'content-type': 'application/json',
-            'x-github-api-version': '2022-11-28',
-            'user-agent': 'camunda-release-notes-gate',
-        };
+        return (0, github_1.githubHeaders)(this.token, { json: true });
     }
     async list() {
-        // The comment is posted on the first gate run and stays put, so the first
-        // page (100) always contains it — no pagination needed.
-        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=100`, {
-            headers: this.headers(),
-        });
-        if (!res.ok)
-            throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
-        return (await res.json());
+        // Paginate through ALL comments. If the gate first runs on a PR that already
+        // has >100 comments, its own sticky comment is the newest and lands past
+        // page 1 — a page-1-only read would miss it and create a duplicate on every
+        // rerun. GitHub caps per_page at 100; a short page marks the end.
+        const perPage = 100;
+        const all = [];
+        for (let page = 1;; page++) {
+            const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`, { headers: this.headers() });
+            if (!res.ok)
+                throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
+            const batch = (await res.json());
+            all.push(...batch);
+            if (batch.length < perPage)
+                break;
+        }
+        return all;
     }
     async create(body) {
         const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
@@ -141,13 +144,30 @@ async function evaluateGate(resolver, input) {
     // by inheriting the ORIGINAL PR's attribution.
     let deliveryPath = 'direct';
     let link = await evaluateLink(resolver, input.body);
-    if (link.outcome === 'fail') {
+    // Only hop for a genuinely undeclared link. A `pr-ref-in-section` failure is a
+    // hard error (the section itself links a PR) — an unrelated `Backport of #N`
+    // marker must not silently discard it and flip the gate to pass.
+    if (link.outcome === 'fail' && link.code === 'unlinked-undeclared') {
         const backport = (0, parser_1.parseRefs)(input.body).find((ref) => ref.kind === 'backport');
         if (backport) {
-            const originalBody = await resolver.fetchPullBody(backport.number);
-            if (originalBody !== null) {
+            // fetchPullBody returns null for a 404 target OR a cross-repo marker — the
+            // resolver can only validate its own repo. Either way we cannot inherit
+            // attribution, so surface the dangling marker rather than absorbing it
+            // into the generic "no linked issue" message.
+            const originalBody = await resolver.fetchPullBody(backport.number, backport.repo);
+            deliveryPath = 'backportHop';
+            if (originalBody === null) {
+                link = {
+                    outcome: 'fail',
+                    code: 'unlinked-undeclared',
+                    reasons: [
+                        `Backport of ${backport.repo ? `${backport.repo}#` : '#'}${backport.number}, but that PR could not be resolved in this repo — attribution cannot be inherited.`,
+                        ...link.reasons,
+                    ],
+                };
+            }
+            else {
                 const original = await evaluateLink(resolver, originalBody);
-                deliveryPath = 'backportHop';
                 link =
                     original.outcome === 'pass'
                         ? {
@@ -173,7 +193,7 @@ async function evaluateGate(resolver, input) {
         checks.push({ label: 'Title', outcome: title.outcome, reasons: [...title.reasons] });
     }
     const outcome = checks.every((check) => check.outcome === 'pass') ? 'pass' : 'fail';
-    return { outcome, checks, deliveryPath };
+    return { outcome, checks, deliveryPath, link };
 }
 
 
@@ -243,14 +263,54 @@ exports.summary = new Summary();
 
 /***/ }),
 
-/***/ 855:
+/***/ 631:
 /***/ ((__unused_webpack_module, exports) => {
+
+
+/**
+ * Shared GitHub REST plumbing for the three fetch-based adapters (resolver,
+ * comment, labels). One definition of the bot's auth / API-version / user-agent
+ * headers and the per-repo base URL — previously copied verbatim into each
+ * adapter. The adapters stay octokit-free (a handful of endpoints each); this is
+ * just the common boilerplate, not a client.
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GITHUB_API = void 0;
+exports.githubHeaders = githubHeaders;
+exports.repoApiUrl = repoApiUrl;
+exports.GITHUB_API = 'https://api.github.com';
+const USER_AGENT = 'camunda-release-notes-gate';
+const GITHUB_API_VERSION = '2022-11-28';
+/** Auth + content-negotiation headers for the reused MONOREPO_RELEASE_APP token.
+ *  Pass `json: true` for write requests that send a JSON body. */
+function githubHeaders(token, opts = {}) {
+    const headers = {
+        authorization: `Bearer ${token}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': GITHUB_API_VERSION,
+        'user-agent': USER_AGENT,
+    };
+    if (opts.json)
+        headers['content-type'] = 'application/json';
+    return headers;
+}
+/** `https://api.github.com/repos/<owner>/<repo>` — the common request prefix. */
+function repoApiUrl(owner, repo) {
+    return `${exports.GITHUB_API}/repos/${owner}/${repo}`;
+}
+
+
+/***/ }),
+
+/***/ 855:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GithubLabelApi = exports.NO_ISSUE_LABEL_DESCRIPTION = exports.NO_ISSUE_LABEL_COLOR = exports.NO_ISSUE_LABEL = void 0;
 exports.decideLabelAction = decideLabelAction;
 exports.syncNoIssueLabel = syncNoIssueLabel;
+const github_1 = __nccwpck_require__(631);
 /**
  * Syncs the display-only `no-issue` label to mirror the PR-issue-link check
  * only (not the title check — the label answers one question: "does this PR
@@ -275,15 +335,12 @@ function decideLabelAction(currentLabels, linkOutcome) {
 }
 /**
  * Reconcile the no-issue label against the gate's PR-issue-link check.
- * Reads the check by label rather than gate.outcome so a title-only failure
- * never adds a label whose name specifically means "no linked issue".
+ * Reads the typed `gate.link` decision (not gate.outcome) so a title-only
+ * failure never adds a label whose name specifically means "no linked issue".
  */
 async function syncNoIssueLabel(api, gate) {
-    const link = gate.checks.find((check) => check.label === 'PR-issue link');
-    if (!link)
-        return 'noop'; // defensive — the link check is always present today
     const current = await api.list();
-    const action = decideLabelAction(current, link.outcome);
+    const action = decideLabelAction(current, gate.link.outcome);
     if (action === 'added')
         await api.add(exports.NO_ISSUE_LABEL);
     if (action === 'removed')
@@ -302,16 +359,10 @@ class GithubLabelApi {
     constructor(token, owner, repo, issueNumber) {
         this.token = token;
         this.issueNumber = issueNumber;
-        this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+        this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
     }
     headers() {
-        return {
-            authorization: `Bearer ${this.token}`,
-            accept: 'application/vnd.github+json',
-            'content-type': 'application/json',
-            'x-github-api-version': '2022-11-28',
-            'user-agent': 'camunda-release-notes-gate',
-        };
+        return (0, github_1.githubHeaders)(this.token, { json: true });
     }
     async list() {
         const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
@@ -443,11 +494,24 @@ async function run() {
     }
     const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
     const resolver = new resolver_1.GithubResolver(token, owner ?? '', repo ?? '');
-    const gate = await (0, gate_1.evaluateGate)(resolver, {
-        body: pr.body ?? '',
-        title: pr.title ?? '',
-        authorLogin: pr.user?.login,
-    });
+    // A transient resolver error (403/500) must respect `enforce`: warn-only means
+    // the gate never hard-fails, so an API blip cannot turn a green check red.
+    let gate;
+    try {
+        gate = await (0, gate_1.evaluateGate)(resolver, {
+            body: pr.body ?? '',
+            title: pr.title ?? '',
+            authorLogin: pr.user?.login,
+        });
+    }
+    catch (err) {
+        const msg = `Release-notes gate could not be evaluated: ${err instanceof Error ? err.message : String(err)}`;
+        if (enforce)
+            core.setFailed(msg);
+        else
+            core.warning(`[warn-only] ${msg}`);
+        return;
+    }
     const failed = gate.checks.filter((check) => check.outcome === 'fail');
     const reasons = failed.flatMap((check) => check.reasons.map((reason) => `${check.label}: ${reason}`));
     core.setOutput('outcome', gate.outcome);
@@ -456,29 +520,35 @@ async function run() {
     const heading = gate.outcome === 'pass' ? '✅ Release-notes checks passed' : '❌ Release-notes checks failed';
     const summaryLines = gate.checks.map((check) => `${check.outcome === 'pass' ? '✅' : '❌'} ${check.label}: ${check.reasons.join(' ')}`);
     await core.summary.addHeading(heading, 3).addList(summaryLines).write();
-    // Sticky PR comment (D24: comments from day one). A comment sync failure must
+    // Sticky PR comment (D24: comments from day one) + the display-only `no-issue`
+    // label. Both only need `gate` + the PR number and are independent, so run
+    // them concurrently. Each is best-effort: a sync failure is logged and must
     // never fail the gate — warn or not, the outcome above stands.
     if (pr.number) {
-        try {
-            const comments = new comment_1.GithubCommentApi(token, owner ?? '', repo ?? '', pr.number);
-            const action = await (0, comment_1.syncStickyComment)(comments, gate);
-            core.info(`Sticky comment: ${action}.`);
-        }
-        catch (err) {
-            core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
-        }
-        // Display-only `no-issue` label, mirroring the PR-issue-link check. Runs
-        // during warn-only rollout too, so the label is already trustworthy by the
-        // time enforce mode lands — a sync failure never fails the gate.
-        try {
-            const labels = new labels_1.GithubLabelApi(token, owner ?? '', repo ?? '', pr.number);
-            const action = await (0, labels_1.syncNoIssueLabel)(labels, gate);
-            core.setOutput('label-action', action);
-            core.info(`no-issue label: ${action}.`);
-        }
-        catch (err) {
-            core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
-        }
+        const prNumber = pr.number;
+        await Promise.allSettled([
+            (async () => {
+                try {
+                    const comments = new comment_1.GithubCommentApi(token, owner ?? '', repo ?? '', prNumber);
+                    const action = await (0, comment_1.syncStickyComment)(comments, gate);
+                    core.info(`Sticky comment: ${action}.`);
+                }
+                catch (err) {
+                    core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+                }
+            })(),
+            (async () => {
+                try {
+                    const labels = new labels_1.GithubLabelApi(token, owner ?? '', repo ?? '', prNumber);
+                    const action = await (0, labels_1.syncNoIssueLabel)(labels, gate);
+                    core.setOutput('label-action', action);
+                    core.info(`no-issue label: ${action}.`);
+                }
+                catch (err) {
+                    core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+                }
+            })(),
+        ]);
     }
     if (gate.outcome === 'fail') {
         const msg = reasons.join(' ');
@@ -502,6 +572,7 @@ run().catch((err) => core.setFailed(err instanceof Error ? err.message : String(
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.SECTION_HEADING = exports.OPT_OUT_PHRASE = void 0;
+exports.stripHtmlComments = stripHtmlComments;
 exports.parseRefs = parseRefs;
 exports.extractSection = extractSection;
 exports.isOptOutTicked = isOptOutTicked;
@@ -535,8 +606,18 @@ function kindOf(keyword) {
         return 'closing';
     return 'contributor'; // bare "#N"
 }
+/**
+ * Strip HTML comments before any parsing. The PR template's own instructional
+ * `<!-- ... closes #1234 ... -->` block lives inside "## Related issues" and is
+ * invisible in GitHub's rendered body, so a PR that leaves the boilerplate
+ * untouched must NOT be attributed to whatever issue the comment names.
+ */
+function stripHtmlComments(text) {
+    return text.replace(/<!--[\s\S]*?-->/g, '');
+}
 /** Extract every reference from the given text (already scoped by the caller). */
 function parseRefs(text) {
+    text = stripHtmlComments(text);
     const refs = [];
     const seen = new Set(); // dedupe by match offset
     const push = (match, repo, num) => {
@@ -564,7 +645,7 @@ function parseRefs(text) {
  * to the next heading of any level (or EOF). Returns null if absent.
  */
 function extractSection(body, heading = exports.SECTION_HEADING) {
-    const lines = body.split(/\r?\n/);
+    const lines = stripHtmlComments(body).split(/\r?\n/);
     const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
     const start = lines.findIndex((line) => headingRe.test(line.trim()));
     if (start < 0)
@@ -576,7 +657,7 @@ function extractSection(body, heading = exports.SECTION_HEADING) {
 /** True when the opt-out checkbox is present and ticked. */
 function isOptOutTicked(body) {
     const re = new RegExp(String.raw `^\s*[-*]\s*\[x\]\s*.*${escapeRe(exports.OPT_OUT_PHRASE)}`, 'im');
-    return re.test(body);
+    return re.test(stripHtmlComments(body));
 }
 function escapeRe(literal) {
     return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -648,11 +729,12 @@ function decide(refs, optOut) {
 /***/ }),
 
 /***/ 306:
-/***/ ((__unused_webpack_module, exports) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.GithubResolver = void 0;
+const github_1 = __nccwpck_require__(631);
 /**
  * GitHub-API resolver: the only part of the pipeline that touches the network.
  * Classifies each ref as issue vs PR vs missing and flags cross-repo refs.
@@ -668,10 +750,12 @@ class GithubResolver {
     token;
     owner;
     repo;
+    repoUrl;
     constructor(token, owner, repo) {
         this.token = token;
         this.owner = owner;
         this.repo = repo;
+        this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
     }
     async resolve(refs) {
         return Promise.all(refs.map((ref) => this.resolveOne(ref)));
@@ -680,10 +764,17 @@ class GithubResolver {
      * Fetch a same-repo pull request's body for backport-hop validation, or null
      * if it does not exist. Used to follow `Backport of #N` to the original PR and
      * validate that PR's attribution (the backport inherits it — C7).
+     *
+     * A cross-repo marker (`Backport of owner/other#N`) resolves to null: this
+     * resolver is hardcoded to its own owner/repo, so #N there would name an
+     * unrelated PR in THIS repo. We only inherit attribution from our own repo.
      */
-    async fetchPullBody(number) {
-        const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/pulls/${number}`, {
-            headers: this.headers(),
+    async fetchPullBody(number, repo) {
+        const crossRepo = repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+        if (crossRepo)
+            return null;
+        const res = await fetch(`${this.repoUrl}/pulls/${number}`, {
+            headers: (0, github_1.githubHeaders)(this.token),
         });
         if (res.status === 404)
             return null;
@@ -692,20 +783,12 @@ class GithubResolver {
         const data = (await res.json());
         return data.body ?? '';
     }
-    headers() {
-        return {
-            authorization: `Bearer ${this.token}`,
-            accept: 'application/vnd.github+json',
-            'x-github-api-version': '2022-11-28',
-            'user-agent': 'camunda-release-notes-gate',
-        };
-    }
     async resolveOne(ref) {
         const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
         if (crossRepo)
             return { ...ref, target: 'missing', crossRepo: true };
-        const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${ref.number}`, {
-            headers: this.headers(),
+        const res = await fetch(`${this.repoUrl}/issues/${ref.number}`, {
+            headers: (0, github_1.githubHeaders)(this.token),
         });
         if (res.status === 404)
             return { ...ref, target: 'missing', crossRepo: false };
@@ -762,6 +845,16 @@ exports.HEADER_MAX = 120;
 // `type` + optional `(scope)` + optional `!` + `: ` + subject. Mirrors the
 // conventional-commit header shape config-conventional parses.
 const HEADER = /^(?<type>[^\s():!]+)(?<scope>\([^)]*\))?!?:[ ](?<subject>.+)$/;
+/**
+ * Wrap user-controlled title fragments before interpolating them into the
+ * sticky comment / job summary. The gate posts under a bot identity on
+ * `pull_request_target`, so a raw `@mention` in a malicious title would notify
+ * (spam) via the bot. Inline code neutralises mentions; stripping backticks
+ * stops the value breaking out of the span.
+ */
+function code(value) {
+    return `\`${(value ?? '').replace(/`/g, '')}\``;
+}
 /** Lint a PR title. Pure — no IO, no bot logic (the caller decides bot skips). */
 function lintTitle(title) {
     if (title.length > exports.HEADER_MAX) {
@@ -787,17 +880,17 @@ function lintTitle(title) {
         return {
             outcome: 'fail',
             code: 'title-scope',
-            reasons: [`Scopes are not used in this repo — drop "${scope}" and write "${type}: …".`],
+            reasons: [`Scopes are not used in this repo — drop ${code(scope)} and write "${code(type)}: …".`],
         };
     }
     if (type !== type?.toLowerCase()) {
-        return { outcome: 'fail', code: 'title-type', reasons: [`The type "${type}" must be lower-case.`] };
+        return { outcome: 'fail', code: 'title-type', reasons: [`The type ${code(type)} must be lower-case.`] };
     }
     if (!exports.TITLE_TYPES.includes(type)) {
         return {
             outcome: 'fail',
             code: 'title-type',
-            reasons: [`"${type}" is not an allowed type. Use one of: ${exports.TITLE_TYPES.join(', ')}.`],
+            reasons: [`${code(type)} is not an allowed type. Use one of: ${exports.TITLE_TYPES.join(', ')}.`],
         };
     }
     return { outcome: 'pass', code: 'title-ok', reasons: [`Title type "${type}" is valid.`] };

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -2,6 +2,119 @@
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
+/***/ 573:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GithubCommentApi = exports.STICKY_MARKER = void 0;
+exports.renderStickyComment = renderStickyComment;
+exports.syncStickyComment = syncStickyComment;
+/**
+ * The single sticky PR comment the gate maintains. One marked comment per PR,
+ * upserted by a hidden marker so re-runs never stack duplicates.
+ *
+ * Split like the resolver (types.ts): the body render + upsert logic are pure /
+ * injectable (unit-tested for idempotency), and only GithubCommentApi touches
+ * the network — plain fetch, no octokit, same rationale as GithubResolver.
+ */
+/** Hidden HTML marker identifying our comment. Never change it — it is how
+ * every future run finds the comment it already posted. */
+exports.STICKY_MARKER = '<!-- release-notes-pr-gate -->';
+/** Build the comment body (pure). Always carries the marker on the first line. */
+function renderStickyComment(decision) {
+    const title = decision.outcome === 'pass'
+        ? '### ✅ Release-notes: PR-issue link resolved'
+        : '### ❌ Release-notes: PR-issue link check';
+    const reasons = decision.reasons.map((reason) => `- ${reason}`).join('\n');
+    const footer = decision.outcome === 'pass'
+        ? '_This check now passes — no action needed._'
+        : '_Warn-only during rollout: this does not block merge yet. Fix the link (or tick the opt-out) so release notes attribute this change._';
+    return `${exports.STICKY_MARKER}\n${title}\n\n${reasons}\n\n${footer}\n`;
+}
+/**
+ * Idempotently reconcile the PR's single sticky comment against the decision.
+ *
+ *  - fail: update the existing comment, or create one if none exists.
+ *  - pass: if a comment exists (the PR failed earlier), update it to the
+ *          resolved body; if none exists, do nothing — a PR that never failed
+ *          stays comment-free, so the gate adds no noise across ~800 PRs.
+ */
+async function syncStickyComment(api, decision) {
+    const existing = (await api.list()).find((comment) => comment.body.includes(exports.STICKY_MARKER));
+    const body = renderStickyComment(decision);
+    if (decision.outcome === 'fail') {
+        if (existing) {
+            await api.update(existing.id, body);
+            return 'updated';
+        }
+        await api.create(body);
+        return 'created';
+    }
+    if (existing) {
+        await api.update(existing.id, body);
+        return 'resolved';
+    }
+    return 'noop';
+}
+/**
+ * issue-comments API over plain fetch (Node global). Same reasoning as
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost is not worth
+ * paying. Reuses the injected MONOREPO_RELEASE_APP token (bot identity, so the
+ * comment triggers downstream automations that GITHUB_TOKEN events would not).
+ */
+class GithubCommentApi {
+    token;
+    issueNumber;
+    repoUrl;
+    constructor(token, owner, repo, issueNumber) {
+        this.token = token;
+        this.issueNumber = issueNumber;
+        this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+    }
+    headers() {
+        return {
+            authorization: `Bearer ${this.token}`,
+            accept: 'application/vnd.github+json',
+            'content-type': 'application/json',
+            'x-github-api-version': '2022-11-28',
+            'user-agent': 'camunda-release-notes-gate',
+        };
+    }
+    async list() {
+        // The comment is posted on the first gate run and stays put, so the first
+        // page (100) always contains it — no pagination needed.
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=100`, {
+            headers: this.headers(),
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
+        return (await res.json());
+    }
+    async create(body) {
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
+            method: 'POST',
+            headers: this.headers(),
+            body: JSON.stringify({ body }),
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} creating comment on #${this.issueNumber}`);
+    }
+    async update(commentId, body) {
+        const res = await fetch(`${this.repoUrl}/issues/comments/${commentId}`, {
+            method: 'PATCH',
+            headers: this.headers(),
+            body: JSON.stringify({ body }),
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} updating comment ${commentId}`);
+    }
+}
+exports.GithubCommentApi = GithubCommentApi;
+
+
+/***/ }),
+
 /***/ 93:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -105,26 +218,30 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const node_fs_1 = __nccwpck_require__(24);
+const comment_1 = __nccwpck_require__(573);
 const core = __importStar(__nccwpck_require__(93));
 const parser_1 = __nccwpck_require__(883);
 const policy_1 = __nccwpck_require__(86);
 const resolver_1 = __nccwpck_require__(306);
 /**
- * PR-gate lint entrypoint (spike / warn-only).
+ * PR-gate lint entrypoint (warn-only rollout).
  *
  * Security: runs on pull_request_target, metadata-only. The PR body is read
  * from the event payload — never by checking out the PR head. The privileged
  * token comes in as an input (reused MONOREPO_RELEASE_APP).
  *
- * ponytail: warn-only for now — reports the decision to the job summary and
- * outputs; the sticky comment, label sync, and enforce mode ship in follow-up
- * PRs. `enforce=true` flips a fail into a non-zero exit.
+ * ponytail: warn-only for now — reports the decision to the job summary, the
+ * outputs, and a single sticky PR comment (created only when the check fails,
+ * flipped to resolved once fixed). Label sync and enforce mode ship in
+ * follow-up PRs. `enforce=true` flips a fail into a non-zero exit.
  */
 async function run() {
     const token = core.getInput('token', { required: true });
     const enforce = core.getBooleanInput('enforce');
     const eventPath = process.env.GITHUB_EVENT_PATH;
-    const event = eventPath ? JSON.parse((0, node_fs_1.readFileSync)(eventPath, 'utf8')) : {};
+    const event = eventPath
+        ? JSON.parse((0, node_fs_1.readFileSync)(eventPath, 'utf8'))
+        : {};
     const pr = event.pull_request;
     if (!pr) {
         core.info('No pull_request in payload; nothing to lint.');
@@ -145,6 +262,18 @@ async function run() {
         .addHeading(heading, 3)
         .addList(decision.reasons.slice())
         .write();
+    // Sticky PR comment (D24: comments from day one). A comment sync failure must
+    // never fail the gate — warn or not, the decision above stands.
+    if (pr.number) {
+        try {
+            const comments = new comment_1.GithubCommentApi(token, owner ?? '', repo ?? '', pr.number);
+            const action = await (0, comment_1.syncStickyComment)(comments, decision);
+            core.info(`Sticky comment: ${action}.`);
+        }
+        catch (err) {
+            core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
     if (decision.outcome === 'fail') {
         const msg = decision.reasons.join(' ');
         if (enforce)

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -1,0 +1,1105 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 573:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GithubCommentApi = exports.GATE_DOCS_URL = exports.STICKY_MARKER = void 0;
+exports.renderStickyComment = renderStickyComment;
+exports.syncStickyComment = syncStickyComment;
+const github_1 = __nccwpck_require__(631);
+/**
+ * The single sticky PR comment the gate maintains. One marked comment per PR,
+ * upserted by a hidden marker so re-runs never stack duplicates.
+ *
+ * Split like the resolver (types.ts): the body render + upsert logic are pure /
+ * injectable (unit-tested for idempotency), and only GithubCommentApi touches
+ * the network — plain fetch, no octokit, same rationale as GithubResolver.
+ */
+/** Hidden HTML marker identifying our comment. Never change it — it is how
+ * every future run finds the comment it already posted. */
+exports.STICKY_MARKER = '<!-- release-notes-pr-gate -->';
+/** Where the comment sends authors for the full list of causes and fixes. */
+exports.GATE_DOCS_URL = 'https://camunda.github.io/camunda/ci/#release-notes-pr-gate';
+/**
+ * Build the comment body (pure). Always carries the marker on the first line.
+ *
+ * Deliberately terse: the reasons name the exact fix, and everything else —
+ * why the rule exists, the full cause list, the rollout state — lives in the
+ * docs behind GATE_DOCS_URL rather than being restated on every failing PR.
+ */
+function renderStickyComment(gate) {
+    if (gate.outcome === 'pass') {
+        return `${exports.STICKY_MARKER}\n### ✅ Release-notes checks passed\n`;
+    }
+    // One block per failing check, each naming the reasons and the fix.
+    const blocks = gate.checks
+        .filter((check) => check.outcome === 'fail')
+        .map((check) => `**${check.label}**\n${check.reasons.map((reason) => `- ${reason}`).join('\n')}`)
+        .join('\n\n');
+    const footer = `[Causes and fixes](${exports.GATE_DOCS_URL}) · advisory, does not block merge`;
+    return `${exports.STICKY_MARKER}\n### ❌ Release-notes checks\n\n${blocks}\n\n${footer}\n`;
+}
+/**
+ * Idempotently reconcile the PR's single sticky comment against the outcome.
+ *
+ *  - fail: update the existing comment, or create one if none exists.
+ *  - pass: if a comment exists (the PR failed earlier), update it to the
+ *          resolved body; if none exists, do nothing — a PR that never failed
+ *          stays comment-free, so the gate adds no noise across ~800 PRs.
+ */
+async function syncStickyComment(api, gate) {
+    const existing = (await api.list()).find((comment) => comment.body.includes(exports.STICKY_MARKER));
+    const body = renderStickyComment(gate);
+    if (gate.outcome === 'fail') {
+        if (existing) {
+            await api.update(existing.id, body);
+            return 'updated';
+        }
+        await api.create(body);
+        return 'created';
+    }
+    if (existing) {
+        await api.update(existing.id, body);
+        return 'resolved';
+    }
+    return 'noop';
+}
+/**
+ * issue-comments API over plain fetch (Node global). Same reasoning as
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost is not worth
+ * paying. Uses GITHUB_TOKEN with `pull-requests: write` — nothing reacts to this
+ * comment as an event, so the gate needs no App identity (and therefore no Vault
+ * secrets) to post it.
+ */
+class GithubCommentApi {
+    issueNumber;
+    repoUrl;
+    headers;
+    constructor(token, owner, repo, issueNumber) {
+        this.issueNumber = issueNumber;
+        this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
+        this.headers = (0, github_1.githubHeaders)(token, { json: true });
+    }
+    async list() {
+        // Paginate through ALL comments. If the gate first runs on a PR that already
+        // has >100 comments, its own sticky comment is the newest and lands past
+        // page 1 — a page-1-only read would miss it and create a duplicate on every
+        // rerun. GitHub caps per_page at 100; a short page marks the end.
+        const perPage = 100;
+        const all = [];
+        for (let page = 1;; page++) {
+            const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`, { headers: this.headers });
+            if (!res.ok)
+                throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
+            const batch = (await res.json());
+            all.push(...batch);
+            if (batch.length < perPage)
+                break;
+        }
+        return all;
+    }
+    async create(body) {
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({ body }),
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} creating comment on #${this.issueNumber}`);
+    }
+    async update(commentId, body) {
+        const res = await fetch(`${this.repoUrl}/issues/comments/${commentId}`, {
+            method: 'PATCH',
+            headers: this.headers,
+            body: JSON.stringify({ body }),
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} updating comment ${commentId}`);
+    }
+}
+exports.GithubCommentApi = GithubCommentApi;
+
+
+/***/ }),
+
+/***/ 155:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.evaluateGate = evaluateGate;
+const parser_1 = __nccwpck_require__(883);
+const policy_1 = __nccwpck_require__(86);
+const title_1 = __nccwpck_require__(150);
+/** Evaluate the PR-issue link for one PR body: section refs + opt-out. */
+async function evaluateLink(resolver, body) {
+    const section = (0, parser_1.extractSection)(body);
+    const optOut = (0, parser_1.isOptOutTicked)(body);
+    const refs = section ? (0, parser_1.parseRefs)(section) : [];
+    const resolved = await resolver.resolve(refs);
+    return (0, policy_1.decide)(resolved, optOut);
+}
+/**
+ * Explain why a `Backport of #N` marker could not be followed to an original
+ * PR, so the author sees the actual problem rather than a generic "no linked
+ * issue". Only reached in the rare failure path, so the extra classify call
+ * (issue vs missing) never touches the hot bot-backport path.
+ */
+async function unresolvableBackportReason(resolver, backport) {
+    const [resolved] = await resolver.resolve([backport]);
+    if (resolved?.crossRepo) {
+        return `Backport of ${backport.repo}#${backport.number} points to another repository — attribution can only be inherited from a pull request in this repo.`;
+    }
+    if (resolved?.target === 'issue') {
+        return `Backport of #${backport.number} points to an issue, not a pull request — a backport marker must reference the original PR.`;
+    }
+    return `Backport of #${backport.number} does not resolve to a pull request in this repo — attribution cannot be inherited.`;
+}
+async function evaluateGate(resolver, input) {
+    // --- PR-issue link, with a backport-hop fallback (C7/V2) ---
+    // A backport PR passes on its own section if it has one (manual template);
+    // otherwise (bot backports carry only `Backport of #N`, no section) it passes
+    // by inheriting the ORIGINAL PR's attribution.
+    let deliveryPath = 'direct';
+    let link = await evaluateLink(resolver, input.body);
+    // Only hop for a genuinely undeclared link. A `pr-ref-in-section` failure is a
+    // hard error (the section itself links a PR) — an unrelated `Backport of #N`
+    // marker must not silently discard it and flip the gate to pass.
+    if (link.outcome === 'fail' && link.code === 'unlinked-undeclared') {
+        const backport = (0, parser_1.parseRefs)(input.body).find((ref) => ref.kind === 'backport');
+        if (backport) {
+            // fetchPullBody returns null for a 404 target OR a cross-repo marker — the
+            // resolver can only validate its own repo. Either way we cannot inherit
+            // attribution, so surface the dangling marker rather than absorbing it
+            // into the generic "no linked issue" message.
+            const originalBody = await resolver.fetchPullBody(backport.number, backport.repo);
+            deliveryPath = 'backportHop';
+            if (originalBody === null) {
+                // The marker is the PR's stated attribution path, so speak to the marker
+                // only — the generic "add a closing keyword / tick opt-out" section advice
+                // is irrelevant for a backport PR and would just be noise.
+                link = {
+                    outcome: 'fail',
+                    code: 'unlinked-undeclared',
+                    reasons: [await unresolvableBackportReason(resolver, backport)],
+                };
+            }
+            else {
+                const original = await evaluateLink(resolver, originalBody);
+                link =
+                    original.outcome === 'pass'
+                        ? {
+                            outcome: 'pass',
+                            code: original.code,
+                            reasons: [`Backport of #${backport.number} — inherits that PR's attribution (${original.code}).`],
+                        }
+                        : {
+                            outcome: 'fail',
+                            code: 'unlinked-undeclared',
+                            reasons: [
+                                `Backport of #${backport.number}, but that PR does not link a tracked issue either.`,
+                                ...original.reasons,
+                            ],
+                        };
+            }
+        }
+    }
+    // Bot link exemption (Renovate). Applied AFTER the hop and only to a still
+    // failing link, so it is a fallback and never a bypass: a bot PR that does
+    // link an issue keeps its real code, and the hop above still runs for the
+    // backport bot. An explicit link therefore always wins over the exemption.
+    if (link.outcome === 'fail' && (0, title_1.isLinkExemptAuthor)(input.authorLogin)) {
+        link = {
+            outcome: 'pass',
+            code: 'bot-exempt',
+            reasons: [`Author ${input.authorLogin} is exempt from the PR-issue link check.`],
+        };
+    }
+    const checks = [{ label: 'PR-issue link', outcome: link.outcome, reasons: [...link.reasons] }];
+    // --- Title lint (D16: skipped for bot authors; link/marker still checked) ---
+    if (!(0, title_1.isTitleExemptAuthor)(input.authorLogin)) {
+        const title = (0, title_1.lintTitle)(input.title);
+        checks.push({ label: 'Title', outcome: title.outcome, reasons: [...title.reasons] });
+    }
+    const outcome = checks.every((check) => check.outcome === 'pass') ? 'pass' : 'fail';
+    return { outcome, checks, deliveryPath, link };
+}
+
+
+/***/ }),
+
+/***/ 93:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.summary = exports.setFailed = exports.warning = exports.info = exports.setOutput = exports.getBooleanInput = exports.getInput = void 0;
+const node_fs_1 = __nccwpck_require__(24);
+/**
+ * ponytail: the ~7 GitHub Actions toolkit calls we actually use, inlined.
+ * @actions/core drags in @actions/exec + http-client + io (~400kB) for OIDC and
+ * command features this action never touches. These are the documented Actions
+ * command/file protocols — nothing clever.
+ */
+const escape = (msg) => msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+// The step summary is built as HTML, so escape anything interpolated into it —
+// reasons carry user-controlled PR title/body fragments.
+const escapeHtml = (text) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const appendEnvFile = (envVar, content) => {
+    const file = process.env[envVar];
+    if (file)
+        (0, node_fs_1.appendFileSync)(file, content);
+};
+const getInput = (name, opts = {}) => {
+    const value = (process.env[`INPUT_${name.toUpperCase().replace(/ /g, '_')}`] ?? '').trim();
+    if (opts.required && !value)
+        throw new Error(`Input required and not supplied: ${name}`);
+    return value;
+};
+exports.getInput = getInput;
+const getBooleanInput = (name) => (0, exports.getInput)(name).toLowerCase() === 'true';
+exports.getBooleanInput = getBooleanInput;
+// GITHUB_OUTPUT file protocol with a heredoc delimiter (safe for multiline values).
+const setOutput = (name, value) => appendEnvFile('GITHUB_OUTPUT', `${name}<<_GHA_EOF_\n${value}\n_GHA_EOF_\n`);
+exports.setOutput = setOutput;
+const info = (msg) => {
+    process.stdout.write(`${msg}\n`);
+};
+exports.info = info;
+const warning = (msg) => {
+    process.stdout.write(`::warning::${escape(msg)}\n`);
+};
+exports.warning = warning;
+const setFailed = (msg) => {
+    process.stdout.write(`::error::${escape(msg)}\n`);
+    process.exitCode = 1;
+};
+exports.setFailed = setFailed;
+class Summary {
+    buf = '';
+    addHeading(text, level = 1) {
+        this.buf += `<h${level}>${escapeHtml(text)}</h${level}>\n`;
+        return this;
+    }
+    addList(items) {
+        this.buf += `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>\n`;
+        return this;
+    }
+    async write() {
+        appendEnvFile('GITHUB_STEP_SUMMARY', this.buf);
+        this.buf = '';
+    }
+}
+exports.summary = new Summary();
+
+
+/***/ }),
+
+/***/ 631:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+/**
+ * Shared GitHub REST plumbing for the three fetch-based adapters (resolver,
+ * comment, labels). One definition of the bot's auth / API-version / user-agent
+ * headers and the per-repo base URL — previously copied verbatim into each
+ * adapter. The adapters stay octokit-free (a handful of endpoints each); this is
+ * just the common boilerplate, not a client.
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GITHUB_API = void 0;
+exports.githubHeaders = githubHeaders;
+exports.repoApiUrl = repoApiUrl;
+exports.GITHUB_API = 'https://api.github.com';
+const USER_AGENT = 'camunda-release-notes-gate';
+const GITHUB_API_VERSION = '2022-11-28';
+/** Auth + content-negotiation headers for the reused MONOREPO_RELEASE_APP token.
+ *  Pass `json: true` for write requests that send a JSON body. */
+function githubHeaders(token, opts = {}) {
+    const headers = {
+        authorization: `Bearer ${token}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': GITHUB_API_VERSION,
+        'user-agent': USER_AGENT,
+    };
+    if (opts.json)
+        headers['content-type'] = 'application/json';
+    return headers;
+}
+/** `https://api.github.com/repos/<owner>/<repo>` — the common request prefix. */
+function repoApiUrl(owner, repo) {
+    return `${exports.GITHUB_API}/repos/${owner}/${repo}`;
+}
+
+
+/***/ }),
+
+/***/ 855:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GithubLabelApi = exports.NO_ISSUE_LABEL_DESCRIPTION = exports.NO_ISSUE_LABEL_COLOR = exports.NO_ISSUE_LABEL = void 0;
+exports.decideLabelAction = decideLabelAction;
+exports.syncNoIssueLabel = syncNoIssueLabel;
+const github_1 = __nccwpck_require__(631);
+/**
+ * Syncs the display-only `no-issue` label to mirror the PR-issue-link check
+ * only (not the title check — the label answers one question: "does this PR
+ * link a tracked issue?"). Best-effort like the sticky comment: a sync
+ * failure never fails the gate, and it runs regardless of `enforce` — the
+ * label is informational, not a blocking mechanism.
+ */
+/** The label the gate syncs. Single source of truth — do not rename without
+ *  updating any saved searches/dashboards that filter on it. */
+exports.NO_ISSUE_LABEL = 'no-issue';
+/**
+ * Used only by GithubLabelApi.ensureLabelExists, which recreates the label if
+ * someone deletes it, so a missing label degrades to a self-heal instead of a
+ * failed sync.
+ *
+ * These MUST match the label as it exists in the repo today (colour `ededed`,
+ * no description beyond this one) — otherwise a delete-then-heal cycle would
+ * silently reskin a label that predates this gate. The wording deliberately
+ * avoids "warn-only": that becomes wrong at the required-flip, and nobody would
+ * think to update a label description then.
+ */
+exports.NO_ISSUE_LABEL_COLOR = 'ededed';
+exports.NO_ISSUE_LABEL_DESCRIPTION = 'Release-notes gate: this PR does not link a tracked issue.';
+/** Pure decision: given the PR's current labels and the link check's
+ * outcome, decide whether to add/remove the no-issue label. */
+function decideLabelAction(currentLabels, linkOutcome) {
+    const has = currentLabels.includes(exports.NO_ISSUE_LABEL);
+    if (linkOutcome === 'fail')
+        return has ? 'noop' : 'added';
+    return has ? 'removed' : 'noop';
+}
+/**
+ * Reconcile the no-issue label against the gate's PR-issue-link check.
+ * Reads the typed `gate.link` decision (not gate.outcome) so a title-only
+ * failure never adds a label whose name specifically means "no linked issue".
+ */
+async function syncNoIssueLabel(api, gate) {
+    const current = await api.list();
+    const action = decideLabelAction(current, gate.link.outcome);
+    if (action === 'added')
+        await api.add(exports.NO_ISSUE_LABEL);
+    if (action === 'removed')
+        await api.remove(exports.NO_ISSUE_LABEL);
+    return action;
+}
+/**
+ * issue-labels API over plain fetch. Same rationale as GithubCommentApi /
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost isn't
+ * worth paying.
+ */
+class GithubLabelApi {
+    issueNumber;
+    repoUrl;
+    headers;
+    constructor(token, owner, repo, issueNumber) {
+        this.issueNumber = issueNumber;
+        this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
+        this.headers = (0, github_1.githubHeaders)(token, { json: true });
+    }
+    async list() {
+        // No pagination (unlike GithubCommentApi): GitHub caps an issue/PR at 100
+        // labels, so a single per_page=100 page is always the complete set.
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
+            headers: this.headers,
+        });
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} listing labels on #${this.issueNumber}`);
+        const data = (await res.json());
+        return data.map((label) => label.name);
+    }
+    async add(label) {
+        const res = await this.postLabel(label);
+        if (res.status === 404) {
+            // Repo doesn't have this label defined yet — create it once, then retry.
+            await this.ensureLabelExists(label);
+            const retry = await this.postLabel(label);
+            if (!retry.ok) {
+                throw new Error(`GitHub API ${retry.status} adding label "${label}" to #${this.issueNumber} after creating it`);
+            }
+            return;
+        }
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} adding label "${label}" to #${this.issueNumber}`);
+    }
+    async remove(label) {
+        const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels/${encodeURIComponent(label)}`, {
+            method: 'DELETE',
+            headers: this.headers,
+        });
+        // 404 means the label is already gone (e.g. a concurrent run removed it) — not an error.
+        if (!res.ok && res.status !== 404) {
+            throw new Error(`GitHub API ${res.status} removing label "${label}" from #${this.issueNumber}`);
+        }
+    }
+    postLabel(label) {
+        return fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({ labels: [label] }),
+        });
+    }
+    async ensureLabelExists(label) {
+        const res = await fetch(`${this.repoUrl}/labels`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({ name: label, color: exports.NO_ISSUE_LABEL_COLOR, description: exports.NO_ISSUE_LABEL_DESCRIPTION }),
+        });
+        // 422 means another concurrent run already created it — not an error.
+        if (!res.ok && res.status !== 422) {
+            throw new Error(`GitHub API ${res.status} creating label "${label}"`);
+        }
+    }
+}
+exports.GithubLabelApi = GithubLabelApi;
+
+
+/***/ }),
+
+/***/ 554:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const comment_1 = __nccwpck_require__(573);
+const gate_1 = __nccwpck_require__(155);
+const core = __importStar(__nccwpck_require__(93));
+const labels_1 = __nccwpck_require__(855);
+const resolver_1 = __nccwpck_require__(306);
+/**
+ * PR-gate lint entrypoint (warn-only rollout).
+ *
+ * Security: runs on `pull_request`, so the workflow and this action resolve from
+ * the PR head — the same trust model as every other lint in ci.yml, and the
+ * reason there is no privileged token anywhere here. A fork PR gets a read-only
+ * GITHUB_TOKEN and no secrets, which is exactly why the writes below are guarded
+ * by `can-write` instead of failing.
+ *
+ * The PR number comes from the event payload; the body and title are then
+ * fetched from the API, so they are current at evaluation time rather than a
+ * snapshot from whenever the event fired (a PR edited twice in quick succession
+ * must not be judged on the older body).
+ *
+ * ponytail: warn-only for now — reports the combined gate outcome (PR-issue link
+ * + title lint, with a backport hop) to the job summary, the outputs, a single
+ * sticky PR comment, and the display-only `no-issue` label. The check itself is
+ * the job's own conclusion; GitHub renders it on the PR without us publishing
+ * anything. Both syncs run regardless of `enforce` — they are informational, not
+ * the enforcement mechanism. `enforce=true` flips a fail into a non-zero exit;
+ * enforce mode ships in a follow-up PR.
+ */
+async function run() {
+    const token = core.getInput('token', { required: true });
+    const enforce = core.getBooleanInput('enforce');
+    // False on fork PRs: GitHub issues a read-only token and withholds secrets
+    // there, whatever the workflow's `permissions:` block asks for. Everything the
+    // gate READS still works, so it evaluates and reports normally — only the two
+    // writes are skipped, and the log says so rather than surfacing a 403.
+    const canWrite = core.getBooleanInput('can-write');
+    const prNumberInput = core.getInput('pr-number').trim();
+    const prNumber = Number(prNumberInput);
+    if (!Number.isInteger(prNumber) || prNumber <= 0) {
+        core.setFailed(`pr-number must be a positive integer, got "${prNumberInput}".`);
+        return;
+    }
+    const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
+    const resolver = new resolver_1.GithubResolver(token, owner ?? '', repo ?? '');
+    // A transient API error (403/500) must respect `enforce`: warn-only means the
+    // gate never hard-fails, so a blip cannot turn a green check red.
+    let gate;
+    try {
+        const pull = await resolver.fetchPull(prNumber);
+        if (!pull) {
+            core.info(`PR #${prNumber} could not be fetched; nothing to lint.`);
+            return;
+        }
+        gate = await (0, gate_1.evaluateGate)(resolver, {
+            body: pull.body,
+            title: pull.title,
+            authorLogin: pull.authorLogin,
+        });
+    }
+    catch (err) {
+        const msg = `Release-notes gate could not be evaluated: ${err instanceof Error ? err.message : String(err)}`;
+        if (enforce)
+            core.setFailed(msg);
+        else
+            core.warning(`[warn-only] ${msg}`);
+        return;
+    }
+    const failed = gate.checks.filter((check) => check.outcome === 'fail');
+    const reasons = failed.flatMap((check) => check.reasons.map((reason) => `${check.label}: ${reason}`));
+    core.setOutput('outcome', gate.outcome);
+    core.setOutput('delivery-path', gate.deliveryPath);
+    core.setOutput('failed-checks', failed.map((check) => check.label).join(','));
+    // The job summary is the gate's primary report: it is the one channel that
+    // works everywhere, fork PRs included, and needs no token at all.
+    const heading = gate.outcome === 'pass' ? '✅ Release-notes checks passed' : '❌ Release-notes checks failed';
+    const summaryLines = gate.checks.map((check) => `${check.outcome === 'pass' ? '✅' : '❌'} ${check.label}: ${check.reasons.join(' ')}`);
+    await core.summary.addHeading(heading, 3).addList(summaryLines).write();
+    if (!canWrite) {
+        // Not a failure: a fork PR is still fully evaluated above, and the verdict is
+        // in the summary and this log. Stated explicitly so the absence of the usual
+        // comment reads as designed rather than broken.
+        core.info('Fork pull request: no write token available, so the sticky comment and no-issue label are skipped.');
+    }
+    else {
+        // The sticky comment and the display-only `no-issue` label. Independent of
+        // each other, so run them concurrently. Each is best-effort: a sync failure
+        // is logged and must never fail the gate — warn or not, the outcome above
+        // stands.
+        await Promise.allSettled([
+            (async () => {
+                try {
+                    const comments = new comment_1.GithubCommentApi(token, owner ?? '', repo ?? '', prNumber);
+                    const action = await (0, comment_1.syncStickyComment)(comments, gate);
+                    core.info(`Sticky comment: ${action}.`);
+                }
+                catch (err) {
+                    core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+                }
+            })(),
+            (async () => {
+                try {
+                    const labels = new labels_1.GithubLabelApi(token, owner ?? '', repo ?? '', prNumber);
+                    const action = await (0, labels_1.syncNoIssueLabel)(labels, gate);
+                    core.setOutput('label-action', action);
+                    core.info(`no-issue label: ${action}.`);
+                }
+                catch (err) {
+                    core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+                }
+            })(),
+        ]);
+    }
+    if (gate.outcome === 'fail') {
+        const msg = reasons.join(' ');
+        if (enforce)
+            core.setFailed(msg);
+        else
+            core.warning(`[warn-only] ${msg}`);
+    }
+    else {
+        core.info('All release-notes checks passed.');
+    }
+}
+run().catch((err) => core.setFailed(err instanceof Error ? err.message : String(err)));
+
+
+/***/ }),
+
+/***/ 883:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.SECTION_HEADING = exports.OPT_OUT_PHRASE = void 0;
+exports.stripHtmlComments = stripHtmlComments;
+exports.parseRefs = parseRefs;
+exports.extractSection = extractSection;
+exports.isOptOutTicked = isOptOutTicked;
+/**
+ * Pure, section-scoped reference parser. Shared verbatim with the generator
+ * (#57713) — no IO, no repo awareness. Cross-repo detection and issue-vs-PR
+ * classification belong to the Resolver, not here.
+ */
+/** The template's opt-out phrase. Kept as an exported constant so the PR template
+ *  and the parser cannot drift (enforced by the repo-constant grep in CI). */
+exports.OPT_OUT_PHRASE = 'this pr does not need a linked issue';
+/** The section whose refs the gate evaluates. */
+exports.SECTION_HEADING = 'Related issues';
+// GitHub's closing keywords + our custom "completes". Case-insensitive.
+const CLOSING = /^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?)$/i;
+const RELATES = /^relates?\s+to$/i;
+const BACKPORT = /^backport\s+of$/i;
+// Optional keyword prefix shared by both ref shapes.
+const KW = String.raw `(?:\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?|relates?\s+to|backport\s+of)\b[\s:]+)?`;
+const OWNER_REPO = String.raw `([A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*)`;
+// "closes #12", "camunda/other#7", bare "#12".
+const SHORTHAND = new RegExp(KW + `(?:${OWNER_REPO})?#(\\d+)`, 'gi');
+// Full GitHub URLs: ".../owner/repo/issues/12" or ".../pull/12".
+const URL = new RegExp(KW + String.raw `https?:\/\/github\.com\/${OWNER_REPO}\/(?:issues|pull)\/(\d+)`, 'gi');
+function kindOf(keyword) {
+    if (keyword && BACKPORT.test(keyword))
+        return 'backport';
+    if (keyword && RELATES.test(keyword))
+        return 'contributor';
+    if (keyword && CLOSING.test(keyword))
+        return 'closing';
+    return 'contributor'; // bare "#N"
+}
+/**
+ * Strip HTML comments before any parsing. The PR template's own instructional
+ * `<!-- ... closes #1234 ... -->` block lives inside "## Related issues" and is
+ * invisible in GitHub's rendered body, so a PR that leaves the boilerplate
+ * untouched must NOT be attributed to whatever issue the comment names.
+ */
+function stripHtmlComments(text) {
+    return text.replace(/<!--[\s\S]*?-->/g, '');
+}
+/** Extract every reference from the given text (already scoped by the caller). */
+function parseRefs(text) {
+    text = stripHtmlComments(text);
+    const refs = [];
+    const seen = new Set(); // dedupe by match offset
+    const push = (match, repo, num) => {
+        if (seen.has(match.index))
+            return;
+        seen.add(match.index);
+        const keyword = match[1] ? match[1].toLowerCase().replace(/\s+/g, ' ') : null;
+        refs.push({
+            raw: match[0].trim(),
+            number: Number(num),
+            repo: repo ?? null,
+            keyword,
+            kind: kindOf(keyword),
+            index: match.index,
+        });
+    };
+    for (const match of text.matchAll(URL))
+        push(match, match[2] ?? null, match[3]);
+    for (const match of text.matchAll(SHORTHAND))
+        push(match, match[2] ?? null, match[3]);
+    return refs.sort((first, second) => first.index - second.index);
+}
+/**
+ * Slice out a markdown section body: everything after the matching heading up
+ * to the next heading of any level (or EOF). Returns null if absent.
+ */
+function extractSection(body, heading = exports.SECTION_HEADING) {
+    const lines = stripHtmlComments(body).split(/\r?\n/);
+    const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
+    const start = lines.findIndex((line) => headingRe.test(line.trim()));
+    if (start < 0)
+        return null;
+    const rest = lines.slice(start + 1);
+    const end = rest.findIndex((line) => /^#{1,6}\s+\S/.test(line));
+    return (end < 0 ? rest : rest.slice(0, end)).join('\n');
+}
+/** True when the opt-out checkbox is present and ticked. */
+function isOptOutTicked(body) {
+    const re = new RegExp(String.raw `^\s*[-*]\s*\[x\]\s*.*${escapeRe(exports.OPT_OUT_PHRASE)}`, 'im');
+    return re.test(stripHtmlComments(body));
+}
+function escapeRe(literal) {
+    return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+
+/***/ }),
+
+/***/ 86:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.decide = decide;
+/**
+ * Pure PR-gate decision. Given the resolved refs found inside the section and
+ * whether the opt-out checkbox is ticked, decide PASS/FAIL with reasons that
+ * name the offending ref and the exact fix.
+ *
+ * Precedence (a PR ref is always an error, even alongside a valid issue ref):
+ *   1. any same-repo ref resolves to a PR      -> FAIL pr-ref-in-section
+ *   2. opt-out ticked                          -> PASS opt-out
+ *   3. a same-repo ref resolves to a live issue -> PASS section-(closing|contributor)
+ *   4. otherwise                               -> FAIL unlinked-undeclared
+ *
+ * Cross-repo refs and backport markers never satisfy the requirement on their own.
+ */
+function decide(refs, optOut) {
+    const sameRepo = refs.filter((ref) => !ref.crossRepo && ref.kind !== 'backport');
+    const prRefs = sameRepo.filter((ref) => ref.target === 'pullRequest');
+    if (prRefs.length > 0) {
+        const list = prRefs.map((ref) => `#${ref.number}`).join(', ');
+        return {
+            outcome: 'fail',
+            code: 'pr-ref-in-section',
+            reasons: [
+                `The "Related issues" section links a pull request (${list}), not an issue.`,
+                'Link the tracked issue this PR resolves (e.g. `closes #1234`), or tick the opt-out checkbox.',
+            ],
+        };
+    }
+    if (optOut) {
+        return { outcome: 'pass', code: 'opt-out', reasons: ['Opt-out checkbox ticked: no linked issue required.'] };
+    }
+    const liveIssues = sameRepo.filter((ref) => ref.target === 'issue');
+    if (liveIssues.length > 0) {
+        const closing = liveIssues.some((ref) => ref.kind === 'closing');
+        const list = liveIssues.map((ref) => `#${ref.number}`).join(', ');
+        return {
+            outcome: 'pass',
+            code: closing ? 'section-closing' : 'section-contributor',
+            reasons: [`Linked to issue ${list} in the "Related issues" section.`],
+        };
+    }
+    const dead = sameRepo.filter((ref) => ref.target === 'missing').map((ref) => `#${ref.number}`);
+    const crossRepo = refs.filter((ref) => ref.crossRepo).map((ref) => ref.raw);
+    const reasons = [
+        'No linked issue found in the "Related issues" section, and the opt-out checkbox is not ticked.',
+        'Add a closing keyword with the tracked issue (e.g. `closes #1234`), or tick the opt-out checkbox.',
+    ];
+    if (dead.length)
+        reasons.push(`These refs do not resolve to an existing issue: ${dead.join(', ')}.`);
+    if (crossRepo.length)
+        reasons.push(`Cross-repo refs do not count toward this repo's release notes: ${crossRepo.join(', ')}.`);
+    return { outcome: 'fail', code: 'unlinked-undeclared', reasons };
+}
+
+
+/***/ }),
+
+/***/ 306:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GithubResolver = void 0;
+const github_1 = __nccwpck_require__(631);
+/** A PR body can carry at most this many refs to the API. A legitimate PR never
+ *  needs more than a handful — this bounds the worst case (a body stuffed with
+ *  hundreds of `#N` shorthands on `pull_request_target`) to a fixed cost. */
+const MAX_REFS = 20;
+/** How many classify calls run concurrently. Caps the fan-out against GitHub's
+ *  API even after dedup + the cap above, so a burst of distinct numbers cannot
+ *  open dozens of sockets at once. */
+const CONCURRENCY = 5;
+/**
+ * GitHub-API resolver: the only part of the pipeline that touches the network.
+ * Classifies each ref as issue vs PR vs missing and flags cross-repo refs.
+ *
+ * GitHub's issues API returns PRs too (a PR is an issue with a `pull_request`
+ * field), so one lookup per number classifies both. Cross-repo refs are not
+ * queried — they never satisfy the gate, so their target stays "missing".
+ *
+ * ponytail: plain fetch (Node 24 global) over octokit — we hit exactly one
+ * endpoint; octokit would inline the whole REST client into the bundle.
+ */
+class GithubResolver {
+    token;
+    owner;
+    repo;
+    repoUrl;
+    headers;
+    constructor(token, owner, repo) {
+        this.token = token;
+        this.owner = owner;
+        this.repo = repo;
+        this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
+        this.headers = (0, github_1.githubHeaders)(token);
+    }
+    /**
+     * Resolve every ref, deduped (repeats of the same "#N" cost one API call),
+     * capped at MAX_REFS (a legitimate PR never needs more), and bounded to
+     * CONCURRENCY in flight — defense against a body engineered to fan out
+     * unbounded concurrent requests using the privileged gate token.
+     */
+    async resolve(refs) {
+        const capped = refs.slice(0, MAX_REFS);
+        const cache = new Map();
+        const classifyCached = (ref) => {
+            const key = `${ref.repo ?? ''}#${ref.number}`;
+            let promise = cache.get(key);
+            if (!promise) {
+                promise = this.classify(ref);
+                cache.set(key, promise);
+            }
+            return promise;
+        };
+        const results = [];
+        for (let i = 0; i < capped.length; i += CONCURRENCY) {
+            const batch = capped.slice(i, i + CONCURRENCY);
+            const classified = await Promise.all(batch.map(classifyCached));
+            batch.forEach((ref, index) => {
+                const { target, crossRepo } = classified[index];
+                results.push({ ...ref, target, crossRepo });
+            });
+        }
+        return results;
+    }
+    /**
+     * Fetch a same-repo pull request's body for backport-hop validation, or null
+     * if it does not exist. Used to follow `Backport of #N` to the original PR and
+     * validate that PR's attribution (the backport inherits it — C7).
+     *
+     * A cross-repo marker (`Backport of owner/other#N`) resolves to null: this
+     * resolver is hardcoded to its own owner/repo, so #N there would name an
+     * unrelated PR in THIS repo. We only inherit attribution from our own repo.
+     */
+    async fetchPullBody(number, repo) {
+        if (this.isCrossRepo(repo))
+            return null;
+        const pull = await this.fetchPull(number);
+        return pull?.body ?? null;
+    }
+    /**
+     * Fetch the fields the gate evaluates for one same-repo pull request, or null
+     * if it does not exist.
+     *
+     * This is how the entrypoint obtains the PR under `workflow_run`, where the
+     * event payload carries no `pull_request` object at all. Fetching also means
+     * the body is read at evaluation time, so a stale or superseded trigger run
+     * can never evaluate an out-of-date body.
+     */
+    async fetchPull(number) {
+        const res = await fetch(`${this.repoUrl}/pulls/${number}`, {
+            headers: this.headers,
+        });
+        if (res.status === 404)
+            return null;
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} fetching PR #${number}`);
+        const data = (await res.json());
+        return { body: data.body ?? '', title: data.title ?? '', authorLogin: data.user?.login };
+    }
+    /** A ref points at a different repo than the one being gated (case-insensitive). */
+    isCrossRepo(repo) {
+        return repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+    }
+    /** Classify one (repo, number) pair — the part of a ref that actually needs
+     *  an API call. Keyed independently of the ParsedRef's own fields (raw,
+     *  keyword, kind, index) so `resolve()` can cache and reuse it across every
+     *  ref that shares the same repo/number. */
+    async classify(ref) {
+        if (this.isCrossRepo(ref.repo))
+            return { target: 'missing', crossRepo: true };
+        const res = await fetch(`${this.repoUrl}/issues/${ref.number}`, {
+            headers: this.headers,
+        });
+        if (res.status === 404)
+            return { target: 'missing', crossRepo: false };
+        if (!res.ok)
+            throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);
+        const data = (await res.json());
+        return { target: data.pull_request ? 'pullRequest' : 'issue', crossRepo: false };
+    }
+}
+exports.GithubResolver = GithubResolver;
+
+
+/***/ }),
+
+/***/ 150:
+/***/ ((__unused_webpack_module, exports) => {
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.BOT_LINK_EXEMPT = exports.BOT_TITLE_EXEMPT = exports.HEADER_MAX = exports.TITLE_TYPES = void 0;
+exports.lintTitle = lintTitle;
+exports.isTitleExemptAuthor = isTitleExemptAuthor;
+exports.isLinkExemptAuthor = isLinkExemptAuthor;
+/**
+ * PR-title lint — the active rules of `commitlint.config.cjs`, reimplemented as
+ * a pure check so the action keeps zero runtime deps (pulling @commitlint +
+ * config-conventional would vendor hundreds of kB into the committed bundle for
+ * a handful of trivial rules). The config's other rules are disabled ([0,...]).
+ *
+ * DRIFT GUARD: TITLE_TYPES and HEADER_MAX are the single source of truth here,
+ * and the action CI greps commitlint.config.cjs to assert they still match —
+ * so a change to the repo's commit rules fails CI until this is updated.
+ *
+ * Active rules mirrored (see commitlint.config.cjs):
+ *   type-empty:never · type-case:lower-case · type-enum · scope-empty:always ·
+ *   header-max-length:120. Subject/body/footer rules are disabled there.
+ */
+/** commitlint.config.cjs `type-enum`. Keep in sync — CI enforces it. */
+exports.TITLE_TYPES = [
+    'build',
+    'ci',
+    'deps',
+    'docs',
+    'feat',
+    'fix',
+    'merge',
+    'perf',
+    'refactor',
+    'revert',
+    'style',
+    'test',
+];
+/** commitlint.config.cjs `header-max-length`. Keep in sync — CI enforces it. */
+exports.HEADER_MAX = 120;
+// `type` + optional `(scope)` + optional `!` + `: ` + subject. Mirrors the
+// conventional-commit header shape config-conventional parses.
+const HEADER = /^(?<type>[^\s():!]+)(?<scope>\([^)]*\))?!?:[ ](?<subject>.+)$/;
+/**
+ * Wrap user-controlled title fragments before interpolating them into the
+ * sticky comment / job summary. The gate posts the comment with a write token,
+ * so a raw `@mention` in a malicious title would notify (spam) via the bot.
+ * Inline code neutralises mentions; stripping backticks stops the value
+ * breaking out of the span.
+ */
+function code(value) {
+    return `\`${(value ?? '').replace(/`/g, '')}\``;
+}
+/** Lint a PR title. Pure — no IO, no bot logic (the caller decides bot skips). */
+function lintTitle(title) {
+    if (title.length > exports.HEADER_MAX) {
+        return {
+            outcome: 'fail',
+            code: 'title-length',
+            reasons: [`The title is ${title.length} characters; keep it within ${exports.HEADER_MAX}.`],
+        };
+    }
+    const match = HEADER.exec(title);
+    if (!match?.groups) {
+        return {
+            outcome: 'fail',
+            code: 'title-format',
+            reasons: [
+                'The title must follow Conventional Commits: `type: summary` (e.g. "fix: correct retry backoff").',
+                `Allowed types: ${exports.TITLE_TYPES.join(', ')}.`,
+            ],
+        };
+    }
+    const { type, scope } = match.groups;
+    if (scope) {
+        return {
+            outcome: 'fail',
+            code: 'title-scope',
+            reasons: [`Scopes are not used in this repo — drop ${code(scope)} and write "${code(type)}: …".`],
+        };
+    }
+    if (type !== type?.toLowerCase()) {
+        return { outcome: 'fail', code: 'title-type', reasons: [`The type ${code(type)} must be lower-case.`] };
+    }
+    if (!exports.TITLE_TYPES.includes(type)) {
+        return {
+            outcome: 'fail',
+            code: 'title-type',
+            reasons: [`${code(type)} is not an allowed type. Use one of: ${exports.TITLE_TYPES.join(', ')}.`],
+        };
+    }
+    return { outcome: 'pass', code: 'title-ok', reasons: [`Title type "${type}" is valid.`] };
+}
+/**
+ * Bot authors whose titles are machine-generated and exempt from title lint
+ * (D16). Their PR-issue link / backport marker is still validated — only the
+ * title check is skipped.
+ */
+exports.BOT_TITLE_EXEMPT = new Set([
+    'backport-action',
+    'monorepo-devops-automation[bot]',
+    'renovate[bot]',
+    'dependabot[bot]',
+]);
+function isTitleExemptAuthor(login) {
+    return login !== undefined && exports.BOT_TITLE_EXEMPT.has(login);
+}
+/**
+ * Bot authors exempt from the PR-issue-LINK check, because they open PRs from
+ * their own template and will never tick the opt-out checkbox. Dependency bumps
+ * are not release-notes material, so an exemption is the agreed answer rather
+ * than teaching each bot to write the section.
+ *
+ * DELIBERATELY SEPARATE from BOT_TITLE_EXEMPT, which must never be reused here:
+ * that set contains `monorepo-devops-automation[bot]`, the author of every
+ * backport PR. Exempting it from the link check would skip the backport hop, so
+ * backports would stop inheriting the original PR's issue — silently dropping
+ * them from the release notes, which is the failure this gate exists to prevent.
+ */
+exports.BOT_LINK_EXEMPT = new Set(['renovate[bot]']);
+function isLinkExemptAuthor(login) {
+    return login !== undefined && exports.BOT_LINK_EXEMPT.has(login);
+}
+
+
+/***/ }),
+
+/***/ 24:
+/***/ ((module) => {
+
+module.exports = require("node:fs");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __nccwpck_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __nccwpck_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete __webpack_module_cache__[moduleId];
+/******/ 		}
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __nccwpck_require__(554);
+/******/ 	module.exports = __webpack_exports__;
+/******/ 	
+/******/ })()
+;

--- a/.github/actions/release-notes/lint/dist/index.js
+++ b/.github/actions/release-notes/lint/dist/index.js
@@ -67,16 +67,13 @@ async function syncStickyComment(api, gate) {
  * comment triggers downstream automations that GITHUB_TOKEN events would not).
  */
 class GithubCommentApi {
-    token;
     issueNumber;
     repoUrl;
+    headers;
     constructor(token, owner, repo, issueNumber) {
-        this.token = token;
         this.issueNumber = issueNumber;
         this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
-    }
-    headers() {
-        return (0, github_1.githubHeaders)(this.token, { json: true });
+        this.headers = (0, github_1.githubHeaders)(token, { json: true });
     }
     async list() {
         // Paginate through ALL comments. If the gate first runs on a PR that already
@@ -86,7 +83,7 @@ class GithubCommentApi {
         const perPage = 100;
         const all = [];
         for (let page = 1;; page++) {
-            const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`, { headers: this.headers() });
+            const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`, { headers: this.headers });
             if (!res.ok)
                 throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
             const batch = (await res.json());
@@ -99,7 +96,7 @@ class GithubCommentApi {
     async create(body) {
         const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
             method: 'POST',
-            headers: this.headers(),
+            headers: this.headers,
             body: JSON.stringify({ body }),
         });
         if (!res.ok)
@@ -108,7 +105,7 @@ class GithubCommentApi {
     async update(commentId, body) {
         const res = await fetch(`${this.repoUrl}/issues/comments/${commentId}`, {
             method: 'PATCH',
-            headers: this.headers(),
+            headers: this.headers,
             body: JSON.stringify({ body }),
         });
         if (!res.ok)
@@ -213,6 +210,9 @@ const node_fs_1 = __nccwpck_require__(24);
  * command/file protocols — nothing clever.
  */
 const escape = (msg) => msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+// The step summary is built as HTML, so escape anything interpolated into it —
+// reasons carry user-controlled PR title/body fragments.
+const escapeHtml = (text) => text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 const appendEnvFile = (envVar, content) => {
     const file = process.env[envVar];
     if (file)
@@ -246,11 +246,11 @@ exports.setFailed = setFailed;
 class Summary {
     buf = '';
     addHeading(text, level = 1) {
-        this.buf += `<h${level}>${text}</h${level}>\n`;
+        this.buf += `<h${level}>${escapeHtml(text)}</h${level}>\n`;
         return this;
     }
     addList(items) {
-        this.buf += `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>\n`;
+        this.buf += `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>\n`;
         return this;
     }
     async write() {
@@ -353,20 +353,19 @@ async function syncNoIssueLabel(api, gate) {
  * worth paying.
  */
 class GithubLabelApi {
-    token;
     issueNumber;
     repoUrl;
+    headers;
     constructor(token, owner, repo, issueNumber) {
-        this.token = token;
         this.issueNumber = issueNumber;
         this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
-    }
-    headers() {
-        return (0, github_1.githubHeaders)(this.token, { json: true });
+        this.headers = (0, github_1.githubHeaders)(token, { json: true });
     }
     async list() {
+        // No pagination (unlike GithubCommentApi): GitHub caps an issue/PR at 100
+        // labels, so a single per_page=100 page is always the complete set.
         const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
-            headers: this.headers(),
+            headers: this.headers,
         });
         if (!res.ok)
             throw new Error(`GitHub API ${res.status} listing labels on #${this.issueNumber}`);
@@ -390,7 +389,7 @@ class GithubLabelApi {
     async remove(label) {
         const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels/${encodeURIComponent(label)}`, {
             method: 'DELETE',
-            headers: this.headers(),
+            headers: this.headers,
         });
         // 404 means the label is already gone (e.g. a concurrent run removed it) — not an error.
         if (!res.ok && res.status !== 404) {
@@ -400,14 +399,14 @@ class GithubLabelApi {
     postLabel(label) {
         return fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels`, {
             method: 'POST',
-            headers: this.headers(),
+            headers: this.headers,
             body: JSON.stringify({ labels: [label] }),
         });
     }
     async ensureLabelExists(label) {
         const res = await fetch(`${this.repoUrl}/labels`, {
             method: 'POST',
-            headers: this.headers(),
+            headers: this.headers,
             body: JSON.stringify({ name: label, color: exports.NO_ISSUE_LABEL_COLOR, description: exports.NO_ISSUE_LABEL_DESCRIPTION }),
         });
         // 422 means another concurrent run already created it — not an error.
@@ -751,11 +750,13 @@ class GithubResolver {
     owner;
     repo;
     repoUrl;
+    headers;
     constructor(token, owner, repo) {
         this.token = token;
         this.owner = owner;
         this.repo = repo;
         this.repoUrl = (0, github_1.repoApiUrl)(owner, repo);
+        this.headers = (0, github_1.githubHeaders)(token);
     }
     async resolve(refs) {
         return Promise.all(refs.map((ref) => this.resolveOne(ref)));
@@ -770,11 +771,10 @@ class GithubResolver {
      * unrelated PR in THIS repo. We only inherit attribution from our own repo.
      */
     async fetchPullBody(number, repo) {
-        const crossRepo = repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
-        if (crossRepo)
+        if (this.isCrossRepo(repo))
             return null;
         const res = await fetch(`${this.repoUrl}/pulls/${number}`, {
-            headers: (0, github_1.githubHeaders)(this.token),
+            headers: this.headers,
         });
         if (res.status === 404)
             return null;
@@ -783,12 +783,15 @@ class GithubResolver {
         const data = (await res.json());
         return data.body ?? '';
     }
+    /** A ref points at a different repo than the one being gated (case-insensitive). */
+    isCrossRepo(repo) {
+        return repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+    }
     async resolveOne(ref) {
-        const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
-        if (crossRepo)
+        if (this.isCrossRepo(ref.repo))
             return { ...ref, target: 'missing', crossRepo: true };
         const res = await fetch(`${this.repoUrl}/issues/${ref.number}`, {
-            headers: (0, github_1.githubHeaders)(this.token),
+            headers: this.headers,
         });
         if (res.status === 404)
             return { ...ref, target: 'missing', crossRepo: false };

--- a/.github/actions/release-notes/package-lock.json
+++ b/.github/actions/release-notes/package-lock.json
@@ -1,0 +1,568 @@
+{
+  "name": "release-notes-action",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "release-notes-action",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "24.0.0",
+        "@vercel/ncc": "0.38.3",
+        "tsx": "4.19.2",
+        "typescript": "5.7.3"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@vercel/ncc": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
+      "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
+      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/actions/release-notes/package.json
+++ b/.github/actions/release-notes/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "release-notes-action",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Shared release-notes reference parser + PR-gate lint (epic camunda/camunda#53605). The parser module is imported unchanged by the generator (#57713) — do not fork logic.",
+  "engines": {
+    "node": ">=24"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "build:lint": "ncc build src/lint.ts -o lint/dist --no-source-map-register",
+    "build": "npm run build:lint",
+    "test": "node --import tsx --test test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "24.0.0",
+    "@vercel/ncc": "0.38.3",
+    "tsx": "4.19.2",
+    "typescript": "5.7.3"
+  }
+}

--- a/.github/actions/release-notes/src/comment/index.ts
+++ b/.github/actions/release-notes/src/comment/index.ts
@@ -1,0 +1,133 @@
+import type { PolicyDecision } from '../types';
+
+/**
+ * The single sticky PR comment the gate maintains. One marked comment per PR,
+ * upserted by a hidden marker so re-runs never stack duplicates.
+ *
+ * Split like the resolver (types.ts): the body render + upsert logic are pure /
+ * injectable (unit-tested for idempotency), and only GithubCommentApi touches
+ * the network — plain fetch, no octokit, same rationale as GithubResolver.
+ */
+
+/** Hidden HTML marker identifying our comment. Never change it — it is how
+ * every future run finds the comment it already posted. */
+export const STICKY_MARKER = '<!-- release-notes-pr-gate -->';
+
+/** The subset of an issue comment the sticky logic reads. */
+export interface IssueComment {
+  readonly id: number;
+  readonly body: string;
+}
+
+/**
+ * The issue-comments API surface the sticky comment needs, injected so the
+ * upsert logic is testable without mocking fetch. (PR comments are issue
+ * comments — the issues API serves both.)
+ */
+export interface CommentApi {
+  list(): Promise<IssueComment[]>;
+  create(body: string): Promise<void>;
+  update(id: number, body: string): Promise<void>;
+}
+
+/** What syncStickyComment did — surfaced to the job log, and asserted in tests. */
+export type StickyAction = 'created' | 'updated' | 'resolved' | 'noop';
+
+/** Build the comment body (pure). Always carries the marker on the first line. */
+export function renderStickyComment(decision: PolicyDecision): string {
+  const title =
+    decision.outcome === 'pass'
+      ? '### ✅ Release-notes: PR-issue link resolved'
+      : '### ❌ Release-notes: PR-issue link check';
+  const reasons = decision.reasons.map((reason) => `- ${reason}`).join('\n');
+  const footer =
+    decision.outcome === 'pass'
+      ? '_This check now passes — no action needed._'
+      : '_Warn-only during rollout: this does not block merge yet. Fix the link (or tick the opt-out) so release notes attribute this change._';
+  return `${STICKY_MARKER}\n${title}\n\n${reasons}\n\n${footer}\n`;
+}
+
+/**
+ * Idempotently reconcile the PR's single sticky comment against the decision.
+ *
+ *  - fail: update the existing comment, or create one if none exists.
+ *  - pass: if a comment exists (the PR failed earlier), update it to the
+ *          resolved body; if none exists, do nothing — a PR that never failed
+ *          stays comment-free, so the gate adds no noise across ~800 PRs.
+ */
+export async function syncStickyComment(api: CommentApi, decision: PolicyDecision): Promise<StickyAction> {
+  const existing = (await api.list()).find((comment) => comment.body.includes(STICKY_MARKER));
+  const body = renderStickyComment(decision);
+
+  if (decision.outcome === 'fail') {
+    if (existing) {
+      await api.update(existing.id, body);
+      return 'updated';
+    }
+    await api.create(body);
+    return 'created';
+  }
+
+  if (existing) {
+    await api.update(existing.id, body);
+    return 'resolved';
+  }
+  return 'noop';
+}
+
+/**
+ * issue-comments API over plain fetch (Node global). Same reasoning as
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost is not worth
+ * paying. Reuses the injected MONOREPO_RELEASE_APP token (bot identity, so the
+ * comment triggers downstream automations that GITHUB_TOKEN events would not).
+ */
+export class GithubCommentApi implements CommentApi {
+  private readonly repoUrl: string;
+
+  constructor(
+    private readonly token: string,
+    owner: string,
+    repo: string,
+    private readonly issueNumber: number,
+  ) {
+    this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Bearer ${this.token}`,
+      accept: 'application/vnd.github+json',
+      'content-type': 'application/json',
+      'x-github-api-version': '2022-11-28',
+      'user-agent': 'camunda-release-notes-gate',
+    };
+  }
+
+  async list(): Promise<IssueComment[]> {
+    // The comment is posted on the first gate run and stays put, so the first
+    // page (100) always contains it — no pagination needed.
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=100`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
+    return (await res.json()) as IssueComment[];
+  }
+
+  async create(body: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} creating comment on #${this.issueNumber}`);
+  }
+
+  async update(commentId: number, body: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/issues/comments/${commentId}`, {
+      method: 'PATCH',
+      headers: this.headers(),
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} updating comment ${commentId}`);
+  }
+}

--- a/.github/actions/release-notes/src/comment/index.ts
+++ b/.github/actions/release-notes/src/comment/index.ts
@@ -1,4 +1,4 @@
-import type { PolicyDecision } from '../types';
+import type { GateOutcome } from '../types';
 
 /**
  * The single sticky PR comment the gate maintains. One marked comment per PR,
@@ -34,32 +34,34 @@ export interface CommentApi {
 export type StickyAction = 'created' | 'updated' | 'resolved' | 'noop';
 
 /** Build the comment body (pure). Always carries the marker on the first line. */
-export function renderStickyComment(decision: PolicyDecision): string {
-  const title =
-    decision.outcome === 'pass'
-      ? '### ✅ Release-notes: PR-issue link resolved'
-      : '### ❌ Release-notes: PR-issue link check';
-  const reasons = decision.reasons.map((reason) => `- ${reason}`).join('\n');
+export function renderStickyComment(gate: GateOutcome): string {
+  if (gate.outcome === 'pass') {
+    return `${STICKY_MARKER}\n### ✅ Release-notes checks passed\n\n_These checks now pass — no action needed._\n`;
+  }
+
+  // One block per failing check, each naming the reasons and the fix.
+  const blocks = gate.checks
+    .filter((check) => check.outcome === 'fail')
+    .map((check) => `**${check.label}**\n${check.reasons.map((reason) => `- ${reason}`).join('\n')}`)
+    .join('\n\n');
   const footer =
-    decision.outcome === 'pass'
-      ? '_This check now passes — no action needed._'
-      : '_Warn-only during rollout: this does not block merge yet. Fix the link (or tick the opt-out) so release notes attribute this change._';
-  return `${STICKY_MARKER}\n${title}\n\n${reasons}\n\n${footer}\n`;
+    '_Warn-only during rollout: this does not block merge yet. Addressing it keeps release notes accurate._';
+  return `${STICKY_MARKER}\n### ❌ Release-notes checks\n\n${blocks}\n\n${footer}\n`;
 }
 
 /**
- * Idempotently reconcile the PR's single sticky comment against the decision.
+ * Idempotently reconcile the PR's single sticky comment against the outcome.
  *
  *  - fail: update the existing comment, or create one if none exists.
  *  - pass: if a comment exists (the PR failed earlier), update it to the
  *          resolved body; if none exists, do nothing — a PR that never failed
  *          stays comment-free, so the gate adds no noise across ~800 PRs.
  */
-export async function syncStickyComment(api: CommentApi, decision: PolicyDecision): Promise<StickyAction> {
+export async function syncStickyComment(api: CommentApi, gate: GateOutcome): Promise<StickyAction> {
   const existing = (await api.list()).find((comment) => comment.body.includes(STICKY_MARKER));
-  const body = renderStickyComment(decision);
+  const body = renderStickyComment(gate);
 
-  if (decision.outcome === 'fail') {
+  if (gate.outcome === 'fail') {
     if (existing) {
       await api.update(existing.id, body);
       return 'updated';

--- a/.github/actions/release-notes/src/comment/index.ts
+++ b/.github/actions/release-notes/src/comment/index.ts
@@ -1,3 +1,4 @@
+import { githubHeaders, repoApiUrl } from '../github';
 import type { GateOutcome } from '../types';
 
 /**
@@ -92,27 +93,31 @@ export class GithubCommentApi implements CommentApi {
     repo: string,
     private readonly issueNumber: number,
   ) {
-    this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+    this.repoUrl = repoApiUrl(owner, repo);
   }
 
   private headers(): Record<string, string> {
-    return {
-      authorization: `Bearer ${this.token}`,
-      accept: 'application/vnd.github+json',
-      'content-type': 'application/json',
-      'x-github-api-version': '2022-11-28',
-      'user-agent': 'camunda-release-notes-gate',
-    };
+    return githubHeaders(this.token, { json: true });
   }
 
   async list(): Promise<IssueComment[]> {
-    // The comment is posted on the first gate run and stays put, so the first
-    // page (100) always contains it — no pagination needed.
-    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=100`, {
-      headers: this.headers(),
-    });
-    if (!res.ok) throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
-    return (await res.json()) as IssueComment[];
+    // Paginate through ALL comments. If the gate first runs on a PR that already
+    // has >100 comments, its own sticky comment is the newest and lands past
+    // page 1 — a page-1-only read would miss it and create a duplicate on every
+    // rerun. GitHub caps per_page at 100; a short page marks the end.
+    const perPage = 100;
+    const all: IssueComment[] = [];
+    for (let page = 1; ; page++) {
+      const res = await fetch(
+        `${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`,
+        { headers: this.headers() },
+      );
+      if (!res.ok) throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
+      const batch = (await res.json()) as IssueComment[];
+      all.push(...batch);
+      if (batch.length < perPage) break;
+    }
+    return all;
   }
 
   async create(body: string): Promise<void> {

--- a/.github/actions/release-notes/src/comment/index.ts
+++ b/.github/actions/release-notes/src/comment/index.ts
@@ -1,0 +1,147 @@
+import { githubHeaders, repoApiUrl } from '../github';
+import type { GateOutcome } from '../types';
+
+/**
+ * The single sticky PR comment the gate maintains. One marked comment per PR,
+ * upserted by a hidden marker so re-runs never stack duplicates.
+ *
+ * Split like the resolver (types.ts): the body render + upsert logic are pure /
+ * injectable (unit-tested for idempotency), and only GithubCommentApi touches
+ * the network — plain fetch, no octokit, same rationale as GithubResolver.
+ */
+
+/** Hidden HTML marker identifying our comment. Never change it — it is how
+ * every future run finds the comment it already posted. */
+export const STICKY_MARKER = '<!-- release-notes-pr-gate -->';
+
+/** The subset of an issue comment the sticky logic reads. */
+export interface IssueComment {
+  readonly id: number;
+  readonly body: string;
+}
+
+/**
+ * The issue-comments API surface the sticky comment needs, injected so the
+ * upsert logic is testable without mocking fetch. (PR comments are issue
+ * comments — the issues API serves both.)
+ */
+export interface CommentApi {
+  list(): Promise<IssueComment[]>;
+  create(body: string): Promise<void>;
+  update(id: number, body: string): Promise<void>;
+}
+
+/** What syncStickyComment did — surfaced to the job log, and asserted in tests. */
+export type StickyAction = 'created' | 'updated' | 'resolved' | 'noop';
+
+/** Where the comment sends authors for the full list of causes and fixes. */
+export const GATE_DOCS_URL = 'https://camunda.github.io/camunda/ci/#release-notes-pr-gate';
+
+/**
+ * Build the comment body (pure). Always carries the marker on the first line.
+ *
+ * Deliberately terse: the reasons name the exact fix, and everything else —
+ * why the rule exists, the full cause list, the rollout state — lives in the
+ * docs behind GATE_DOCS_URL rather than being restated on every failing PR.
+ */
+export function renderStickyComment(gate: GateOutcome): string {
+  if (gate.outcome === 'pass') {
+    return `${STICKY_MARKER}\n### ✅ Release-notes checks passed\n`;
+  }
+
+  // One block per failing check, each naming the reasons and the fix.
+  const blocks = gate.checks
+    .filter((check) => check.outcome === 'fail')
+    .map((check) => `**${check.label}**\n${check.reasons.map((reason) => `- ${reason}`).join('\n')}`)
+    .join('\n\n');
+  const footer = `[Causes and fixes](${GATE_DOCS_URL}) · advisory, does not block merge`;
+  return `${STICKY_MARKER}\n### ❌ Release-notes checks\n\n${blocks}\n\n${footer}\n`;
+}
+
+/**
+ * Idempotently reconcile the PR's single sticky comment against the outcome.
+ *
+ *  - fail: update the existing comment, or create one if none exists.
+ *  - pass: if a comment exists (the PR failed earlier), update it to the
+ *          resolved body; if none exists, do nothing — a PR that never failed
+ *          stays comment-free, so the gate adds no noise across ~800 PRs.
+ */
+export async function syncStickyComment(api: CommentApi, gate: GateOutcome): Promise<StickyAction> {
+  const existing = (await api.list()).find((comment) => comment.body.includes(STICKY_MARKER));
+  const body = renderStickyComment(gate);
+
+  if (gate.outcome === 'fail') {
+    if (existing) {
+      await api.update(existing.id, body);
+      return 'updated';
+    }
+    await api.create(body);
+    return 'created';
+  }
+
+  if (existing) {
+    await api.update(existing.id, body);
+    return 'resolved';
+  }
+  return 'noop';
+}
+
+/**
+ * issue-comments API over plain fetch (Node global). Same reasoning as
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost is not worth
+ * paying. Uses GITHUB_TOKEN with `pull-requests: write` — nothing reacts to this
+ * comment as an event, so the gate needs no App identity (and therefore no Vault
+ * secrets) to post it.
+ */
+export class GithubCommentApi implements CommentApi {
+  private readonly repoUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(
+    token: string,
+    owner: string,
+    repo: string,
+    private readonly issueNumber: number,
+  ) {
+    this.repoUrl = repoApiUrl(owner, repo);
+    this.headers = githubHeaders(token, { json: true });
+  }
+
+  async list(): Promise<IssueComment[]> {
+    // Paginate through ALL comments. If the gate first runs on a PR that already
+    // has >100 comments, its own sticky comment is the newest and lands past
+    // page 1 — a page-1-only read would miss it and create a duplicate on every
+    // rerun. GitHub caps per_page at 100; a short page marks the end.
+    const perPage = 100;
+    const all: IssueComment[] = [];
+    for (let page = 1; ; page++) {
+      const res = await fetch(
+        `${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`,
+        { headers: this.headers },
+      );
+      if (!res.ok) throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
+      const batch = (await res.json()) as IssueComment[];
+      all.push(...batch);
+      if (batch.length < perPage) break;
+    }
+    return all;
+  }
+
+  async create(body: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} creating comment on #${this.issueNumber}`);
+  }
+
+  async update(commentId: number, body: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/issues/comments/${commentId}`, {
+      method: 'PATCH',
+      headers: this.headers,
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} updating comment ${commentId}`);
+  }
+}

--- a/.github/actions/release-notes/src/comment/index.ts
+++ b/.github/actions/release-notes/src/comment/index.ts
@@ -86,18 +86,16 @@ export async function syncStickyComment(api: CommentApi, gate: GateOutcome): Pro
  */
 export class GithubCommentApi implements CommentApi {
   private readonly repoUrl: string;
+  private readonly headers: Record<string, string>;
 
   constructor(
-    private readonly token: string,
+    token: string,
     owner: string,
     repo: string,
     private readonly issueNumber: number,
   ) {
     this.repoUrl = repoApiUrl(owner, repo);
-  }
-
-  private headers(): Record<string, string> {
-    return githubHeaders(this.token, { json: true });
+    this.headers = githubHeaders(token, { json: true });
   }
 
   async list(): Promise<IssueComment[]> {
@@ -110,7 +108,7 @@ export class GithubCommentApi implements CommentApi {
     for (let page = 1; ; page++) {
       const res = await fetch(
         `${this.repoUrl}/issues/${this.issueNumber}/comments?per_page=${perPage}&page=${page}`,
-        { headers: this.headers() },
+        { headers: this.headers },
       );
       if (!res.ok) throw new Error(`GitHub API ${res.status} listing comments on #${this.issueNumber}`);
       const batch = (await res.json()) as IssueComment[];
@@ -123,7 +121,7 @@ export class GithubCommentApi implements CommentApi {
   async create(body: string): Promise<void> {
     const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/comments`, {
       method: 'POST',
-      headers: this.headers(),
+      headers: this.headers,
       body: JSON.stringify({ body }),
     });
     if (!res.ok) throw new Error(`GitHub API ${res.status} creating comment on #${this.issueNumber}`);
@@ -132,7 +130,7 @@ export class GithubCommentApi implements CommentApi {
   async update(commentId: number, body: string): Promise<void> {
     const res = await fetch(`${this.repoUrl}/issues/comments/${commentId}`, {
       method: 'PATCH',
-      headers: this.headers(),
+      headers: this.headers,
       body: JSON.stringify({ body }),
     });
     if (!res.ok) throw new Error(`GitHub API ${res.status} updating comment ${commentId}`);

--- a/.github/actions/release-notes/src/gate/index.ts
+++ b/.github/actions/release-notes/src/gate/index.ts
@@ -14,7 +14,10 @@ import type { DeliveryPath, GateCheck, GateOutcome, ParsedRef, PolicyDecision, R
 /** The slice of the resolver the gate needs (GithubResolver satisfies it). */
 export interface GateResolver {
   resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]>;
-  fetchPullBody(number: number): Promise<string | null>;
+  /** Fetch the original PR's body for a backport hop. `repo` is the marker's
+   *  explicit `owner/repo` prefix, or null for a same-repo marker; the resolver
+   *  returns null for a cross-repo marker (it can only validate its own repo). */
+  fetchPullBody(number: number, repo: string | null): Promise<string | null>;
 }
 
 export interface GateInput {
@@ -40,13 +43,29 @@ export async function evaluateGate(resolver: GateResolver, input: GateInput): Pr
   let deliveryPath: DeliveryPath = 'direct';
   let link = await evaluateLink(resolver, input.body);
 
-  if (link.outcome === 'fail') {
+  // Only hop for a genuinely undeclared link. A `pr-ref-in-section` failure is a
+  // hard error (the section itself links a PR) — an unrelated `Backport of #N`
+  // marker must not silently discard it and flip the gate to pass.
+  if (link.outcome === 'fail' && link.code === 'unlinked-undeclared') {
     const backport = parseRefs(input.body).find((ref) => ref.kind === 'backport');
     if (backport) {
-      const originalBody = await resolver.fetchPullBody(backport.number);
-      if (originalBody !== null) {
+      // fetchPullBody returns null for a 404 target OR a cross-repo marker — the
+      // resolver can only validate its own repo. Either way we cannot inherit
+      // attribution, so surface the dangling marker rather than absorbing it
+      // into the generic "no linked issue" message.
+      const originalBody = await resolver.fetchPullBody(backport.number, backport.repo);
+      deliveryPath = 'backportHop';
+      if (originalBody === null) {
+        link = {
+          outcome: 'fail',
+          code: 'unlinked-undeclared',
+          reasons: [
+            `Backport of ${backport.repo ? `${backport.repo}#` : '#'}${backport.number}, but that PR could not be resolved in this repo — attribution cannot be inherited.`,
+            ...link.reasons,
+          ],
+        };
+      } else {
         const original = await evaluateLink(resolver, originalBody);
-        deliveryPath = 'backportHop';
         link =
           original.outcome === 'pass'
             ? {
@@ -75,5 +94,5 @@ export async function evaluateGate(resolver: GateResolver, input: GateInput): Pr
   }
 
   const outcome = checks.every((check) => check.outcome === 'pass') ? 'pass' : 'fail';
-  return { outcome, checks, deliveryPath };
+  return { outcome, checks, deliveryPath, link };
 }

--- a/.github/actions/release-notes/src/gate/index.ts
+++ b/.github/actions/release-notes/src/gate/index.ts
@@ -1,0 +1,79 @@
+import { extractSection, isOptOutTicked, parseRefs } from '../parser';
+import { decide } from '../policy';
+import { isTitleExemptAuthor, lintTitle } from '../title';
+import type { DeliveryPath, GateCheck, GateOutcome, ParsedRef, PolicyDecision, ResolvedRef } from '../types';
+
+/**
+ * Composes the pure parser/policy/title pieces with the network resolver into a
+ * single gate outcome: the PR-issue link check (with a backport-hop fallback)
+ * plus the title check. Kept separate from the entrypoint and depending only on
+ * GateResolver, so the orchestration — including the hop — is unit-tested with a
+ * fake resolver, no network.
+ */
+
+/** The slice of the resolver the gate needs (GithubResolver satisfies it). */
+export interface GateResolver {
+  resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]>;
+  fetchPullBody(number: number): Promise<string | null>;
+}
+
+export interface GateInput {
+  readonly body: string;
+  readonly title: string;
+  readonly authorLogin?: string;
+}
+
+/** Evaluate the PR-issue link for one PR body: section refs + opt-out. */
+async function evaluateLink(resolver: GateResolver, body: string): Promise<PolicyDecision> {
+  const section = extractSection(body);
+  const optOut = isOptOutTicked(body);
+  const refs = section ? parseRefs(section) : [];
+  const resolved = await resolver.resolve(refs);
+  return decide(resolved, optOut);
+}
+
+export async function evaluateGate(resolver: GateResolver, input: GateInput): Promise<GateOutcome> {
+  // --- PR-issue link, with a backport-hop fallback (C7/V2) ---
+  // A backport PR passes on its own section if it has one (manual template);
+  // otherwise (bot backports carry only `Backport of #N`, no section) it passes
+  // by inheriting the ORIGINAL PR's attribution.
+  let deliveryPath: DeliveryPath = 'direct';
+  let link = await evaluateLink(resolver, input.body);
+
+  if (link.outcome === 'fail') {
+    const backport = parseRefs(input.body).find((ref) => ref.kind === 'backport');
+    if (backport) {
+      const originalBody = await resolver.fetchPullBody(backport.number);
+      if (originalBody !== null) {
+        const original = await evaluateLink(resolver, originalBody);
+        deliveryPath = 'backportHop';
+        link =
+          original.outcome === 'pass'
+            ? {
+                outcome: 'pass',
+                code: original.code,
+                reasons: [`Backport of #${backport.number} — inherits that PR's attribution (${original.code}).`],
+              }
+            : {
+                outcome: 'fail',
+                code: 'unlinked-undeclared',
+                reasons: [
+                  `Backport of #${backport.number}, but that PR does not link a tracked issue either.`,
+                  ...original.reasons,
+                ],
+              };
+      }
+    }
+  }
+
+  const checks: GateCheck[] = [{ label: 'PR-issue link', outcome: link.outcome, reasons: [...link.reasons] }];
+
+  // --- Title lint (D16: skipped for bot authors; link/marker still checked) ---
+  if (!isTitleExemptAuthor(input.authorLogin)) {
+    const title = lintTitle(input.title);
+    checks.push({ label: 'Title', outcome: title.outcome, reasons: [...title.reasons] });
+  }
+
+  const outcome = checks.every((check) => check.outcome === 'pass') ? 'pass' : 'fail';
+  return { outcome, checks, deliveryPath };
+}

--- a/.github/actions/release-notes/src/gate/index.ts
+++ b/.github/actions/release-notes/src/gate/index.ts
@@ -1,0 +1,130 @@
+import { extractSection, isOptOutTicked, parseRefs } from '../parser';
+import { decide } from '../policy';
+import { isLinkExemptAuthor, isTitleExemptAuthor, lintTitle } from '../title';
+import type { DeliveryPath, GateCheck, GateOutcome, ParsedRef, PolicyDecision, ResolvedRef } from '../types';
+
+/**
+ * Composes the pure parser/policy/title pieces with the network resolver into a
+ * single gate outcome: the PR-issue link check (with a backport-hop fallback)
+ * plus the title check. Kept separate from the entrypoint and depending only on
+ * GateResolver, so the orchestration — including the hop — is unit-tested with a
+ * fake resolver, no network.
+ */
+
+/** The slice of the resolver the gate needs (GithubResolver satisfies it). */
+export interface GateResolver {
+  resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]>;
+  /** Fetch the original PR's body for a backport hop. `repo` is the marker's
+   *  explicit `owner/repo` prefix, or null for a same-repo marker; the resolver
+   *  returns null for a cross-repo marker (it can only validate its own repo). */
+  fetchPullBody(number: number, repo: string | null): Promise<string | null>;
+}
+
+export interface GateInput {
+  readonly body: string;
+  readonly title: string;
+  readonly authorLogin?: string;
+}
+
+/** Evaluate the PR-issue link for one PR body: section refs + opt-out. */
+async function evaluateLink(resolver: GateResolver, body: string): Promise<PolicyDecision> {
+  const section = extractSection(body);
+  const optOut = isOptOutTicked(body);
+  const refs = section ? parseRefs(section) : [];
+  const resolved = await resolver.resolve(refs);
+  return decide(resolved, optOut);
+}
+
+/**
+ * Explain why a `Backport of #N` marker could not be followed to an original
+ * PR, so the author sees the actual problem rather than a generic "no linked
+ * issue". Only reached in the rare failure path, so the extra classify call
+ * (issue vs missing) never touches the hot bot-backport path.
+ */
+async function unresolvableBackportReason(
+  resolver: GateResolver,
+  backport: ParsedRef,
+): Promise<string> {
+  const [resolved] = await resolver.resolve([backport]);
+  if (resolved?.crossRepo) {
+    return `Backport of ${backport.repo}#${backport.number} points to another repository — attribution can only be inherited from a pull request in this repo.`;
+  }
+  if (resolved?.target === 'issue') {
+    return `Backport of #${backport.number} points to an issue, not a pull request — a backport marker must reference the original PR.`;
+  }
+  return `Backport of #${backport.number} does not resolve to a pull request in this repo — attribution cannot be inherited.`;
+}
+
+export async function evaluateGate(resolver: GateResolver, input: GateInput): Promise<GateOutcome> {
+  // --- PR-issue link, with a backport-hop fallback (C7/V2) ---
+  // A backport PR passes on its own section if it has one (manual template);
+  // otherwise (bot backports carry only `Backport of #N`, no section) it passes
+  // by inheriting the ORIGINAL PR's attribution.
+  let deliveryPath: DeliveryPath = 'direct';
+  let link = await evaluateLink(resolver, input.body);
+
+  // Only hop for a genuinely undeclared link. A `pr-ref-in-section` failure is a
+  // hard error (the section itself links a PR) — an unrelated `Backport of #N`
+  // marker must not silently discard it and flip the gate to pass.
+  if (link.outcome === 'fail' && link.code === 'unlinked-undeclared') {
+    const backport = parseRefs(input.body).find((ref) => ref.kind === 'backport');
+    if (backport) {
+      // fetchPullBody returns null for a 404 target OR a cross-repo marker — the
+      // resolver can only validate its own repo. Either way we cannot inherit
+      // attribution, so surface the dangling marker rather than absorbing it
+      // into the generic "no linked issue" message.
+      const originalBody = await resolver.fetchPullBody(backport.number, backport.repo);
+      deliveryPath = 'backportHop';
+      if (originalBody === null) {
+        // The marker is the PR's stated attribution path, so speak to the marker
+        // only — the generic "add a closing keyword / tick opt-out" section advice
+        // is irrelevant for a backport PR and would just be noise.
+        link = {
+          outcome: 'fail',
+          code: 'unlinked-undeclared',
+          reasons: [await unresolvableBackportReason(resolver, backport)],
+        };
+      } else {
+        const original = await evaluateLink(resolver, originalBody);
+        link =
+          original.outcome === 'pass'
+            ? {
+                outcome: 'pass',
+                code: original.code,
+                reasons: [`Backport of #${backport.number} — inherits that PR's attribution (${original.code}).`],
+              }
+            : {
+                outcome: 'fail',
+                code: 'unlinked-undeclared',
+                reasons: [
+                  `Backport of #${backport.number}, but that PR does not link a tracked issue either.`,
+                  ...original.reasons,
+                ],
+              };
+      }
+    }
+  }
+
+  // Bot link exemption (Renovate). Applied AFTER the hop and only to a still
+  // failing link, so it is a fallback and never a bypass: a bot PR that does
+  // link an issue keeps its real code, and the hop above still runs for the
+  // backport bot. An explicit link therefore always wins over the exemption.
+  if (link.outcome === 'fail' && isLinkExemptAuthor(input.authorLogin)) {
+    link = {
+      outcome: 'pass',
+      code: 'bot-exempt',
+      reasons: [`Author ${input.authorLogin} is exempt from the PR-issue link check.`],
+    };
+  }
+
+  const checks: GateCheck[] = [{ label: 'PR-issue link', outcome: link.outcome, reasons: [...link.reasons] }];
+
+  // --- Title lint (D16: skipped for bot authors; link/marker still checked) ---
+  if (!isTitleExemptAuthor(input.authorLogin)) {
+    const title = lintTitle(input.title);
+    checks.push({ label: 'Title', outcome: title.outcome, reasons: [...title.reasons] });
+  }
+
+  const outcome = checks.every((check) => check.outcome === 'pass') ? 'pass' : 'fail';
+  return { outcome, checks, deliveryPath, link };
+}

--- a/.github/actions/release-notes/src/gha.ts
+++ b/.github/actions/release-notes/src/gha.ts
@@ -1,0 +1,56 @@
+import { appendFileSync } from 'node:fs';
+
+/**
+ * ponytail: the ~7 GitHub Actions toolkit calls we actually use, inlined.
+ * @actions/core drags in @actions/exec + http-client + io (~400kB) for OIDC and
+ * command features this action never touches. These are the documented Actions
+ * command/file protocols — nothing clever.
+ */
+
+const escape = (s: string): string => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+
+const appendEnvFile = (envVar: string, content: string): void => {
+  const file = process.env[envVar];
+  if (file) appendFileSync(file, content);
+};
+
+export const getInput = (name: string, opts: { required?: boolean } = {}): string => {
+  const value = (process.env[`INPUT_${name.toUpperCase().replace(/ /g, '_')}`] ?? '').trim();
+  if (opts.required && !value) throw new Error(`Input required and not supplied: ${name}`);
+  return value;
+};
+
+export const getBooleanInput = (name: string): boolean => getInput(name).toLowerCase() === 'true';
+
+// GITHUB_OUTPUT file protocol with a heredoc delimiter (safe for multiline values).
+export const setOutput = (name: string, value: string): void =>
+  appendEnvFile('GITHUB_OUTPUT', `${name}<<_GHA_EOF_\n${value}\n_GHA_EOF_\n`);
+
+export const info = (msg: string): void => {
+  process.stdout.write(`${msg}\n`);
+};
+export const warning = (msg: string): void => {
+  process.stdout.write(`::warning::${escape(msg)}\n`);
+};
+export const setFailed = (msg: string): void => {
+  process.stdout.write(`::error::${escape(msg)}\n`);
+  process.exitCode = 1;
+};
+
+class Summary {
+  private buf = '';
+  addHeading(text: string, level = 1): this {
+    this.buf += `<h${level}>${text}</h${level}>\n`;
+    return this;
+  }
+  addList(items: string[]): this {
+    this.buf += `<ul>${items.map((i) => `<li>${i}</li>`).join('')}</ul>\n`;
+    return this;
+  }
+  async write(): Promise<void> {
+    appendEnvFile('GITHUB_STEP_SUMMARY', this.buf);
+    this.buf = '';
+  }
+}
+
+export const summary = new Summary();

--- a/.github/actions/release-notes/src/gha.ts
+++ b/.github/actions/release-notes/src/gha.ts
@@ -7,7 +7,7 @@ import { appendFileSync } from 'node:fs';
  * command/file protocols — nothing clever.
  */
 
-const escape = (s: string): string => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+const escape = (msg: string): string => msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 
 const appendEnvFile = (envVar: string, content: string): void => {
   const file = process.env[envVar];
@@ -44,7 +44,7 @@ class Summary {
     return this;
   }
   addList(items: string[]): this {
-    this.buf += `<ul>${items.map((i) => `<li>${i}</li>`).join('')}</ul>\n`;
+    this.buf += `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>\n`;
     return this;
   }
   async write(): Promise<void> {

--- a/.github/actions/release-notes/src/gha.ts
+++ b/.github/actions/release-notes/src/gha.ts
@@ -1,0 +1,61 @@
+import { appendFileSync } from 'node:fs';
+
+/**
+ * ponytail: the ~7 GitHub Actions toolkit calls we actually use, inlined.
+ * @actions/core drags in @actions/exec + http-client + io (~400kB) for OIDC and
+ * command features this action never touches. These are the documented Actions
+ * command/file protocols — nothing clever.
+ */
+
+const escape = (msg: string): string => msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+
+// The step summary is built as HTML, so escape anything interpolated into it —
+// reasons carry user-controlled PR title/body fragments.
+const escapeHtml = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const appendEnvFile = (envVar: string, content: string): void => {
+  const file = process.env[envVar];
+  if (file) appendFileSync(file, content);
+};
+
+export const getInput = (name: string, opts: { required?: boolean } = {}): string => {
+  const value = (process.env[`INPUT_${name.toUpperCase().replace(/ /g, '_')}`] ?? '').trim();
+  if (opts.required && !value) throw new Error(`Input required and not supplied: ${name}`);
+  return value;
+};
+
+export const getBooleanInput = (name: string): boolean => getInput(name).toLowerCase() === 'true';
+
+// GITHUB_OUTPUT file protocol with a heredoc delimiter (safe for multiline values).
+export const setOutput = (name: string, value: string): void =>
+  appendEnvFile('GITHUB_OUTPUT', `${name}<<_GHA_EOF_\n${value}\n_GHA_EOF_\n`);
+
+export const info = (msg: string): void => {
+  process.stdout.write(`${msg}\n`);
+};
+export const warning = (msg: string): void => {
+  process.stdout.write(`::warning::${escape(msg)}\n`);
+};
+export const setFailed = (msg: string): void => {
+  process.stdout.write(`::error::${escape(msg)}\n`);
+  process.exitCode = 1;
+};
+
+class Summary {
+  private buf = '';
+  addHeading(text: string, level = 1): this {
+    this.buf += `<h${level}>${escapeHtml(text)}</h${level}>\n`;
+    return this;
+  }
+  addList(items: string[]): this {
+    this.buf += `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>\n`;
+    return this;
+  }
+  async write(): Promise<void> {
+    appendEnvFile('GITHUB_STEP_SUMMARY', this.buf);
+    this.buf = '';
+  }
+}
+
+export const summary = new Summary();

--- a/.github/actions/release-notes/src/gha.ts
+++ b/.github/actions/release-notes/src/gha.ts
@@ -9,6 +9,11 @@ import { appendFileSync } from 'node:fs';
 
 const escape = (msg: string): string => msg.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
 
+// The step summary is built as HTML, so escape anything interpolated into it —
+// reasons carry user-controlled PR title/body fragments.
+const escapeHtml = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
 const appendEnvFile = (envVar: string, content: string): void => {
   const file = process.env[envVar];
   if (file) appendFileSync(file, content);
@@ -40,11 +45,11 @@ export const setFailed = (msg: string): void => {
 class Summary {
   private buf = '';
   addHeading(text: string, level = 1): this {
-    this.buf += `<h${level}>${text}</h${level}>\n`;
+    this.buf += `<h${level}>${escapeHtml(text)}</h${level}>\n`;
     return this;
   }
   addList(items: string[]): this {
-    this.buf += `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>\n`;
+    this.buf += `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>\n`;
     return this;
   }
   async write(): Promise<void> {

--- a/.github/actions/release-notes/src/github/index.ts
+++ b/.github/actions/release-notes/src/github/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared GitHub REST plumbing for the three fetch-based adapters (resolver,
+ * comment, labels). One definition of the bot's auth / API-version / user-agent
+ * headers and the per-repo base URL — previously copied verbatim into each
+ * adapter. The adapters stay octokit-free (a handful of endpoints each); this is
+ * just the common boilerplate, not a client.
+ */
+
+export const GITHUB_API = 'https://api.github.com';
+const USER_AGENT = 'camunda-release-notes-gate';
+const GITHUB_API_VERSION = '2022-11-28';
+
+/** Auth + content-negotiation headers for the reused MONOREPO_RELEASE_APP token.
+ *  Pass `json: true` for write requests that send a JSON body. */
+export function githubHeaders(token: string, opts: { json?: boolean } = {}): Record<string, string> {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${token}`,
+    accept: 'application/vnd.github+json',
+    'x-github-api-version': GITHUB_API_VERSION,
+    'user-agent': USER_AGENT,
+  };
+  if (opts.json) headers['content-type'] = 'application/json';
+  return headers;
+}
+
+/** `https://api.github.com/repos/<owner>/<repo>` — the common request prefix. */
+export function repoApiUrl(owner: string, repo: string): string {
+  return `${GITHUB_API}/repos/${owner}/${repo}`;
+}

--- a/.github/actions/release-notes/src/labels/index.ts
+++ b/.github/actions/release-notes/src/labels/index.ts
@@ -1,3 +1,4 @@
+import { githubHeaders, repoApiUrl } from '../github';
 import type { GateOutcome, PolicyOutcome } from '../types';
 
 /**
@@ -40,15 +41,12 @@ export function decideLabelAction(currentLabels: readonly string[], linkOutcome:
 
 /**
  * Reconcile the no-issue label against the gate's PR-issue-link check.
- * Reads the check by label rather than gate.outcome so a title-only failure
- * never adds a label whose name specifically means "no linked issue".
+ * Reads the typed `gate.link` decision (not gate.outcome) so a title-only
+ * failure never adds a label whose name specifically means "no linked issue".
  */
 export async function syncNoIssueLabel(api: LabelApi, gate: GateOutcome): Promise<LabelAction> {
-  const link = gate.checks.find((check) => check.label === 'PR-issue link');
-  if (!link) return 'noop'; // defensive — the link check is always present today
-
   const current = await api.list();
-  const action = decideLabelAction(current, link.outcome);
+  const action = decideLabelAction(current, gate.link.outcome);
   if (action === 'added') await api.add(NO_ISSUE_LABEL);
   if (action === 'removed') await api.remove(NO_ISSUE_LABEL);
   return action;
@@ -68,17 +66,11 @@ export class GithubLabelApi implements LabelApi {
     repo: string,
     private readonly issueNumber: number,
   ) {
-    this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+    this.repoUrl = repoApiUrl(owner, repo);
   }
 
   private headers(): Record<string, string> {
-    return {
-      authorization: `Bearer ${this.token}`,
-      accept: 'application/vnd.github+json',
-      'content-type': 'application/json',
-      'x-github-api-version': '2022-11-28',
-      'user-agent': 'camunda-release-notes-gate',
-    };
+    return githubHeaders(this.token, { json: true });
   }
 
   async list(): Promise<string[]> {

--- a/.github/actions/release-notes/src/labels/index.ts
+++ b/.github/actions/release-notes/src/labels/index.ts
@@ -1,0 +1,137 @@
+import type { GateOutcome, PolicyOutcome } from '../types';
+
+/**
+ * Syncs the display-only `no-issue` label to mirror the PR-issue-link check
+ * only (not the title check — the label answers one question: "does this PR
+ * link a tracked issue?"). Best-effort like the sticky comment: a sync
+ * failure never fails the gate, and it runs regardless of `enforce` — the
+ * label is informational, not a blocking mechanism.
+ */
+
+/** The label the gate syncs. Single source of truth — do not rename without
+ *  updating any saved searches/dashboards that filter on it. */
+export const NO_ISSUE_LABEL = 'no-issue';
+
+/** Created on demand (see GithubLabelApi.ensureLabelExists) if the repo does
+ *  not already have this label — keeps rollout self-contained. */
+export const NO_ISSUE_LABEL_COLOR = 'e4e669';
+export const NO_ISSUE_LABEL_DESCRIPTION = 'Release-notes gate: this PR does not link a tracked issue (warn-only).';
+
+/** What syncNoIssueLabel did — surfaced to the job log, and asserted in tests. */
+export type LabelAction = 'added' | 'removed' | 'noop';
+
+/**
+ * The issue-labels API surface the sync needs, injected so the decision logic
+ * is testable without mocking fetch.
+ */
+export interface LabelApi {
+  list(): Promise<string[]>;
+  add(label: string): Promise<void>;
+  remove(label: string): Promise<void>;
+}
+
+/** Pure decision: given the PR's current labels and the link check's
+ * outcome, decide whether to add/remove the no-issue label. */
+export function decideLabelAction(currentLabels: readonly string[], linkOutcome: PolicyOutcome): LabelAction {
+  const has = currentLabels.includes(NO_ISSUE_LABEL);
+  if (linkOutcome === 'fail') return has ? 'noop' : 'added';
+  return has ? 'removed' : 'noop';
+}
+
+/**
+ * Reconcile the no-issue label against the gate's PR-issue-link check.
+ * Reads the check by label rather than gate.outcome so a title-only failure
+ * never adds a label whose name specifically means "no linked issue".
+ */
+export async function syncNoIssueLabel(api: LabelApi, gate: GateOutcome): Promise<LabelAction> {
+  const link = gate.checks.find((check) => check.label === 'PR-issue link');
+  if (!link) return 'noop'; // defensive — the link check is always present today
+
+  const current = await api.list();
+  const action = decideLabelAction(current, link.outcome);
+  if (action === 'added') await api.add(NO_ISSUE_LABEL);
+  if (action === 'removed') await api.remove(NO_ISSUE_LABEL);
+  return action;
+}
+
+/**
+ * issue-labels API over plain fetch. Same rationale as GithubCommentApi /
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost isn't
+ * worth paying.
+ */
+export class GithubLabelApi implements LabelApi {
+  private readonly repoUrl: string;
+
+  constructor(
+    private readonly token: string,
+    owner: string,
+    repo: string,
+    private readonly issueNumber: number,
+  ) {
+    this.repoUrl = `https://api.github.com/repos/${owner}/${repo}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Bearer ${this.token}`,
+      accept: 'application/vnd.github+json',
+      'content-type': 'application/json',
+      'x-github-api-version': '2022-11-28',
+      'user-agent': 'camunda-release-notes-gate',
+    };
+  }
+
+  async list(): Promise<string[]> {
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
+      headers: this.headers(),
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} listing labels on #${this.issueNumber}`);
+    const data = (await res.json()) as { name: string }[];
+    return data.map((label) => label.name);
+  }
+
+  async add(label: string): Promise<void> {
+    const res = await this.postLabel(label);
+    if (res.status === 404) {
+      // Repo doesn't have this label defined yet — create it once, then retry.
+      await this.ensureLabelExists(label);
+      const retry = await this.postLabel(label);
+      if (!retry.ok) {
+        throw new Error(`GitHub API ${retry.status} adding label "${label}" to #${this.issueNumber} after creating it`);
+      }
+      return;
+    }
+    if (!res.ok) throw new Error(`GitHub API ${res.status} adding label "${label}" to #${this.issueNumber}`);
+  }
+
+  async remove(label: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels/${encodeURIComponent(label)}`, {
+      method: 'DELETE',
+      headers: this.headers(),
+    });
+    // 404 means the label is already gone (e.g. a concurrent run removed it) — not an error.
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`GitHub API ${res.status} removing label "${label}" from #${this.issueNumber}`);
+    }
+  }
+
+  private postLabel(label: string): Promise<Response> {
+    return fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ labels: [label] }),
+    });
+  }
+
+  private async ensureLabelExists(label: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/labels`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify({ name: label, color: NO_ISSUE_LABEL_COLOR, description: NO_ISSUE_LABEL_DESCRIPTION }),
+    });
+    // 422 means another concurrent run already created it — not an error.
+    if (!res.ok && res.status !== 422) {
+      throw new Error(`GitHub API ${res.status} creating label "${label}"`);
+    }
+  }
+}

--- a/.github/actions/release-notes/src/labels/index.ts
+++ b/.github/actions/release-notes/src/labels/index.ts
@@ -1,0 +1,138 @@
+import { githubHeaders, repoApiUrl } from '../github';
+import type { GateOutcome, PolicyOutcome } from '../types';
+
+/**
+ * Syncs the display-only `no-issue` label to mirror the PR-issue-link check
+ * only (not the title check — the label answers one question: "does this PR
+ * link a tracked issue?"). Best-effort like the sticky comment: a sync
+ * failure never fails the gate, and it runs regardless of `enforce` — the
+ * label is informational, not a blocking mechanism.
+ */
+
+/** The label the gate syncs. Single source of truth — do not rename without
+ *  updating any saved searches/dashboards that filter on it. */
+export const NO_ISSUE_LABEL = 'no-issue';
+
+/**
+ * Used only by GithubLabelApi.ensureLabelExists, which recreates the label if
+ * someone deletes it, so a missing label degrades to a self-heal instead of a
+ * failed sync.
+ *
+ * These MUST match the label as it exists in the repo today (colour `ededed`,
+ * no description beyond this one) — otherwise a delete-then-heal cycle would
+ * silently reskin a label that predates this gate. The wording deliberately
+ * avoids "warn-only": that becomes wrong at the required-flip, and nobody would
+ * think to update a label description then.
+ */
+export const NO_ISSUE_LABEL_COLOR = 'ededed';
+export const NO_ISSUE_LABEL_DESCRIPTION = 'Release-notes gate: this PR does not link a tracked issue.';
+
+/** What syncNoIssueLabel did — surfaced to the job log, and asserted in tests. */
+export type LabelAction = 'added' | 'removed' | 'noop';
+
+/**
+ * The issue-labels API surface the sync needs, injected so the decision logic
+ * is testable without mocking fetch.
+ */
+export interface LabelApi {
+  list(): Promise<string[]>;
+  add(label: string): Promise<void>;
+  remove(label: string): Promise<void>;
+}
+
+/** Pure decision: given the PR's current labels and the link check's
+ * outcome, decide whether to add/remove the no-issue label. */
+export function decideLabelAction(currentLabels: readonly string[], linkOutcome: PolicyOutcome): LabelAction {
+  const has = currentLabels.includes(NO_ISSUE_LABEL);
+  if (linkOutcome === 'fail') return has ? 'noop' : 'added';
+  return has ? 'removed' : 'noop';
+}
+
+/**
+ * Reconcile the no-issue label against the gate's PR-issue-link check.
+ * Reads the typed `gate.link` decision (not gate.outcome) so a title-only
+ * failure never adds a label whose name specifically means "no linked issue".
+ */
+export async function syncNoIssueLabel(api: LabelApi, gate: GateOutcome): Promise<LabelAction> {
+  const current = await api.list();
+  const action = decideLabelAction(current, gate.link.outcome);
+  if (action === 'added') await api.add(NO_ISSUE_LABEL);
+  if (action === 'removed') await api.remove(NO_ISSUE_LABEL);
+  return action;
+}
+
+/**
+ * issue-labels API over plain fetch. Same rationale as GithubCommentApi /
+ * GithubResolver: a handful of endpoints, so octokit's bundle cost isn't
+ * worth paying.
+ */
+export class GithubLabelApi implements LabelApi {
+  private readonly repoUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(
+    token: string,
+    owner: string,
+    repo: string,
+    private readonly issueNumber: number,
+  ) {
+    this.repoUrl = repoApiUrl(owner, repo);
+    this.headers = githubHeaders(token, { json: true });
+  }
+
+  async list(): Promise<string[]> {
+    // No pagination (unlike GithubCommentApi): GitHub caps an issue/PR at 100
+    // labels, so a single per_page=100 page is always the complete set.
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
+      headers: this.headers,
+    });
+    if (!res.ok) throw new Error(`GitHub API ${res.status} listing labels on #${this.issueNumber}`);
+    const data = (await res.json()) as { name: string }[];
+    return data.map((label) => label.name);
+  }
+
+  async add(label: string): Promise<void> {
+    const res = await this.postLabel(label);
+    if (res.status === 404) {
+      // Repo doesn't have this label defined yet — create it once, then retry.
+      await this.ensureLabelExists(label);
+      const retry = await this.postLabel(label);
+      if (!retry.ok) {
+        throw new Error(`GitHub API ${retry.status} adding label "${label}" to #${this.issueNumber} after creating it`);
+      }
+      return;
+    }
+    if (!res.ok) throw new Error(`GitHub API ${res.status} adding label "${label}" to #${this.issueNumber}`);
+  }
+
+  async remove(label: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels/${encodeURIComponent(label)}`, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+    // 404 means the label is already gone (e.g. a concurrent run removed it) — not an error.
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`GitHub API ${res.status} removing label "${label}" from #${this.issueNumber}`);
+    }
+  }
+
+  private postLabel(label: string): Promise<Response> {
+    return fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ labels: [label] }),
+    });
+  }
+
+  private async ensureLabelExists(label: string): Promise<void> {
+    const res = await fetch(`${this.repoUrl}/labels`, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ name: label, color: NO_ISSUE_LABEL_COLOR, description: NO_ISSUE_LABEL_DESCRIPTION }),
+    });
+    // 422 means another concurrent run already created it — not an error.
+    if (!res.ok && res.status !== 422) {
+      throw new Error(`GitHub API ${res.status} creating label "${label}"`);
+    }
+  }
+}

--- a/.github/actions/release-notes/src/labels/index.ts
+++ b/.github/actions/release-notes/src/labels/index.ts
@@ -59,23 +59,23 @@ export async function syncNoIssueLabel(api: LabelApi, gate: GateOutcome): Promis
  */
 export class GithubLabelApi implements LabelApi {
   private readonly repoUrl: string;
+  private readonly headers: Record<string, string>;
 
   constructor(
-    private readonly token: string,
+    token: string,
     owner: string,
     repo: string,
     private readonly issueNumber: number,
   ) {
     this.repoUrl = repoApiUrl(owner, repo);
-  }
-
-  private headers(): Record<string, string> {
-    return githubHeaders(this.token, { json: true });
+    this.headers = githubHeaders(token, { json: true });
   }
 
   async list(): Promise<string[]> {
+    // No pagination (unlike GithubCommentApi): GitHub caps an issue/PR at 100
+    // labels, so a single per_page=100 page is always the complete set.
     const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels?per_page=100`, {
-      headers: this.headers(),
+      headers: this.headers,
     });
     if (!res.ok) throw new Error(`GitHub API ${res.status} listing labels on #${this.issueNumber}`);
     const data = (await res.json()) as { name: string }[];
@@ -99,7 +99,7 @@ export class GithubLabelApi implements LabelApi {
   async remove(label: string): Promise<void> {
     const res = await fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels/${encodeURIComponent(label)}`, {
       method: 'DELETE',
-      headers: this.headers(),
+      headers: this.headers,
     });
     // 404 means the label is already gone (e.g. a concurrent run removed it) — not an error.
     if (!res.ok && res.status !== 404) {
@@ -110,7 +110,7 @@ export class GithubLabelApi implements LabelApi {
   private postLabel(label: string): Promise<Response> {
     return fetch(`${this.repoUrl}/issues/${this.issueNumber}/labels`, {
       method: 'POST',
-      headers: this.headers(),
+      headers: this.headers,
       body: JSON.stringify({ labels: [label] }),
     });
   }
@@ -118,7 +118,7 @@ export class GithubLabelApi implements LabelApi {
   private async ensureLabelExists(label: string): Promise<void> {
     const res = await fetch(`${this.repoUrl}/labels`, {
       method: 'POST',
-      headers: this.headers(),
+      headers: this.headers,
       body: JSON.stringify({ name: label, color: NO_ISSUE_LABEL_COLOR, description: NO_ISSUE_LABEL_DESCRIPTION }),
     });
     // 422 means another concurrent run already created it — not an error.

--- a/.github/actions/release-notes/src/lint.ts
+++ b/.github/actions/release-notes/src/lint.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { GithubCommentApi, syncStickyComment } from './comment';
 import { evaluateGate } from './gate';
 import * as core from './gha';
+import { GithubLabelApi, syncNoIssueLabel } from './labels';
 import { GithubResolver } from './resolver';
 
 /**
@@ -12,9 +13,11 @@ import { GithubResolver } from './resolver';
  * privileged token comes in as an input (reused MONOREPO_RELEASE_APP).
  *
  * ponytail: warn-only for now — reports the combined gate outcome (PR-issue
- * link + title lint, with a backport hop) to the job summary, the outputs, and
- * a single sticky PR comment (created only on failure, flipped to resolved once
- * fixed). Label sync and enforce mode ship in follow-up PRs. `enforce=true`
+ * link + title lint, with a backport hop) to the job summary, the outputs, a
+ * single sticky PR comment (created only on failure, flipped to resolved once
+ * fixed), and the display-only `no-issue` label. Both the comment and the
+ * label sync regardless of `enforce` — they're informational, not the
+ * enforcement mechanism. Enforce mode ships in a follow-up PR. `enforce=true`
  * flips a fail into a non-zero exit.
  */
 async function run(): Promise<void> {
@@ -63,6 +66,18 @@ async function run(): Promise<void> {
       core.info(`Sticky comment: ${action}.`);
     } catch (err) {
       core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    // Display-only `no-issue` label, mirroring the PR-issue-link check. Runs
+    // during warn-only rollout too, so the label is already trustworthy by the
+    // time enforce mode lands — a sync failure never fails the gate.
+    try {
+      const labels = new GithubLabelApi(token, owner ?? '', repo ?? '', pr.number);
+      const action = await syncNoIssueLabel(labels, gate);
+      core.setOutput('label-action', action);
+      core.info(`no-issue label: ${action}.`);
+    } catch (err) {
+      core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/.github/actions/release-notes/src/lint.ts
+++ b/.github/actions/release-notes/src/lint.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import * as core from './gha';
+import { extractSection, isOptOutTicked, parseRefs } from './parser';
+import { decide } from './policy';
+import { GithubResolver } from './resolver';
+
+/**
+ * PR-gate lint entrypoint (spike / warn-only).
+ *
+ * Security: runs on pull_request_target, metadata-only. The PR body is read
+ * from the event payload — never by checking out the PR head. The privileged
+ * token comes in as an input (reused MONOREPO_RELEASE_APP).
+ *
+ * ponytail: warn-only for now — reports the decision to the job summary and
+ * outputs; the sticky comment, label sync, and enforce mode ship in follow-up
+ * PRs. `enforce=true` flips a fail into a non-zero exit.
+ */
+async function run(): Promise<void> {
+  const token = core.getInput('token', { required: true });
+  const enforce = core.getBooleanInput('enforce');
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const event = eventPath ? (JSON.parse(readFileSync(eventPath, 'utf8')) as { pull_request?: { body?: string } }) : {};
+  const pr = event.pull_request;
+  if (!pr) {
+    core.info('No pull_request in payload; nothing to lint.');
+    return;
+  }
+
+  const body = pr.body ?? '';
+  const section = extractSection(body);
+  const optOut = isOptOutTicked(body);
+  const refs = section ? parseRefs(section) : [];
+
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
+  const resolver = new GithubResolver(token, owner ?? '', repo ?? '');
+  const resolved = await resolver.resolve(refs);
+  const decision = decide(resolved, optOut);
+
+  core.setOutput('outcome', decision.outcome);
+  core.setOutput('code', decision.code);
+
+  const heading = decision.outcome === 'pass' ? '✅ PR-issue link check passed' : '❌ PR-issue link check failed';
+  await core.summary
+    .addHeading(heading, 3)
+    .addList(decision.reasons.slice())
+    .write();
+
+  if (decision.outcome === 'fail') {
+    const msg = decision.reasons.join(' ');
+    if (enforce) core.setFailed(msg);
+    else core.warning(`[warn-only] ${msg}`);
+  } else {
+    core.info(decision.reasons.join(' '));
+  }
+}
+
+run().catch((err) => core.setFailed(err instanceof Error ? err.message : String(err)));

--- a/.github/actions/release-notes/src/lint.ts
+++ b/.github/actions/release-notes/src/lint.ts
@@ -38,11 +38,22 @@ async function run(): Promise<void> {
 
   const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
   const resolver = new GithubResolver(token, owner ?? '', repo ?? '');
-  const gate = await evaluateGate(resolver, {
-    body: pr.body ?? '',
-    title: pr.title ?? '',
-    authorLogin: pr.user?.login,
-  });
+
+  // A transient resolver error (403/500) must respect `enforce`: warn-only means
+  // the gate never hard-fails, so an API blip cannot turn a green check red.
+  let gate;
+  try {
+    gate = await evaluateGate(resolver, {
+      body: pr.body ?? '',
+      title: pr.title ?? '',
+      authorLogin: pr.user?.login,
+    });
+  } catch (err) {
+    const msg = `Release-notes gate could not be evaluated: ${err instanceof Error ? err.message : String(err)}`;
+    if (enforce) core.setFailed(msg);
+    else core.warning(`[warn-only] ${msg}`);
+    return;
+  }
 
   const failed = gate.checks.filter((check) => check.outcome === 'fail');
   const reasons = failed.flatMap((check) => check.reasons.map((reason) => `${check.label}: ${reason}`));
@@ -57,28 +68,33 @@ async function run(): Promise<void> {
   );
   await core.summary.addHeading(heading, 3).addList(summaryLines).write();
 
-  // Sticky PR comment (D24: comments from day one). A comment sync failure must
+  // Sticky PR comment (D24: comments from day one) + the display-only `no-issue`
+  // label. Both only need `gate` + the PR number and are independent, so run
+  // them concurrently. Each is best-effort: a sync failure is logged and must
   // never fail the gate — warn or not, the outcome above stands.
   if (pr.number) {
-    try {
-      const comments = new GithubCommentApi(token, owner ?? '', repo ?? '', pr.number);
-      const action = await syncStickyComment(comments, gate);
-      core.info(`Sticky comment: ${action}.`);
-    } catch (err) {
-      core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
-    }
-
-    // Display-only `no-issue` label, mirroring the PR-issue-link check. Runs
-    // during warn-only rollout too, so the label is already trustworthy by the
-    // time enforce mode lands — a sync failure never fails the gate.
-    try {
-      const labels = new GithubLabelApi(token, owner ?? '', repo ?? '', pr.number);
-      const action = await syncNoIssueLabel(labels, gate);
-      core.setOutput('label-action', action);
-      core.info(`no-issue label: ${action}.`);
-    } catch (err) {
-      core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
-    }
+    const prNumber = pr.number;
+    await Promise.allSettled([
+      (async () => {
+        try {
+          const comments = new GithubCommentApi(token, owner ?? '', repo ?? '', prNumber);
+          const action = await syncStickyComment(comments, gate);
+          core.info(`Sticky comment: ${action}.`);
+        } catch (err) {
+          core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })(),
+      (async () => {
+        try {
+          const labels = new GithubLabelApi(token, owner ?? '', repo ?? '', prNumber);
+          const action = await syncNoIssueLabel(labels, gate);
+          core.setOutput('label-action', action);
+          core.info(`no-issue label: ${action}.`);
+        } catch (err) {
+          core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })(),
+    ]);
   }
 
   if (gate.outcome === 'fail') {

--- a/.github/actions/release-notes/src/lint.ts
+++ b/.github/actions/release-notes/src/lint.ts
@@ -1,26 +1,30 @@
 import { readFileSync } from 'node:fs';
+import { GithubCommentApi, syncStickyComment } from './comment';
 import * as core from './gha';
 import { extractSection, isOptOutTicked, parseRefs } from './parser';
 import { decide } from './policy';
 import { GithubResolver } from './resolver';
 
 /**
- * PR-gate lint entrypoint (spike / warn-only).
+ * PR-gate lint entrypoint (warn-only rollout).
  *
  * Security: runs on pull_request_target, metadata-only. The PR body is read
  * from the event payload — never by checking out the PR head. The privileged
  * token comes in as an input (reused MONOREPO_RELEASE_APP).
  *
- * ponytail: warn-only for now — reports the decision to the job summary and
- * outputs; the sticky comment, label sync, and enforce mode ship in follow-up
- * PRs. `enforce=true` flips a fail into a non-zero exit.
+ * ponytail: warn-only for now — reports the decision to the job summary, the
+ * outputs, and a single sticky PR comment (created only when the check fails,
+ * flipped to resolved once fixed). Label sync and enforce mode ship in
+ * follow-up PRs. `enforce=true` flips a fail into a non-zero exit.
  */
 async function run(): Promise<void> {
   const token = core.getInput('token', { required: true });
   const enforce = core.getBooleanInput('enforce');
 
   const eventPath = process.env.GITHUB_EVENT_PATH;
-  const event = eventPath ? (JSON.parse(readFileSync(eventPath, 'utf8')) as { pull_request?: { body?: string } }) : {};
+  const event = eventPath
+    ? (JSON.parse(readFileSync(eventPath, 'utf8')) as { pull_request?: { body?: string; number?: number } })
+    : {};
   const pr = event.pull_request;
   if (!pr) {
     core.info('No pull_request in payload; nothing to lint.');
@@ -45,6 +49,18 @@ async function run(): Promise<void> {
     .addHeading(heading, 3)
     .addList(decision.reasons.slice())
     .write();
+
+  // Sticky PR comment (D24: comments from day one). A comment sync failure must
+  // never fail the gate — warn or not, the decision above stands.
+  if (pr.number) {
+    try {
+      const comments = new GithubCommentApi(token, owner ?? '', repo ?? '', pr.number);
+      const action = await syncStickyComment(comments, decision);
+      core.info(`Sticky comment: ${action}.`);
+    } catch (err) {
+      core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   if (decision.outcome === 'fail') {
     const msg = decision.reasons.join(' ');

--- a/.github/actions/release-notes/src/lint.ts
+++ b/.github/actions/release-notes/src/lint.ts
@@ -1,21 +1,21 @@
 import { readFileSync } from 'node:fs';
 import { GithubCommentApi, syncStickyComment } from './comment';
+import { evaluateGate } from './gate';
 import * as core from './gha';
-import { extractSection, isOptOutTicked, parseRefs } from './parser';
-import { decide } from './policy';
 import { GithubResolver } from './resolver';
 
 /**
  * PR-gate lint entrypoint (warn-only rollout).
  *
- * Security: runs on pull_request_target, metadata-only. The PR body is read
- * from the event payload — never by checking out the PR head. The privileged
- * token comes in as an input (reused MONOREPO_RELEASE_APP).
+ * Security: runs on pull_request_target, metadata-only. The PR body/title are
+ * read from the event payload — never by checking out the PR head. The
+ * privileged token comes in as an input (reused MONOREPO_RELEASE_APP).
  *
- * ponytail: warn-only for now — reports the decision to the job summary, the
- * outputs, and a single sticky PR comment (created only when the check fails,
- * flipped to resolved once fixed). Label sync and enforce mode ship in
- * follow-up PRs. `enforce=true` flips a fail into a non-zero exit.
+ * ponytail: warn-only for now — reports the combined gate outcome (PR-issue
+ * link + title lint, with a backport hop) to the job summary, the outputs, and
+ * a single sticky PR comment (created only on failure, flipped to resolved once
+ * fixed). Label sync and enforce mode ship in follow-up PRs. `enforce=true`
+ * flips a fail into a non-zero exit.
  */
 async function run(): Promise<void> {
   const token = core.getInput('token', { required: true });
@@ -23,7 +23,9 @@ async function run(): Promise<void> {
 
   const eventPath = process.env.GITHUB_EVENT_PATH;
   const event = eventPath
-    ? (JSON.parse(readFileSync(eventPath, 'utf8')) as { pull_request?: { body?: string; number?: number } })
+    ? (JSON.parse(readFileSync(eventPath, 'utf8')) as {
+        pull_request?: { body?: string; title?: string; number?: number; user?: { login?: string } };
+      })
     : {};
   const pr = event.pull_request;
   if (!pr) {
@@ -31,43 +33,45 @@ async function run(): Promise<void> {
     return;
   }
 
-  const body = pr.body ?? '';
-  const section = extractSection(body);
-  const optOut = isOptOutTicked(body);
-  const refs = section ? parseRefs(section) : [];
-
   const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
   const resolver = new GithubResolver(token, owner ?? '', repo ?? '');
-  const resolved = await resolver.resolve(refs);
-  const decision = decide(resolved, optOut);
+  const gate = await evaluateGate(resolver, {
+    body: pr.body ?? '',
+    title: pr.title ?? '',
+    authorLogin: pr.user?.login,
+  });
 
-  core.setOutput('outcome', decision.outcome);
-  core.setOutput('code', decision.code);
+  const failed = gate.checks.filter((check) => check.outcome === 'fail');
+  const reasons = failed.flatMap((check) => check.reasons.map((reason) => `${check.label}: ${reason}`));
 
-  const heading = decision.outcome === 'pass' ? '✅ PR-issue link check passed' : '❌ PR-issue link check failed';
-  await core.summary
-    .addHeading(heading, 3)
-    .addList(decision.reasons.slice())
-    .write();
+  core.setOutput('outcome', gate.outcome);
+  core.setOutput('delivery-path', gate.deliveryPath);
+  core.setOutput('failed-checks', failed.map((check) => check.label).join(','));
+
+  const heading = gate.outcome === 'pass' ? '✅ Release-notes checks passed' : '❌ Release-notes checks failed';
+  const summaryLines = gate.checks.map(
+    (check) => `${check.outcome === 'pass' ? '✅' : '❌'} ${check.label}: ${check.reasons.join(' ')}`,
+  );
+  await core.summary.addHeading(heading, 3).addList(summaryLines).write();
 
   // Sticky PR comment (D24: comments from day one). A comment sync failure must
-  // never fail the gate — warn or not, the decision above stands.
+  // never fail the gate — warn or not, the outcome above stands.
   if (pr.number) {
     try {
       const comments = new GithubCommentApi(token, owner ?? '', repo ?? '', pr.number);
-      const action = await syncStickyComment(comments, decision);
+      const action = await syncStickyComment(comments, gate);
       core.info(`Sticky comment: ${action}.`);
     } catch (err) {
       core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  if (decision.outcome === 'fail') {
-    const msg = decision.reasons.join(' ');
+  if (gate.outcome === 'fail') {
+    const msg = reasons.join(' ');
     if (enforce) core.setFailed(msg);
     else core.warning(`[warn-only] ${msg}`);
   } else {
-    core.info(decision.reasons.join(' '));
+    core.info('All release-notes checks passed.');
   }
 }
 

--- a/.github/actions/release-notes/src/lint.ts
+++ b/.github/actions/release-notes/src/lint.ts
@@ -1,0 +1,126 @@
+import { GithubCommentApi, syncStickyComment } from './comment';
+import { evaluateGate } from './gate';
+import * as core from './gha';
+import { GithubLabelApi, syncNoIssueLabel } from './labels';
+import { GithubResolver } from './resolver';
+
+/**
+ * PR-gate lint entrypoint (warn-only rollout).
+ *
+ * Security: runs on `pull_request`, so the workflow and this action resolve from
+ * the PR head — the same trust model as every other lint in ci.yml, and the
+ * reason there is no privileged token anywhere here. A fork PR gets a read-only
+ * GITHUB_TOKEN and no secrets, which is exactly why the writes below are guarded
+ * by `can-write` instead of failing.
+ *
+ * The PR number comes from the event payload; the body and title are then
+ * fetched from the API, so they are current at evaluation time rather than a
+ * snapshot from whenever the event fired (a PR edited twice in quick succession
+ * must not be judged on the older body).
+ *
+ * ponytail: warn-only for now — reports the combined gate outcome (PR-issue link
+ * + title lint, with a backport hop) to the job summary, the outputs, a single
+ * sticky PR comment, and the display-only `no-issue` label. The check itself is
+ * the job's own conclusion; GitHub renders it on the PR without us publishing
+ * anything. Both syncs run regardless of `enforce` — they are informational, not
+ * the enforcement mechanism. `enforce=true` flips a fail into a non-zero exit;
+ * enforce mode ships in a follow-up PR.
+ */
+async function run(): Promise<void> {
+  const token = core.getInput('token', { required: true });
+  const enforce = core.getBooleanInput('enforce');
+  // False on fork PRs: GitHub issues a read-only token and withholds secrets
+  // there, whatever the workflow's `permissions:` block asks for. Everything the
+  // gate READS still works, so it evaluates and reports normally — only the two
+  // writes are skipped, and the log says so rather than surfacing a 403.
+  const canWrite = core.getBooleanInput('can-write');
+
+  const prNumberInput = core.getInput('pr-number').trim();
+  const prNumber = Number(prNumberInput);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    core.setFailed(`pr-number must be a positive integer, got "${prNumberInput}".`);
+    return;
+  }
+
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '/').split('/');
+  const resolver = new GithubResolver(token, owner ?? '', repo ?? '');
+
+  // A transient API error (403/500) must respect `enforce`: warn-only means the
+  // gate never hard-fails, so a blip cannot turn a green check red.
+  let gate;
+  try {
+    const pull = await resolver.fetchPull(prNumber);
+    if (!pull) {
+      core.info(`PR #${prNumber} could not be fetched; nothing to lint.`);
+      return;
+    }
+    gate = await evaluateGate(resolver, {
+      body: pull.body,
+      title: pull.title,
+      authorLogin: pull.authorLogin,
+    });
+  } catch (err) {
+    const msg = `Release-notes gate could not be evaluated: ${err instanceof Error ? err.message : String(err)}`;
+    if (enforce) core.setFailed(msg);
+    else core.warning(`[warn-only] ${msg}`);
+    return;
+  }
+
+  const failed = gate.checks.filter((check) => check.outcome === 'fail');
+  const reasons = failed.flatMap((check) => check.reasons.map((reason) => `${check.label}: ${reason}`));
+
+  core.setOutput('outcome', gate.outcome);
+  core.setOutput('delivery-path', gate.deliveryPath);
+  core.setOutput('failed-checks', failed.map((check) => check.label).join(','));
+
+  // The job summary is the gate's primary report: it is the one channel that
+  // works everywhere, fork PRs included, and needs no token at all.
+  const heading = gate.outcome === 'pass' ? '✅ Release-notes checks passed' : '❌ Release-notes checks failed';
+  const summaryLines = gate.checks.map(
+    (check) => `${check.outcome === 'pass' ? '✅' : '❌'} ${check.label}: ${check.reasons.join(' ')}`,
+  );
+  await core.summary.addHeading(heading, 3).addList(summaryLines).write();
+
+  if (!canWrite) {
+    // Not a failure: a fork PR is still fully evaluated above, and the verdict is
+    // in the summary and this log. Stated explicitly so the absence of the usual
+    // comment reads as designed rather than broken.
+    core.info('Fork pull request: no write token available, so the sticky comment and no-issue label are skipped.');
+  } else {
+    // The sticky comment and the display-only `no-issue` label. Independent of
+    // each other, so run them concurrently. Each is best-effort: a sync failure
+    // is logged and must never fail the gate — warn or not, the outcome above
+    // stands.
+    await Promise.allSettled([
+      (async () => {
+        try {
+          const comments = new GithubCommentApi(token, owner ?? '', repo ?? '', prNumber);
+          const action = await syncStickyComment(comments, gate);
+          core.info(`Sticky comment: ${action}.`);
+        } catch (err) {
+          core.warning(`Sticky comment sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })(),
+      (async () => {
+        try {
+          const labels = new GithubLabelApi(token, owner ?? '', repo ?? '', prNumber);
+          const action = await syncNoIssueLabel(labels, gate);
+          core.setOutput('label-action', action);
+          core.info(`no-issue label: ${action}.`);
+        } catch (err) {
+          core.warning(`Label sync failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+        }
+      })(),
+    ]);
+  }
+
+  if (gate.outcome === 'fail') {
+    const msg = reasons.join(' ');
+    if (enforce) core.setFailed(msg);
+    else core.warning(`[warn-only] ${msg}`);
+  } else {
+    core.info('All release-notes checks passed.');
+  }
+}
+
+run().catch((err) => core.setFailed(err instanceof Error ? err.message : String(err)));

--- a/.github/actions/release-notes/src/parser/index.ts
+++ b/.github/actions/release-notes/src/parser/index.ts
@@ -42,24 +42,24 @@ export function parseRefs(text: string): ParsedRef[] {
   const refs: ParsedRef[] = [];
   const seen = new Set<number>(); // dedupe by match offset
 
-  const push = (m: RegExpExecArray, repo: string | null, num: string) => {
-    if (seen.has(m.index)) return;
-    seen.add(m.index);
-    const keyword = m[1] ? m[1].toLowerCase().replace(/\s+/g, ' ') : null;
+  const push = (match: RegExpExecArray, repo: string | null, num: string) => {
+    if (seen.has(match.index)) return;
+    seen.add(match.index);
+    const keyword = match[1] ? match[1].toLowerCase().replace(/\s+/g, ' ') : null;
     refs.push({
-      raw: m[0].trim(),
+      raw: match[0].trim(),
       number: Number(num),
       repo: repo ?? null,
       keyword,
       kind: kindOf(keyword),
-      index: m.index,
+      index: match.index,
     });
   };
 
-  for (const m of text.matchAll(URL)) push(m, m[2] ?? null, m[3]!);
-  for (const m of text.matchAll(SHORTHAND)) push(m, m[2] ?? null, m[3]!);
+  for (const match of text.matchAll(URL)) push(match, match[2] ?? null, match[3]!);
+  for (const match of text.matchAll(SHORTHAND)) push(match, match[2] ?? null, match[3]!);
 
-  return refs.sort((a, b) => a.index - b.index);
+  return refs.sort((first, second) => first.index - second.index);
 }
 
 /**
@@ -69,10 +69,10 @@ export function parseRefs(text: string): ParsedRef[] {
 export function extractSection(body: string, heading = SECTION_HEADING): string | null {
   const lines = body.split(/\r?\n/);
   const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
-  const start = lines.findIndex((l) => headingRe.test(l.trim()));
+  const start = lines.findIndex((line) => headingRe.test(line.trim()));
   if (start < 0) return null;
   const rest = lines.slice(start + 1);
-  const end = rest.findIndex((l) => /^#{1,6}\s+\S/.test(l));
+  const end = rest.findIndex((line) => /^#{1,6}\s+\S/.test(line));
   return (end < 0 ? rest : rest.slice(0, end)).join('\n');
 }
 
@@ -82,6 +82,6 @@ export function isOptOutTicked(body: string): boolean {
   return re.test(body);
 }
 
-function escapeRe(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function escapeRe(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/.github/actions/release-notes/src/parser/index.ts
+++ b/.github/actions/release-notes/src/parser/index.ts
@@ -1,0 +1,98 @@
+import type { ParsedRef, RefKind } from '../types';
+
+/**
+ * Pure, section-scoped reference parser. Shared verbatim with the generator
+ * (#57713) — no IO, no repo awareness. Cross-repo detection and issue-vs-PR
+ * classification belong to the Resolver, not here.
+ */
+
+/** The template's opt-out phrase. Kept as an exported constant so the PR template
+ *  and the parser cannot drift (enforced by the repo-constant grep in CI). */
+export const OPT_OUT_PHRASE = 'this pr does not need a linked issue';
+
+/** The section whose refs the gate evaluates. */
+export const SECTION_HEADING = 'Related issues';
+
+// GitHub's closing keywords + our custom "completes". Case-insensitive.
+const CLOSING = /^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?)$/i;
+const RELATES = /^relates?\s+to$/i;
+const BACKPORT = /^backport\s+of$/i;
+
+// Optional keyword prefix shared by both ref shapes.
+const KW = String.raw`(?:\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?|relates?\s+to|backport\s+of)\b[\s:]+)?`;
+const OWNER_REPO = String.raw`([A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*)`;
+
+// "closes #12", "camunda/other#7", bare "#12".
+const SHORTHAND = new RegExp(KW + `(?:${OWNER_REPO})?#(\\d+)`, 'gi');
+// Full GitHub URLs: ".../owner/repo/issues/12" or ".../pull/12".
+const URL = new RegExp(
+  KW + String.raw`https?:\/\/github\.com\/${OWNER_REPO}\/(?:issues|pull)\/(\d+)`,
+  'gi',
+);
+
+function kindOf(keyword: string | null): RefKind {
+  if (keyword && BACKPORT.test(keyword)) return 'backport';
+  if (keyword && RELATES.test(keyword)) return 'contributor';
+  if (keyword && CLOSING.test(keyword)) return 'closing';
+  return 'contributor'; // bare "#N"
+}
+
+/**
+ * Strip HTML comments before any parsing. The PR template's own instructional
+ * `<!-- ... closes #1234 ... -->` block lives inside "## Related issues" and is
+ * invisible in GitHub's rendered body, so a PR that leaves the boilerplate
+ * untouched must NOT be attributed to whatever issue the comment names.
+ */
+export function stripHtmlComments(text: string): string {
+  return text.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/** Extract every reference from the given text (already scoped by the caller). */
+export function parseRefs(text: string): ParsedRef[] {
+  text = stripHtmlComments(text);
+  const refs: ParsedRef[] = [];
+  const seen = new Set<number>(); // dedupe by match offset
+
+  const push = (match: RegExpExecArray, repo: string | null, num: string) => {
+    if (seen.has(match.index)) return;
+    seen.add(match.index);
+    const keyword = match[1] ? match[1].toLowerCase().replace(/\s+/g, ' ') : null;
+    refs.push({
+      raw: match[0].trim(),
+      number: Number(num),
+      repo: repo ?? null,
+      keyword,
+      kind: kindOf(keyword),
+      index: match.index,
+    });
+  };
+
+  for (const match of text.matchAll(URL)) push(match, match[2] ?? null, match[3]!);
+  for (const match of text.matchAll(SHORTHAND)) push(match, match[2] ?? null, match[3]!);
+
+  return refs.sort((first, second) => first.index - second.index);
+}
+
+/**
+ * Slice out a markdown section body: everything after the matching heading up
+ * to the next heading of any level (or EOF). Returns null if absent.
+ */
+export function extractSection(body: string, heading = SECTION_HEADING): string | null {
+  const lines = stripHtmlComments(body).split(/\r?\n/);
+  const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
+  const start = lines.findIndex((line) => headingRe.test(line.trim()));
+  if (start < 0) return null;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^#{1,6}\s+\S/.test(line));
+  return (end < 0 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/** True when the opt-out checkbox is present and ticked. */
+export function isOptOutTicked(body: string): boolean {
+  const re = new RegExp(String.raw`^\s*[-*]\s*\[x\]\s*.*${escapeRe(OPT_OUT_PHRASE)}`, 'im');
+  return re.test(stripHtmlComments(body));
+}
+
+function escapeRe(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/.github/actions/release-notes/src/parser/index.ts
+++ b/.github/actions/release-notes/src/parser/index.ts
@@ -1,0 +1,87 @@
+import type { ParsedRef, RefKind } from '../types';
+
+/**
+ * Pure, section-scoped reference parser. Shared verbatim with the generator
+ * (#57713) — no IO, no repo awareness. Cross-repo detection and issue-vs-PR
+ * classification belong to the Resolver, not here.
+ */
+
+/** The template's opt-out phrase. Kept as an exported constant so the PR template
+ *  and the parser cannot drift (enforced by the repo-constant grep in CI). */
+export const OPT_OUT_PHRASE = 'this pr does not need a linked issue';
+
+/** The section whose refs the gate evaluates. */
+export const SECTION_HEADING = 'Related issues';
+
+// GitHub's closing keywords + our custom "completes". Case-insensitive.
+const CLOSING = /^(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?)$/i;
+const RELATES = /^relates?\s+to$/i;
+const BACKPORT = /^backport\s+of$/i;
+
+// Optional keyword prefix shared by both ref shapes.
+const KW = String.raw`(?:\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?|completes?|relates?\s+to|backport\s+of)\b[\s:]+)?`;
+const OWNER_REPO = String.raw`([A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*)`;
+
+// "closes #12", "camunda/other#7", bare "#12".
+const SHORTHAND = new RegExp(KW + `(?:${OWNER_REPO})?#(\\d+)`, 'gi');
+// Full GitHub URLs: ".../owner/repo/issues/12" or ".../pull/12".
+const URL = new RegExp(
+  KW + String.raw`https?:\/\/github\.com\/${OWNER_REPO}\/(?:issues|pull)\/(\d+)`,
+  'gi',
+);
+
+function kindOf(keyword: string | null): RefKind {
+  if (keyword && BACKPORT.test(keyword)) return 'backport';
+  if (keyword && RELATES.test(keyword)) return 'contributor';
+  if (keyword && CLOSING.test(keyword)) return 'closing';
+  return 'contributor'; // bare "#N"
+}
+
+/** Extract every reference from the given text (already scoped by the caller). */
+export function parseRefs(text: string): ParsedRef[] {
+  const refs: ParsedRef[] = [];
+  const seen = new Set<number>(); // dedupe by match offset
+
+  const push = (m: RegExpExecArray, repo: string | null, num: string) => {
+    if (seen.has(m.index)) return;
+    seen.add(m.index);
+    const keyword = m[1] ? m[1].toLowerCase().replace(/\s+/g, ' ') : null;
+    refs.push({
+      raw: m[0].trim(),
+      number: Number(num),
+      repo: repo ?? null,
+      keyword,
+      kind: kindOf(keyword),
+      index: m.index,
+    });
+  };
+
+  for (const m of text.matchAll(URL)) push(m, m[2] ?? null, m[3]!);
+  for (const m of text.matchAll(SHORTHAND)) push(m, m[2] ?? null, m[3]!);
+
+  return refs.sort((a, b) => a.index - b.index);
+}
+
+/**
+ * Slice out a markdown section body: everything after the matching heading up
+ * to the next heading of any level (or EOF). Returns null if absent.
+ */
+export function extractSection(body: string, heading = SECTION_HEADING): string | null {
+  const lines = body.split(/\r?\n/);
+  const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
+  const start = lines.findIndex((l) => headingRe.test(l.trim()));
+  if (start < 0) return null;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((l) => /^#{1,6}\s+\S/.test(l));
+  return (end < 0 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/** True when the opt-out checkbox is present and ticked. */
+export function isOptOutTicked(body: string): boolean {
+  const re = new RegExp(String.raw`^\s*[-*]\s*\[x\]\s*.*${escapeRe(OPT_OUT_PHRASE)}`, 'im');
+  return re.test(body);
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/.github/actions/release-notes/src/parser/index.ts
+++ b/.github/actions/release-notes/src/parser/index.ts
@@ -37,8 +37,19 @@ function kindOf(keyword: string | null): RefKind {
   return 'contributor'; // bare "#N"
 }
 
+/**
+ * Strip HTML comments before any parsing. The PR template's own instructional
+ * `<!-- ... closes #1234 ... -->` block lives inside "## Related issues" and is
+ * invisible in GitHub's rendered body, so a PR that leaves the boilerplate
+ * untouched must NOT be attributed to whatever issue the comment names.
+ */
+export function stripHtmlComments(text: string): string {
+  return text.replace(/<!--[\s\S]*?-->/g, '');
+}
+
 /** Extract every reference from the given text (already scoped by the caller). */
 export function parseRefs(text: string): ParsedRef[] {
+  text = stripHtmlComments(text);
   const refs: ParsedRef[] = [];
   const seen = new Set<number>(); // dedupe by match offset
 
@@ -67,7 +78,7 @@ export function parseRefs(text: string): ParsedRef[] {
  * to the next heading of any level (or EOF). Returns null if absent.
  */
 export function extractSection(body: string, heading = SECTION_HEADING): string | null {
-  const lines = body.split(/\r?\n/);
+  const lines = stripHtmlComments(body).split(/\r?\n/);
   const headingRe = new RegExp(`^#{1,6}\\s+${escapeRe(heading)}\\s*$`, 'i');
   const start = lines.findIndex((line) => headingRe.test(line.trim()));
   if (start < 0) return null;
@@ -79,7 +90,7 @@ export function extractSection(body: string, heading = SECTION_HEADING): string 
 /** True when the opt-out checkbox is present and ticked. */
 export function isOptOutTicked(body: string): boolean {
   const re = new RegExp(String.raw`^\s*[-*]\s*\[x\]\s*.*${escapeRe(OPT_OUT_PHRASE)}`, 'im');
-  return re.test(body);
+  return re.test(stripHtmlComments(body));
 }
 
 function escapeRe(literal: string): string {

--- a/.github/actions/release-notes/src/policy/index.ts
+++ b/.github/actions/release-notes/src/policy/index.ts
@@ -1,0 +1,56 @@
+import type { PolicyDecision, ResolvedRef } from '../types';
+
+/**
+ * Pure PR-gate decision. Given the resolved refs found inside the section and
+ * whether the opt-out checkbox is ticked, decide PASS/FAIL with reasons that
+ * name the offending ref and the exact fix.
+ *
+ * Precedence (a PR ref is always an error, even alongside a valid issue ref):
+ *   1. any same-repo ref resolves to a PR      -> FAIL pr-ref-in-section
+ *   2. opt-out ticked                          -> PASS opt-out
+ *   3. a same-repo ref resolves to a live issue -> PASS section-(closing|contributor)
+ *   4. otherwise                               -> FAIL unlinked-undeclared
+ *
+ * Cross-repo refs and backport markers never satisfy the requirement on their own.
+ */
+export function decide(refs: readonly ResolvedRef[], optOut: boolean): PolicyDecision {
+  const sameRepo = refs.filter((r) => !r.crossRepo && r.kind !== 'backport');
+
+  const prRefs = sameRepo.filter((r) => r.target === 'pullRequest');
+  if (prRefs.length > 0) {
+    const list = prRefs.map((r) => `#${r.number}`).join(', ');
+    return {
+      outcome: 'fail',
+      code: 'pr-ref-in-section',
+      reasons: [
+        `The "Related issues" section links a pull request (${list}), not an issue.`,
+        'Link the tracked issue this PR resolves (e.g. "closes #1234"), or tick the opt-out checkbox.',
+      ],
+    };
+  }
+
+  if (optOut) {
+    return { outcome: 'pass', code: 'opt-out', reasons: ['Opt-out checkbox ticked: no linked issue required.'] };
+  }
+
+  const liveIssues = sameRepo.filter((r) => r.target === 'issue');
+  if (liveIssues.length > 0) {
+    const closing = liveIssues.some((r) => r.kind === 'closing');
+    const list = liveIssues.map((r) => `#${r.number}`).join(', ');
+    return {
+      outcome: 'pass',
+      code: closing ? 'section-closing' : 'section-contributor',
+      reasons: [`Linked to issue ${list} in the "Related issues" section.`],
+    };
+  }
+
+  const dead = sameRepo.filter((r) => r.target === 'missing').map((r) => `#${r.number}`);
+  const crossRepo = refs.filter((r) => r.crossRepo).map((r) => r.raw);
+  const reasons = [
+    'No linked issue found in the "Related issues" section, and the opt-out checkbox is not ticked.',
+    'Add a closing keyword with the tracked issue (e.g. "closes #1234"), or tick the opt-out checkbox.',
+  ];
+  if (dead.length) reasons.push(`These refs do not resolve to an existing issue: ${dead.join(', ')}.`);
+  if (crossRepo.length) reasons.push(`Cross-repo refs do not count toward this repo's release notes: ${crossRepo.join(', ')}.`);
+  return { outcome: 'fail', code: 'unlinked-undeclared', reasons };
+}

--- a/.github/actions/release-notes/src/policy/index.ts
+++ b/.github/actions/release-notes/src/policy/index.ts
@@ -14,11 +14,11 @@ import type { PolicyDecision, ResolvedRef } from '../types';
  * Cross-repo refs and backport markers never satisfy the requirement on their own.
  */
 export function decide(refs: readonly ResolvedRef[], optOut: boolean): PolicyDecision {
-  const sameRepo = refs.filter((r) => !r.crossRepo && r.kind !== 'backport');
+  const sameRepo = refs.filter((ref) => !ref.crossRepo && ref.kind !== 'backport');
 
-  const prRefs = sameRepo.filter((r) => r.target === 'pullRequest');
+  const prRefs = sameRepo.filter((ref) => ref.target === 'pullRequest');
   if (prRefs.length > 0) {
-    const list = prRefs.map((r) => `#${r.number}`).join(', ');
+    const list = prRefs.map((ref) => `#${ref.number}`).join(', ');
     return {
       outcome: 'fail',
       code: 'pr-ref-in-section',
@@ -33,10 +33,10 @@ export function decide(refs: readonly ResolvedRef[], optOut: boolean): PolicyDec
     return { outcome: 'pass', code: 'opt-out', reasons: ['Opt-out checkbox ticked: no linked issue required.'] };
   }
 
-  const liveIssues = sameRepo.filter((r) => r.target === 'issue');
+  const liveIssues = sameRepo.filter((ref) => ref.target === 'issue');
   if (liveIssues.length > 0) {
-    const closing = liveIssues.some((r) => r.kind === 'closing');
-    const list = liveIssues.map((r) => `#${r.number}`).join(', ');
+    const closing = liveIssues.some((ref) => ref.kind === 'closing');
+    const list = liveIssues.map((ref) => `#${ref.number}`).join(', ');
     return {
       outcome: 'pass',
       code: closing ? 'section-closing' : 'section-contributor',
@@ -44,8 +44,8 @@ export function decide(refs: readonly ResolvedRef[], optOut: boolean): PolicyDec
     };
   }
 
-  const dead = sameRepo.filter((r) => r.target === 'missing').map((r) => `#${r.number}`);
-  const crossRepo = refs.filter((r) => r.crossRepo).map((r) => r.raw);
+  const dead = sameRepo.filter((ref) => ref.target === 'missing').map((ref) => `#${ref.number}`);
+  const crossRepo = refs.filter((ref) => ref.crossRepo).map((ref) => ref.raw);
   const reasons = [
     'No linked issue found in the "Related issues" section, and the opt-out checkbox is not ticked.',
     'Add a closing keyword with the tracked issue (e.g. "closes #1234"), or tick the opt-out checkbox.',

--- a/.github/actions/release-notes/src/policy/index.ts
+++ b/.github/actions/release-notes/src/policy/index.ts
@@ -1,0 +1,56 @@
+import type { PolicyDecision, ResolvedRef } from '../types';
+
+/**
+ * Pure PR-gate decision. Given the resolved refs found inside the section and
+ * whether the opt-out checkbox is ticked, decide PASS/FAIL with reasons that
+ * name the offending ref and the exact fix.
+ *
+ * Precedence (a PR ref is always an error, even alongside a valid issue ref):
+ *   1. any same-repo ref resolves to a PR      -> FAIL pr-ref-in-section
+ *   2. opt-out ticked                          -> PASS opt-out
+ *   3. a same-repo ref resolves to a live issue -> PASS section-(closing|contributor)
+ *   4. otherwise                               -> FAIL unlinked-undeclared
+ *
+ * Cross-repo refs and backport markers never satisfy the requirement on their own.
+ */
+export function decide(refs: readonly ResolvedRef[], optOut: boolean): PolicyDecision {
+  const sameRepo = refs.filter((ref) => !ref.crossRepo && ref.kind !== 'backport');
+
+  const prRefs = sameRepo.filter((ref) => ref.target === 'pullRequest');
+  if (prRefs.length > 0) {
+    const list = prRefs.map((ref) => `#${ref.number}`).join(', ');
+    return {
+      outcome: 'fail',
+      code: 'pr-ref-in-section',
+      reasons: [
+        `The "Related issues" section links a pull request (${list}), not an issue.`,
+        'Link the tracked issue this PR resolves (e.g. `closes #1234`), or tick the opt-out checkbox.',
+      ],
+    };
+  }
+
+  if (optOut) {
+    return { outcome: 'pass', code: 'opt-out', reasons: ['Opt-out checkbox ticked: no linked issue required.'] };
+  }
+
+  const liveIssues = sameRepo.filter((ref) => ref.target === 'issue');
+  if (liveIssues.length > 0) {
+    const closing = liveIssues.some((ref) => ref.kind === 'closing');
+    const list = liveIssues.map((ref) => `#${ref.number}`).join(', ');
+    return {
+      outcome: 'pass',
+      code: closing ? 'section-closing' : 'section-contributor',
+      reasons: [`Linked to issue ${list} in the "Related issues" section.`],
+    };
+  }
+
+  const dead = sameRepo.filter((ref) => ref.target === 'missing').map((ref) => `#${ref.number}`);
+  const crossRepo = refs.filter((ref) => ref.crossRepo).map((ref) => ref.raw);
+  const reasons = [
+    'No linked issue found in the "Related issues" section, and the opt-out checkbox is not ticked.',
+    'Add a closing keyword with the tracked issue (e.g. `closes #1234`), or tick the opt-out checkbox.',
+  ];
+  if (dead.length) reasons.push(`These refs do not resolve to an existing issue: ${dead.join(', ')}.`);
+  if (crossRepo.length) reasons.push(`Cross-repo refs do not count toward this repo's release notes: ${crossRepo.join(', ')}.`);
+  return { outcome: 'fail', code: 'unlinked-undeclared', reasons };
+}

--- a/.github/actions/release-notes/src/resolver/index.ts
+++ b/.github/actions/release-notes/src/resolver/index.ts
@@ -22,17 +22,36 @@ export class GithubResolver implements Resolver {
     return Promise.all(refs.map((ref) => this.resolveOne(ref)));
   }
 
+  /**
+   * Fetch a same-repo pull request's body for backport-hop validation, or null
+   * if it does not exist. Used to follow `Backport of #N` to the original PR and
+   * validate that PR's attribution (the backport inherits it — C7).
+   */
+  async fetchPullBody(number: number): Promise<string | null> {
+    const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/pulls/${number}`, {
+      headers: this.headers(),
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`GitHub API ${res.status} fetching PR #${number}`);
+    const data = (await res.json()) as { body?: string | null };
+    return data.body ?? '';
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      authorization: `Bearer ${this.token}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      'user-agent': 'camunda-release-notes-gate',
+    };
+  }
+
   private async resolveOne(ref: ParsedRef): Promise<ResolvedRef> {
     const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
     if (crossRepo) return { ...ref, target: 'missing', crossRepo: true };
 
     const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${ref.number}`, {
-      headers: {
-        authorization: `Bearer ${this.token}`,
-        accept: 'application/vnd.github+json',
-        'x-github-api-version': '2022-11-28',
-        'user-agent': 'camunda-release-notes-gate',
-      },
+      headers: this.headers(),
     });
     if (res.status === 404) return { ...ref, target: 'missing', crossRepo: false };
     if (!res.ok) throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);

--- a/.github/actions/release-notes/src/resolver/index.ts
+++ b/.github/actions/release-notes/src/resolver/index.ts
@@ -1,3 +1,4 @@
+import { githubHeaders, repoApiUrl } from '../github';
 import type { ParsedRef, ResolvedRef, Resolver } from '../types';
 
 /**
@@ -12,11 +13,15 @@ import type { ParsedRef, ResolvedRef, Resolver } from '../types';
  * endpoint; octokit would inline the whole REST client into the bundle.
  */
 export class GithubResolver implements Resolver {
+  private readonly repoUrl: string;
+
   constructor(
     private readonly token: string,
     private readonly owner: string,
     private readonly repo: string,
-  ) {}
+  ) {
+    this.repoUrl = repoApiUrl(owner, repo);
+  }
 
   async resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]> {
     return Promise.all(refs.map((ref) => this.resolveOne(ref)));
@@ -26,10 +31,17 @@ export class GithubResolver implements Resolver {
    * Fetch a same-repo pull request's body for backport-hop validation, or null
    * if it does not exist. Used to follow `Backport of #N` to the original PR and
    * validate that PR's attribution (the backport inherits it — C7).
+   *
+   * A cross-repo marker (`Backport of owner/other#N`) resolves to null: this
+   * resolver is hardcoded to its own owner/repo, so #N there would name an
+   * unrelated PR in THIS repo. We only inherit attribution from our own repo.
    */
-  async fetchPullBody(number: number): Promise<string | null> {
-    const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/pulls/${number}`, {
-      headers: this.headers(),
+  async fetchPullBody(number: number, repo: string | null): Promise<string | null> {
+    const crossRepo = repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+    if (crossRepo) return null;
+
+    const res = await fetch(`${this.repoUrl}/pulls/${number}`, {
+      headers: githubHeaders(this.token),
     });
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`GitHub API ${res.status} fetching PR #${number}`);
@@ -37,21 +49,12 @@ export class GithubResolver implements Resolver {
     return data.body ?? '';
   }
 
-  private headers(): Record<string, string> {
-    return {
-      authorization: `Bearer ${this.token}`,
-      accept: 'application/vnd.github+json',
-      'x-github-api-version': '2022-11-28',
-      'user-agent': 'camunda-release-notes-gate',
-    };
-  }
-
   private async resolveOne(ref: ParsedRef): Promise<ResolvedRef> {
     const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
     if (crossRepo) return { ...ref, target: 'missing', crossRepo: true };
 
-    const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${ref.number}`, {
-      headers: this.headers(),
+    const res = await fetch(`${this.repoUrl}/issues/${ref.number}`, {
+      headers: githubHeaders(this.token),
     });
     if (res.status === 404) return { ...ref, target: 'missing', crossRepo: false };
     if (!res.ok) throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);

--- a/.github/actions/release-notes/src/resolver/index.ts
+++ b/.github/actions/release-notes/src/resolver/index.ts
@@ -1,0 +1,43 @@
+import type { ParsedRef, ResolvedRef, Resolver } from '../types';
+
+/**
+ * GitHub-API resolver: the only part of the pipeline that touches the network.
+ * Classifies each ref as issue vs PR vs missing and flags cross-repo refs.
+ *
+ * GitHub's issues API returns PRs too (a PR is an issue with a `pull_request`
+ * field), so one lookup per number classifies both. Cross-repo refs are not
+ * queried — they never satisfy the gate, so their target stays "missing".
+ *
+ * ponytail: plain fetch (Node 24 global) over octokit — we hit exactly one
+ * endpoint; octokit would inline the whole REST client into the bundle.
+ */
+export class GithubResolver implements Resolver {
+  constructor(
+    private readonly token: string,
+    private readonly owner: string,
+    private readonly repo: string,
+  ) {}
+
+  async resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]> {
+    return Promise.all(refs.map((ref) => this.resolveOne(ref)));
+  }
+
+  private async resolveOne(ref: ParsedRef): Promise<ResolvedRef> {
+    const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+    if (crossRepo) return { ...ref, target: 'missing', crossRepo: true };
+
+    const res = await fetch(`https://api.github.com/repos/${this.owner}/${this.repo}/issues/${ref.number}`, {
+      headers: {
+        authorization: `Bearer ${this.token}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+        'user-agent': 'camunda-release-notes-gate',
+      },
+    });
+    if (res.status === 404) return { ...ref, target: 'missing', crossRepo: false };
+    if (!res.ok) throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);
+
+    const data = (await res.json()) as { pull_request?: unknown };
+    return { ...ref, target: data.pull_request ? 'pullRequest' : 'issue', crossRepo: false };
+  }
+}

--- a/.github/actions/release-notes/src/resolver/index.ts
+++ b/.github/actions/release-notes/src/resolver/index.ts
@@ -1,0 +1,128 @@
+import { githubHeaders, repoApiUrl } from '../github';
+import type { ParsedRef, PullMeta, ResolvedRef, Resolver } from '../types';
+
+/** A PR body can carry at most this many refs to the API. A legitimate PR never
+ *  needs more than a handful — this bounds the worst case (a body stuffed with
+ *  hundreds of `#N` shorthands on `pull_request_target`) to a fixed cost. */
+const MAX_REFS = 20;
+
+/** How many classify calls run concurrently. Caps the fan-out against GitHub's
+ *  API even after dedup + the cap above, so a burst of distinct numbers cannot
+ *  open dozens of sockets at once. */
+const CONCURRENCY = 5;
+
+/**
+ * GitHub-API resolver: the only part of the pipeline that touches the network.
+ * Classifies each ref as issue vs PR vs missing and flags cross-repo refs.
+ *
+ * GitHub's issues API returns PRs too (a PR is an issue with a `pull_request`
+ * field), so one lookup per number classifies both. Cross-repo refs are not
+ * queried — they never satisfy the gate, so their target stays "missing".
+ *
+ * ponytail: plain fetch (Node 24 global) over octokit — we hit exactly one
+ * endpoint; octokit would inline the whole REST client into the bundle.
+ */
+export class GithubResolver implements Resolver {
+  private readonly repoUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(
+    private readonly token: string,
+    private readonly owner: string,
+    private readonly repo: string,
+  ) {
+    this.repoUrl = repoApiUrl(owner, repo);
+    this.headers = githubHeaders(token);
+  }
+
+  /**
+   * Resolve every ref, deduped (repeats of the same "#N" cost one API call),
+   * capped at MAX_REFS (a legitimate PR never needs more), and bounded to
+   * CONCURRENCY in flight — defense against a body engineered to fan out
+   * unbounded concurrent requests using the privileged gate token.
+   */
+  async resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]> {
+    const capped = refs.slice(0, MAX_REFS);
+    const cache = new Map<string, Promise<Pick<ResolvedRef, 'target' | 'crossRepo'>>>();
+    const classifyCached = (ref: ParsedRef): Promise<Pick<ResolvedRef, 'target' | 'crossRepo'>> => {
+      const key = `${ref.repo ?? ''}#${ref.number}`;
+      let promise = cache.get(key);
+      if (!promise) {
+        promise = this.classify(ref);
+        cache.set(key, promise);
+      }
+      return promise;
+    };
+
+    const results: ResolvedRef[] = [];
+    for (let i = 0; i < capped.length; i += CONCURRENCY) {
+      const batch = capped.slice(i, i + CONCURRENCY);
+      const classified = await Promise.all(batch.map(classifyCached));
+      batch.forEach((ref, index) => {
+        const { target, crossRepo } = classified[index]!;
+        results.push({ ...ref, target, crossRepo });
+      });
+    }
+    return results;
+  }
+
+  /**
+   * Fetch a same-repo pull request's body for backport-hop validation, or null
+   * if it does not exist. Used to follow `Backport of #N` to the original PR and
+   * validate that PR's attribution (the backport inherits it — C7).
+   *
+   * A cross-repo marker (`Backport of owner/other#N`) resolves to null: this
+   * resolver is hardcoded to its own owner/repo, so #N there would name an
+   * unrelated PR in THIS repo. We only inherit attribution from our own repo.
+   */
+  async fetchPullBody(number: number, repo: string | null): Promise<string | null> {
+    if (this.isCrossRepo(repo)) return null;
+    const pull = await this.fetchPull(number);
+    return pull?.body ?? null;
+  }
+
+  /**
+   * Fetch the fields the gate evaluates for one same-repo pull request, or null
+   * if it does not exist.
+   *
+   * This is how the entrypoint obtains the PR under `workflow_run`, where the
+   * event payload carries no `pull_request` object at all. Fetching also means
+   * the body is read at evaluation time, so a stale or superseded trigger run
+   * can never evaluate an out-of-date body.
+   */
+  async fetchPull(number: number): Promise<PullMeta | null> {
+    const res = await fetch(`${this.repoUrl}/pulls/${number}`, {
+      headers: this.headers,
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) throw new Error(`GitHub API ${res.status} fetching PR #${number}`);
+    const data = (await res.json()) as {
+      body?: string | null;
+      title?: string | null;
+      user?: { login?: string } | null;
+    };
+    return { body: data.body ?? '', title: data.title ?? '', authorLogin: data.user?.login };
+  }
+
+  /** A ref points at a different repo than the one being gated (case-insensitive). */
+  private isCrossRepo(repo: string | null): boolean {
+    return repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+  }
+
+  /** Classify one (repo, number) pair — the part of a ref that actually needs
+   *  an API call. Keyed independently of the ParsedRef's own fields (raw,
+   *  keyword, kind, index) so `resolve()` can cache and reuse it across every
+   *  ref that shares the same repo/number. */
+  private async classify(ref: ParsedRef): Promise<Pick<ResolvedRef, 'target' | 'crossRepo'>> {
+    if (this.isCrossRepo(ref.repo)) return { target: 'missing', crossRepo: true };
+
+    const res = await fetch(`${this.repoUrl}/issues/${ref.number}`, {
+      headers: this.headers,
+    });
+    if (res.status === 404) return { target: 'missing', crossRepo: false };
+    if (!res.ok) throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);
+
+    const data = (await res.json()) as { pull_request?: unknown };
+    return { target: data.pull_request ? 'pullRequest' : 'issue', crossRepo: false };
+  }
+}

--- a/.github/actions/release-notes/src/resolver/index.ts
+++ b/.github/actions/release-notes/src/resolver/index.ts
@@ -14,6 +14,7 @@ import type { ParsedRef, ResolvedRef, Resolver } from '../types';
  */
 export class GithubResolver implements Resolver {
   private readonly repoUrl: string;
+  private readonly headers: Record<string, string>;
 
   constructor(
     private readonly token: string,
@@ -21,6 +22,7 @@ export class GithubResolver implements Resolver {
     private readonly repo: string,
   ) {
     this.repoUrl = repoApiUrl(owner, repo);
+    this.headers = githubHeaders(token);
   }
 
   async resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]> {
@@ -37,11 +39,10 @@ export class GithubResolver implements Resolver {
    * unrelated PR in THIS repo. We only inherit attribution from our own repo.
    */
   async fetchPullBody(number: number, repo: string | null): Promise<string | null> {
-    const crossRepo = repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
-    if (crossRepo) return null;
+    if (this.isCrossRepo(repo)) return null;
 
     const res = await fetch(`${this.repoUrl}/pulls/${number}`, {
-      headers: githubHeaders(this.token),
+      headers: this.headers,
     });
     if (res.status === 404) return null;
     if (!res.ok) throw new Error(`GitHub API ${res.status} fetching PR #${number}`);
@@ -49,12 +50,16 @@ export class GithubResolver implements Resolver {
     return data.body ?? '';
   }
 
+  /** A ref points at a different repo than the one being gated (case-insensitive). */
+  private isCrossRepo(repo: string | null): boolean {
+    return repo !== null && repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
+  }
+
   private async resolveOne(ref: ParsedRef): Promise<ResolvedRef> {
-    const crossRepo = ref.repo !== null && ref.repo.toLowerCase() !== `${this.owner}/${this.repo}`.toLowerCase();
-    if (crossRepo) return { ...ref, target: 'missing', crossRepo: true };
+    if (this.isCrossRepo(ref.repo)) return { ...ref, target: 'missing', crossRepo: true };
 
     const res = await fetch(`${this.repoUrl}/issues/${ref.number}`, {
-      headers: githubHeaders(this.token),
+      headers: this.headers,
     });
     if (res.status === 404) return { ...ref, target: 'missing', crossRepo: false };
     if (!res.ok) throw new Error(`GitHub API ${res.status} resolving #${ref.number}`);

--- a/.github/actions/release-notes/src/title/index.ts
+++ b/.github/actions/release-notes/src/title/index.ts
@@ -38,6 +38,17 @@ export const HEADER_MAX = 120;
 // conventional-commit header shape config-conventional parses.
 const HEADER = /^(?<type>[^\s():!]+)(?<scope>\([^)]*\))?!?:[ ](?<subject>.+)$/;
 
+/**
+ * Wrap user-controlled title fragments before interpolating them into the
+ * sticky comment / job summary. The gate posts under a bot identity on
+ * `pull_request_target`, so a raw `@mention` in a malicious title would notify
+ * (spam) via the bot. Inline code neutralises mentions; stripping backticks
+ * stops the value breaking out of the span.
+ */
+function code(value: string | undefined): string {
+  return `\`${(value ?? '').replace(/`/g, '')}\``;
+}
+
 /** Lint a PR title. Pure — no IO, no bot logic (the caller decides bot skips). */
 export function lintTitle(title: string): TitleDecision {
   if (title.length > HEADER_MAX) {
@@ -66,19 +77,19 @@ export function lintTitle(title: string): TitleDecision {
     return {
       outcome: 'fail',
       code: 'title-scope',
-      reasons: [`Scopes are not used in this repo — drop "${scope}" and write "${type}: …".`],
+      reasons: [`Scopes are not used in this repo — drop ${code(scope)} and write "${code(type)}: …".`],
     };
   }
 
   if (type !== type?.toLowerCase()) {
-    return { outcome: 'fail', code: 'title-type', reasons: [`The type "${type}" must be lower-case.`] };
+    return { outcome: 'fail', code: 'title-type', reasons: [`The type ${code(type)} must be lower-case.`] };
   }
 
   if (!TITLE_TYPES.includes(type as (typeof TITLE_TYPES)[number])) {
     return {
       outcome: 'fail',
       code: 'title-type',
-      reasons: [`"${type}" is not an allowed type. Use one of: ${TITLE_TYPES.join(', ')}.`],
+      reasons: [`${code(type)} is not an allowed type. Use one of: ${TITLE_TYPES.join(', ')}.`],
     };
   }
 

--- a/.github/actions/release-notes/src/title/index.ts
+++ b/.github/actions/release-notes/src/title/index.ts
@@ -1,0 +1,102 @@
+import type { TitleDecision } from '../types';
+
+/**
+ * PR-title lint — the active rules of `commitlint.config.cjs`, reimplemented as
+ * a pure check so the action keeps zero runtime deps (pulling @commitlint +
+ * config-conventional would vendor hundreds of kB into the committed bundle for
+ * a handful of trivial rules). The config's other rules are disabled ([0,...]).
+ *
+ * DRIFT GUARD: TITLE_TYPES and HEADER_MAX are the single source of truth here,
+ * and the action CI greps commitlint.config.cjs to assert they still match —
+ * so a change to the repo's commit rules fails CI until this is updated.
+ *
+ * Active rules mirrored (see commitlint.config.cjs):
+ *   type-empty:never · type-case:lower-case · type-enum · scope-empty:always ·
+ *   header-max-length:120. Subject/body/footer rules are disabled there.
+ */
+
+/** commitlint.config.cjs `type-enum`. Keep in sync — CI enforces it. */
+export const TITLE_TYPES = [
+  'build',
+  'ci',
+  'deps',
+  'docs',
+  'feat',
+  'fix',
+  'merge',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+] as const;
+
+/** commitlint.config.cjs `header-max-length`. Keep in sync — CI enforces it. */
+export const HEADER_MAX = 120;
+
+// `type` + optional `(scope)` + optional `!` + `: ` + subject. Mirrors the
+// conventional-commit header shape config-conventional parses.
+const HEADER = /^(?<type>[^\s():!]+)(?<scope>\([^)]*\))?!?:[ ](?<subject>.+)$/;
+
+/** Lint a PR title. Pure — no IO, no bot logic (the caller decides bot skips). */
+export function lintTitle(title: string): TitleDecision {
+  if (title.length > HEADER_MAX) {
+    return {
+      outcome: 'fail',
+      code: 'title-length',
+      reasons: [`The title is ${title.length} characters; keep it within ${HEADER_MAX}.`],
+    };
+  }
+
+  const match = HEADER.exec(title);
+  if (!match?.groups) {
+    return {
+      outcome: 'fail',
+      code: 'title-format',
+      reasons: [
+        'The title must follow Conventional Commits: `type: summary` (e.g. "fix: correct retry backoff").',
+        `Allowed types: ${TITLE_TYPES.join(', ')}.`,
+      ],
+    };
+  }
+
+  const { type, scope } = match.groups;
+
+  if (scope) {
+    return {
+      outcome: 'fail',
+      code: 'title-scope',
+      reasons: [`Scopes are not used in this repo — drop "${scope}" and write "${type}: …".`],
+    };
+  }
+
+  if (type !== type?.toLowerCase()) {
+    return { outcome: 'fail', code: 'title-type', reasons: [`The type "${type}" must be lower-case.`] };
+  }
+
+  if (!TITLE_TYPES.includes(type as (typeof TITLE_TYPES)[number])) {
+    return {
+      outcome: 'fail',
+      code: 'title-type',
+      reasons: [`"${type}" is not an allowed type. Use one of: ${TITLE_TYPES.join(', ')}.`],
+    };
+  }
+
+  return { outcome: 'pass', code: 'title-ok', reasons: [`Title type "${type}" is valid.`] };
+}
+
+/**
+ * Bot authors whose titles are machine-generated and exempt from title lint
+ * (D16). Their PR-issue link / backport marker is still validated — only the
+ * title check is skipped.
+ */
+export const BOT_TITLE_EXEMPT = new Set([
+  'backport-action',
+  'monorepo-devops-automation[bot]',
+  'renovate[bot]',
+  'dependabot[bot]',
+]);
+
+export function isTitleExemptAuthor(login: string | undefined): boolean {
+  return login !== undefined && BOT_TITLE_EXEMPT.has(login);
+}

--- a/.github/actions/release-notes/src/title/index.ts
+++ b/.github/actions/release-notes/src/title/index.ts
@@ -1,0 +1,131 @@
+import type { TitleDecision } from '../types';
+
+/**
+ * PR-title lint — the active rules of `commitlint.config.cjs`, reimplemented as
+ * a pure check so the action keeps zero runtime deps (pulling @commitlint +
+ * config-conventional would vendor hundreds of kB into the committed bundle for
+ * a handful of trivial rules). The config's other rules are disabled ([0,...]).
+ *
+ * DRIFT GUARD: TITLE_TYPES and HEADER_MAX are the single source of truth here,
+ * and the action CI greps commitlint.config.cjs to assert they still match —
+ * so a change to the repo's commit rules fails CI until this is updated.
+ *
+ * Active rules mirrored (see commitlint.config.cjs):
+ *   type-empty:never · type-case:lower-case · type-enum · scope-empty:always ·
+ *   header-max-length:120. Subject/body/footer rules are disabled there.
+ */
+
+/** commitlint.config.cjs `type-enum`. Keep in sync — CI enforces it. */
+export const TITLE_TYPES = [
+  'build',
+  'ci',
+  'deps',
+  'docs',
+  'feat',
+  'fix',
+  'merge',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+] as const;
+
+/** commitlint.config.cjs `header-max-length`. Keep in sync — CI enforces it. */
+export const HEADER_MAX = 120;
+
+// `type` + optional `(scope)` + optional `!` + `: ` + subject. Mirrors the
+// conventional-commit header shape config-conventional parses.
+const HEADER = /^(?<type>[^\s():!]+)(?<scope>\([^)]*\))?!?:[ ](?<subject>.+)$/;
+
+/**
+ * Wrap user-controlled title fragments before interpolating them into the
+ * sticky comment / job summary. The gate posts the comment with a write token,
+ * so a raw `@mention` in a malicious title would notify (spam) via the bot.
+ * Inline code neutralises mentions; stripping backticks stops the value
+ * breaking out of the span.
+ */
+function code(value: string | undefined): string {
+  return `\`${(value ?? '').replace(/`/g, '')}\``;
+}
+
+/** Lint a PR title. Pure — no IO, no bot logic (the caller decides bot skips). */
+export function lintTitle(title: string): TitleDecision {
+  if (title.length > HEADER_MAX) {
+    return {
+      outcome: 'fail',
+      code: 'title-length',
+      reasons: [`The title is ${title.length} characters; keep it within ${HEADER_MAX}.`],
+    };
+  }
+
+  const match = HEADER.exec(title);
+  if (!match?.groups) {
+    return {
+      outcome: 'fail',
+      code: 'title-format',
+      reasons: [
+        'The title must follow Conventional Commits: `type: summary` (e.g. "fix: correct retry backoff").',
+        `Allowed types: ${TITLE_TYPES.join(', ')}.`,
+      ],
+    };
+  }
+
+  const { type, scope } = match.groups;
+
+  if (scope) {
+    return {
+      outcome: 'fail',
+      code: 'title-scope',
+      reasons: [`Scopes are not used in this repo — drop ${code(scope)} and write "${code(type)}: …".`],
+    };
+  }
+
+  if (type !== type?.toLowerCase()) {
+    return { outcome: 'fail', code: 'title-type', reasons: [`The type ${code(type)} must be lower-case.`] };
+  }
+
+  if (!TITLE_TYPES.includes(type as (typeof TITLE_TYPES)[number])) {
+    return {
+      outcome: 'fail',
+      code: 'title-type',
+      reasons: [`${code(type)} is not an allowed type. Use one of: ${TITLE_TYPES.join(', ')}.`],
+    };
+  }
+
+  return { outcome: 'pass', code: 'title-ok', reasons: [`Title type "${type}" is valid.`] };
+}
+
+/**
+ * Bot authors whose titles are machine-generated and exempt from title lint
+ * (D16). Their PR-issue link / backport marker is still validated — only the
+ * title check is skipped.
+ */
+export const BOT_TITLE_EXEMPT = new Set([
+  'backport-action',
+  'monorepo-devops-automation[bot]',
+  'renovate[bot]',
+  'dependabot[bot]',
+]);
+
+export function isTitleExemptAuthor(login: string | undefined): boolean {
+  return login !== undefined && BOT_TITLE_EXEMPT.has(login);
+}
+
+/**
+ * Bot authors exempt from the PR-issue-LINK check, because they open PRs from
+ * their own template and will never tick the opt-out checkbox. Dependency bumps
+ * are not release-notes material, so an exemption is the agreed answer rather
+ * than teaching each bot to write the section.
+ *
+ * DELIBERATELY SEPARATE from BOT_TITLE_EXEMPT, which must never be reused here:
+ * that set contains `monorepo-devops-automation[bot]`, the author of every
+ * backport PR. Exempting it from the link check would skip the backport hop, so
+ * backports would stop inheriting the original PR's issue — silently dropping
+ * them from the release notes, which is the failure this gate exists to prevent.
+ */
+export const BOT_LINK_EXEMPT = new Set(['renovate[bot]']);
+
+export function isLinkExemptAuthor(login: string | undefined): boolean {
+  return login !== undefined && BOT_LINK_EXEMPT.has(login);
+}

--- a/.github/actions/release-notes/src/types.ts
+++ b/.github/actions/release-notes/src/types.ts
@@ -58,3 +58,35 @@ export interface PolicyDecision {
 export interface Resolver {
   resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]>;
 }
+
+/** How the linked PR was delivered — a direct PR, or a backport hop to an original. */
+export type DeliveryPath = 'direct' | 'backportHop';
+
+export type TitleCode =
+  | 'title-ok' // PASS: the title matches the conventional-commit rules
+  | 'title-format' // FAIL: not `type: subject` shape
+  | 'title-type' // FAIL: type missing, not lower-case, or not in the enum
+  | 'title-scope' // FAIL: a scope is present (scope-empty: always)
+  | 'title-length' // FAIL: header exceeds the max length
+  | 'title-skipped'; // PASS: author is a bot — title lint does not apply (D16)
+
+/** Result of linting the PR title against commitlint.config.cjs (the active rules). */
+export interface TitleDecision {
+  readonly outcome: PolicyOutcome;
+  readonly code: TitleCode;
+  readonly reasons: readonly string[];
+}
+
+/** One named check within the gate (the PR-issue link, or the title). */
+export interface GateCheck {
+  readonly label: string;
+  readonly outcome: PolicyOutcome;
+  readonly reasons: readonly string[];
+}
+
+/** The aggregate gate outcome the entrypoint reports and the comment renders. */
+export interface GateOutcome {
+  readonly outcome: PolicyOutcome;
+  readonly checks: readonly GateCheck[];
+  readonly deliveryPath: DeliveryPath;
+}

--- a/.github/actions/release-notes/src/types.ts
+++ b/.github/actions/release-notes/src/types.ts
@@ -89,4 +89,7 @@ export interface GateOutcome {
   readonly outcome: PolicyOutcome;
   readonly checks: readonly GateCheck[];
   readonly deliveryPath: DeliveryPath;
+  /** The PR-issue-link decision, threaded through directly so the no-issue label
+   *  sync reads it by type rather than by matching a check's label string. */
+  readonly link: PolicyDecision;
 }

--- a/.github/actions/release-notes/src/types.ts
+++ b/.github/actions/release-notes/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * The attribution contract shared by the PR-gate lint and the release-notes
+ * generator (#57713): ParsedRef -> ResolvedRef -> PolicyDecision.
+ *
+ * ParsedRef is pure text extraction (no IO). ResolvedRef adds the facts only
+ * the GitHub API can supply (issue vs PR, alive vs dead, same-repo vs cross).
+ * PolicyDecision is a pure function of ResolvedRef[] + opt-out state.
+ */
+
+/** How a reference was written, which decides whether it satisfies the gate. */
+export type RefKind =
+  | 'closing' // close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved, completes
+  | 'contributor' // "relates to #N" or a bare "#N" in the section
+  | 'backport'; // "Backport of #N" — a delivery-hop marker, never satisfies on its own
+
+/** A reference extracted from text. Pure — knows nothing about the API or the owning repo. */
+export interface ParsedRef {
+  /** The full matched text, e.g. "closes #123" or "camunda/other#7". */
+  readonly raw: string;
+  /** The referenced number. Issue-vs-PR is unknown until resolved. */
+  readonly number: number;
+  /** Explicit "owner/repo" prefix if the ref carried one, else null. */
+  readonly repo: string | null;
+  /** The lowercased keyword that introduced the ref, or null for a bare "#N". */
+  readonly keyword: string | null;
+  readonly kind: RefKind;
+  /** Character offset of the match within the scanned text. */
+  readonly index: number;
+}
+
+/** What the target number turned out to be once queried. */
+export type RefTarget = 'issue' | 'pullRequest' | 'missing';
+
+/** A ParsedRef enriched with the facts the resolver looked up. */
+export interface ResolvedRef extends ParsedRef {
+  readonly target: RefTarget;
+  /** true when the ref points at a different repo than the one being gated. */
+  readonly crossRepo: boolean;
+}
+
+export type PolicyOutcome = 'pass' | 'fail';
+
+export type PolicyCode =
+  | 'section-closing' // PASS: a closing ref resolves to an issue in this repo
+  | 'section-contributor' // PASS: a contributor ref resolves to an issue in this repo
+  | 'opt-out' // PASS: the opt-out checkbox is ticked
+  | 'pr-ref-in-section' // FAIL: the section links a PR, not an issue
+  | 'unlinked-undeclared'; // FAIL: no satisfying ref and no opt-out
+
+export interface PolicyDecision {
+  readonly outcome: PolicyOutcome;
+  readonly code: PolicyCode;
+  /** Human-readable lines naming what passed/failed and the exact fix. */
+  readonly reasons: readonly string[];
+}
+
+/** Contract for the API adapter. The pure core depends only on this, never on octokit. */
+export interface Resolver {
+  resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]>;
+}

--- a/.github/actions/release-notes/src/types.ts
+++ b/.github/actions/release-notes/src/types.ts
@@ -1,0 +1,111 @@
+/**
+ * The attribution contract shared by the PR-gate lint and the release-notes
+ * generator (#57713): ParsedRef -> ResolvedRef -> PolicyDecision.
+ *
+ * ParsedRef is pure text extraction (no IO). ResolvedRef adds the facts only
+ * the GitHub API can supply (issue vs PR, alive vs dead, same-repo vs cross).
+ * PolicyDecision is a pure function of ResolvedRef[] + opt-out state.
+ */
+
+/** How a reference was written, which decides whether it satisfies the gate. */
+export type RefKind =
+  | 'closing' // close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved, completes
+  | 'contributor' // "relates to #N" or a bare "#N" in the section
+  | 'backport'; // "Backport of #N" — a delivery-hop marker, never satisfies on its own
+
+/** A reference extracted from text. Pure — knows nothing about the API or the owning repo. */
+export interface ParsedRef {
+  /** The full matched text, e.g. "closes #123" or "camunda/other#7". */
+  readonly raw: string;
+  /** The referenced number. Issue-vs-PR is unknown until resolved. */
+  readonly number: number;
+  /** Explicit "owner/repo" prefix if the ref carried one, else null. */
+  readonly repo: string | null;
+  /** The lowercased keyword that introduced the ref, or null for a bare "#N". */
+  readonly keyword: string | null;
+  readonly kind: RefKind;
+  /** Character offset of the match within the scanned text. */
+  readonly index: number;
+}
+
+/** What the target number turned out to be once queried. */
+export type RefTarget = 'issue' | 'pullRequest' | 'missing';
+
+/** A ParsedRef enriched with the facts the resolver looked up. */
+export interface ResolvedRef extends ParsedRef {
+  readonly target: RefTarget;
+  /** true when the ref points at a different repo than the one being gated. */
+  readonly crossRepo: boolean;
+}
+
+export type PolicyOutcome = 'pass' | 'fail';
+
+export type PolicyCode =
+  | 'section-closing' // PASS: a closing ref resolves to an issue in this repo
+  | 'section-contributor' // PASS: a contributor ref resolves to an issue in this repo
+  | 'opt-out' // PASS: the opt-out checkbox is ticked
+  | 'bot-exempt' // PASS: the author is a bot that cannot follow the PR template
+  | 'pr-ref-in-section' // FAIL: the section links a PR, not an issue
+  | 'unlinked-undeclared'; // FAIL: no satisfying ref and no opt-out
+
+export interface PolicyDecision {
+  readonly outcome: PolicyOutcome;
+  readonly code: PolicyCode;
+  /** Human-readable lines naming what passed/failed and the exact fix. */
+  readonly reasons: readonly string[];
+}
+
+/** Contract for the API adapter. The pure core depends only on this, never on octokit. */
+export interface Resolver {
+  resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]>;
+}
+
+/**
+ * The pull-request fields the gate evaluates. Fetched from the API rather than
+ * read off the event payload: on `workflow_run` there is no `pull_request` in
+ * the payload at all, and fetching also guarantees the body is current at
+ * evaluation time rather than a snapshot from whenever the event fired.
+ */
+export interface PullMeta {
+  readonly body: string;
+  readonly title: string;
+  /** Drives the bot exemptions (title lint per D16, and the Renovate link
+   *  exemption). Absent means "not exempt", so a missing author degrades to a
+   *  stricter check, never a looser one. */
+  readonly authorLogin?: string;
+}
+
+/** How the linked PR was delivered — a direct PR, or a backport hop to an original. */
+export type DeliveryPath = 'direct' | 'backportHop';
+
+export type TitleCode =
+  | 'title-ok' // PASS: the title matches the conventional-commit rules
+  | 'title-format' // FAIL: not `type: subject` shape
+  | 'title-type' // FAIL: type missing, not lower-case, or not in the enum
+  | 'title-scope' // FAIL: a scope is present (scope-empty: always)
+  | 'title-length' // FAIL: header exceeds the max length
+  | 'title-skipped'; // PASS: author is a bot — title lint does not apply (D16)
+
+/** Result of linting the PR title against commitlint.config.cjs (the active rules). */
+export interface TitleDecision {
+  readonly outcome: PolicyOutcome;
+  readonly code: TitleCode;
+  readonly reasons: readonly string[];
+}
+
+/** One named check within the gate (the PR-issue link, or the title). */
+export interface GateCheck {
+  readonly label: string;
+  readonly outcome: PolicyOutcome;
+  readonly reasons: readonly string[];
+}
+
+/** The aggregate gate outcome the entrypoint reports and the comment renders. */
+export interface GateOutcome {
+  readonly outcome: PolicyOutcome;
+  readonly checks: readonly GateCheck[];
+  readonly deliveryPath: DeliveryPath;
+  /** The PR-issue-link decision, threaded through directly so the no-issue label
+   *  sync reads it by type rather than by matching a check's label string. */
+  readonly link: PolicyDecision;
+}

--- a/.github/actions/release-notes/test/comment.test.ts
+++ b/.github/actions/release-notes/test/comment.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { type CommentApi, type IssueComment, renderStickyComment, STICKY_MARKER, syncStickyComment } from '../src/comment';
+import type { PolicyDecision } from '../src/types';
+
+const FAIL: PolicyDecision = { outcome: 'fail', code: 'unlinked-undeclared', reasons: ['No linked issue found.', 'Add "closes #1234".'] };
+const PASS: PolicyDecision = { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] };
+
+/** Records every call so a test can assert what the sync did. */
+class FakeApi implements CommentApi {
+  readonly created: string[] = [];
+  readonly updated: { id: number; body: string }[] = [];
+  constructor(private readonly comments: IssueComment[] = []) {}
+  async list(): Promise<IssueComment[]> {
+    return this.comments;
+  }
+  async create(body: string): Promise<void> {
+    this.created.push(body);
+  }
+  async update(id: number, body: string): Promise<void> {
+    this.updated.push({ id, body });
+  }
+}
+
+test('renderStickyComment always carries the marker and the reasons', () => {
+  const body = renderStickyComment(FAIL);
+  assert.ok(body.startsWith(STICKY_MARKER));
+  assert.ok(body.includes('No linked issue found.'));
+});
+
+test('fail with no existing comment creates one', async () => {
+  const api = new FakeApi([]);
+  const action = await syncStickyComment(api, FAIL);
+  assert.equal(action, 'created');
+  assert.equal(api.created.length, 1);
+  assert.equal(api.updated.length, 0);
+  assert.ok(api.created[0]?.includes(STICKY_MARKER));
+});
+
+test('fail with an existing marked comment updates it — no duplicate', async () => {
+  const api = new FakeApi([{ id: 42, body: `${STICKY_MARKER}\nold` }]);
+  const action = await syncStickyComment(api, FAIL);
+  assert.equal(action, 'updated');
+  assert.equal(api.created.length, 0);
+  assert.deepEqual(api.updated.map((call) => call.id), [42]);
+});
+
+test('pass with an existing marked comment flips it to resolved', async () => {
+  const api = new FakeApi([{ id: 7, body: `${STICKY_MARKER}\nfailure` }]);
+  const action = await syncStickyComment(api, PASS);
+  assert.equal(action, 'resolved');
+  assert.equal(api.created.length, 0);
+  assert.equal(api.updated[0]?.id, 7);
+  assert.ok(api.updated[0]?.body.includes('resolved'));
+});
+
+test('pass with no existing comment does nothing — never-failed PRs stay clean', async () => {
+  const api = new FakeApi([{ id: 1, body: 'an unrelated human comment' }]);
+  const action = await syncStickyComment(api, PASS);
+  assert.equal(action, 'noop');
+  assert.equal(api.created.length, 0);
+  assert.equal(api.updated.length, 0);
+});
+
+test('unmarked comments are ignored when locating the sticky comment', async () => {
+  const api = new FakeApi([{ id: 1, body: 'unrelated' }, { id: 2, body: 'also unrelated' }]);
+  const action = await syncStickyComment(api, FAIL);
+  assert.equal(action, 'created');
+  assert.equal(api.updated.length, 0);
+});

--- a/.github/actions/release-notes/test/comment.test.ts
+++ b/.github/actions/release-notes/test/comment.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { type CommentApi, GithubCommentApi, type IssueComment, renderStickyComment, STICKY_MARKER, syncStickyComment } from '../src/comment';
+import type { GateOutcome } from '../src/types';
+
+const FAIL: GateOutcome = {
+  outcome: 'fail',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'fail', reasons: ['No linked issue found.', 'Add "closes #1234".'] }],
+  link: { outcome: 'fail', code: 'unlinked-undeclared', reasons: ['No linked issue found.', 'Add "closes #1234".'] },
+};
+const PASS: GateOutcome = {
+  outcome: 'pass',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] }],
+  link: { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] },
+};
+
+/** Records every call so a test can assert what the sync did. */
+class FakeApi implements CommentApi {
+  readonly created: string[] = [];
+  readonly updated: { id: number; body: string }[] = [];
+  constructor(private readonly comments: IssueComment[] = []) {}
+  async list(): Promise<IssueComment[]> {
+    return this.comments;
+  }
+  async create(body: string): Promise<void> {
+    this.created.push(body);
+  }
+  async update(id: number, body: string): Promise<void> {
+    this.updated.push({ id, body });
+  }
+}
+
+test('renderStickyComment always carries the marker and the reasons', () => {
+  const body = renderStickyComment(FAIL);
+  assert.ok(body.startsWith(STICKY_MARKER));
+  assert.ok(body.includes('No linked issue found.'));
+});
+
+test('fail with no existing comment creates one', async () => {
+  const api = new FakeApi([]);
+  const action = await syncStickyComment(api, FAIL);
+  assert.equal(action, 'created');
+  assert.equal(api.created.length, 1);
+  assert.equal(api.updated.length, 0);
+  assert.ok(api.created[0]?.includes(STICKY_MARKER));
+});
+
+test('fail with an existing marked comment updates it — no duplicate', async () => {
+  const api = new FakeApi([{ id: 42, body: `${STICKY_MARKER}\nold` }]);
+  const action = await syncStickyComment(api, FAIL);
+  assert.equal(action, 'updated');
+  assert.equal(api.created.length, 0);
+  assert.deepEqual(api.updated.map((call) => call.id), [42]);
+});
+
+test('pass with an existing marked comment flips it to resolved', async () => {
+  const api = new FakeApi([{ id: 7, body: `${STICKY_MARKER}\nfailure` }]);
+  const action = await syncStickyComment(api, PASS);
+  assert.equal(action, 'resolved');
+  assert.equal(api.created.length, 0);
+  assert.equal(api.updated[0]?.id, 7);
+  assert.ok(api.updated[0]?.body.includes('passed'));
+});
+
+test('pass with no existing comment does nothing — never-failed PRs stay clean', async () => {
+  const api = new FakeApi([{ id: 1, body: 'an unrelated human comment' }]);
+  const action = await syncStickyComment(api, PASS);
+  assert.equal(action, 'noop');
+  assert.equal(api.created.length, 0);
+  assert.equal(api.updated.length, 0);
+});
+
+test('unmarked comments are ignored when locating the sticky comment', async () => {
+  const api = new FakeApi([{ id: 1, body: 'unrelated' }, { id: 2, body: 'also unrelated' }]);
+  const action = await syncStickyComment(api, FAIL);
+  assert.equal(action, 'created');
+  assert.equal(api.updated.length, 0);
+});
+
+test('GithubCommentApi.list paginates so a sticky past page 1 is still found', async () => {
+  // A busy PR: page 1 is 100 unrelated comments, the sticky is comment #101.
+  const page1: IssueComment[] = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, body: `noise ${i}` }));
+  const page2: IssueComment[] = [{ id: 101, body: `${STICKY_MARKER}\nfailure` }];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string) => {
+    const body = new URL(url).searchParams.get('page') === '2' ? page2 : page1;
+    return { ok: true, status: 200, json: async () => body } as Response;
+  }) as typeof fetch;
+  try {
+    const api = new GithubCommentApi('tok', 'camunda', 'camunda', 42);
+    const all = await api.list();
+    assert.equal(all.length, 101);
+    assert.ok(all.some((comment) => comment.body.includes(STICKY_MARKER)));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/.github/actions/release-notes/test/comment.test.ts
+++ b/.github/actions/release-notes/test/comment.test.ts
@@ -1,10 +1,18 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { type CommentApi, type IssueComment, renderStickyComment, STICKY_MARKER, syncStickyComment } from '../src/comment';
-import type { PolicyDecision } from '../src/types';
+import type { GateOutcome } from '../src/types';
 
-const FAIL: PolicyDecision = { outcome: 'fail', code: 'unlinked-undeclared', reasons: ['No linked issue found.', 'Add "closes #1234".'] };
-const PASS: PolicyDecision = { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] };
+const FAIL: GateOutcome = {
+  outcome: 'fail',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'fail', reasons: ['No linked issue found.', 'Add "closes #1234".'] }],
+};
+const PASS: GateOutcome = {
+  outcome: 'pass',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] }],
+};
 
 /** Records every call so a test can assert what the sync did. */
 class FakeApi implements CommentApi {
@@ -51,7 +59,7 @@ test('pass with an existing marked comment flips it to resolved', async () => {
   assert.equal(action, 'resolved');
   assert.equal(api.created.length, 0);
   assert.equal(api.updated[0]?.id, 7);
-  assert.ok(api.updated[0]?.body.includes('resolved'));
+  assert.ok(api.updated[0]?.body.includes('passed'));
 });
 
 test('pass with no existing comment does nothing — never-failed PRs stay clean', async () => {

--- a/.github/actions/release-notes/test/comment.test.ts
+++ b/.github/actions/release-notes/test/comment.test.ts
@@ -1,17 +1,19 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { type CommentApi, type IssueComment, renderStickyComment, STICKY_MARKER, syncStickyComment } from '../src/comment';
+import { type CommentApi, GithubCommentApi, type IssueComment, renderStickyComment, STICKY_MARKER, syncStickyComment } from '../src/comment';
 import type { GateOutcome } from '../src/types';
 
 const FAIL: GateOutcome = {
   outcome: 'fail',
   deliveryPath: 'direct',
   checks: [{ label: 'PR-issue link', outcome: 'fail', reasons: ['No linked issue found.', 'Add "closes #1234".'] }],
+  link: { outcome: 'fail', code: 'unlinked-undeclared', reasons: ['No linked issue found.', 'Add "closes #1234".'] },
 };
 const PASS: GateOutcome = {
   outcome: 'pass',
   deliveryPath: 'direct',
   checks: [{ label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] }],
+  link: { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] },
 };
 
 /** Records every call so a test can assert what the sync did. */
@@ -75,4 +77,23 @@ test('unmarked comments are ignored when locating the sticky comment', async () 
   const action = await syncStickyComment(api, FAIL);
   assert.equal(action, 'created');
   assert.equal(api.updated.length, 0);
+});
+
+test('GithubCommentApi.list paginates so a sticky past page 1 is still found', async () => {
+  // A busy PR: page 1 is 100 unrelated comments, the sticky is comment #101.
+  const page1: IssueComment[] = Array.from({ length: 100 }, (_, i) => ({ id: i + 1, body: `noise ${i}` }));
+  const page2: IssueComment[] = [{ id: 101, body: `${STICKY_MARKER}\nfailure` }];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string) => {
+    const body = new URL(url).searchParams.get('page') === '2' ? page2 : page1;
+    return { ok: true, status: 200, json: async () => body } as Response;
+  }) as typeof fetch;
+  try {
+    const api = new GithubCommentApi('tok', 'camunda', 'camunda', 42);
+    const all = await api.list();
+    assert.equal(all.length, 101);
+    assert.ok(all.some((comment) => comment.body.includes(STICKY_MARKER)));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/.github/actions/release-notes/test/gate.test.ts
+++ b/.github/actions/release-notes/test/gate.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { evaluateGate, type GateResolver } from '../src/gate';
+import type { ParsedRef, RefTarget, ResolvedRef } from '../src/types';
+
+/** Fake resolver: classify by a number→target map; serve PR bodies by number. */
+class FakeResolver implements GateResolver {
+  constructor(
+    private readonly targets: Record<number, RefTarget>,
+    private readonly bodies: Record<number, string> = {},
+  ) {}
+  async resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]> {
+    return refs.map((ref) => ({
+      ...ref,
+      target: this.targets[ref.number] ?? 'missing',
+      crossRepo: ref.repo !== null && ref.repo.toLowerCase() !== 'camunda/camunda',
+    }));
+  }
+  async fetchPullBody(number: number): Promise<string | null> {
+    return number in this.bodies ? (this.bodies[number] ?? '') : null;
+  }
+}
+
+const withSection = (refLine: string) => `## Related issues\n\n${refLine}\n`;
+const BOT_BACKPORT = '⤵️ Backport of #500 → `stable/8.8`\n\nrelates to #10\n';
+
+test('direct PR with a live issue in the section passes', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, { body: withSection('closes #10'), title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.deliveryPath, 'direct');
+});
+
+test('bot backport with no section passes by inheriting the original PR attribution', async () => {
+  const resolver = new FakeResolver({ 10: 'issue', 500: 'pullRequest' }, { 500: withSection('closes #10') });
+  const gate = await evaluateGate(resolver, { body: BOT_BACKPORT, title: 'anything', authorLogin: 'backport-action' });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  // bot author → title check is skipped, so only the link check is present
+  assert.deepEqual(gate.checks.map((check) => check.label), ['PR-issue link']);
+});
+
+test('backport fails when the original PR is also unlinked — names the original', async () => {
+  const resolver = new FakeResolver({ 500: 'pullRequest' }, { 500: 'no related-issues section here' });
+  const gate = await evaluateGate(resolver, { body: BOT_BACKPORT, title: 'x', authorLogin: 'backport-action' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('#500')));
+});
+
+test('a valid link but a bad title fails the gate (both checks reported)', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, {
+    body: withSection('closes #10'),
+    title: 'no type here',
+    authorLogin: 'szpraat',
+  });
+  assert.equal(gate.outcome, 'fail');
+  assert.deepEqual(gate.checks.map((check) => `${check.label}:${check.outcome}`), ['PR-issue link:pass', 'Title:fail']);
+});
+
+test('bot authors skip title lint — a valid link alone passes', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, {
+    body: withSection('closes #10'),
+    title: 'this would fail title lint',
+    authorLogin: 'renovate[bot]',
+  });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.checks.length, 1);
+});

--- a/.github/actions/release-notes/test/gate.test.ts
+++ b/.github/actions/release-notes/test/gate.test.ts
@@ -16,7 +16,9 @@ class FakeResolver implements GateResolver {
       crossRepo: ref.repo !== null && ref.repo.toLowerCase() !== 'camunda/camunda',
     }));
   }
-  async fetchPullBody(number: number): Promise<string | null> {
+  async fetchPullBody(number: number, repo: string | null): Promise<string | null> {
+    const crossRepo = repo !== null && repo.toLowerCase() !== 'camunda/camunda';
+    if (crossRepo) return null; // resolver only validates its own repo
     return number in this.bodies ? (this.bodies[number] ?? '') : null;
   }
 }
@@ -68,4 +70,35 @@ test('bot authors skip title lint — a valid link alone passes', async () => {
   });
   assert.equal(gate.outcome, 'pass');
   assert.equal(gate.checks.length, 1);
+});
+
+test('a PR ref in the section is NOT rescued by an unrelated Backport marker', async () => {
+  // #10 is a PR (hard error pr-ref-in-section); #500's original links a live issue.
+  // The hop must not fire — the section-level PR ref stands as a fail.
+  const resolver = new FakeResolver({ 10: 'pullRequest', 20: 'issue', 500: 'pullRequest' }, { 500: withSection('closes #20') });
+  const body = `${withSection('closes #10')}\n⤵️ Backport of #500\n`;
+  const gate = await evaluateGate(resolver, { body, title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'direct'); // no hop happened
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('pull request')));
+});
+
+test('a cross-repo Backport marker cannot inherit attribution (resolves to null)', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' }, { 500: withSection('closes #10') });
+  const gate = await evaluateGate(resolver, {
+    body: '⤵️ Backport of other-org/other-repo#500\n',
+    title: 'fix: x',
+    authorLogin: 'szpraat',
+  });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('could not be resolved')));
+});
+
+test('a dangling Backport target (404) is surfaced, not absorbed into a generic message', async () => {
+  const resolver = new FakeResolver({}, {}); // #500 has no body → fetchPullBody returns null
+  const gate = await evaluateGate(resolver, { body: '⤵️ Backport of #500\n', title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('#500') && reason.includes('could not be resolved')));
 });

--- a/.github/actions/release-notes/test/gate.test.ts
+++ b/.github/actions/release-notes/test/gate.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { evaluateGate, type GateResolver } from '../src/gate';
+import type { ParsedRef, RefTarget, ResolvedRef } from '../src/types';
+
+/** Fake resolver: classify by a number→target map; serve PR bodies by number. */
+class FakeResolver implements GateResolver {
+  constructor(
+    private readonly targets: Record<number, RefTarget>,
+    private readonly bodies: Record<number, string> = {},
+  ) {}
+  async resolve(refs: readonly ParsedRef[]): Promise<ResolvedRef[]> {
+    return refs.map((ref) => ({
+      ...ref,
+      target: this.targets[ref.number] ?? 'missing',
+      crossRepo: ref.repo !== null && ref.repo.toLowerCase() !== 'camunda/camunda',
+    }));
+  }
+  async fetchPullBody(number: number, repo: string | null): Promise<string | null> {
+    const crossRepo = repo !== null && repo.toLowerCase() !== 'camunda/camunda';
+    if (crossRepo) return null; // resolver only validates its own repo
+    return number in this.bodies ? (this.bodies[number] ?? '') : null;
+  }
+}
+
+const withSection = (refLine: string) => `## Related issues\n\n${refLine}\n`;
+const BOT_BACKPORT = '⤵️ Backport of #500 → `stable/8.8`\n\nrelates to #10\n';
+
+test('direct PR with a live issue in the section passes', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, { body: withSection('closes #10'), title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.deliveryPath, 'direct');
+});
+
+test('bot backport with no section passes by inheriting the original PR attribution', async () => {
+  const resolver = new FakeResolver({ 10: 'issue', 500: 'pullRequest' }, { 500: withSection('closes #10') });
+  const gate = await evaluateGate(resolver, { body: BOT_BACKPORT, title: 'anything', authorLogin: 'backport-action' });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  // bot author → title check is skipped, so only the link check is present
+  assert.deepEqual(gate.checks.map((check) => check.label), ['PR-issue link']);
+});
+
+test('backport fails when the original PR is also unlinked — names the original', async () => {
+  const resolver = new FakeResolver({ 500: 'pullRequest' }, { 500: 'no related-issues section here' });
+  const gate = await evaluateGate(resolver, { body: BOT_BACKPORT, title: 'x', authorLogin: 'backport-action' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('#500')));
+});
+
+test('a valid link but a bad title fails the gate (both checks reported)', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, {
+    body: withSection('closes #10'),
+    title: 'no type here',
+    authorLogin: 'szpraat',
+  });
+  assert.equal(gate.outcome, 'fail');
+  assert.deepEqual(gate.checks.map((check) => `${check.label}:${check.outcome}`), ['PR-issue link:pass', 'Title:fail']);
+});
+
+test('bot authors skip title lint — a valid link alone passes', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, {
+    body: withSection('closes #10'),
+    title: 'this would fail title lint',
+    authorLogin: 'renovate[bot]',
+  });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.checks.length, 1);
+});
+
+test('a PR ref in the section is NOT rescued by an unrelated Backport marker', async () => {
+  // #10 is a PR (hard error pr-ref-in-section); #500's original links a live issue.
+  // The hop must not fire — the section-level PR ref stands as a fail.
+  const resolver = new FakeResolver({ 10: 'pullRequest', 20: 'issue', 500: 'pullRequest' }, { 500: withSection('closes #20') });
+  const body = `${withSection('closes #10')}\n⤵️ Backport of #500\n`;
+  const gate = await evaluateGate(resolver, { body, title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'direct'); // no hop happened
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('pull request')));
+});
+
+test('a cross-repo Backport marker cannot inherit attribution — says so explicitly', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' }, { 500: withSection('closes #10') });
+  const gate = await evaluateGate(resolver, {
+    body: '⤵️ Backport of other-org/other-repo#500\n',
+    title: 'fix: x',
+    authorLogin: 'szpraat',
+  });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('another repository')));
+});
+
+test('a Backport marker pointing at an issue (not a PR) says exactly that', async () => {
+  // Mirrors gate-test-07: `Backport of #53593` where #53593 is an issue.
+  const resolver = new FakeResolver({ 500: 'issue' }, {}); // resolves as issue; no PR body
+  const gate = await evaluateGate(resolver, { body: '⤵️ Backport of #500\n', title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('#500') && reason.includes('issue, not a pull request')));
+});
+
+test('a dangling Backport target (missing) is surfaced, not absorbed into a generic message', async () => {
+  const resolver = new FakeResolver({}, {}); // #500 neither a PR body nor a known target → missing
+  const gate = await evaluateGate(resolver, { body: '⤵️ Backport of #500\n', title: 'fix: x', authorLogin: 'szpraat' });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.ok(gate.checks[0]?.reasons.some((reason) => reason.includes('#500') && reason.includes('does not resolve to a pull request')));
+});
+
+test('an unlinked Renovate PR passes via the bot link exemption', async () => {
+  const resolver = new FakeResolver({});
+  const gate = await evaluateGate(resolver, {
+    body: 'This PR updates a dependency.\n',
+    title: 'deps: Update dependency zstd-jni to v1.5.7-13',
+    authorLogin: 'renovate[bot]',
+  });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.link.code, 'bot-exempt');
+});
+
+test('the exemption is a fallback — a Renovate PR that does link an issue keeps its real code', async () => {
+  const resolver = new FakeResolver({ 10: 'issue' });
+  const gate = await evaluateGate(resolver, {
+    body: withSection('closes #10'),
+    title: 'deps: Update dependency zstd-jni to v1.5.7-13',
+    authorLogin: 'renovate[bot]',
+  });
+  assert.equal(gate.outcome, 'pass');
+  assert.equal(gate.link.code, 'section-closing');
+});
+
+test('the backport bot is NOT link-exempt — an unlinked backport still fails', async () => {
+  // Guards the reason BOT_LINK_EXEMPT is separate from BOT_TITLE_EXEMPT: the
+  // backport author must keep going through the hop, so a backport whose
+  // original is also unlinked stays a failure instead of being exempted away.
+  const resolver = new FakeResolver({ 500: 'pullRequest' }, { 500: 'no related-issues section here' });
+  const gate = await evaluateGate(resolver, {
+    body: BOT_BACKPORT,
+    title: 'fix: x',
+    authorLogin: 'monorepo-devops-automation[bot]',
+  });
+  assert.equal(gate.outcome, 'fail');
+  assert.equal(gate.deliveryPath, 'backportHop');
+  assert.notEqual(gate.link.code, 'bot-exempt');
+});

--- a/.github/actions/release-notes/test/labels.test.ts
+++ b/.github/actions/release-notes/test/labels.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decideLabelAction, type LabelApi, NO_ISSUE_LABEL, syncNoIssueLabel } from '../src/labels';
+import type { GateOutcome } from '../src/types';
+
+const LINK_FAIL: GateOutcome = {
+  outcome: 'fail',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'fail', reasons: ['No linked issue found.'] }],
+  link: { outcome: 'fail', code: 'unlinked-undeclared', reasons: ['No linked issue found.'] },
+};
+const LINK_PASS: GateOutcome = {
+  outcome: 'pass',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] }],
+  link: { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] },
+};
+const TITLE_ONLY_FAIL: GateOutcome = {
+  outcome: 'fail',
+  deliveryPath: 'direct',
+  checks: [
+    { label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] },
+    { label: 'Title', outcome: 'fail', reasons: ['bad title'] },
+  ],
+  link: { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] },
+};
+
+/** Records every call so a test can assert what the sync did. */
+class FakeApi implements LabelApi {
+  readonly added: string[] = [];
+  readonly removed: string[] = [];
+  constructor(private labels: string[] = []) {}
+  async list(): Promise<string[]> {
+    return this.labels;
+  }
+  async add(label: string): Promise<void> {
+    this.added.push(label);
+  }
+  async remove(label: string): Promise<void> {
+    this.removed.push(label);
+  }
+}
+
+test('decideLabelAction adds when the link fails and the label is absent', () => {
+  assert.equal(decideLabelAction([], 'fail'), 'added');
+});
+
+test('decideLabelAction is a noop when the link fails and the label is already present', () => {
+  assert.equal(decideLabelAction([NO_ISSUE_LABEL], 'fail'), 'noop');
+});
+
+test('decideLabelAction removes when the link passes and the label is present', () => {
+  assert.equal(decideLabelAction([NO_ISSUE_LABEL], 'pass'), 'removed');
+});
+
+test('decideLabelAction is a noop when the link passes and the label is absent', () => {
+  assert.equal(decideLabelAction([], 'pass'), 'noop');
+});
+
+test('syncNoIssueLabel adds the label when the link check fails', async () => {
+  const api = new FakeApi([]);
+  const action = await syncNoIssueLabel(api, LINK_FAIL);
+  assert.equal(action, 'added');
+  assert.deepEqual(api.added, [NO_ISSUE_LABEL]);
+  assert.deepEqual(api.removed, []);
+});
+
+test('syncNoIssueLabel removes the label once the link check passes', async () => {
+  const api = new FakeApi([NO_ISSUE_LABEL]);
+  const action = await syncNoIssueLabel(api, LINK_PASS);
+  assert.equal(action, 'removed');
+  assert.deepEqual(api.removed, [NO_ISSUE_LABEL]);
+});
+
+test('syncNoIssueLabel reflects the link check only — a title-only failure does not add the label', async () => {
+  const api = new FakeApi([]);
+  const action = await syncNoIssueLabel(api, TITLE_ONLY_FAIL);
+  assert.equal(action, 'noop');
+  assert.deepEqual(api.added, []);
+});
+
+test('syncNoIssueLabel leaves unrelated labels untouched', async () => {
+  const api = new FakeApi(['bug', 'priority/high']);
+  const action = await syncNoIssueLabel(api, LINK_FAIL);
+  assert.equal(action, 'added');
+  assert.deepEqual(api.added, [NO_ISSUE_LABEL]);
+});
+
+test('syncNoIssueLabel is a noop when already correctly labeled and link still fails', async () => {
+  const api = new FakeApi([NO_ISSUE_LABEL]);
+  const action = await syncNoIssueLabel(api, LINK_FAIL);
+  assert.equal(action, 'noop');
+  assert.deepEqual(api.added, []);
+  assert.deepEqual(api.removed, []);
+});

--- a/.github/actions/release-notes/test/labels.test.ts
+++ b/.github/actions/release-notes/test/labels.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decideLabelAction, type LabelApi, NO_ISSUE_LABEL, syncNoIssueLabel } from '../src/labels';
+import type { GateOutcome } from '../src/types';
+
+const LINK_FAIL: GateOutcome = {
+  outcome: 'fail',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'fail', reasons: ['No linked issue found.'] }],
+};
+const LINK_PASS: GateOutcome = {
+  outcome: 'pass',
+  deliveryPath: 'direct',
+  checks: [{ label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] }],
+};
+const TITLE_ONLY_FAIL: GateOutcome = {
+  outcome: 'fail',
+  deliveryPath: 'direct',
+  checks: [
+    { label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] },
+    { label: 'Title', outcome: 'fail', reasons: ['bad title'] },
+  ],
+};
+
+/** Records every call so a test can assert what the sync did. */
+class FakeApi implements LabelApi {
+  readonly added: string[] = [];
+  readonly removed: string[] = [];
+  constructor(private labels: string[] = []) {}
+  async list(): Promise<string[]> {
+    return this.labels;
+  }
+  async add(label: string): Promise<void> {
+    this.added.push(label);
+  }
+  async remove(label: string): Promise<void> {
+    this.removed.push(label);
+  }
+}
+
+test('decideLabelAction adds when the link fails and the label is absent', () => {
+  assert.equal(decideLabelAction([], 'fail'), 'added');
+});
+
+test('decideLabelAction is a noop when the link fails and the label is already present', () => {
+  assert.equal(decideLabelAction([NO_ISSUE_LABEL], 'fail'), 'noop');
+});
+
+test('decideLabelAction removes when the link passes and the label is present', () => {
+  assert.equal(decideLabelAction([NO_ISSUE_LABEL], 'pass'), 'removed');
+});
+
+test('decideLabelAction is a noop when the link passes and the label is absent', () => {
+  assert.equal(decideLabelAction([], 'pass'), 'noop');
+});
+
+test('syncNoIssueLabel adds the label when the link check fails', async () => {
+  const api = new FakeApi([]);
+  const action = await syncNoIssueLabel(api, LINK_FAIL);
+  assert.equal(action, 'added');
+  assert.deepEqual(api.added, [NO_ISSUE_LABEL]);
+  assert.deepEqual(api.removed, []);
+});
+
+test('syncNoIssueLabel removes the label once the link check passes', async () => {
+  const api = new FakeApi([NO_ISSUE_LABEL]);
+  const action = await syncNoIssueLabel(api, LINK_PASS);
+  assert.equal(action, 'removed');
+  assert.deepEqual(api.removed, [NO_ISSUE_LABEL]);
+});
+
+test('syncNoIssueLabel reflects the link check only — a title-only failure does not add the label', async () => {
+  const api = new FakeApi([]);
+  const action = await syncNoIssueLabel(api, TITLE_ONLY_FAIL);
+  assert.equal(action, 'noop');
+  assert.deepEqual(api.added, []);
+});
+
+test('syncNoIssueLabel leaves unrelated labels untouched', async () => {
+  const api = new FakeApi(['bug', 'priority/high']);
+  const action = await syncNoIssueLabel(api, LINK_FAIL);
+  assert.equal(action, 'added');
+  assert.deepEqual(api.added, [NO_ISSUE_LABEL]);
+});
+
+test('syncNoIssueLabel is a noop when already correctly labeled and link still fails', async () => {
+  const api = new FakeApi([NO_ISSUE_LABEL]);
+  const action = await syncNoIssueLabel(api, LINK_FAIL);
+  assert.equal(action, 'noop');
+  assert.deepEqual(api.added, []);
+  assert.deepEqual(api.removed, []);
+});

--- a/.github/actions/release-notes/test/labels.test.ts
+++ b/.github/actions/release-notes/test/labels.test.ts
@@ -7,11 +7,13 @@ const LINK_FAIL: GateOutcome = {
   outcome: 'fail',
   deliveryPath: 'direct',
   checks: [{ label: 'PR-issue link', outcome: 'fail', reasons: ['No linked issue found.'] }],
+  link: { outcome: 'fail', code: 'unlinked-undeclared', reasons: ['No linked issue found.'] },
 };
 const LINK_PASS: GateOutcome = {
   outcome: 'pass',
   deliveryPath: 'direct',
   checks: [{ label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] }],
+  link: { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] },
 };
 const TITLE_ONLY_FAIL: GateOutcome = {
   outcome: 'fail',
@@ -20,6 +22,7 @@ const TITLE_ONLY_FAIL: GateOutcome = {
     { label: 'PR-issue link', outcome: 'pass', reasons: ['Linked to issue #1234.'] },
     { label: 'Title', outcome: 'fail', reasons: ['bad title'] },
   ],
+  link: { outcome: 'pass', code: 'section-closing', reasons: ['Linked to issue #1234.'] },
 };
 
 /** Records every call so a test can assert what the sync did. */

--- a/.github/actions/release-notes/test/parser.test.ts
+++ b/.github/actions/release-notes/test/parser.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { extractSection, isOptOutTicked, parseRefs } from '../src/parser';
+
+test('extractSection slices the Related issues body up to the next heading', () => {
+  const body = ['## Description', 'x', '## Related issues', 'closes #12', '', '## Checklist', '- [ ] a'].join('\n');
+  assert.equal(extractSection(body), 'closes #12\n');
+});
+
+test('extractSection is case-insensitive and returns null when absent', () => {
+  assert.equal(extractSection('## RELATED ISSUES\ncloses #1'), 'closes #1');
+  assert.equal(extractSection('## Something else\ncloses #1'), null);
+});
+
+test('extractSection reads to EOF when no trailing heading', () => {
+  assert.equal(extractSection('## Related issues\ncloses #7'), 'closes #7');
+});
+
+test('parseRefs classifies every closing keyword variant', () => {
+  for (const kw of ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved', 'completes']) {
+    const [ref] = parseRefs(`${kw} #42`);
+    assert.equal(ref?.kind, 'closing', `${kw} should be closing`);
+    assert.equal(ref?.number, 42);
+  }
+});
+
+test('parseRefs treats "relates to" and bare #N as contributor', () => {
+  assert.equal(parseRefs('relates to #5')[0]?.kind, 'contributor');
+  assert.equal(parseRefs('see #5 for context')[0]?.kind, 'contributor');
+});
+
+test('parseRefs marks "Backport of #N" as backport', () => {
+  const [ref] = parseRefs('Backport of #99');
+  assert.equal(ref?.kind, 'backport');
+  assert.equal(ref?.number, 99);
+});
+
+test('parseRefs records the explicit owner/repo prefix (cross-repo left to resolver)', () => {
+  const [ref] = parseRefs('closes camunda/other#7');
+  assert.equal(ref?.repo, 'camunda/other');
+  assert.equal(ref?.number, 7);
+});
+
+test('parseRefs parses full GitHub URLs', () => {
+  const refs = parseRefs('fixes https://github.com/camunda/camunda/issues/321');
+  assert.equal(refs[0]?.number, 321);
+  assert.equal(refs[0]?.kind, 'closing');
+  assert.equal(refs[0]?.repo, 'camunda/camunda');
+});
+
+test('parseRefs ignores markdown headings and colon separators', () => {
+  assert.equal(parseRefs('## Related issues').length, 0);
+  assert.equal(parseRefs('closes: #8')[0]?.number, 8);
+});
+
+test('isOptOutTicked only fires on a ticked checkbox with the phrase', () => {
+  assert.equal(isOptOutTicked('- [x] This PR does not need a linked issue'), true);
+  assert.equal(isOptOutTicked('- [ ] This PR does not need a linked issue'), false);
+  assert.equal(isOptOutTicked('This PR does not need a linked issue'), false);
+});

--- a/.github/actions/release-notes/test/parser.test.ts
+++ b/.github/actions/release-notes/test/parser.test.ts
@@ -53,6 +53,19 @@ test('parseRefs ignores markdown headings and colon separators', () => {
   assert.equal(parseRefs('closes: #8')[0]?.number, 8);
 });
 
+test('HTML comments are stripped so template boilerplate is not parsed as a ref', () => {
+  // The PR template ships an instructional comment inside "## Related issues".
+  const body = ['## Related issues', '<!-- e.g. closes #1234 to auto-close on merge -->', ''].join('\n');
+  assert.equal(parseRefs(extractSection(body) ?? '').length, 0);
+  // A multi-line comment naming a ref is likewise ignored.
+  const multiline = 'closes #1234\nline\n-->';
+  assert.equal(parseRefs(`<!-- ${multiline}`).length, 0);
+});
+
+test('a commented-out opt-out checkbox does not count as ticked', () => {
+  assert.equal(isOptOutTicked('<!-- - [x] This PR does not need a linked issue -->'), false);
+});
+
 test('isOptOutTicked only fires on a ticked checkbox with the phrase', () => {
   assert.equal(isOptOutTicked('- [x] This PR does not need a linked issue'), true);
   assert.equal(isOptOutTicked('- [ ] This PR does not need a linked issue'), false);

--- a/.github/actions/release-notes/test/parser.test.ts
+++ b/.github/actions/release-notes/test/parser.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { extractSection, isOptOutTicked, parseRefs } from '../src/parser';
+
+test('extractSection slices the Related issues body up to the next heading', () => {
+  const body = ['## Description', 'x', '## Related issues', 'closes #12', '', '## Checklist', '- [ ] a'].join('\n');
+  assert.equal(extractSection(body), 'closes #12\n');
+});
+
+test('extractSection is case-insensitive and returns null when absent', () => {
+  assert.equal(extractSection('## RELATED ISSUES\ncloses #1'), 'closes #1');
+  assert.equal(extractSection('## Something else\ncloses #1'), null);
+});
+
+test('extractSection reads to EOF when no trailing heading', () => {
+  assert.equal(extractSection('## Related issues\ncloses #7'), 'closes #7');
+});
+
+test('parseRefs classifies every closing keyword variant', () => {
+  for (const kw of ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved', 'completes']) {
+    const [ref] = parseRefs(`${kw} #42`);
+    assert.equal(ref?.kind, 'closing', `${kw} should be closing`);
+    assert.equal(ref?.number, 42);
+  }
+});
+
+test('parseRefs treats "relates to" and bare #N as contributor', () => {
+  assert.equal(parseRefs('relates to #5')[0]?.kind, 'contributor');
+  assert.equal(parseRefs('see #5 for context')[0]?.kind, 'contributor');
+});
+
+test('parseRefs marks "Backport of #N" as backport', () => {
+  const [ref] = parseRefs('Backport of #99');
+  assert.equal(ref?.kind, 'backport');
+  assert.equal(ref?.number, 99);
+});
+
+test('parseRefs records the explicit owner/repo prefix (cross-repo left to resolver)', () => {
+  const [ref] = parseRefs('closes camunda/other#7');
+  assert.equal(ref?.repo, 'camunda/other');
+  assert.equal(ref?.number, 7);
+});
+
+test('parseRefs parses full GitHub URLs', () => {
+  const refs = parseRefs('fixes https://github.com/camunda/camunda/issues/321');
+  assert.equal(refs[0]?.number, 321);
+  assert.equal(refs[0]?.kind, 'closing');
+  assert.equal(refs[0]?.repo, 'camunda/camunda');
+});
+
+test('parseRefs ignores markdown headings and colon separators', () => {
+  assert.equal(parseRefs('## Related issues').length, 0);
+  assert.equal(parseRefs('closes: #8')[0]?.number, 8);
+});
+
+test('HTML comments are stripped so template boilerplate is not parsed as a ref', () => {
+  // The PR template ships an instructional comment inside "## Related issues".
+  const body = ['## Related issues', '<!-- e.g. closes #1234 to auto-close on merge -->', ''].join('\n');
+  assert.equal(parseRefs(extractSection(body) ?? '').length, 0);
+  // A multi-line comment naming a ref is likewise ignored.
+  const multiline = 'closes #1234\nline\n-->';
+  assert.equal(parseRefs(`<!-- ${multiline}`).length, 0);
+});
+
+test('a commented-out opt-out checkbox does not count as ticked', () => {
+  assert.equal(isOptOutTicked('<!-- - [x] This PR does not need a linked issue -->'), false);
+});
+
+test('isOptOutTicked only fires on a ticked checkbox with the phrase', () => {
+  assert.equal(isOptOutTicked('- [x] This PR does not need a linked issue'), true);
+  assert.equal(isOptOutTicked('- [ ] This PR does not need a linked issue'), false);
+  assert.equal(isOptOutTicked('This PR does not need a linked issue'), false);
+});

--- a/.github/actions/release-notes/test/policy.test.ts
+++ b/.github/actions/release-notes/test/policy.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decide } from '../src/policy';
+import type { ParsedRef, RefKind, ResolvedRef, RefTarget } from '../src/types';
+
+function ref(
+  number: number,
+  kind: RefKind,
+  target: RefTarget,
+  opts: { crossRepo?: boolean; repo?: string | null } = {},
+): ResolvedRef {
+  const base: ParsedRef = { raw: `#${number}`, number, repo: opts.repo ?? null, keyword: null, kind, index: 0 };
+  return { ...base, target, crossRepo: opts.crossRepo ?? false };
+}
+
+test('closing ref to a live issue passes', () => {
+  const d = decide([ref(1, 'closing', 'issue')], false);
+  assert.equal(d.outcome, 'pass');
+  assert.equal(d.code, 'section-closing');
+});
+
+test('contributor ref (bare #N) to a live issue passes', () => {
+  const d = decide([ref(1, 'contributor', 'issue')], false);
+  assert.equal(d.outcome, 'pass');
+  assert.equal(d.code, 'section-contributor');
+});
+
+test('opt-out ticked passes with no refs', () => {
+  assert.equal(decide([], true).code, 'opt-out');
+});
+
+test('a PR ref in the section fails and is named — even alongside a valid issue', () => {
+  const d = decide([ref(2, 'closing', 'issue'), ref(3, 'contributor', 'pullRequest')], false);
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'pr-ref-in-section');
+  assert.ok(d.reasons.some((r) => r.includes('#3')));
+});
+
+test('no ref and no opt-out fails unlinked-undeclared', () => {
+  const d = decide([], false);
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'unlinked-undeclared');
+});
+
+test('cross-repo ref alone does not satisfy', () => {
+  const d = decide([ref(7, 'closing', 'missing', { crossRepo: true, repo: 'camunda/other' })], false);
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'unlinked-undeclared');
+});
+
+test('backport marker alone does not satisfy', () => {
+  const d = decide([ref(9, 'backport', 'issue')], false);
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'unlinked-undeclared');
+});
+
+test('a dead (missing) issue ref does not satisfy and is reported', () => {
+  const d = decide([ref(404, 'closing', 'missing')], false);
+  assert.equal(d.outcome, 'fail');
+  assert.ok(d.reasons.some((r) => r.includes('#404')));
+});
+
+test('a PR ref fails even when opt-out is ticked (PR ref is always an error)', () => {
+  assert.equal(decide([ref(5, 'contributor', 'pullRequest')], true).code, 'pr-ref-in-section');
+});

--- a/.github/actions/release-notes/test/resolver.test.ts
+++ b/.github/actions/release-notes/test/resolver.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { GithubResolver } from '../src/resolver';
+import type { ParsedRef } from '../src/types';
+
+function ref(number: number, repo: string | null = null): ParsedRef {
+  return { raw: `#${number}`, number, repo, keyword: null, kind: 'contributor', index: 0 };
+}
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test('resolve() dedupes repeated refs to a single API call', async () => {
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls++;
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as typeof fetch;
+
+  const resolver = new GithubResolver('token', 'camunda', 'camunda');
+  const refs = [ref(1), ref(1), ref(1)];
+  const resolved = await resolver.resolve(refs);
+
+  assert.equal(calls, 1, 'three refs to the same number must cost one API call');
+  assert.equal(resolved.length, 3, 'one ResolvedRef per input ref is still returned');
+  assert.ok(resolved.every((r) => r.target === 'issue'));
+});
+
+test('resolve() caps the number of refs it will resolve', async () => {
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls++;
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as typeof fetch;
+
+  const resolver = new GithubResolver('token', 'camunda', 'camunda');
+  const refs = Array.from({ length: 500 }, (_, i) => ref(i + 1));
+  const resolved = await resolver.resolve(refs);
+
+  assert.ok(calls <= 20, `a body stuffed with 500 distinct refs must not fire 500 API calls (fired ${calls})`);
+  assert.ok(resolved.length <= 20, 'refs beyond the cap are not resolved');
+});
+
+test('resolve() bounds how many requests are ever in flight at once', async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  globalThis.fetch = (async () => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight--;
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as typeof fetch;
+
+  const resolver = new GithubResolver('token', 'camunda', 'camunda');
+  const refs = Array.from({ length: 20 }, (_, i) => ref(i + 1));
+  await resolver.resolve(refs);
+
+  assert.ok(maxInFlight <= 5, `concurrency must be bounded, saw ${maxInFlight} in flight at once`);
+});

--- a/.github/actions/release-notes/test/title.test.ts
+++ b/.github/actions/release-notes/test/title.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { HEADER_MAX, isTitleExemptAuthor, lintTitle, TITLE_TYPES } from '../src/title';
+
+test('a plain conventional title passes', () => {
+  const d = lintTitle('fix: correct retry backoff');
+  assert.equal(d.outcome, 'pass');
+  assert.equal(d.code, 'title-ok');
+});
+
+test('breaking-change marker is allowed', () => {
+  assert.equal(lintTitle('feat!: drop legacy endpoint').outcome, 'pass');
+});
+
+test('every enum type is accepted', () => {
+  for (const type of TITLE_TYPES) {
+    assert.equal(lintTitle(`${type}: something`).outcome, 'pass', `${type} should pass`);
+  }
+});
+
+test('a non-conventional title fails on format', () => {
+  const d = lintTitle('correct the retry backoff');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-format');
+});
+
+test('an unknown type fails on type', () => {
+  const d = lintTitle('chore: tidy up');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-type');
+});
+
+test('an upper-case type fails on type', () => {
+  const d = lintTitle('Fix: something');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-type');
+});
+
+test('a scope is rejected (scope-empty: always)', () => {
+  const d = lintTitle('feat(api): add field');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-scope');
+});
+
+test('an over-length header fails', () => {
+  const d = lintTitle(`fix: ${'x'.repeat(HEADER_MAX)}`);
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-length');
+});
+
+test('release-merge titles (D25) pass as merge type', () => {
+  assert.equal(lintTitle('merge: release-8.8.0 back to stable/8.8').outcome, 'pass');
+});
+
+test('bot authors are title-exempt (D16), humans are not', () => {
+  assert.ok(isTitleExemptAuthor('renovate[bot]'));
+  assert.ok(isTitleExemptAuthor('backport-action'));
+  assert.ok(!isTitleExemptAuthor('szpraat'));
+  assert.ok(!isTitleExemptAuthor(undefined));
+});

--- a/.github/actions/release-notes/test/title.test.ts
+++ b/.github/actions/release-notes/test/title.test.ts
@@ -52,6 +52,20 @@ test('release-merge titles (D25) pass as merge type', () => {
   assert.equal(lintTitle('merge: release-8.8.0 back to stable/8.8').outcome, 'pass');
 });
 
+test('a malicious @mention in the type is neutralised (wrapped in inline code)', () => {
+  const d = lintTitle('@here: ship it');
+  assert.equal(d.outcome, 'fail');
+  // The raw "@here" must never appear un-escaped — it would notify via the bot identity.
+  assert.ok(d.reasons.every((reason) => !reason.includes('"@here"')));
+  assert.ok(d.reasons.some((reason) => reason.includes('`@here`')));
+});
+
+test('a mention in a scope is neutralised too', () => {
+  const d = lintTitle('feat(@channel): x');
+  assert.equal(d.code, 'title-scope');
+  assert.ok(d.reasons.some((reason) => reason.includes('`(@channel)`')));
+});
+
 test('bot authors are title-exempt (D16), humans are not', () => {
   assert.ok(isTitleExemptAuthor('renovate[bot]'));
   assert.ok(isTitleExemptAuthor('backport-action'));

--- a/.github/actions/release-notes/test/title.test.ts
+++ b/.github/actions/release-notes/test/title.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { HEADER_MAX, isTitleExemptAuthor, lintTitle, TITLE_TYPES } from '../src/title';
+
+test('a plain conventional title passes', () => {
+  const d = lintTitle('fix: correct retry backoff');
+  assert.equal(d.outcome, 'pass');
+  assert.equal(d.code, 'title-ok');
+});
+
+test('breaking-change marker is allowed', () => {
+  assert.equal(lintTitle('feat!: drop legacy endpoint').outcome, 'pass');
+});
+
+test('every enum type is accepted', () => {
+  for (const type of TITLE_TYPES) {
+    assert.equal(lintTitle(`${type}: something`).outcome, 'pass', `${type} should pass`);
+  }
+});
+
+test('a non-conventional title fails on format', () => {
+  const d = lintTitle('correct the retry backoff');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-format');
+});
+
+test('an unknown type fails on type', () => {
+  const d = lintTitle('chore: tidy up');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-type');
+});
+
+test('an upper-case type fails on type', () => {
+  const d = lintTitle('Fix: something');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-type');
+});
+
+test('a scope is rejected (scope-empty: always)', () => {
+  const d = lintTitle('feat(api): add field');
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-scope');
+});
+
+test('an over-length header fails', () => {
+  const d = lintTitle(`fix: ${'x'.repeat(HEADER_MAX)}`);
+  assert.equal(d.outcome, 'fail');
+  assert.equal(d.code, 'title-length');
+});
+
+test('release-merge titles (D25) pass as merge type', () => {
+  assert.equal(lintTitle('merge: release-8.8.0 back to stable/8.8').outcome, 'pass');
+});
+
+test('a malicious @mention in the type is neutralised (wrapped in inline code)', () => {
+  const d = lintTitle('@here: ship it');
+  assert.equal(d.outcome, 'fail');
+  // The raw "@here" must never appear un-escaped — it would notify via the bot identity.
+  assert.ok(d.reasons.every((reason) => !reason.includes('"@here"')));
+  assert.ok(d.reasons.some((reason) => reason.includes('`@here`')));
+});
+
+test('a mention in a scope is neutralised too', () => {
+  const d = lintTitle('feat(@channel): x');
+  assert.equal(d.code, 'title-scope');
+  assert.ok(d.reasons.some((reason) => reason.includes('`(@channel)`')));
+});
+
+test('bot authors are title-exempt (D16), humans are not', () => {
+  assert.ok(isTitleExemptAuthor('renovate[bot]'));
+  assert.ok(isTitleExemptAuthor('backport-action'));
+  assert.ok(!isTitleExemptAuthor('szpraat'));
+  assert.ok(!isTitleExemptAuthor(undefined));
+});

--- a/.github/actions/release-notes/tsconfig.json
+++ b/.github/actions/release-notes/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,13 @@
 
 ## Related issues
 
+<!--
+  Link the tracked ISSUE this PR delivers with a closing keyword:
+    closes #1234        (also: fixes #1234, resolves #1234)
+  A bare "#1234" or "relates to #1234" also counts. Link the issue, NOT a PR.
+  No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
+-->
+
 closes #
+
+- [ ] This PR does not need a linked issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,12 +11,13 @@
 ## Related issues
 
 <!--
-  Link the tracked ISSUE this PR delivers with a closing keyword:
-    closes #1234        (also: fixes #1234, resolves #1234)
-  A bare "#1234" or "relates to #1234" also counts. Link the issue, NOT a PR.
-  No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
+Link the tracked ISSUE this PR delivers with a closing keyword:
+closes #1234        (also: fixes #1234, resolves #1234)
+A bare "#1234" or "relates to #1234" also counts. Link the issue, NOT a PR.
+No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
 -->
 
 closes #
 
 - [ ] This PR does not need a linked issue
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,15 @@
 
 ## Related issues
 
+<!--
+Link the tracked ISSUE this PR belongs to (link the issue, NOT a PR):
+- This PR fully resolves the issue:  closes #1234  (also: fixes #1234, resolves #1234 — auto-closes it on merge)
+- One of several PRs for the issue (an epic, or work split across releases):  relates to #1234  or a bare  #1234
+This satisfies the gate but does NOT close the issue, so it stays open until the last PR lands.
+No tracked issue (hotfix, dep bump, CI/refactor)? Tick the opt-out below instead.
+-->
+
 closes #
+
+- [ ] This PR does not need a linked issue
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       actionlint: ${{ steps.filter.outputs.actionlint }}
       commitlint: ${{ steps.filter.outputs.commitlint }}
       codeowners-check: ${{ steps.filter.outputs.codeowners-check }}
+      release-notes-action: ${{ steps.filter.outputs.release-notes-action }}
       maven-spotless-linter: ${{ steps.filter.outputs.maven-spotless-linter }}
       validate-pom-metadata: ${{ steps.filter.outputs.validate-pom-metadata }}
       java-code-changes: ${{ steps.filter.outputs.java-code-changes }}
@@ -330,6 +331,15 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  release-notes-action:
+    if: needs.detect-changes.outputs.release-notes-action == 'true'
+    name: "Lint / Release-notes action"
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/release-notes-action-ci.yml
+    secrets: inherit
+    permissions:
+      contents: read
 
   codeowners-check:
     if: needs.detect-changes.outputs.codeowners-check == 'true'
@@ -2527,6 +2537,7 @@ jobs:
       - pr-vuln-check
       - protobuf-checks
       - rdbms-integration-tests
+      - release-notes-action
       - renovatelint
       - scripts-tests
       - setup-tests

--- a/.github/workflows/release-notes-action-ci.yml
+++ b/.github/workflows/release-notes-action-ci.yml
@@ -49,3 +49,12 @@ jobs:
           test -n "$phrase" || { echo "::error::OPT_OUT_PHRASE not found in src/parser/index.ts"; exit 1; }
           grep -iqF "$phrase" ../../pull_request_template.md \
             || { echo "::error::PR template is missing the opt-out phrase: '$phrase'"; exit 1; }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/release-notes-action-ci.yml
+++ b/.github/workflows/release-notes-action-ci.yml
@@ -1,0 +1,51 @@
+# CI for the release-notes TypeScript action package.
+# Guards the committed ncc bundle against drift and runs the parser/policy tests.
+name: Release-notes action CI
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/release-notes/**
+      - .github/workflows/release-notes-action-ci.yml
+      - .github/pull_request_template.md
+  push:
+    branches: [main]
+    paths:
+      - .github/actions/release-notes/**
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: .github/actions/release-notes
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test (parser + policy)
+        run: npm test
+      - name: Rebuild bundle
+        run: npm run build
+      - name: Fail if committed dist is stale
+        run: |
+          if ! git diff --exit-code -- lint/dist; then
+            echo "::error::lint/dist is out of date. Run 'npm run build' in .github/actions/release-notes and commit the result."
+            exit 1
+          fi
+      - name: Repo-constant grep — PR template matches the parser opt-out phrase
+        run: |
+          # The parser is the single source of truth for the opt-out text; the PR
+          # template must carry the same phrase or the checkbox silently stops working.
+          phrase=$(sed -nE "s/.*OPT_OUT_PHRASE = '([^']+)'.*/\1/p" src/parser/index.ts)
+          test -n "$phrase" || { echo "::error::OPT_OUT_PHRASE not found in src/parser/index.ts"; exit 1; }
+          grep -iqF "$phrase" ../../pull_request_template.md \
+            || { echo "::error::PR template is missing the opt-out phrase: '$phrase'"; exit 1; }

--- a/.github/workflows/release-notes-action-ci.yml
+++ b/.github/workflows/release-notes-action-ci.yml
@@ -8,6 +8,7 @@ on:
       - .github/actions/release-notes/**
       - .github/workflows/release-notes-action-ci.yml
       - .github/pull_request_template.md
+      - commitlint.config.cjs
   push:
     branches: [main]
     paths:
@@ -49,6 +50,16 @@ jobs:
           test -n "$phrase" || { echo "::error::OPT_OUT_PHRASE not found in src/parser/index.ts"; exit 1; }
           grep -iqF "$phrase" ../../pull_request_template.md \
             || { echo "::error::PR template is missing the opt-out phrase: '$phrase'"; exit 1; }
+      - name: Drift guard — title-lint constants match commitlint.config.cjs
+        run: |
+          # The regex title lint reimplements the ACTIVE commitlint rules to keep
+          # the action dependency-free. This fails CI if the repo's type-enum or
+          # header-max-length changes without src/title being updated to match.
+          cfg=$(node -e 'const c=require("../../../commitlint.config.cjs");console.log(JSON.stringify({types:[...c.rules["type-enum"][2]].sort(),max:c.rules["header-max-length"][2]}))')
+          ours=$(node --import tsx -e 'import("./src/title/index.ts").then(m=>console.log(JSON.stringify({types:[...m.TITLE_TYPES].sort(),max:m.HEADER_MAX})))')
+          echo "commitlint.config.cjs: $cfg"
+          echo "src/title/index.ts:    $ours"
+          [ "$cfg" = "$ours" ] || { echo "::error::title-lint constants drifted from commitlint.config.cjs — update TITLE_TYPES/HEADER_MAX in src/title/index.ts"; exit 1; }
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/release-notes-action-ci.yml
+++ b/.github/workflows/release-notes-action-ci.yml
@@ -1,0 +1,82 @@
+# CI for the release-notes TypeScript action package.
+# Guards the committed ncc bundle against drift and runs the parser/policy tests.
+#
+# Part of Unified CI: called by ci.yml, which owns the trigger and the path
+# filtering (the `release-notes-action` filter on its detect-changes job). Do not
+# add `pull_request`/`push` triggers back here — see
+# https://camunda.github.io/camunda/ci/#unified-ci
+name: Release-notes action CI
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: .github/actions/release-notes
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      TEST_OWNER: '@camunda/engineering-operations'
+      TEST_PRODUCT: Orchestration Cluster
+      TEST_TYPE: CI Helper
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: .github/actions/release-notes
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Test (parser + policy)
+        run: npm test
+      - name: Rebuild bundle
+        run: npm run build
+      - name: Fail if committed dist is stale
+        run: |
+          if ! git diff --exit-code -- lint/dist; then
+            echo "::error::lint/dist is out of date. Run 'npm run build' in .github/actions/release-notes and commit the result."
+            exit 1
+          fi
+      - name: Repo-constant grep — PR template matches the parser opt-out phrase
+        run: |
+          # The parser is the single source of truth for the opt-out text; the PR
+          # template must carry the same phrase or the checkbox silently stops working.
+          phrase=$(sed -nE "s/.*OPT_OUT_PHRASE = '([^']+)'.*/\1/p" src/parser/index.ts)
+          test -n "$phrase" || { echo "::error::OPT_OUT_PHRASE not found in src/parser/index.ts"; exit 1; }
+          grep -iqF "$phrase" ../../pull_request_template.md \
+            || { echo "::error::PR template is missing the opt-out phrase: '$phrase'"; exit 1; }
+      - name: Drift guard — title-lint constants match commitlint.config.cjs
+        run: |
+          # The regex title lint reimplements the ACTIVE commitlint rules to keep
+          # the action dependency-free. This fails CI if the repo's type-enum or
+          # header-max-length changes without src/title being updated to match.
+          cfg=$(node -e 'const c=require("../../../commitlint.config.cjs");console.log(JSON.stringify({types:[...c.rules["type-enum"][2]].sort(),max:c.rules["header-max-length"][2]}))')
+          ours=$(node --import tsx -e 'import("./src/title/index.ts").then(m=>console.log(JSON.stringify({types:[...m.TITLE_TYPES].sort(),max:m.HEADER_MAX})))')
+          echo "commitlint.config.cjs: $cfg"
+          echo "src/title/index.ts:    $ours"
+          [ "$cfg" = "$ours" ] || { echo "::error::title-lint constants drifted from commitlint.config.cjs — update TITLE_TYPES/HEADER_MAX in src/title/index.ts"; exit 1; }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/release-notes-pr-gate.yml
+++ b/.github/workflows/release-notes-pr-gate.yml
@@ -18,7 +18,15 @@ name: Release-notes PR-gate
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, labeled, unlabeled]
+    # Scope the privileged (app-token) flow to the branches whose release notes
+    # this gate governs — not every PR against any branch.
+    branches: [main, 'stable/**']
+    # Deliberately NOT labeled/unlabeled: the gate itself syncs the `no-issue`
+    # label, and each add/remove would re-trigger this workflow on its own label
+    # write (GitHub's push-loop protection does not cover label events), costing
+    # a full extra job per pass/fail transition. Body/title edits already re-run
+    # it via `edited`, which is the only signal that changes the outcome.
+    types: [opened, edited, synchronize]
 
 # One run per PR; newer events cancel older ones.
 concurrency:

--- a/.github/workflows/release-notes-pr-gate.yml
+++ b/.github/workflows/release-notes-pr-gate.yml
@@ -1,0 +1,56 @@
+# Release-notes PR-gate (epic #53605, work unit #53593).
+#
+# SECURITY MODEL (v1.1) — read before editing:
+#   * Runs on pull_request_target so the workflow + the local action resolve from
+#     the BASE ref, and a privileged token can post comments / sync labels on
+#     fork PRs. The PR body is read from the event payload only.
+#   * HARD RULE: never `actions/checkout` the PR head. The checkout below takes
+#     the default (base) ref — do not add `ref: ${{ github.event.pull_request.head.* }}`.
+#   * Warn-only during rollout (enforce=false). The flip to enforce + required
+#     status check is done later via branch protection (see epic #53605).
+#
+# SPIKE (AC#1): this workflow is also the harness for proving the required-check
+# mechanism against fork-PR head SHAs. On pull_request_target the job's check is
+# natively associated with the PR head SHA (mechanism a). If that proves
+# insufficient for fork PRs, publish an explicit Check Run via the app token on
+# github.event.pull_request.head.sha (mechanism b). See the PR description.
+name: Release-notes PR-gate
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, labeled, unlabeled]
+
+# One run per PR; newer events cancel older ones.
+concurrency:
+  group: release-notes-pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # checkout of the BASE ref only
+
+jobs:
+  pr-issue-link:
+    name: PR-issue link
+    runs-on: ubuntu-latest
+    steps:
+      # Base ref only — provides the local action. NEVER the PR head.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # v1.1.0
+        with:
+          github-app-id-vault-key: MONOREPO_RELEASE_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_RELEASE_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - name: Lint PR-issue link
+        uses: ./.github/actions/release-notes/lint
+        with:
+          token: ${{ steps.github-token.outputs.token }}
+          enforce: 'false' # warn-only during rollout

--- a/.github/workflows/release-notes-pr-gate.yml
+++ b/.github/workflows/release-notes-pr-gate.yml
@@ -1,0 +1,93 @@
+# Release-notes PR-gate (epic #53605, work unit #53593).
+#
+# SECURITY MODEL (v3) — read before editing:
+#   * Runs on plain `pull_request`. There is NO `pull_request_target` here, and
+#     none may be added: it is denied repo-wide by
+#     .github/conftest-gha-best-practices.rego.
+#   * On `pull_request` this workflow and the local action resolve from the PR
+#     head, so a PR can edit the code that judges it. That is the same trust
+#     model as every other lint in ci.yml (actionlint, spotless, commitlint), and
+#     it is acceptable because this check is ADVISORY: it is not a required
+#     status check, so it is not a security boundary. `.github/**` is
+#     CODEOWNERS-gated, so a tampering diff still needs review.
+#     ⚠ BEFORE MAKING THIS CHECK REQUIRED, resolve that: a PR could then pass
+#     itself by editing the action. See epic #53605.
+#   * No privileged token. The gate itself runs on GITHUB_TOKEN alone — no Vault,
+#     no App token. (The observe-build-status step reads Vault for CI health
+#     metrics, like every other job in the repo; it is continue-on-error and
+#     plays no part in the verdict.) Fork PRs get a read-only token from GitHub
+#     whatever `permissions:` asks for, which is why the action takes `can-write`
+#     and skips its two writes rather than 403-ing.
+#   * Metadata-only: the action reads the PR through the API. Nothing checks out
+#     or executes PR code, on any trigger.
+#   * Warn-only during rollout (enforce=false). The job reports red on failure
+#     from day one but is NOT a required check, so it blocks nobody. The flip to
+#     enforce + required status check happens later via branch protection.
+#
+# The gate is deliberately NOT part of Unified CI: ci.yml does not listen to
+# `edited`, and a PR body edit is the primary way an author fixes a gate
+# failure. This is a PR-metadata policy check, not CI on code changes — the same
+# shape as reject-updates-using-merge-commit.yml.
+#
+# type: CI Helper
+# owner: @camunda/engineering-operations
+---
+name: Release-notes PR-gate
+
+on:
+  pull_request:
+    # The branches whose release notes this gate governs.
+    branches: [main, 'stable/**']
+    # `edited` is load-bearing: a body edit is how an author fixes a gate
+    # failure, and it is also how a passing PR could silently lose its issue
+    # link. Without it the gate's verdict can go stale against the current body.
+    types: [opened, edited, synchronize, reopened]
+
+# One run per PR; a newer event supersedes an in-flight one.
+concurrency:
+  group: release-notes-pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+jobs:
+  pr-issue-link:
+    name: PR-issue link
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read # checkout, for the local action
+      pull-requests: write # sticky comment + no-issue label (internal PRs only)
+      issues: write # recreate the no-issue label if it was deleted
+    env:
+      TEST_OWNER: '@camunda/engineering-operations'
+      TEST_PRODUCT: Orchestration Cluster
+      TEST_TYPE: CI Helper
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+
+      - name: Lint PR-issue link
+        uses: ./.github/actions/release-notes/lint
+        with:
+          token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+          # False on fork PRs: GitHub withholds write access there, so the gate
+          # evaluates and reports to the job summary but skips its two writes.
+          can-write: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          enforce: 'false' # warn-only during rollout
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/release-notes-pr-gate.yml
+++ b/.github/workflows/release-notes-pr-gate.yml
@@ -17,15 +17,7 @@
 name: Release-notes PR-gate
 
 on:
-  pull_request_target:
-    # Scope the privileged (app-token) flow to the branches whose release notes
-    # this gate governs — not every PR against any branch.
-    branches: [main, 'stable/**']
-    # Deliberately NOT labeled/unlabeled: the gate itself syncs the `no-issue`
-    # label, and each add/remove would re-trigger this workflow on its own label
-    # write (GitHub's push-loop protection does not cover label events), costing
-    # a full extra job per pass/fail transition. Body/title edits already re-run
-    # it via `edited`, which is the only signal that changes the outcome.
+  pull_request:
     types: [opened, edited, synchronize]
 
 # One run per PR; newer events cancel older ones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,8 +299,16 @@ Load extra context on demand — only when relevant, only if the files exist.
 
 ### Pull request conventions
 
-- PR title should be clear and descriptive
-- Reference the issue number in the description (e.g., `Closes #1234`)
+- PR title should be clear and descriptive, and follow Conventional Commits with no scope (the
+  release-notes PR-gate lints it — see "Commit message guidelines" above)
+- Link the tracked issue under a `## Related issues` section (this exact heading — the release-notes
+  gate only reads refs inside it; a ref elsewhere in the body does not count). Link the issue, NOT a PR:
+  - `closes #1234` (or `fixes`/`resolves`) when this PR fully resolves the issue — auto-closes it on merge.
+  - `relates to #1234` or a bare `#1234` when this is one of several PRs for the issue (an epic, or work
+    split across releases) — satisfies the gate but does NOT close the issue.
+  - No tracked issue (hotfix, dep bump, CI/refactor)? Tick `- [ ] This PR does not need a linked issue`.
+    When opening the PR yourself (CLI/API), reproduce this section — GitHub only auto-fills the template in
+    the web UI, so an agent-authored body must include it explicitly.
 - Keep PRs focused on a single concern
 - Describe why the changes are necessary and note alternatives considered
 - Keep descriptions brief and concise

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,6 +25,9 @@
 /.github/actions/renew-github-token/*                    @camunda/engineering-operations
 /.github/actions/dependency-vuln-check/*                 @camunda/engineering-operations
 /.github/dependency-review-config.json                   @camunda/engineering-operations
+/.github/actions/release-notes/**                        @camunda/engineering-operations
+/.github/workflows/release-notes-pr-gate.yml             @camunda/engineering-operations
+/.github/workflows/release-notes-action-ci.yml           @camunda/engineering-operations
 
 ###################
 ## Core Features ##

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,6 +25,8 @@
 /.github/actions/renew-github-token/*                    @camunda/engineering-operations
 /.github/actions/dependency-vuln-check/*                 @camunda/engineering-operations
 /.github/dependency-review-config.json                   @camunda/engineering-operations
+/.github/actions/release-notes/**                        @camunda/engineering-operations
+/.github/workflows/release-notes*                        @camunda/engineering-operations
 
 ###################
 ## Core Features ##

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -77,6 +77,37 @@ Dealing with reported issues that are identified as urgent/**high severity**:
 
 > A: Disable the flaky test(s) and comment on existing ticket or create a new one that the flaky test needs to be re-enabled _after_ fixing it. No single test can be more important that the stability of the remaining CI system impacting dozens of developers.
 
+## Release-notes PR-gate
+
+The `Release-notes PR-gate` check verifies that a pull request can be attributed in the release notes: it must link a tracked **issue** (or explicitly opt out), and its title must be a conventional commit. Release notes are generated from those links, so an unlinked PR silently disappears from them.
+
+The check is currently **advisory** — it reports red on failure but is not a required status check, so it never blocks a merge. On failure it posts a single sticky comment naming the reason, and adds the `no-issue` label when the issue link is what failed.
+
+### Causes and fixes
+
+| Reported reason | Cause | Fix |
+|---|---|---|
+| No linked issue and no opt-out | The `## Related issues` section has no reference, or the section is missing/renamed | Add `closes #1234` to the `## Related issues` section, or tick the opt-out checkbox |
+| The section links a pull request | A closing keyword points at a PR instead of an issue | Reference the tracked **issue**; a PR is never a valid attribution target |
+| The referenced issue does not exist | The number is wrong, or the issue was deleted | Correct the number |
+| Only a cross-repo reference | `owner/repo#N` refers to another repository, which this check cannot validate | Link an issue in this repository, or tick the opt-out |
+| `Backport of #N` cannot be followed | The marker points at an issue, at nothing, or at another repository | Fix the marker so it names the original **pull request** in this repository |
+| `Backport of #N`, but that PR is not linked either | The original PR was merged without an issue link | Add the issue link to the **original** PR; the backport inherits it |
+| Title is not `type: subject` | The title does not follow [Conventional Commits](https://www.conventionalcommits.org/) | Rewrite as `fix: correct retry backoff` |
+| Unknown or upper-case type | The type is not in the allowed enum | Use one of `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`, `revert`, `style`, `test`, lower-case |
+| Scopes are not used in this repo | The title carries a `(scope)` | Drop the scope: `fix: …`, not `fix(engine): …` |
+| Title too long | The header exceeds 120 characters | Shorten it |
+
+### When you do not need a linked issue
+
+Tick `- [ ] This PR does not need a linked issue` in the PR template. Use it for hotfixes, dependency bumps, and pure CI or refactoring work. `renovate[bot]` is exempt automatically and does not need the checkbox.
+
+If a PR is one of several for the same issue (an epic, or work split across releases), use `relates to #1234` or a bare `#1234` instead of `closes` — that satisfies the check without closing the issue on merge.
+
+### Fork pull requests
+
+On a pull request from a fork, GitHub issues a read-only token and withholds secrets, so the check cannot post its comment or apply the label. It still evaluates the PR fully and reports the verdict in the **job summary** of the failed run — open the check's log to see the reason. This is a GitHub limitation: writing to the PR would require a privileged token, which must not be exposed to code from a fork.
+
 ## GitHub Merge Queue
 
 [GitHub Merge Queue](https://github.blog/2023-07-12-github-merge-queue-is-generally-available/) helps automate the Pull Request (PR) merging process by creating a temporary branch for each batch of PRs, running checks against the latest target branch, and merging changes only if the checks pass, ensuring a more streamlined and error-free workflow.


### PR DESCRIPTION
Test case: backport body carries only the marker (no "Related issues" section), mirroring a bot backport.
Expected: PASS via backport hop — inherits the attribution of the original PR #58521.

⤵️ Backport of #58521 → `stable/8.8`
