### PR TITLE
refactor: route claims-map checks through AuthorizationCheckPort.check(Map,...) directly

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -253,6 +253,16 @@ public final class CslAuthorizationCheck {
       final RequiredAuthorization<?> required,
       final T value,
       final Rejection noPrincipalRejection) {
+    return checkWithClaims(
+        claims, required, value, noPrincipalRejection, AuthorizationRejectionMapper::toRejection);
+  }
+
+  private <T> Either<Rejection, T> checkWithClaims(
+      final Map<String, Object> claims,
+      final RequiredAuthorization<?> required,
+      final T value,
+      final Rejection noPrincipalRejection,
+      final Function<AuthorizationRejection, Rejection> denialMapper) {
     if (Boolean.TRUE.equals(claims.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
       return Either.right(value);
     }
@@ -269,7 +279,7 @@ public final class CslAuthorizationCheck {
     }
     final var result = authzService.check(claims, required);
     if (result.isLeft()) {
-      return Either.left(AuthorizationRejectionMapper.toRejection(result.leftValue()));
+      return Either.left(denialMapper.apply(result.leftValue()));
     }
     return Either.right(value);
   }
@@ -277,9 +287,9 @@ public final class CslAuthorizationCheck {
   /**
    * Full authorization check for single-check sites.
    *
-   * <p>Applies {@link #resolveForCheck} and, if a principal is present, delegates to {@link
-   * AuthorizationCheckPort#check}. Maps any CSL rejection to a {@link Rejection} via {@link
-   * AuthorizationRejectionMapper#toRejection}.
+   * <p>Applies the same skip-logic as {@link #checkWithClaims} using the command's claims,
+   * delegating to {@link AuthorizationCheckPort#check(Map, RequiredAuthorization)}. Maps any CSL
+   * rejection to a {@link Rejection} via {@link AuthorizationRejectionMapper#toRejection}.
    *
    * @param value the value to return on success
    * @param noPrincipalRejection the rejection to use when no principal claim is present and
@@ -313,21 +323,19 @@ public final class CslAuthorizationCheck {
       final T value,
       final Rejection noPrincipalRejection,
       final Function<AuthorizationRejection, Rejection> denialMapper) {
-    return resolveForCheck(command, noPrincipalRejection)
-        .flatMap(
-            maybeAuth -> {
-              if (maybeAuth.isEmpty()) {
-                return Either.right(value);
-              }
-              final var result = authzService.check(maybeAuth.get(), required);
-              if (result.isLeft()) {
-                LOG.debug(
-                    "Authorization check rejected for command {}: {}",
-                    command.getIntent(),
-                    result.leftValue());
-                return Either.left(denialMapper.apply(result.leftValue()));
-              }
-              return Either.right(value);
-            });
+    if (command.isInternalCommand()) {
+      LOG.trace("Skipping authorization check for internal command {}", command.getIntent());
+      return Either.right(value);
+    }
+    return checkWithClaims(
+        command.getAuthorizations(),
+        required,
+        value,
+        noPrincipalRejection,
+        rejection -> {
+          LOG.debug(
+              "Authorization check rejected for command {}: {}", command.getIntent(), rejection);
+          return denialMapper.apply(rejection);
+        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -267,8 +267,7 @@ public final class CslAuthorizationCheck {
       }
       return Either.left(noPrincipalRejection);
     }
-    final var auth = claimsConverter.resolve(claims);
-    final var result = authzService.check(auth, required);
+    final var result = authzService.check(claims, required);
     if (result.isLeft()) {
       return Either.left(AuthorizationRejectionMapper.toRejection(result.leftValue()));
     }


### PR DESCRIPTION
## Summary

`CslAuthorizationCheck.checkWithClaims` converted a claims map to a `CamundaAuthentication` via
`claimsConverter.resolve(claims)` before calling `authzService.check(auth, required)`.
`AuthorizationCheckPort` exposes a `check(Map<String, Object>, RequiredAuthorization)` overload that
performs this conversion internally, using the same `LazyTokenClaimsConverter` instance (the
`AuthorizationPortsFactory` wiring guarantees `authzService` and `claimsConverter` share one
converter instance, and `EngineProcessors.java` derives both from a single
`AuthorizationPortsFactory.create(...)` call for every `CslAuthorizationCheck` construction site).
So the intermediate conversion step was redundant — this replaces it with a direct
`authzService.check(claims, required)` call.

Guards for the anonymous-user short-circuit, both-checks-disabled short-circuit, and no-principal
rejection are unchanged; only the resolve+check block was simplified. The `claimsConverter` field
stays — it's still used by `resolveForCheck` and `resolveAuthorizedTenants`.

Raised as a review comment on #58181, deferred pending verification that the CSL-side claims
resolution is equivalent — confirmed by reading library source at `camunda-security-library`
`0.1.0-alpha57` (the version this repo depends on): the `Map` overload delegates into the
`CamundaAuthentication` overload after conversion via the same converter instance, and the past
tenant/membership conflation defect (camunda-security-library#486) is absent from both overloads
alike.

**Follow-on (second commit):** while confirming `checkWithClaims` was the only place with this
redundancy, found one more instance: the single-check entry point
`check(TypedRecord, RequiredAuthorization, T, Rejection, Function)` had the identical
resolve-then-check pattern via `resolveForCheck` + `authzService.check(auth, required)`. This
method backs ~20 call sites across the engine (`PermissionsBehavior`, batch-operation processors,
cluster-variable processors, job processors, etc.), so it's a much larger blast radius than the
first change even though the edit itself is confined to this one class. `resolveForCheck` itself is
untouched — it's still needed by `UserTaskAuthorizationCheck` and `JobBatchCollector`, which resolve
the principal once and call `checkAuth` multiple times against it (switching those to the map
overload would re-run claims resolution on every check instead of once). `check(TypedRecord, ...)`
now peels off the TypedRecord-specific `isInternalCommand()` guard (no equivalent on a raw claims
map) and delegates the rest to `checkWithClaims`, reusing its already-fixed logic. The equivalence
argument from the first change applies identically here: `command.getAuthorizations()` decodes from
the same broker-populated, gateway-normalized claims blob verified for `checkWithClaims`'s callers.

Closes camunda/camunda-security-library#555
Part of camunda/camunda-security-library#402

## Test plan

- [x] `./mvnw verify -pl zeebe/engine -Dtest=ActivatableJobsPushTest,MultiTenancyActivatableJobsPushTest -DskipTests=false -DskipITs -Dquickly` — 10/10 passing
- [x] `./mvnw verify -pl zeebe/engine -DskipTests=false -Dquickly` — full module suite green after each commit (7161/7161 passing after the second commit; one flaky, unrelated `MultiPartitionDeploymentLifecycleTest` failure seen once, confirmed passing on retry and again in the full run after the second commit)
- [x] `./mvnw install -Dquickly -T1C` — full repo still compiles after each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)