### PR TITLE
feat: rename "Starting" to "Initializing" in agent status overlay

### DIFF
--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.test.tsx
@@ -20,7 +20,7 @@ const createOverlay = (status: AgentInstanceStatus): DiagramOverlay => ({
 
 describe('agentStatusOverlay', () => {
   it.each<[AgentInstanceStatus, string]>([
-    ['INITIALIZING', 'Starting...'],
+    ['INITIALIZING', 'Initializing...'],
     ['TOOL_DISCOVERY', 'Discovering tools...'],
     ['THINKING', 'Thinking...'],
     ['TOOL_CALLING', 'Calling tools...'],

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/agentStatusOverlay.tsx
@@ -74,7 +74,7 @@ const AgentStatus = styled.span`
 
 const AGENT_STATUS_LABELS: Record<AgentInstanceStatus, string | null> = {
   UNKNOWN: null,
-  INITIALIZING: 'Starting...',
+  INITIALIZING: 'Initializing...',
   TOOL_DISCOVERY: 'Discovering tools...',
   THINKING: 'Thinking...',
   TOOL_CALLING: 'Calling tools...',


### PR DESCRIPTION
## Description

This PR fixes an inconsistency between the agent details and agent status overlay naming. No all statuses have the same name between the two UI areas.

## Related issues

closes #58525
