### PR TITLE
fix: calculate correct checksum for chunked received snapshots

### DIFF
--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -46,7 +46,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
   private @Nullable FileBasedSnapshotMetadata metadata;
   private @Nullable ByteBuffer metadataBuffer;
   private long writtenMetadataBytes;
-  private @Nullable SfvChecksumImpl checksumCollection;
+  private final IncrementalChecksums incrementalChecksums = new IncrementalChecksums();
 
   FileBasedReceivedSnapshot(
       final FileBasedSnapshotId snapshotId,
@@ -107,8 +107,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
     LOGGER.trace("Consume snapshot snapshotChunk {} of snapshot {}", chunkName, snapshotId);
     writeReceivedSnapshotChunk(snapshotChunk, snapshotFile);
 
-    getChecksumCollection()
-        .updateFromBytes(snapshotFile.getFileName().toString(), snapshotChunk.getContent());
+    incrementalChecksums.update(snapshotChunk);
 
     if (snapshotChunk.getChunkName().equals(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME)) {
       try {
@@ -277,7 +276,7 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
           snapshotStore.persistNewSnapshot(
               directory,
               snapshotId,
-              getChecksumCollection(),
+              incrementalChecksums.complete(),
               persistedMetadata,
               writtenMetadataBytes);
       future.complete(value);
@@ -296,13 +295,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
       }
     }
     return totalSize;
-  }
-
-  private SfvChecksumImpl getChecksumCollection() {
-    if (checksumCollection == null) {
-      checksumCollection = new SfvChecksumImpl();
-    }
-    return checksumCollection;
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksums.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksums.java
@@ -43,7 +43,8 @@ final class IncrementalChecksums {
           if (checksum == null) {
             return FileChecksum.of(chunk);
           } else {
-            return checksum.next(chunk);
+            checksum.update(chunk);
+            return checksum;
           }
         });
   }
@@ -65,7 +66,7 @@ final class IncrementalChecksums {
       if (!fileChecksum.isComplete()) {
         throw new IllegalStateException(
             "Checksum for file %s is not complete (had size %s, expected size %s)"
-                .formatted(fileName, fileChecksum.size, fileChecksum.totalSize));
+                .formatted(fileName, fileChecksum.currentSize, fileChecksum.totalSize));
       }
 
       checksums.put(fileName, fileChecksum.checksum.getValue());
@@ -76,12 +77,12 @@ final class IncrementalChecksums {
 
   private static final class FileChecksum {
     private final Checksum checksum;
-    private final long size;
+    private long currentSize;
     private final long totalSize;
 
-    private FileChecksum(final Checksum checksum, final long size, final long totalSize) {
+    private FileChecksum(final Checksum checksum, final long currentSize, final long totalSize) {
       this.checksum = checksum;
-      this.size = size;
+      this.currentSize = currentSize;
       this.totalSize = totalSize;
     }
 
@@ -92,18 +93,21 @@ final class IncrementalChecksums {
             "Expected first chunk at offset 0 but got %s".formatted(fileBlockPosition));
       }
 
-      return new FileChecksum(new CRC32C(), 0, chunk.getTotalFileSize()).next(chunk);
+      final var checksum = new FileChecksum(new CRC32C(), 0, chunk.getTotalFileSize());
+      checksum.update(chunk);
+      return checksum;
     }
 
     public boolean isComplete() {
-      return size == totalSize;
+      return currentSize == totalSize;
     }
 
-    public FileChecksum next(final SnapshotChunk chunk) {
+    public void update(final SnapshotChunk chunk) {
       final long fileBlockPosition = chunk.getFileBlockPosition();
-      if (fileBlockPosition != size) {
+      if (fileBlockPosition != currentSize) {
         throw new IllegalArgumentException(
-            "Expected next chunk at offset %s but got %s".formatted(size, fileBlockPosition));
+            "Expected next chunk at offset %s but got %s"
+                .formatted(currentSize, fileBlockPosition));
       }
 
       final long totalFileSize = chunk.getTotalFileSize();
@@ -113,16 +117,15 @@ final class IncrementalChecksums {
       }
 
       final byte[] content = chunk.getContent();
-      final long newSize = size + content.length;
+      final long newSize = currentSize + content.length;
       if (newSize > totalSize) {
         throw new IllegalArgumentException(
             "Chunk size %s + current size %s exceeds total size %s"
-                .formatted(content.length, size, totalSize));
+                .formatted(content.length, currentSize, totalSize));
       }
 
       checksum.update(content);
-
-      return new FileChecksum(checksum, newSize, totalSize);
+      currentSize = newSize;
     }
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksums.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksums.java
@@ -65,16 +65,26 @@ final class IncrementalChecksums {
       if (!fileChecksum.isComplete()) {
         throw new IllegalStateException(
             "Checksum for file %s is not complete (had size %s, expected size %s)"
-                .formatted(fileName, fileChecksum.size(), fileChecksum.totalSize()));
+                .formatted(fileName, fileChecksum.size, fileChecksum.totalSize));
       }
 
-      checksums.put(fileName, fileChecksum.checksum().getValue());
+      checksums.put(fileName, fileChecksum.checksum.getValue());
     }
 
     return new SfvChecksumImpl(checksums);
   }
 
-  private record FileChecksum(Checksum checksum, long size, long totalSize) {
+  private static final class FileChecksum {
+    private final Checksum checksum;
+    private final long size;
+    private final long totalSize;
+
+    private FileChecksum(final Checksum checksum, final long size, final long totalSize) {
+      this.checksum = checksum;
+      this.size = size;
+      this.totalSize = totalSize;
+    }
+
     public static FileChecksum of(final SnapshotChunk chunk) {
       final long fileBlockPosition = chunk.getFileBlockPosition();
       if (fileBlockPosition != 0) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksums.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksums.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.zip.CRC32C;
+import java.util.zip.Checksum;
+
+/**
+ * Supports calculating rolling CRC32C checksums for a set of snapshot files received as sequential
+ * chunks.
+ *
+ * <p>Chunks must be sequential and contiguous with regards to each file, but chunks from different
+ * files may be interleaved.
+ */
+final class IncrementalChecksums {
+  private final Map<String, FileChecksum> fileChecksums = new HashMap<>();
+
+  /**
+   * Update the rolling checksum for a single file with the next received chunk for that file.
+   *
+   * <p>This method will throw an exception if the chunk is not the next expected chunk for the
+   * given file (according to the previously seen offsets and sizes), or if the observed total size
+   * for the file changes.
+   *
+   * @param chunk The chunk.
+   * @throws IllegalArgumentException If the chunk was not the next expected chunk for the given
+   *     file, or had a different total file size.
+   */
+  public void update(final SnapshotChunk chunk) {
+    fileChecksums.compute(
+        chunk.getChunkName(),
+        (name, checksum) -> {
+          if (checksum == null) {
+            return FileChecksum.of(chunk);
+          } else {
+            return checksum.next(chunk);
+          }
+        });
+  }
+
+  /**
+   * Validate and return the completed checksums.
+   *
+   * <p>This method will throw an exception if any file was only partially processed (i.e. we saw at
+   * least one chunk for it, but not all chunks).
+   *
+   * @return The completed checksums.
+   * @throws IllegalStateException If any file was only partially processed.
+   */
+  public ImmutableChecksumsSFV complete() {
+    final var checksums = new TreeMap<String, Long>();
+    for (final var entry : fileChecksums.entrySet()) {
+      final var fileName = entry.getKey();
+      final var fileChecksum = entry.getValue();
+      if (!fileChecksum.isComplete()) {
+        throw new IllegalStateException(
+            "Checksum for file %s is not complete (had size %s, expected size %s)"
+                .formatted(fileName, fileChecksum.size(), fileChecksum.totalSize()));
+      }
+
+      checksums.put(fileName, fileChecksum.checksum().getValue());
+    }
+
+    return new SfvChecksumImpl(checksums);
+  }
+
+  private record FileChecksum(Checksum checksum, long size, long totalSize) {
+    public static FileChecksum of(final SnapshotChunk chunk) {
+      final long fileBlockPosition = chunk.getFileBlockPosition();
+      if (fileBlockPosition != 0) {
+        throw new IllegalArgumentException(
+            "Expected first chunk at offset 0 but got %s".formatted(fileBlockPosition));
+      }
+
+      return new FileChecksum(new CRC32C(), 0, chunk.getTotalFileSize()).next(chunk);
+    }
+
+    public boolean isComplete() {
+      return size == totalSize;
+    }
+
+    public FileChecksum next(final SnapshotChunk chunk) {
+      final long fileBlockPosition = chunk.getFileBlockPosition();
+      if (fileBlockPosition != size) {
+        throw new IllegalArgumentException(
+            "Expected next chunk at offset %s but got %s".formatted(size, fileBlockPosition));
+      }
+
+      final long totalFileSize = chunk.getTotalFileSize();
+      if (totalFileSize != totalSize) {
+        throw new IllegalArgumentException(
+            "Expected chunk to match totalSize %s but got %s".formatted(totalSize, totalFileSize));
+      }
+
+      final byte[] content = chunk.getContent();
+      final long newSize = size + content.length;
+      if (newSize > totalSize) {
+        throw new IllegalArgumentException(
+            "Chunk size %s + current size %s exceeds total size %s"
+                .formatted(content.length, size, totalSize));
+      }
+
+      checksum.update(content);
+
+      return new FileChecksum(checksum, newSize, totalSize);
+    }
+  }
+}

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -46,10 +46,16 @@ public final class SfvChecksumImpl implements MutableChecksumsSFV {
   private static final String FILE_CRC_SEPARATOR_REGEX = " {3}";
   private static final Pattern FILE_CRC_PATTERN =
       Pattern.compile("(.*)" + FILE_CRC_SEPARATOR_REGEX + "([0-9a-fA-F]{1,16})");
-  private final SortedMap<String, Long> checksums = new TreeMap<>();
+  private final SortedMap<String, Long> checksums;
   private @Nullable String snapshotDirectoryComment;
 
-  public SfvChecksumImpl() {}
+  public SfvChecksumImpl() {
+    checksums = new TreeMap<>();
+  }
+
+  public SfvChecksumImpl(final SortedMap<String, Long> checksums) {
+    this.checksums = checksums;
+  }
 
   @Override
   public void write(final OutputStream stream) throws IOException {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -152,33 +152,6 @@ public class ReceivedSnapshotTest {
   }
 
   @Test
-  public void shouldPersistEvenIfSameChunkIsConsumedMultipleTimes() {
-    // given
-    final var persistedSnapshot = takePersistedSnapshot();
-
-    // when
-    final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
-
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      final SnapshotChunk chunk = snapshotChunkReader.next();
-      receivedSnapshot.apply(chunk).join();
-      receivedSnapshot.apply(chunk).join();
-
-      while (snapshotChunkReader.hasNext()) {
-        receivedSnapshot.apply(snapshotChunkReader.next()).join();
-      }
-    }
-
-    final var receivedPersistedSnapshot = receivedSnapshot.persist().join();
-
-    // then
-    assertThat(receivedPersistedSnapshot)
-        .as("the snapshot was persisted even if one chunk was applied more than once")
-        .isEqualTo(receiverSnapshotStore.getLatestSnapshot().orElseThrow());
-  }
-
-  @Test
   public void shouldThrowWhenAlreadyExistingSnapshotWasReceivedAgain() {
     // given
     final var persistedSnapshot = takePersistedSnapshot();

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -370,32 +370,21 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   @Test
-  public void shouldCalculateSizeCorrectlyWithDuplicatedChunks() throws IOException {
+  public void shouldRejectDuplicatedChunks() {
     // given
-    final var senderSnapshot = (FileBasedSnapshot) takePersistedSnapshot(1L);
-    rewriteMetadataSize(senderSnapshot, 0L);
-    final var metadataSizeBytes = expectedMetadataSizeBytes(senderSnapshot);
-
-    // when
+    final var senderSnapshot = takePersistedSnapshot(1L);
     final var receivedSnapshot =
         receiverSnapshotStore.newReceivedSnapshot(senderSnapshot.getId()).join();
-    try (final var reader = senderSnapshot.newChunkReader()) {
-      var replayedDataChunk = false;
-      while (reader.hasNext()) {
-        final var chunk = reader.next();
-        receivedSnapshot.apply(chunk).join();
-        if (!replayedDataChunk
-            && !chunk.getChunkName().equals(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME)) {
-          receivedSnapshot.apply(chunk).join();
-          replayedDataChunk = true;
-        }
-      }
-    }
-    final var persistedSnapshot = receivedSnapshot.persist().join();
 
-    // then
-    assertThat(persistedSnapshot.getTotalSizeInBytes())
-        .isEqualTo(expectedTotalDataSize() + metadataSizeBytes);
+    try (final var reader = senderSnapshot.newChunkReader()) {
+      final var chunk = reader.next();
+      receivedSnapshot.apply(chunk).join();
+
+      // when/then
+      assertThatThrownBy(() -> receivedSnapshot.apply(chunk).join())
+          .hasCauseInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Expected next chunk at offset");
+    }
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -555,6 +555,54 @@ public class FileBasedSnapshotStoreTest {
   }
 
   @Test
+  public void shouldRestartWithAChunkedReceivedSnapshot() throws IOException {
+    // given
+    final Map<String, Long> fileChecksums = new HashMap<>();
+    final var fileContentChecksum = new CRC32C();
+    fileContentChecksum.update(SNAPSHOT_CONTENT.getBytes(StandardCharsets.UTF_8));
+    fileChecksums.put(SNAPSHOT_CONTENT_FILE_NAME, fileContentChecksum.getValue());
+    final var receiverStorePath = temporaryFolder.newFolder("receiver").toPath();
+
+    final var store =
+        new FileBasedSnapshotStore(
+            0,
+            PARTITION_ID,
+            receiverStorePath,
+            new TestSnapshotFileInfoProvider(fileChecksums),
+            new SimpleMeterRegistry());
+    scheduler.submitActor(store);
+
+    // when
+    final var persistedSnapshot = takeTransientSnapshot().persist().join();
+    final var receivedSnapshot = store.newReceivedSnapshot(persistedSnapshot.getId()).join();
+    try (final var reader = persistedSnapshot.newChunkReader()) {
+      reader.setMaximumChunkSize(2);
+      while (reader.hasNext()) {
+        receivedSnapshot.apply(reader.next()).join();
+      }
+    }
+
+    receivedSnapshot.persist().join();
+
+    store.close();
+
+    final var restartedStore =
+        new FileBasedSnapshotStore(
+            0,
+            PARTITION_ID,
+            receiverStorePath,
+            new TestSnapshotFileInfoProvider(fileChecksums),
+            new SimpleMeterRegistry());
+    scheduler.submitActor(restartedStore).join();
+
+    // then
+    assertThat(restartedStore.getLatestSnapshot())
+        .describedAs(
+            "The latest snapshot is not detected as corrupted and should be loaded after restart")
+        .hasValueSatisfying(s -> assertThat(s.getId()).isEqualTo(persistedSnapshot.getId()));
+  }
+
+  @Test
   public void shouldCreateASnapshotForBootstrap() throws IOException {
     // given
     final var transientSnapshot = takeTransientSnapshotWithFiles(123L);

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksumsTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/IncrementalChecksumsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.snapshots.SnapshotChunk;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+
+public final class IncrementalChecksumsTest {
+
+  private final IncrementalChecksums checksums = new IncrementalChecksums();
+
+  @Test
+  public void shouldCalculateChecksumFromSequentialChunks() {
+    // when
+    checksums.update(chunk("file", "ab", 0, 4));
+    checksums.update(chunk("file", "cd", 2, 4));
+
+    // then
+    assertThat(checksums.complete().getChecksums())
+        .containsExactlyEntriesOf(
+            new java.util.TreeMap<>(java.util.Map.of("file", checksum("abcd"))));
+  }
+
+  @Test
+  public void shouldCalculateChecksumsForInterleavedFiles() {
+    // when
+    checksums.update(chunk("file1", "ab", 0, 4));
+    checksums.update(chunk("file2", "12", 0, 4));
+    checksums.update(chunk("file1", "cd", 2, 4));
+    checksums.update(chunk("file2", "34", 2, 4));
+
+    // then
+    assertThat(checksums.complete().getChecksums())
+        .containsExactlyEntriesOf(
+            new java.util.TreeMap<>(
+                java.util.Map.of(
+                    "file1", checksum("abcd"),
+                    "file2", checksum("1234"))));
+  }
+
+  @Test
+  public void shouldRejectFirstChunkWithNonZeroOffset() {
+    assertThatThrownBy(() -> checksums.update(chunk("file", "ab", 1, 3)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Expected first chunk at offset 0 but got 1");
+  }
+
+  @Test
+  public void shouldRejectNonSequentialChunk() {
+    // given
+    checksums.update(chunk("file", "ab", 0, 4));
+
+    // when/then
+    assertThatThrownBy(() -> checksums.update(chunk("file", "d", 3, 4)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Expected next chunk at offset 2 but got 3");
+  }
+
+  @Test
+  public void shouldRejectDuplicatedChunk() {
+    // given
+    final var chunk = chunk("file", "ab", 0, 4);
+    checksums.update(chunk);
+
+    // when/then
+    assertThatThrownBy(() -> checksums.update(chunk))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Expected next chunk at offset 2 but got 0");
+  }
+
+  @Test
+  public void shouldRejectChangedTotalFileSize() {
+    // given
+    checksums.update(chunk("file", "ab", 0, 4));
+
+    // when/then
+    assertThatThrownBy(() -> checksums.update(chunk("file", "cd", 2, 5)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Expected chunk to match totalSize 4 but got 5");
+  }
+
+  @Test
+  public void shouldRejectChunkExceedingTotalFileSize() {
+    assertThatThrownBy(() -> checksums.update(chunk("file", "abc", 0, 2)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Chunk size 3 + current size 0 exceeds total size 2");
+  }
+
+  @Test
+  public void shouldRejectIncompleteChecksumCollection() {
+    // given
+    checksums.update(chunk("file", "ab", 0, 4));
+
+    // when/then
+    assertThatThrownBy(checksums::complete)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Checksum for file file is not complete (had size 2, expected size 4)");
+  }
+
+  @Test
+  public void shouldHandleEmptyFile() {
+    // when
+    checksums.update(chunk("file", "", 0, 0));
+
+    // then
+    assertThat(checksums.complete().getChecksums()).containsEntry("file", checksum(""));
+  }
+
+  private static SnapshotChunk chunk(
+      final String fileName, final String content, final long offset, final long totalSize) {
+    return SnapshotChunkUtil.createSnapshotChunkFromFileChunk(
+        "1-0-0-0-0-0", 1, fileName, ByteBuffer.wrap(content.getBytes(UTF_8)), offset, totalSize);
+  }
+
+  private static long checksum(final String content) {
+    return SnapshotChunkUtil.createChecksum(content.getBytes(UTF_8));
+  }
+}


### PR DESCRIPTION
Previously, if a received snapshot spanned more than one SnapshotChunk, the persisted checksum would be incorrect (and the snapshot would fail verification after restart). This would happen because the checksums were calculated for each chunk as if they were for the whole file (i.e. the checksum gets replaced rather than being incrementally updated).

This should be rare under the default configuration, but could occur more frequently if the snapshot chunk size is reduced.

Closes #57874.