### PR TITLE
feat: adapt ClusterConfigurationManagerService to the new multi-group model

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.Initializ
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -49,7 +50,7 @@ import org.slf4j.LoggerFactory;
  *     ClusterConfigurationModifier}. For example, {@link ExporterStateInitializer} overwrites the
  *     local member's state to keep it in sync with the statically configured exporters.
  */
-public interface ClusterConfigurationInitializer {
+public interface ClusterConfigurationInitializer<T extends InitializableClusterConfiguration> {
   Logger LOG = LoggerFactory.getLogger(ClusterConfigurationInitializer.class);
 
   /**
@@ -57,7 +58,7 @@ public interface ClusterConfigurationInitializer {
    *
    * @return a future that completes with a configuration which can be initialized or uninitialized
    */
-  ActorFuture<ClusterConfiguration> initialize();
+  ActorFuture<T> initialize();
 
   /**
    * Chain initializers in oder. If this initializer returns an uninitialized configuration, the
@@ -69,10 +70,11 @@ public interface ClusterConfigurationInitializer {
    *     succeed with an initialized configuration.
    * @return a chained ClusterConfigurationInitializer
    */
-  default ClusterConfigurationInitializer orThen(final ClusterConfigurationInitializer after) {
-    final ClusterConfigurationInitializer actual = this;
+  default ClusterConfigurationInitializer<T> orThen(
+      final ClusterConfigurationInitializer<T> after) {
+    final ClusterConfigurationInitializer<T> actual = this;
     return () -> {
-      final ActorFuture<ClusterConfiguration> chainedInitialize = new CompletableActorFuture<>();
+      final ActorFuture<T> chainedInitialize = new CompletableActorFuture<>();
       actual
           .initialize()
           .onComplete(
@@ -96,10 +98,11 @@ public interface ClusterConfigurationInitializer {
    * @param modifier a modifier that updates the configuration
    * @return the chained initializer
    */
-  default ClusterConfigurationInitializer andThen(final ClusterConfigurationModifier modifier) {
-    final ClusterConfigurationInitializer actual = this;
+  default ClusterConfigurationInitializer<T> andThen(
+      final ClusterConfigurationModifier<T> modifier) {
+    final ClusterConfigurationInitializer<T> actual = this;
     return () -> {
-      final ActorFuture<ClusterConfiguration> chainedInitialize = new CompletableActorFuture<>();
+      final ActorFuture<T> chainedInitialize = new CompletableActorFuture<T>();
       actual
           .initialize()
           .onComplete(
@@ -134,12 +137,12 @@ public interface ClusterConfigurationInitializer {
    * @return a {@link ClusterConfigurationInitializer} that can be used for further chaining with
    *     {@link #orThen(ClusterConfigurationInitializer)}.
    */
-  default ClusterConfigurationInitializer recover(
+  default ClusterConfigurationInitializer<T> recover(
       final Class<? extends InitializerError> exception,
-      final ClusterConfigurationInitializer recovery) {
-    final ClusterConfigurationInitializer actual = this;
+      final ClusterConfigurationInitializer<T> recovery) {
+    final ClusterConfigurationInitializer<T> actual = this;
     return () -> {
-      final ActorFuture<ClusterConfiguration> chainedInitialize = new CompletableActorFuture<>();
+      final ActorFuture<T> chainedInitialize = new CompletableActorFuture<>();
       actual
           .initialize()
           .onComplete(
@@ -158,23 +161,44 @@ public interface ClusterConfigurationInitializer {
   }
 
   /** Initialized configuration from the locally persisted configuration */
-  class FileInitializer implements ClusterConfigurationInitializer {
+  class FileInitializer<T extends InitializableClusterConfiguration>
+      implements ClusterConfigurationInitializer<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileInitializer.class);
 
     private final Path configurationFile;
     private final ClusterConfigurationSerializer serializer;
+    private final ConfigurationReader<T> reader;
 
     public FileInitializer(
-        final Path configurationFile, final ClusterConfigurationSerializer serializer) {
+        final Path configurationFile,
+        final ClusterConfigurationSerializer serializer,
+        final ConfigurationReader<T> reader) {
       this.configurationFile = configurationFile;
       this.serializer = serializer;
+      this.reader = reader;
+    }
+
+    public static FileInitializer<ClusterConfiguration> legacyFileInitializer(
+        final Path configurationFile, final ClusterConfigurationSerializer serializer) {
+      return new FileInitializer<>(
+          configurationFile,
+          serializer,
+          (f, s) -> PersistedClusterConfiguration.ofFile(f, s).getConfiguration());
+    }
+
+    public static FileInitializer<CurrentClusterConfiguration> fromPersistedConfiguration(
+        final Path configurationFile, final ClusterConfigurationSerializer serializer) {
+      return new FileInitializer<CurrentClusterConfiguration>(
+          configurationFile,
+          serializer,
+          (f, s) -> PersistedCurrentClusterConfiguration.ofFile(f, s).getConfiguration());
     }
 
     @Override
-    public ActorFuture<ClusterConfiguration> initialize() {
+    public ActorFuture<T> initialize() {
       try {
-        final var persistedTopology =
-            PersistedClusterConfiguration.ofFile(configurationFile, serializer).getConfiguration();
+        final var persistedTopology = reader.read(configurationFile, serializer);
+
         if (!persistedTopology.isUninitialized()) {
           LOGGER.debug(
               "Initialized cluster configuration '{}' from file '{}'",
@@ -187,6 +211,11 @@ public interface ClusterConfigurationInitializer {
             new PersistedConfigurationIsBroken(configurationFile, e));
       }
     }
+
+    @FunctionalInterface
+    public interface ConfigurationReader<T extends InitializableClusterConfiguration> {
+      T read(Path configurationFile, ClusterConfigurationSerializer serializer) throws Exception;
+    }
   }
 
   /**
@@ -196,7 +225,8 @@ public interface ClusterConfigurationInitializer {
    * received.
    */
   class GossipInitializer
-      implements ClusterConfigurationInitializer, ClusterConfigurationUpdateListener {
+      implements ClusterConfigurationInitializer<ClusterConfiguration>,
+          ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GossipInitializer.class);
     private final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier;
@@ -256,7 +286,8 @@ public interface ClusterConfigurationInitializer {
    * configuration, letting the caller's initializer chain decide how to proceed.
    */
   class SyncInitializer
-      implements ClusterConfigurationInitializer, ClusterConfigurationUpdateListener {
+      implements ClusterConfigurationInitializer<ClusterConfiguration>,
+          ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SyncInitializer.class);
     private final Duration syncDelay;
@@ -419,20 +450,25 @@ public interface ClusterConfigurationInitializer {
   }
 
   /** Initialized configuration from the given static partition distribution */
-  class StaticInitializer implements ClusterConfigurationInitializer {
+  class StaticInitializer<T extends InitializableClusterConfiguration>
+      implements ClusterConfigurationInitializer<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StaticInitializer.class);
+    private final Supplier<T> configurationSupplier;
 
-    private final StaticConfiguration staticConfiguration;
+    public StaticInitializer(final Supplier<T> configurationSupplier) {
+      this.configurationSupplier = configurationSupplier;
+    }
 
-    public StaticInitializer(final StaticConfiguration staticConfiguration) {
-      this.staticConfiguration = staticConfiguration;
+    public static StaticInitializer<ClusterConfiguration> legacyStaticInitializer(
+        final StaticConfiguration staticConfiguration) {
+      return new StaticInitializer<>(staticConfiguration::generateTopology);
     }
 
     @Override
-    public ActorFuture<ClusterConfiguration> initialize() {
+    public ActorFuture<T> initialize() {
       try {
-        final var configuration = staticConfiguration.generateTopology();
+        final var configuration = configurationSupplier.get();
         LOGGER.debug(
             "Generated cluster configuration from provided configuration. {}", configuration);
         return CompletableActorFuture.completed(configuration);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImpl.java
@@ -66,6 +66,7 @@ import org.slf4j.LoggerFactory;
  * See {@link ConfigurationChangeAppliers} to see how a change is applied locally.
  */
 public final class ClusterConfigurationManagerImpl implements ClusterConfigurationManager {
+
   private static final Logger LOG = LoggerFactory.getLogger(ClusterConfigurationManagerImpl.class);
   private static final Duration MIN_RETRY_DELAY = Duration.ofSeconds(10);
   private static final Duration MAX_RETRY_DELAY = Duration.ofMinutes(1);
@@ -82,9 +83,6 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   private final ExponentialBackoffRetryDelay backoffRetry;
   private boolean initialized = false;
   private final TopologyManagerMetrics topologyMetrics;
-
-  // Temporary flag to switch between the old single-partition-group model and the new
-  // multi-partition-group model. This is used for testing and will be removed in the future.
   private final boolean useNewConfig;
 
   // New-model state, only used when useNewConfig is true.
@@ -139,9 +137,24 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
   }
 
   /**
-   * Constructs a manager operating on the new multi-partition-group model. Used only in tests now.
-   * The legacy {@code PersistedClusterConfiguration} is not used in this mode.
+   * Constructs a manager operating on the new multi-partition-group model. Used when {@link
+   * ClusterConfigurationManagerService#USE_NEW_CONFIG} is enabled. The legacy {@code
+   * PersistedClusterConfiguration} is not used in this mode.
    */
+  ClusterConfigurationManagerImpl(
+      final ConcurrencyControl executor,
+      final MemberId localMemberId,
+      final PersistedCurrentClusterConfiguration persistedCurrentConfiguration,
+      final TopologyManagerMetrics topologyMetrics) {
+    this(
+        executor,
+        localMemberId,
+        persistedCurrentConfiguration,
+        topologyMetrics,
+        MIN_RETRY_DELAY,
+        MAX_RETRY_DELAY);
+  }
+
   @VisibleForTesting
   ClusterConfigurationManagerImpl(
       final ConcurrencyControl executor,
@@ -247,7 +260,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     return future;
   }
 
-  ActorFuture<Void> start(final ClusterConfigurationInitializer clusterConfigurationInitializer) {
+  ActorFuture<Void> start(
+      final ClusterConfigurationInitializer<? extends InitializableClusterConfiguration>
+          clusterConfigurationInitializer) {
     executor.run(
         () -> {
           if (startFuture.isDone()) {
@@ -263,7 +278,9 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
     this.configurationGossiper = configurationGossiper;
   }
 
-  private void initialize(final ClusterConfigurationInitializer clusterConfigurationInitializer) {
+  private void initialize(
+      final ClusterConfigurationInitializer<? extends InitializableClusterConfiguration>
+          clusterConfigurationInitializer) {
     clusterConfigurationInitializer
         .initialize()
         .onComplete(
@@ -277,19 +294,45 @@ public final class ClusterConfigurationManagerImpl implements ClusterConfigurati
                 LOG.error(errorMessage);
                 startFuture.completeExceptionally(new IllegalStateException(errorMessage));
               } else {
-                try {
-                  // merge in case there was a concurrent update via gossip
-                  persistedClusterConfiguration.update(
-                      configuration.merge(persistedClusterConfiguration.getConfiguration()));
-                  LOG.debug(
-                      "Initialized cluster configuration '{}'",
-                      persistedClusterConfiguration.getConfiguration());
-                  configurationGossiper.accept(persistedClusterConfiguration.getConfiguration());
-                  setStarted();
-                } catch (final IOException e) {
+                // temporary workaround to support both legacy and new configuration models.
+                if (configuration instanceof final ClusterConfiguration clusterConfiguration) {
+                  try {
+                    // merge in case there was a concurrent update via gossip
+                    persistedClusterConfiguration.update(
+                        clusterConfiguration.merge(
+                            persistedClusterConfiguration.getConfiguration()));
+                    LOG.debug(
+                        "Initialized (legacy) cluster configuration '{}'",
+                        persistedClusterConfiguration.getConfiguration());
+                    configurationGossiper.accept(persistedClusterConfiguration.getConfiguration());
+                  } catch (final IOException e) {
+                    startFuture.completeExceptionally(
+                        "Failed to start update cluster configuration", e);
+                  }
+                } else if (configuration
+                    instanceof final CurrentClusterConfiguration currentClusterConfiguration) {
+                  try {
+                    // merge in case there was a concurrent update via gossip
+                    persistedCurrentConfiguration.update(
+                        currentClusterConfiguration.merge(
+                            persistedCurrentConfiguration.getConfiguration()));
+                    LOG.debug(
+                        "Initialized cluster configuration '{}'",
+                        persistedCurrentConfiguration.getConfiguration());
+                    if (currentConfigurationGossiper != null) {
+                      currentConfigurationGossiper.accept(
+                          persistedCurrentConfiguration.getConfiguration());
+                    }
+                  } catch (final IOException e) {
+                    startFuture.completeExceptionally(
+                        "Failed to start update cluster configuration", e);
+                  }
+                } else {
                   startFuture.completeExceptionally(
-                      "Failed to start update cluster configuration", e);
+                      new IllegalStateException(
+                          "Unexpected configuration type: " + configuration.getClass()));
                 }
+                setStarted();
               }
             });
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -25,9 +25,11 @@ import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.ModeChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionGroupConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.RestoreChangeExecutor;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiper;
@@ -36,6 +38,7 @@ import io.camunda.zeebe.dynamic.config.metrics.TopologyManagerMetrics;
 import io.camunda.zeebe.dynamic.config.metrics.TopologyMetrics;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.RequestValidatorRegistry;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -43,6 +46,7 @@ import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -57,9 +61,24 @@ import org.jspecify.annotations.Nullable;
 public final class ClusterConfigurationManagerService
     implements ClusterConfigurationUpdateNotifier, AsyncClosable {
   public static final String TOPOLOGY_FILE_NAME = ".topology.meta";
+
+  /**
+   * Static feature flag switching the manager between the legacy single-group model and the new
+   * multi-partition-group model. Kept {@code false} in production for now; the new path is
+   * exercised via the {@code useNewConfig} constructor parameter (see {@link #USE_NEW_CONFIG}).
+   * When {@code false}, the legacy code path runs completely unchanged.
+   */
+  static final boolean USE_NEW_CONFIG = false;
+
   private final ClusterConfigurationManagerImpl clusterConfigurationManager;
   private final ClusterConfigurationGossiper clusterConfigurationGossiper;
-  private final PersistedClusterConfiguration persistedClusterConfiguration;
+  // Exactly one of persistedClusterConfiguration (legacy model) /
+  // persistedCurrentClusterConfiguration
+  // (new model) is set, matching ClusterConfigurationManagerImpl.USE_NEW_CONFIG. Both classes read
+  // the same on-disk file, distinguished by an internal header version, so only one may ever open
+  // it.
+  private final @Nullable PersistedClusterConfiguration persistedClusterConfiguration;
+  private final @Nullable PersistedCurrentClusterConfiguration persistedCurrentClusterConfiguration;
   private final Path configurationFile;
   private final ConfigurationChangeCoordinator configurationChangeCoordinator;
   private final ClusterConfigurationRequestServer configurationRequestServer;
@@ -72,6 +91,7 @@ public final class ClusterConfigurationManagerService
   private final ClusterMembershipService membershipService;
   private final MemberId localMemberId;
   private final RequestValidatorRegistry validators = new RequestValidatorRegistry();
+  private final boolean useNewConfig;
   private ModeChangeExecutor modeChangeExecutor;
 
   public ClusterConfigurationManagerService(
@@ -81,6 +101,31 @@ public final class ClusterConfigurationManagerService
       final ClusterConfigurationGossiperConfig config,
       final ClusterChangeExecutor clusterChangeExecutor,
       final MeterRegistry meterRegistry) {
+    this(
+        dataRootDirectory,
+        communicationService,
+        memberShipService,
+        config,
+        clusterChangeExecutor,
+        meterRegistry,
+        USE_NEW_CONFIG);
+  }
+
+  /**
+   * @param useNewConfig overrides {@link ClusterConfigurationManagerService#USE_NEW_CONFIG} for
+   *     testing; production code always goes through the constructor above, which uses the
+   *     compile-time flag.
+   */
+  @VisibleForTesting
+  ClusterConfigurationManagerService(
+      final Path dataRootDirectory,
+      final ClusterCommunicationService communicationService,
+      final ClusterMembershipService memberShipService,
+      final ClusterConfigurationGossiperConfig config,
+      final ClusterChangeExecutor clusterChangeExecutor,
+      final MeterRegistry meterRegistry,
+      final boolean useNewConfig) {
+    this.useNewConfig = useNewConfig;
     gossiperConfig = config;
     this.clusterChangeExecutor = clusterChangeExecutor;
     topologyMetrics = new TopologyMetrics(meterRegistry);
@@ -94,13 +139,28 @@ public final class ClusterConfigurationManagerService
     membershipService = memberShipService;
     localMemberId = memberShipService.getLocalMember().id();
     configurationFile = dataRootDirectory.resolve(TOPOLOGY_FILE_NAME);
-    persistedClusterConfiguration =
-        PersistedClusterConfiguration.ofFile(configurationFile, new ProtoBufSerializer());
     gossipActor = Actor.newActor().name("ClusterConfigGossip").build();
     managerActor = Actor.newActor().name("ClusterConfigManager").build();
-    clusterConfigurationManager =
-        new ClusterConfigurationManagerImpl(
-            managerActor, localMemberId, persistedClusterConfiguration, topologyManagerMetrics);
+
+    if (useNewConfig) {
+      persistedClusterConfiguration = null;
+      persistedCurrentClusterConfiguration =
+          PersistedCurrentClusterConfiguration.ofFile(configurationFile, new ProtoBufSerializer());
+      clusterConfigurationManager =
+          new ClusterConfigurationManagerImpl(
+              managerActor,
+              localMemberId,
+              persistedCurrentClusterConfiguration,
+              topologyManagerMetrics);
+    } else {
+      persistedCurrentClusterConfiguration = null;
+      persistedClusterConfiguration =
+          PersistedClusterConfiguration.ofFile(configurationFile, new ProtoBufSerializer());
+      clusterConfigurationManager =
+          new ClusterConfigurationManagerImpl(
+              managerActor, localMemberId, persistedClusterConfiguration, topologyManagerMetrics);
+    }
+
     clusterConfigurationGossiper =
         new ClusterConfigurationGossiper(
             gossipActor,
@@ -108,7 +168,10 @@ public final class ClusterConfigurationManagerService
             memberShipService,
             new ProtoBufSerializer(),
             config,
-            clusterConfigurationManager::onGossipReceived,
+            // Dead on the new model: setCurrentConfigurationUpdateHandler (below) makes the
+            // gossiper prefer the new-model handler, so this legacy one is never invoked.
+            useNewConfig ? ignored -> {} : clusterConfigurationManager::onGossipReceived,
+            useNewConfig ? clusterConfigurationManager::onGossipReceivedCurrent : null,
             topologyMetrics);
     configurationChangeCoordinator =
         new ConfigurationChangeCoordinatorImpl(
@@ -120,17 +183,24 @@ public final class ClusterConfigurationManagerService
             new ClusterConfigurationManagementRequestsHandler(
                 configurationChangeCoordinator, localMemberId, managerActor, validators));
 
-    clusterConfigurationManager.setConfigurationGossiper(
-        clusterConfigurationGossiper::updateClusterConfiguration);
+    if (useNewConfig) {
+      clusterConfigurationManager.setCurrentConfigurationGossiper(
+          clusterConfigurationGossiper::updateCurrentClusterConfiguration);
+    } else {
+      clusterConfigurationManager.setConfigurationGossiper(
+          clusterConfigurationGossiper::updateClusterConfiguration);
+    }
   }
 
-  private ClusterConfigurationInitializer getNonCoordinatorInitializer(
+  private ClusterConfigurationInitializer<ClusterConfiguration> getNonCoordinatorInitializer(
       final StaticConfiguration staticConfiguration) {
     final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
-    return new FileInitializer(configurationFile, new ProtoBufSerializer())
+    return FileInitializer.legacyFileInitializer(configurationFile, new ProtoBufSerializer())
         // Recover via sync to ensure that we don't gossip an uninitialized configuration.
-        // This is important so that we don't silently revert to uninitialized configuration when
-        // multiple members have a broken configuration file at the same time, for example because
+        // This is important so that we don't silently revert to uninitialized configuration
+        // when
+        // multiple members have a broken configuration file at the same time, for example
+        // because
         // of a serialization bug.
         .recover(
             PersistedConfigurationIsBroken.class,
@@ -154,18 +224,20 @@ public final class ClusterConfigurationManagerService
                 managerActor,
                 false))
         .andThen(new RoutingStateInitializer(staticConfiguration.partitionCount()))
-        // Must be initialized by the coordinator only. However, we still define it here because the
-        // actual coordinator might be different from what is provided in the static configuration.
+        // Must be initialized by the coordinator only. However, we still define it here because
+        // the
+        // actual coordinator might be different from what is provided in the static
+        // configuration.
         // These initializers will be skipped if they are not running on the latest coordinator
         // based on the initialized configuration.
         .andThen(new PartitionDistributorInitializer(staticConfiguration))
         .andThen(new ClusterIdInitializer(staticConfiguration.clusterId(), localMemberId));
   }
 
-  private ClusterConfigurationInitializer getCoordinatorInitializer(
+  private ClusterConfigurationInitializer<ClusterConfiguration> getCoordinatorInitializer(
       final StaticConfiguration staticConfiguration) {
     final Supplier<List<MemberId>> otherKnownMembers = initializationMembers(staticConfiguration);
-    return new FileInitializer(configurationFile, new ProtoBufSerializer())
+    return FileInitializer.legacyFileInitializer(configurationFile, new ProtoBufSerializer())
         .orThen(
             new SyncInitializer(
                 gossiperConfig.syncInitializerDelay(),
@@ -174,7 +246,7 @@ public final class ClusterConfigurationManagerService
                 managerActor,
                 clusterConfigurationGossiper::queryClusterConfiguration,
                 gossiperConfig.bootstrapTimeout()))
-        .orThen(new StaticInitializer(staticConfiguration))
+        .orThen(new StaticInitializer<>(staticConfiguration::generateTopology))
         .andThen(
             new ExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
@@ -218,14 +290,6 @@ public final class ClusterConfigurationManagerService
       final ActorSchedulingService actorSchedulingService,
       final StaticConfiguration staticConfiguration) {
     final var result = new CompletableActorFuture<Void>();
-    final var coordinatorMemberId =
-        ClusterConfigurationCoordinatorSupplier.ofMembers(staticConfiguration.clusterMembers())
-            .getDefaultCoordinator();
-    final var isCoordinator = coordinatorMemberId.equals(localMemberId);
-    final ClusterConfigurationInitializer clusterConfigurationInitializer =
-        isCoordinator
-            ? getCoordinatorInitializer(staticConfiguration)
-            : getNonCoordinatorInitializer(staticConfiguration);
 
     configurationRequestServer.start();
 
@@ -237,7 +301,34 @@ public final class ClusterConfigurationManagerService
             (ok, error) -> {
               if (error != null) {
                 result.completeExceptionally(error);
+              } else if (useNewConfig) {
+                // Registered here rather than in the constructor: registerGlobalChangeAppliers goes
+                // through managerActor's executor.
+                clusterConfigurationManager.registerGlobalChangeAppliers(
+                    new GlobalConfigurationChangeAppliersImpl(
+                        new NoopClusterMembershipChangeExecutor(), clusterChangeExecutor));
+                // Intermediate migration step: only the file and static initializer exists for the
+                // new model, used unconditionally for both coordinator and non-coordinator role.
+                // File/gossip/sync recovery and the coordinator/non-coordinator split are a
+                // follow-up.
+                final ClusterConfigurationInitializer<CurrentClusterConfiguration> initializer =
+                    FileInitializer.fromPersistedConfiguration(
+                            configurationFile, new ProtoBufSerializer())
+                        .orThen(
+                            new StaticInitializer<>(
+                                staticConfiguration::generateCurrentClusterConfiguration));
+                clusterConfigurationManager.start(initializer).onComplete(result);
               } else {
+                final var coordinatorMemberId =
+                    ClusterConfigurationCoordinatorSupplier.ofMembers(
+                            staticConfiguration.clusterMembers())
+                        .getDefaultCoordinator();
+                final var isCoordinator = coordinatorMemberId.equals(localMemberId);
+                final ClusterConfigurationInitializer<ClusterConfiguration>
+                    clusterConfigurationInitializer =
+                        isCoordinator
+                            ? getCoordinatorInitializer(staticConfiguration)
+                            : getNonCoordinatorInitializer(staticConfiguration);
                 clusterConfigurationManager
                     .start(clusterConfigurationInitializer)
                     .onComplete(result);
@@ -302,6 +393,45 @@ public final class ClusterConfigurationManagerService
 
   public void removeModeChangeExecutor() {
     managerActor.run(() -> modeChangeExecutor = null);
+  }
+
+  /**
+   * Registers the appliers for a single partition group (physical tenant) on the new
+   * multi-partition-group model, keyed by {@code groupId}. Unlike {@link
+   * #registerPartitionChangeExecutors}/{@link #registerModeChangeExecutor} (one shared registration
+   * for the single legacy group), this is called once per physical tenant — each tenant's own
+   * executors are scoped to that tenant only.
+   *
+   * <p>Not yet called by any broker code: broker integration (registering every physical tenant's
+   * {@code PartitionManagerImpl}/{@code PartitionModeHandler} here instead of only the default
+   * tenant's) is a follow-up.
+   */
+  public void registerPartitionGroupChangeExecutors(
+      final String groupId,
+      final PartitionChangeExecutor partitionChangeExecutor,
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
+      final ModeChangeExecutor modeChangeExecutor,
+      final RestoreChangeExecutor restoreChangeExecutor) {
+    if (!useNewConfig) {
+      return; // noop on legacy mode
+    }
+    managerActor.run(
+        () ->
+            clusterConfigurationManager.registerPartitionGroupChangeAppliers(
+                groupId,
+                new PartitionGroupConfigurationChangeAppliersImpl(
+                    partitionChangeExecutor,
+                    partitionScalingChangeExecutor,
+                    clusterChangeExecutor,
+                    modeChangeExecutor,
+                    restoreChangeExecutor)));
+  }
+
+  public void removePartitionGroupChangeExecutors(final String groupId) {
+    if (!useNewConfig) {
+      return; // noop on legacy mode
+    }
+    managerActor.run(() -> clusterConfigurationManager.removePartitionGroupChangeAppliers(groupId));
   }
 
   public void registerTopologyChangedListener(final InconsistentConfigurationListener listener) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.dynamic.config;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.Collection;
 import java.util.Set;
@@ -24,7 +23,7 @@ import java.util.Set;
  * <p>Ideally, a modifier should only update the configuration of the local member to avoid any
  * concurrent conflicting changes from other members.
  */
-public interface ClusterConfigurationModifier {
+public interface ClusterConfigurationModifier<T extends InitializableClusterConfiguration> {
 
   default ExecutionFilter filter() {
     return new ExecutionFilter(false, null);
@@ -36,7 +35,7 @@ public interface ClusterConfigurationModifier {
    * @param configuration current configuration
    * @return modified configuration
    */
-  ActorFuture<ClusterConfiguration> modify(ClusterConfiguration configuration);
+  ActorFuture<T> modify(T configuration);
 
   record ExecutionFilter(boolean coordinatorOnly, MemberId localMemberId) {
     public boolean canRunInitializer(final Collection<MemberId> clusterMembers) {
@@ -49,12 +48,13 @@ public interface ClusterConfigurationModifier {
       return coordinator.equals(localMemberId);
     }
 
-    public boolean canRunInitializer(final ClusterConfiguration configuration) {
-      return canRunInitializer(configuration.members().keySet());
+    public boolean canRunInitializer(final InitializableClusterConfiguration configuration) {
+      return canRunInitializer(configuration.getMembers());
     }
   }
 
-  abstract class CoordinatorOnly implements ClusterConfigurationModifier {
+  abstract class CoordinatorOnly<T extends InitializableClusterConfiguration>
+      implements ClusterConfigurationModifier<T> {
 
     private final ExecutionFilter filter;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterIdInitializer.java
@@ -24,7 +24,8 @@ import org.slf4j.LoggerFactory;
  * configured partition counts match).
  */
 @NullMarked
-public class ClusterIdInitializer extends ClusterConfigurationModifier.CoordinatorOnly {
+public class ClusterIdInitializer
+    extends ClusterConfigurationModifier.CoordinatorOnly<ClusterConfiguration> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterIdInitializer.class);
   private final String clusterId;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -31,7 +31,8 @@ import org.slf4j.Logger;
  * dynamic config with state ENABLED. If existing exporters are removed, they are marked as
  * CONFIG_NOT_FOUND. Note that the exporters are not removed from the dynamic config.
  */
-public class ExporterStateInitializer implements ClusterConfigurationModifier {
+public class ExporterStateInitializer
+    implements ClusterConfigurationModifier<ClusterConfiguration> {
 
   private static final Logger LOGGER = getLogger(ExporterStateInitializer.class);
   private final Set<String> configuredExporters;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
@@ -53,6 +53,7 @@ public class GatewayClusterConfigurationService extends Actor
             new ProtoBufSerializer(),
             config,
             this::updateClusterTopology,
+            null, // This should be handled in a follow up.
             topologyMetrics);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/InitializableClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/InitializableClusterConfiguration.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import java.util.Set;
+
+public interface InitializableClusterConfiguration {
+
+  boolean isUninitialized();
+
+  Set<MemberId> getMembers();
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/PartitionDistributorInitializer.java
@@ -24,7 +24,8 @@ import org.slf4j.LoggerFactory;
  * to static configuration.
  */
 @NullMarked
-public class PartitionDistributorInitializer extends ClusterConfigurationModifier.CoordinatorOnly {
+public class PartitionDistributorInitializer
+    extends ClusterConfigurationModifier.CoordinatorOnly<ClusterConfiguration> {
 
   private static final Logger LOG = LoggerFactory.getLogger(PartitionDistributorInitializer.class);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
  * enabled. All members will initialize the same routing state (as long as their statically
  * configured partition counts match).
  */
-public class RoutingStateInitializer implements ClusterConfigurationModifier {
+public class RoutingStateInitializer implements ClusterConfigurationModifier<ClusterConfiguration> {
 
   private final int staticPartitionCount;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.List;
@@ -36,6 +37,19 @@ public record StaticConfiguration(
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
     return ConfigurationUtil.getClusterConfigFrom(
         partitionDistribution, partitionConfig, clusterId);
+  }
+
+  /**
+   * Generates the multi-partition-group counterpart of {@link #generateTopology()}, used by the new
+   * configuration model. Partitions are split into groups by their {@link
+   * io.camunda.cluster.PartitionId#group()}; every configured cluster member is visible in the
+   * result regardless of partition assignment. See {@link
+   * ConfigurationUtil#getCurrentClusterConfigurationFrom} for details.
+   */
+  public CurrentClusterConfiguration generateCurrentClusterConfiguration() {
+    final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
+    return ConfigurationUtil.getCurrentClusterConfigurationFrom(
+        clusterMembers, partitionDistribution, partitionConfig, clusterId);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -57,7 +57,7 @@ public final class ClusterConfigurationGossiper
   private final Consumer<ClusterConfiguration> clusterConfigurationUpdateHandler;
   // New-model handler; when set, received gossip is delivered as a CurrentClusterConfiguration
   // (field 2, or migrated from field 1) instead of through the legacy handler.
-  private Consumer<CurrentClusterConfiguration> currentConfigurationUpdateHandler;
+  private final Consumer<CurrentClusterConfiguration> currentConfigurationUpdateHandler;
   private final TopologyMetrics topologyMetrics;
 
   public ClusterConfigurationGossiper(
@@ -67,6 +67,7 @@ public final class ClusterConfigurationGossiper
       final ClusterConfigurationSerializer serializer,
       final ClusterConfigurationGossiperConfig config,
       final Consumer<ClusterConfiguration> clusterConfigurationUpdateHandler,
+      final Consumer<CurrentClusterConfiguration> currentConfigurationUpdateHandler,
       final TopologyMetrics topologyMetrics) {
     this.executor = executor;
     this.communicationService = communicationService;
@@ -74,6 +75,7 @@ public final class ClusterConfigurationGossiper
     this.config = config;
     this.serializer = serializer;
     this.clusterConfigurationUpdateHandler = clusterConfigurationUpdateHandler;
+    this.currentConfigurationUpdateHandler = currentConfigurationUpdateHandler;
     this.topologyMetrics = topologyMetrics;
   }
 
@@ -240,15 +242,6 @@ public final class ClusterConfigurationGossiper
             onConfigurationUpdated(clusterConfiguration);
           }
         });
-  }
-
-  /**
-   * Sets the handler invoked with the received {@link CurrentClusterConfiguration} (new model).
-   * Setting it switches the receive path from the legacy handler to this one.
-   */
-  public void setCurrentConfigurationUpdateHandler(
-      final Consumer<CurrentClusterConfiguration> handler) {
-    executor.run(() -> currentConfigurationUpdateHandler = handler);
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.state;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.InitializableClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
@@ -21,6 +22,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -47,7 +49,8 @@ public record ClusterConfiguration(
     Optional<RoutingState> routingState,
     Optional<String> clusterId,
     long incarnationNumber,
-    Optional<PartitionDistributorConfig> partitionDistributorConfig) {
+    Optional<PartitionDistributorConfig> partitionDistributorConfig)
+    implements InitializableClusterConfiguration {
 
   public static final int INITIAL_VERSION = 1;
   public static final long INITIAL_INCARNATION_NUMBER = 0;
@@ -103,8 +106,14 @@ public record ClusterConfiguration(
         Optional.empty());
   }
 
+  @Override
   public boolean isUninitialized() {
     return version == UNINITIALIZED_VERSION;
+  }
+
+  @Override
+  public Set<MemberId> getMembers() {
+    return members.keySet();
   }
 
   public static ClusterConfiguration init() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.state;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.InitializableClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
 import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -48,7 +50,8 @@ public record CurrentClusterConfiguration(
     long version,
     GlobalConfiguration globalConfiguration,
     Map<String, PartitionGroupConfiguration> partitionGroups,
-    PhasedChangeState phasedChangeState) {
+    PhasedChangeState phasedChangeState)
+    implements InitializableClusterConfiguration {
 
   public static final long INITIAL_VERSION = 0;
   public static final String DEFAULT_GROUP = "default";
@@ -65,8 +68,14 @@ public record CurrentClusterConfiguration(
         INITIAL_VERSION, GlobalConfiguration.uninitialized(), Map.of(), PhasedChangeState.empty());
   }
 
+  @Override
   public boolean isUninitialized() {
     return globalConfiguration.isUninitialized();
+  }
+
+  @Override
+  public Set<MemberId> getMembers() {
+    return globalConfiguration.members().keySet();
   }
 
   /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -58,6 +58,7 @@ public record PartitionGroupConfiguration(
     Optional<ClusterChangePlan> pendingChanges,
     Optional<CompletedChange> lastChange) {
 
+  public static final long INITIAL_VERSION = 1;
   public static final long INITIAL_INCARNATION_NUMBER = 0;
 
   public PartitionGroupConfiguration {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -10,13 +10,20 @@ package io.camunda.zeebe.dynamic.config.util;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -57,6 +64,81 @@ public final class ConfigurationUtil {
         .clusterId(Optional.ofNullable(clusterId))
         .incarnationNumber(ClusterConfiguration.INITIAL_INCARNATION_NUMBER)
         .build();
+  }
+
+  /**
+   * Generates the multi-partition-group counterpart of {@link #getClusterConfigFrom}, used by the
+   * new configuration model. Every member in {@code clusterMembers} appears in the returned {@link
+   * GlobalConfiguration} as {@code ACTIVE}, regardless of whether it replicates any partition — the
+   * global configuration is the single authority for cluster membership, independent of partition
+   * assignment. {@code partitionDistribution} is split into one {@link PartitionGroupConfiguration}
+   * per distinct {@link PartitionId#group()} found in it, each with its own {@link RoutingState}
+   * initialized from that group's own partition count; only members that replicate at least one
+   * partition of a group appear in that group.
+   *
+   * <p>{@code partitionConfig} (exporter state) is applied uniformly to every partition regardless
+   * of group, since {@code StaticConfiguration} has no per-group exporter configuration yet.
+   */
+  public static CurrentClusterConfiguration getCurrentClusterConfigurationFrom(
+      final Set<MemberId> clusterMembers,
+      final Set<PartitionMetadata> partitionDistribution,
+      final DynamicPartitionConfig partitionConfig,
+      @Nullable final String clusterId) {
+    final Map<MemberId, BrokerState> brokerStates = new HashMap<>();
+    for (final var member : clusterMembers) {
+      brokerStates.put(member, BrokerState.initializeAsActive());
+    }
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            GlobalConfiguration.INITIAL_VERSION,
+            Optional.ofNullable(clusterId),
+            brokerStates,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+
+    final var partitionStatesByGroupAndMember =
+        new HashMap<String, Map<MemberId, Map<Integer, PartitionState>>>();
+    for (final var partitionMetadata : partitionDistribution) {
+      final var groupId = partitionMetadata.id().group();
+      final var partitionId = partitionMetadata.id().number();
+      for (final var member : partitionMetadata.members()) {
+        final var memberPriority = partitionMetadata.getPriority(member);
+        partitionStatesByGroupAndMember
+            .computeIfAbsent(groupId, ignored -> new HashMap<>())
+            .computeIfAbsent(member, ignored -> new HashMap<>())
+            .put(partitionId, PartitionState.active(memberPriority, partitionConfig));
+      }
+    }
+
+    final Map<String, PartitionGroupConfiguration> partitionGroups = new HashMap<>();
+    for (final var groupEntry : partitionStatesByGroupAndMember.entrySet()) {
+      final var partitionsByMember = groupEntry.getValue();
+      final Map<MemberId, BrokerPartitionState> brokerPartitionStates = new HashMap<>();
+      final var partitionIdsInGroup = new HashSet<Integer>();
+      for (final var memberEntry : partitionsByMember.entrySet()) {
+        brokerPartitionStates.put(
+            memberEntry.getKey(), BrokerPartitionState.initialize(memberEntry.getValue()));
+        partitionIdsInGroup.addAll(memberEntry.getValue().keySet());
+      }
+      final var routingState =
+          Optional.of(RoutingState.initializeWithPartitionCount(partitionIdsInGroup.size()));
+      partitionGroups.put(
+          groupEntry.getKey(),
+          new PartitionGroupConfiguration(
+              PartitionGroupConfiguration.INITIAL_VERSION,
+              PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+              brokerPartitionStates,
+              routingState,
+              Optional.empty(),
+              Optional.empty()));
+    }
+
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        partitionGroups,
+        PhasedChangeState.empty());
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -74,7 +74,8 @@ final class ClusterConfigurationInitializerTest {
   @Test
   void shouldInitializeFromExistingFile() throws IOException {
     // given
-    final var fileInitializer = new FileInitializer(topologyFile, new ProtoBufSerializer());
+    final var fileInitializer =
+        FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer());
     // write initial topology to the file
     persistedClusterConfiguration.update(initialClusterConfiguration);
     // when
@@ -87,7 +88,8 @@ final class ClusterConfigurationInitializerTest {
   @Test
   void shouldNotInitializeFromEmptyFile() {
     // given
-    final var fileInitializer = new FileInitializer(topologyFile, new ProtoBufSerializer());
+    final var fileInitializer =
+        FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer());
 
     // when
     final var initializeFuture = fileInitializer.initialize();
@@ -99,7 +101,8 @@ final class ClusterConfigurationInitializerTest {
   @Test
   void shouldNotInitializeFromCorruptedFile() throws IOException {
     // given
-    final var fileInitializer = new FileInitializer(topologyFile, new ProtoBufSerializer());
+    final var fileInitializer =
+        FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer());
     // Corrupt file
     Files.write(
         topologyFile, "random".getBytes(), StandardOpenOption.WRITE, StandardOpenOption.CREATE);
@@ -433,9 +436,10 @@ final class ClusterConfigurationInitializerTest {
     assertThatClusterTopology(initializeFuture.join()).isUninitialized();
   }
 
-  private ClusterConfigurationInitializer getStaticInitializer() {
+  private ClusterConfigurationInitializer<ClusterConfiguration> getStaticInitializer() {
     final var member = MemberId.from("10");
-    return new StaticInitializer(getStaticConfiguration(member, Set.of(member)));
+    return StaticInitializer.legacyStaticInitializer(
+        getStaticConfiguration(member, Set.of(member)));
   }
 
   private StaticConfiguration getStaticConfiguration(
@@ -485,7 +489,7 @@ final class ClusterConfigurationInitializerTest {
     void shouldInitializeFromFileWhenNotEmpty() throws IOException {
       // given
       final var fileInitializer =
-          new FileInitializer(topologyFile, new ProtoBufSerializer())
+          FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(
                   new GossipInitializer(
                       new TestClusterConfigurationNotifier(),
@@ -508,7 +512,7 @@ final class ClusterConfigurationInitializerTest {
       final TestClusterConfigurationNotifier topologyUpdateNotifier =
           new TestClusterConfigurationNotifier();
       final var initializer =
-          new FileInitializer(topologyFile, new ProtoBufSerializer())
+          FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(
                   new GossipInitializer(
                       topologyUpdateNotifier,
@@ -537,7 +541,7 @@ final class ClusterConfigurationInitializerTest {
       final TestClusterConfigurationNotifier topologyUpdateNotifier =
           new TestClusterConfigurationNotifier();
       final var initializer =
-          new FileInitializer(topologyFile, new ProtoBufSerializer())
+          FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(
                   new GossipInitializer(
                       topologyUpdateNotifier,
@@ -572,7 +576,8 @@ final class ClusterConfigurationInitializerTest {
               ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
       final var initializer =
-          new FileInitializer(topologyFile, new ProtoBufSerializer()).orThen(syncInitializer);
+          FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
+              .orThen(syncInitializer);
 
       // when
       final var initializeFuture = initializer.initialize();
@@ -603,7 +608,7 @@ final class ClusterConfigurationInitializerTest {
               ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
       final var initializer =
-          new FileInitializer(topologyFile, new ProtoBufSerializer())
+          FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer())
               .orThen(syncInitializer)
               .orThen(getStaticInitializer());
 
@@ -632,7 +637,7 @@ final class ClusterConfigurationInitializerTest {
           // member 0 was removed, member 1 last remaining in the cluster
           getStaticConfiguration(MemberId.from("1"), Set.of(MemberId.from("1")));
       final var initializer =
-          new StaticInitializer(updatedConfiguration)
+          StaticInitializer.legacyStaticInitializer(updatedConfiguration)
               .andThen(new PartitionDistributorInitializer(staticConfiguration));
 
       // when
@@ -651,7 +656,7 @@ final class ClusterConfigurationInitializerTest {
           getStaticConfiguration(
               MemberId.from("1"), Set.of(MemberId.from("0"), MemberId.from("1")));
       final var initializer =
-          new StaticInitializer(staticConfiguration)
+          StaticInitializer.legacyStaticInitializer(staticConfiguration)
               .andThen(new PartitionDistributorInitializer(staticConfiguration));
 
       // when
@@ -670,7 +675,7 @@ final class ClusterConfigurationInitializerTest {
           getStaticConfiguration(
               MemberId.from("1"), Set.of(MemberId.from("0"), MemberId.from("1")));
       final var initializer =
-          new StaticInitializer(staticConfiguration)
+          StaticInitializer.legacyStaticInitializer(staticConfiguration)
               .andThen(new ClusterIdInitializer("cluster-id-123", MemberId.from("1")));
 
       // when
@@ -708,8 +713,10 @@ final class ClusterConfigurationInitializerTest {
     @Test
     void shouldIgnoreRecoveryOnSuccess() throws IOException {
       // given
-      final var recovery = Mockito.mock(ClusterConfigurationInitializer.class);
-      final var fileInitializer = new FileInitializer(topologyFile, new ProtoBufSerializer());
+      final ClusterConfigurationInitializer<ClusterConfiguration> recovery =
+          Mockito.mock(ClusterConfigurationInitializer.class);
+      final var fileInitializer =
+          FileInitializer.legacyFileInitializer(topologyFile, new ProtoBufSerializer());
       final var recoveringInitializer =
           fileInitializer.recover(PersistedConfigurationIsBroken.class, recovery);
 
@@ -724,13 +731,13 @@ final class ClusterConfigurationInitializerTest {
     @Test
     void shouldUseChainedInitializerAfterSkippingRecovery() {
       // given
-      final ClusterConfigurationInitializer unsuccessfulInitializer =
+      final ClusterConfigurationInitializer<ClusterConfiguration> unsuccessfulInitializer =
           () -> CompletableActorFuture.completed(ClusterConfiguration.uninitialized());
 
-      final ClusterConfigurationInitializer successfulInitializer =
+      final ClusterConfigurationInitializer<ClusterConfiguration> successfulInitializer =
           () -> CompletableActorFuture.completed(initialClusterConfiguration);
 
-      final ClusterConfigurationInitializer recoveryInitializer =
+      final ClusterConfigurationInitializer<ClusterConfiguration> recoveryInitializer =
           () ->
               CompletableActorFuture.completedExceptionally(
                   new RuntimeException("shouldn't happen"));
@@ -748,15 +755,15 @@ final class ClusterConfigurationInitializerTest {
     @Test
     void shouldUseChainedInitializerAfterUnsuccessfulRecovery() {
       // given
-      final ClusterConfigurationInitializer failingInitializer =
+      final ClusterConfigurationInitializer<ClusterConfiguration> failingInitializer =
           () ->
               CompletableActorFuture.completedExceptionally(
                   new PersistedConfigurationIsBroken(topologyFile, null));
 
-      final ClusterConfigurationInitializer unsuccessfulRecovery =
+      final ClusterConfigurationInitializer<ClusterConfiguration> unsuccessfulRecovery =
           () -> CompletableActorFuture.completed(ClusterConfiguration.uninitialized());
 
-      final ClusterConfigurationInitializer finalInitializer =
+      final ClusterConfigurationInitializer<ClusterConfiguration> finalInitializer =
           () -> CompletableActorFuture.completed(initialClusterConfiguration);
 
       // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerImplNewConfigTest.java
@@ -10,6 +10,9 @@ package io.camunda.zeebe.dynamic.config;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
 import io.camunda.zeebe.dynamic.config.changes.ClusterChangeExecutor.NoopClusterChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeAppliersImpl;
@@ -50,6 +53,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -445,6 +449,41 @@ final class ClusterConfigurationManagerImplNewConfigTest {
         .isEqualTo(State.ACTIVE);
     assertThat(config.globalConfiguration().hasPendingChanges()).isFalse();
     assertThat(config.phasedChangeState().pending()).isEmpty();
+  }
+
+  @Test
+  void shouldStartFromStaticInitializer() {
+    // given — a fresh (never-started) manager and a static configuration for two members
+    final var manager = newManager(MEMBER_0);
+    final var partition =
+        new PartitionMetadata(
+            new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, 1),
+            Set.of(MEMBER_0, MEMBER_1),
+            Map.of(MEMBER_0, 1, MEMBER_1, 1),
+            1,
+            MEMBER_0);
+    final var staticConfiguration =
+        new StaticConfiguration(
+            new ControllablePartitionDistributor().withPartitions(Set.of(partition)),
+            Set.of(MEMBER_0, MEMBER_1),
+            MEMBER_0,
+            List.of(new PartitionId(CurrentClusterConfiguration.DEFAULT_GROUP, 1)),
+            1,
+            partitionConfig,
+            "cluster-x");
+
+    // when
+    manager
+        .start(new StaticInitializer<>(staticConfiguration::generateCurrentClusterConfiguration))
+        .join();
+
+    // then — the generated multi-group configuration was persisted and is retrievable
+    final var config = configuration(manager);
+    assertThat(config.globalConfiguration().members().keySet())
+        .containsExactlyInAnyOrder(MEMBER_0, MEMBER_1);
+    assertThat(config.globalConfiguration().clusterId()).contains("cluster-x");
+    assertThat(config.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members().keySet())
+        .containsExactlyInAnyOrder(MEMBER_0, MEMBER_1);
   }
 
   private static final class FailingExecutor

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
@@ -55,7 +55,7 @@ final class ClusterConfigurationManagerTest {
   private final ClusterConfiguration initialTopology =
       ClusterConfiguration.init()
           .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()));
-  private final ClusterConfigurationInitializer successInitializer =
+  private final ClusterConfigurationInitializer<ClusterConfiguration> successInitializer =
       () -> CompletableActorFuture.completed(initialTopology);
   private final MemberId localMemberId = MemberId.from("1");
 
@@ -70,13 +70,13 @@ final class ClusterConfigurationManagerTest {
   }
 
   private ActorFuture<ClusterConfigurationManagerImpl> startTopologyManager(
-      final ClusterConfigurationInitializer clusterConfigurationInitializer) {
+      final ClusterConfigurationInitializer<ClusterConfiguration> clusterConfigurationInitializer) {
     return startTopologyManager(
         clusterConfigurationInitializer, new NoopConfigurationChangeAppliers());
   }
 
   private ActorFuture<ClusterConfigurationManagerImpl> startTopologyManager(
-      final ClusterConfigurationInitializer clusterConfigurationInitializer,
+      final ClusterConfigurationInitializer<ClusterConfiguration> clusterConfigurationInitializer,
       final ConfigurationChangeAppliers operationsAppliers) {
     final var clusterTopologyManager = createTopologyManager();
 
@@ -226,7 +226,7 @@ final class ClusterConfigurationManagerTest {
     final ClusterConfiguration topologyWithPendingOperation =
         initialTopology.startConfigurationChange(
             List.of(new PartitionLeaveOperation(localMemberId, 1, 1)));
-    final ClusterConfigurationInitializer initializer =
+    final ClusterConfigurationInitializer<ClusterConfiguration> initializer =
         () -> CompletableActorFuture.completed(topologyWithPendingOperation);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -70,13 +70,13 @@ final class ClusterConfigurationGossiperTest {
             ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
     node1 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics, false);
     node2 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics, false);
     node3 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(2), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(2), clusterNodes), config, topologyMetrics, false);
 
     node1.start();
     node2.start();
@@ -107,20 +107,17 @@ final class ClusterConfigurationGossiperTest {
             Duration.ofSeconds(1));
     node1 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics, true);
     node2 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics, true);
     node3 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(2), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(2), clusterNodes), config, topologyMetrics, true);
 
     node1.start();
     node2.start();
     node3.start();
-    node1.enableNewModel();
-    node2.enableNewModel();
-    node3.enableNewModel();
 
     final var legacySeed =
         ClusterConfiguration.init().addMember(node1.id(), MemberState.initializeAsActive(Map.of()));
@@ -151,14 +148,13 @@ final class ClusterConfigurationGossiperTest {
             Duration.ofSeconds(1));
     node1 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics, false);
     node2 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics, true);
 
     node1.start();
     node2.start();
-    node2.enableNewModel();
 
     final var node1Topology =
         ClusterConfiguration.init().addMember(node1.id(), MemberState.initializeAsActive(Map.of()));
@@ -186,14 +182,13 @@ final class ClusterConfigurationGossiperTest {
             Duration.ofSeconds(1));
     node1 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics, true);
     node2 =
         new TestGossiper(
-            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics);
+            createClusterNode(clusterNodes.get(1), clusterNodes), config, topologyMetrics, false);
 
     node1.start();
     node2.start();
-    node1.enableNewModel();
 
     final var node1Configuration =
         CurrentClusterConfiguration.fromLegacy(
@@ -233,7 +228,8 @@ final class ClusterConfigurationGossiperTest {
     private TestGossiper(
         final AtomixCluster atomixCluster,
         final ClusterConfigurationGossiperConfig config,
-        final TopologyMetrics topologyMetrics) {
+        final TopologyMetrics topologyMetrics,
+        final boolean useNewModelHandler) {
       super("Node-" + atomixCluster.getMembershipService().getLocalMember().id());
       gossiper =
           new ClusterConfigurationGossiper(
@@ -242,7 +238,8 @@ final class ClusterConfigurationGossiperTest {
               atomixCluster.getMembershipService(),
               new ProtoBufSerializer(),
               config,
-              this::mergeTopology,
+              useNewModelHandler ? null : this::mergeTopology,
+              useNewModelHandler ? this::mergeCurrentClusterConfiguration : null,
               topologyMetrics);
       this.atomixCluster = atomixCluster;
     }
@@ -266,11 +263,6 @@ final class ClusterConfigurationGossiperTest {
     private ActorFuture<ClusterConfiguration> mergeTopology(final ClusterConfiguration t) {
       clusterConfiguration = clusterConfiguration == null ? t : t.merge(clusterConfiguration);
       return TestActorFuture.completedFuture(clusterConfiguration);
-    }
-
-    /** Switches this broker onto the new-model gossip path (an "upgraded" broker). */
-    void enableNewModel() {
-      gossiper.setCurrentConfigurationUpdateHandler(this::mergeCurrentClusterConfiguration);
     }
 
     void setCurrentClusterConfiguration(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -14,6 +14,7 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.PartitionStateAssert;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
@@ -279,6 +280,66 @@ class ConfigurationUtilTest {
 
     // then
     assertThat(partitionDistribution).containsExactly(partitionOne);
+  }
+
+  @Test
+  void shouldGenerateCurrentClusterConfigurationSplitByGroup() {
+    // given — two groups, "default" and "tenantA", each with their own partitions
+    final PartitionMetadata defaultPartitionOne =
+        new PartitionMetadata(
+            new PartitionId("default", 1),
+            Set.of(member(0), member(1)),
+            Map.of(member(0), 2, member(1), 1),
+            2,
+            member(0));
+    final PartitionMetadata tenantAPartitionOne =
+        new PartitionMetadata(
+            new PartitionId("tenantA", 1), Set.of(member(1)), Map.of(member(1), 1), 1, member(1));
+    final var partitionDistribution = Set.of(defaultPartitionOne, tenantAPartitionOne);
+    // member(2) is part of the cluster but replicates no partition in any group
+    final var clusterMembers = Set.of(member(0), member(1), member(2));
+
+    // when
+    final var configuration =
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            clusterMembers, partitionDistribution, partitionConfig, "clusterId");
+
+    // then — every cluster member is ACTIVE in the global configuration, regardless of partitions
+    assertThat(configuration.globalConfiguration().members().keySet())
+        .containsExactlyInAnyOrder(member(0), member(1), member(2));
+    assertThat(configuration.globalConfiguration().getMember(member(2)).state())
+        .isEqualTo(BrokerState.State.ACTIVE);
+    assertThat(configuration.globalConfiguration().clusterId()).contains("clusterId");
+
+    // and — the partition groups are split by PartitionId.group()
+    assertThat(configuration.partitionGroups()).containsOnlyKeys("default", "tenantA");
+
+    final var defaultGroup = configuration.partitionGroup("default");
+    assertThat(defaultGroup.members().keySet()).containsExactlyInAnyOrder(member(0), member(1));
+    assertThat(defaultGroup.getMember(member(0)).partitions().get(1).priority()).isEqualTo(2);
+    assertThat(defaultGroup.routingState()).isPresent();
+    assertThat(defaultGroup.routingState().orElseThrow().requestHandling().activePartitions())
+        .containsExactly(1);
+
+    final var tenantAGroup = configuration.partitionGroup("tenantA");
+    assertThat(tenantAGroup.members().keySet()).containsExactly(member(1));
+    assertThat(tenantAGroup.getMember(member(1)).partitions().get(1).priority()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldGenerateCurrentClusterConfigurationWithoutClusterId() {
+    // given
+    final PartitionMetadata partitionOne =
+        new PartitionMetadata(
+            new PartitionId(GROUP_NAME, 1), Set.of(member(0)), Map.of(member(0), 1), 1, member(0));
+
+    // when
+    final var configuration =
+        ConfigurationUtil.getCurrentClusterConfigurationFrom(
+            Set.of(member(0)), Set.of(partitionOne), partitionConfig, null);
+
+    // then
+    assertThat(configuration.globalConfiguration().clusterId()).isEmpty();
   }
 
   private MemberId member(final int id) {

--- a/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore-standalone/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -272,7 +272,7 @@ public class RestoreManager implements CloseableSilently {
             .resolve(ClusterConfigurationManagerService.TOPOLOGY_FILE_NAME);
     final var staticConfiguration =
         StaticConfigurationGenerator.getStaticConfiguration(configuration, coordinatorId);
-    final var initializer = new StaticInitializer(staticConfiguration);
+    final var initializer = new StaticInitializer<>(staticConfiguration::generateTopology);
     // it's ok to block, it's not really async
     final var base = initializer.initialize().get();
     final var changePlan =


### PR DESCRIPTION
## Summary
Stacked on #58498 (dd-58399-gossip-new-model).

- `ClusterConfigurationManagerService` now fully switches to the new multi-partition-group model when the (currently hardcoded, `false`) `USE_NEW_CONFIG` flag is on: constructs `PersistedCurrentClusterConfiguration` and the manager's new-mode constructor instead of the legacy ones, wires the gossiper's new-model send/receive path, and registers the stateless global appliers once at startup. The legacy path is completely unchanged when the flag is off.
- Adpated the existing FileInitializer and StaticInitializer to work with both legacy and the new model. The rest of the initializers will be migrated in a follow up. In this PR, both coordinator and non-coordinators initialize from the static. This is intentionally deviating from the legacy model as a temporary migration state. This gap will be closed in https://github.com/camunda/camunda/issues/58533 

Closes #58400
