### PR TITLE
fix(ci): stop paging monorepo-ci-medic for Distribution-owned AlwaysGreen failures

### DIFF
--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -229,7 +229,6 @@ jobs:
                   case "$owner" in
                     "@camunda/test-automation-team")   mentions+=("${MEDIC_TEST_AUTOMATION}") ;;
                     "@camunda/distribution")            mentions+=("${MEDIC_DISTRIBUTION}") ;;
-                    "@camunda/engineering-operations")    mentions+=("${MEDIC_DISTRIBUTION}") ;;
                     "@camunda/core-features")           mentions+=("${MEDIC_CORE_FEATURES}") ;;
                   esac
                 done <<<"$OWNERS"

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -202,11 +202,8 @@ jobs:
             # ----------------------------------------------------------------
             # Build medic pings from failure-context artifacts on the latest run.
             # ----------------------------------------------------------------
-            # Default owner: docker-build-helm-integration.yml's own TEST_OWNER
-            # is Distribution -- not monorepo-ci-medic, who has no runbook for
-            # this pipeline's plumbing and asked not to be paged case-by-case
-            # for failures they don't own (2026-07-23 #alwaysgreen-reliability
-            # thread with Christian).
+            # Default owner: this pipeline's TEST_OWNER is Distribution, not
+            # monorepo-ci-medic.
             MEDIC_PINGS="${MEDIC_DISTRIBUTION}"
 
             if [[ "${IS_STREAK}" == "true" ]]; then

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -202,7 +202,12 @@ jobs:
             # ----------------------------------------------------------------
             # Build medic pings from failure-context artifacts on the latest run.
             # ----------------------------------------------------------------
-            MEDIC_PINGS="${MEDIC_ENGINEERING_OPERATIONS}"   # default owner: pipeline plumbing
+            # Default owner: docker-build-helm-integration.yml's own TEST_OWNER
+            # is Distribution -- not monorepo-ci-medic, who has no runbook for
+            # this pipeline's plumbing and asked not to be paged case-by-case
+            # for failures they don't own (2026-07-23 #alwaysgreen-reliability
+            # thread with Christian).
+            MEDIC_PINGS="${MEDIC_DISTRIBUTION}"
 
             if [[ "${IS_STREAK}" == "true" ]]; then
               WORK_DIR="${RUNNER_TEMP}/streak-context-${BASE_REF//\//-}"
@@ -224,7 +229,7 @@ jobs:
                   case "$owner" in
                     "@camunda/test-automation-team")   mentions+=("${MEDIC_TEST_AUTOMATION}") ;;
                     "@camunda/distribution")            mentions+=("${MEDIC_DISTRIBUTION}") ;;
-                    "@camunda/engineering-operations")    mentions+=("${MEDIC_ENGINEERING_OPERATIONS}") ;;
+                    "@camunda/engineering-operations")    mentions+=("${MEDIC_DISTRIBUTION}") ;;
                     "@camunda/core-features")           mentions+=("${MEDIC_CORE_FEATURES}") ;;
                   esac
                 done <<<"$OWNERS"

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -1094,20 +1094,11 @@ jobs:
           FAILURE_CATEGORY="none"
 
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            if [[ "${{ steps.wait-downstream.outputs.downstream_conclusion }}" == "failure" ]]; then
-              OWNER_TEAM="@camunda/test-automation-team"
-              FAILURE_CATEGORY="saas_e2e"
-            else
-              # This job's own dispatch/wait mechanism (timeout budget,
-              # gh api auth, etc.) is part of THIS workflow, owned by
-              # Distribution (see TEST_OWNER above) -- monorepo-ci-medic
-              # doesn't own or have a runbook for it. Confirmed noisy in
-              # practice: this branch fires whenever the wait simply times
-              # out while the downstream run is still legitimately in
-              # progress, not just on a real dispatch failure.
-              OWNER_TEAM="@camunda/distribution"
-              FAILURE_CATEGORY="orchestration_dispatch_or_wait"
-            fi
+            # SaaS E2E is owned end-to-end by test-automation-team, including
+            # this job's own dispatch/wait mechanism -- always route here
+            # rather than splitting on downstream_conclusion.
+            OWNER_TEAM="@camunda/test-automation-team"
+            FAILURE_CATEGORY="saas_e2e"
           fi
 
           jq -n \

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -72,7 +72,11 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/engineering-operations"
+            # This whole workflow is owned by Distribution (see TEST_OWNER
+            # above) -- a should-run gate failure is this pipeline's own
+            # plumbing, not something the monorepo-ci-medic has a runbook
+            # for. Route to the actual owner instead.
+            OWNER_TEAM="@camunda/distribution"
             FAILURE_CATEGORY="orchestration_should_run"
           fi
           jq -n \
@@ -560,7 +564,9 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/engineering-operations"
+            # Same reasoning as should-run above: this pipeline's own
+            # plumbing is Distribution's to fix, not monorepo-ci-medic's.
+            OWNER_TEAM="@camunda/distribution"
             FAILURE_CATEGORY="orchestration_identifier"
           fi
           jq -n \
@@ -1014,13 +1020,14 @@ jobs:
                 # The artifact was unreachable. Distinguish this from a
                 # genuinely "unknown" categorisation so consumers don't
                 # confuse "we couldn't tell" with "we tried and the data
-                # was ambiguous". Routing falls to monorepo-ci-medic since
-                # this is an integration / permissions problem with the
-                # parent workflow, not a downstream test failure.
+                # was ambiguous". This is an integration / permissions
+                # problem with the parent workflow (owned by Distribution,
+                # see TEST_OWNER above) -- not a downstream test failure,
+                # and not something monorepo-ci-medic has a runbook for.
                 DOWNLOAD_ERR=$(tr '\n' ' ' < "$DOWNLOAD_LOG" 2>/dev/null | sed 's/  */ /g' | cut -c1-300)
                 echo "::warning::Could not download downstream json-report artifact: ${DOWNLOAD_ERR:-no stderr}" >&2
                 DOWNSTREAM_CATEGORY="unknown_artifact_unreachable"
-                DOWNSTREAM_OWNER="@camunda/engineering-operations"
+                DOWNSTREAM_OWNER="@camunda/distribution"
                 {
                   echo "### Downstream Category Unavailable"
                   echo ""
@@ -1091,7 +1098,14 @@ jobs:
               OWNER_TEAM="@camunda/test-automation-team"
               FAILURE_CATEGORY="saas_e2e"
             else
-              OWNER_TEAM="@camunda/engineering-operations"
+              # This job's own dispatch/wait mechanism (timeout budget,
+              # gh api auth, etc.) is part of THIS workflow, owned by
+              # Distribution (see TEST_OWNER above) -- monorepo-ci-medic
+              # doesn't own or have a runbook for it. Confirmed noisy in
+              # practice: this branch fires whenever the wait simply times
+              # out while the downstream run is still legitimately in
+              # progress, not just on a real dispatch failure.
+              OWNER_TEAM="@camunda/distribution"
               FAILURE_CATEGORY="orchestration_dispatch_or_wait"
             fi
           fi


### PR DESCRIPTION
## Summary

Per feedback from Christian in #alwaysgreen-reliability ("10+ unactionable pings" over 24h), the Monorepo CI medic (`@camunda/engineering-operations`) was being paged for failures it doesn't own and has no runbook for. His stated criteria:

> The Monorepo CI medic should only receive pings when they are the owner of a CI job which is failing inside camunda/camunda, and there is a runbook on how to act on that failure.

## Changes

**`docker-build-helm-integration.yml`**
- `should-run` gate failure → `@camunda/distribution` (`orchestration_should_run`)
- `format-identifier` job failure → `@camunda/distribution` (`orchestration_identifier`)
- downstream artifact-unreachable case → `@camunda/distribution` (`unknown_artifact_unreachable`)
- `Trigger SaaS E2E tests` job failure → **always** `@camunda/test-automation-team` (`saas_e2e`), regardless of whether it's a real downstream test failure or the job's own dispatch/wait mechanism — test-automation-team owns this job end-to-end, so the previous split that sent dispatch/wait timeouts to Distribution has been removed

**`alwaysgreen-streak-detector.yml`**
- default `MEDIC_PINGS` fallback now points to `MEDIC_DISTRIBUTION` instead of `MEDIC_ENGINEERING_OPERATIONS`
- removed the now-unreachable `@camunda/engineering-operations` case-statement arm entirely (the parent workflow never emits that owner value anymore, so there's nothing to defend against)

Applies uniformly to `main` and all monitored stable branches (`stable/8.7`, `stable/8.8`, `stable/8.9`) — these are workflow-file-level fixes with no branch-specific logic.

## Test plan
- [x] YAML syntax validated for both files
- [x] Confirmed zero remaining `@camunda/engineering-operations` owner assignments in `docker-build-helm-integration.yml`
- [ ] Watch next scheduled `alwaysgreen-streak-detector.yml` run / next `docker-build-helm-integration.yml` failure to confirm pings route correctly