### PR TITLE
fix(ci): stop paging monorepo-ci-medic for Distribution-owned AlwaysGreen failures (stable/8.8)

### DIFF
--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -316,9 +316,6 @@ jobs:
               "@camunda/distribution")
                 mentions+=("${MEDIC_DISTRIBUTION}")
                 ;;
-              "@camunda/engineering-operations")
-                mentions+=("${MEDIC_ENGINEERING_OPERATIONS}")
-                ;;
               "@camunda/core-features")
                 mentions+=("${MEDIC_CORE_FEATURES}")
                 ;;
@@ -327,10 +324,9 @@ jobs:
 
           # If no failure context was attributable to a team (e.g. the
           # parent run died before any job emitted context), default to
-          # pinging the monorepo-ci-medic since they own the workflow
-          # plumbing itself.
+          # Distribution -- this pipeline's TEST_OWNER, not monorepo-ci-medic.
           if (( ${#mentions[@]} == 0 )); then
-            mentions+=("${MEDIC_ENGINEERING_OPERATIONS}")
+            mentions+=("${MEDIC_DISTRIBUTION}")
           fi
 
           # Dedup + join with spaces for the Slack message body.

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -72,7 +72,11 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/engineering-operations"
+            # This whole workflow is owned by Distribution (see TEST_OWNER
+            # above) -- a should-run gate failure is this pipeline's own
+            # plumbing, not something the monorepo-ci-medic has a runbook
+            # for. Route to the actual owner instead.
+            OWNER_TEAM="@camunda/distribution"
             FAILURE_CATEGORY="orchestration_should_run"
           fi
           jq -n \
@@ -578,7 +582,9 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/engineering-operations"
+            # Same reasoning as should-run above: this pipeline's own
+            # plumbing is Distribution's to fix, not monorepo-ci-medic's.
+            OWNER_TEAM="@camunda/distribution"
             FAILURE_CATEGORY="orchestration_identifier"
           fi
           jq -n \
@@ -1024,13 +1030,14 @@ jobs:
                 # The artifact was unreachable. Distinguish this from a
                 # genuinely "unknown" categorisation so consumers don't
                 # confuse "we couldn't tell" with "we tried and the data
-                # was ambiguous". Routing falls to monorepo-ci-medic since
-                # this is an integration / permissions problem with the
-                # parent workflow, not a downstream test failure.
+                # was ambiguous". This is an integration / permissions
+                # problem with the parent workflow (owned by Distribution,
+                # see TEST_OWNER above) -- not a downstream test failure,
+                # and not something monorepo-ci-medic has a runbook for.
                 DOWNLOAD_ERR=$(tr '\n' ' ' < "$DOWNLOAD_LOG" 2>/dev/null | sed 's/  */ /g' | cut -c1-300)
                 echo "::warning::Could not download downstream json-report artifact: ${DOWNLOAD_ERR:-no stderr}" >&2
                 DOWNSTREAM_CATEGORY="unknown_artifact_unreachable"
-                DOWNSTREAM_OWNER="@camunda/engineering-operations"
+                DOWNSTREAM_OWNER="@camunda/distribution"
                 {
                   echo "### Downstream Category Unavailable"
                   echo ""
@@ -1097,13 +1104,11 @@ jobs:
           FAILURE_CATEGORY="none"
 
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            if [[ "${{ steps.wait-downstream.outputs.downstream_conclusion }}" == "failure" ]]; then
-              OWNER_TEAM="@camunda/test-automation-team"
-              FAILURE_CATEGORY="saas_e2e"
-            else
-              OWNER_TEAM="@camunda/engineering-operations"
-              FAILURE_CATEGORY="orchestration_dispatch_or_wait"
-            fi
+            # SaaS E2E is owned end-to-end by test-automation-team, including
+            # this job's own dispatch/wait mechanism -- always route here
+            # rather than splitting on downstream_conclusion.
+            OWNER_TEAM="@camunda/test-automation-team"
+            FAILURE_CATEGORY="saas_e2e"
           fi
 
           jq -n \


### PR DESCRIPTION
Backport of #58539 to stable/8.8.

Per feedback from Christian in #alwaysgreen-reliability, the Monorepo CI medic (`@camunda/engineering-operations`) should only be paged for failures it owns and has a runbook for. This branch's copies of `docker-build-helm-integration.yml` and `alwaysgreen-streak-detector.yml` had the same hardcoded routing to CI medic as `main` did, so they need the same fix:

- `should-run` / `format-identifier` / `artifact-unreachable` failures → `@camunda/distribution` (this pipeline's `TEST_OWNER`)
- `Trigger SaaS E2E tests` job failures → always `@camunda/test-automation-team` (owns that job end-to-end, no more split on dispatch/wait vs. downstream test failure)
- streak detector default medic ping + owner-to-medic case mapping → `@camunda/distribution` instead of monorepo-ci-medic

## Test plan
- [x] YAML syntax validated for both files
- [x] Confirmed zero remaining `@camunda/engineering-operations` owner assignments