### PR TITLE
feat: Add storageOrdinalKey to Related Records

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/agentinstance/ZeebeAgentInstanceDataDto.java
@@ -96,6 +96,11 @@ public class ZeebeAgentInstanceDataDto implements AgentInstanceRecordValue {
     return rootProcessInstanceKey;
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
   public void setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     this.rootProcessInstanceKey = rootProcessInstanceKey;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
@@ -113,6 +113,11 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
     return -1L; // Not used in Optimize
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
   public void setVariableScopeKey(final long variableScopeKey) {
     this.variableScopeKey = variableScopeKey;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -135,6 +135,11 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
     return ""; // not used in Optimize
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
   public void setParentElementInstanceKey(final long parentElementInstanceKey) {
     this.parentElementInstanceKey = parentElementInstanceKey;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -166,6 +166,11 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
     return ""; // not used in Optimize
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
   public void setTags(final Set<String> tags) {
     this.tags = tags;
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/variable/ZeebeVariableDataDto.java
@@ -85,6 +85,11 @@ public class ZeebeVariableDataDto implements VariableRecordValue {
     return null; // not used in Optimize
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return -1; // not used in Optimize
+  }
+
   public void setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
   }

--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolArchTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.AuditLogProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.WaitStateRelated;
 import java.lang.reflect.Method;
@@ -86,6 +87,7 @@ final class ImmutableProtocolArchTest {
 
   private DescribedPredicate<JavaClass> getExcludedClasses() {
     return Predicates.equivalentTo(ProcessInstanceRelated.class)
+        .or(Predicates.equivalentTo(StorageOrdinalKeyRelated.class))
         .or(Predicates.equivalentTo(BatchOperationRelated.class))
         .or(Predicates.equivalentTo(TenantOwned.class))
         .or(Predicates.equivalentTo(WaitStateRelated.class))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -302,9 +302,9 @@ public final class CreateBatchOperationTest extends AbstractBatchOperationTest {
                 .onlyEvents()
                 .limitByCount(
                     record -> record.getIntent().equals(BatchOperationIntent.INITIALIZING),
-                    4)) // reduce to 5000, 2500, 1250 and then one more init-phase
+                    4)) // reduce to 5000, 2500, 1250, 625 and then one more init-phase
         .extracting(r -> r.getValue().getSearchQueryPageSize())
-        .containsSequence(5000, 2500, 1250, 1250);
+        .containsSequence(5000, 2500, 1250, 625);
 
     assertThat(
             RecordingExporter.batchOperationExecutionRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
@@ -248,5 +248,10 @@ public final class BanInstanceTest {
     public long getProcessDefinitionKey() {
       return -1L;
     }
+
+    @Override
+    public int getStorageOrdinalKey() {
+      return 0;
+    }
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -38,6 +39,7 @@ final class BulkIndexRequest {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
+          .addMixIn(StorageOrdinalKeyRelated.class, StorageOrdinalKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,6 +52,7 @@ final class BulkIndexRequest {
           .addMixIn(UserTaskRecordValue.class, BusinessIdMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, BusinessIdMixin.class)
           .addMixIn(ClusterVariableRecordValue.class, ClusterVariableMixin.class)
+          .addMixIn(StorageOrdinalKeyRelated.class, StorageOrdinalKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -69,6 +72,7 @@ final class BulkIndexRequest {
   private static final String WITH_LEASE_PROPERTY = "withLease";
   private static final String METADATA_PROPERTY = "metadata";
   private static final String KIND_PROPERTY = "kind";
+  private static final String STORAGE_ORDINAL_KEY_PROPERTY = "storageOrdinalKey";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -193,17 +197,28 @@ final class BulkIndexRequest {
     ELEMENT_TYPE_PROPERTY,
     BUSINESS_ID_PROPERTY,
     LEASE_TOKEN_PROPERTY,
-    SECRET_REFERENCES_PROPERTY
+    SECRET_REFERENCES_PROPERTY,
+    STORAGE_ORDINAL_KEY_PROPERTY
   })
   private static final class JobMixin {}
 
   @JsonIgnoreProperties({WITH_LEASE_PROPERTY})
   private static final class JobBatchMixin {}
 
-  /** Shared by record values that only need to strip {@code businessId} for previous versions. */
-  @JsonIgnoreProperties({BUSINESS_ID_PROPERTY})
+  /**
+   * Shared by record values that need to strip {@code businessId} and {@code storageOrdinalKey} for
+   * previous versions.
+   */
+  @JsonIgnoreProperties({BUSINESS_ID_PROPERTY, STORAGE_ORDINAL_KEY_PROPERTY})
   private static final class BusinessIdMixin {}
 
   @JsonIgnoreProperties({METADATA_PROPERTY, KIND_PROPERTY, SECRET_REFERENCES_PROPERTY})
   private static final class ClusterVariableMixin {}
+
+  /**
+   * The storage ordinal key is only used to route a record's document to its storage location; it
+   * must not be stored in the document itself.
+   */
+  @JsonIgnoreProperties({STORAGE_ORDINAL_KEY_PROPERTY})
+  private static final class StorageOrdinalKeyMixin {}
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -92,7 +93,19 @@ final class BulkIndexRequestTest {
     recordAsMap.remove("agent");
     recordAsMap.remove("requestChannelType");
     recordAsMap.remove("requestToolName");
+    // the storage ordinal key is stripped from every record value during serialization; it can
+    // appear at any nesting level (e.g. embedded job records), so remove it recursively
+    removeStorageOrdinalKeys(recordAsMap);
     return MAPPER.writeValueAsBytes(recordAsMap).length;
+  }
+
+  private static void removeStorageOrdinalKeys(final Object node) {
+    if (node instanceof final Map<?, ?> map) {
+      map.remove("storageOrdinalKey");
+      map.values().forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+    } else if (node instanceof final Collection<?> collection) {
+      collection.forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+    }
   }
 
   @Test

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.StorageOrdinalKeyRelated;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
@@ -38,6 +39,7 @@ final class BulkIndexRequest {
           .addMixIn(Record.class, RecordSequenceMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
+          .addMixIn(StorageOrdinalKeyRelated.class, StorageOrdinalKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   private static final ObjectMapper PREVIOUS_VERSION_MAPPER =
@@ -50,6 +52,7 @@ final class BulkIndexRequest {
           .addMixIn(UserTaskRecordValue.class, BusinessIdMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, BusinessIdMixin.class)
           .addMixIn(ClusterVariableRecordValue.class, ClusterVariableMixin.class)
+          .addMixIn(StorageOrdinalKeyRelated.class, StorageOrdinalKeyMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
 
   // The property of the ES record template to store the sequence of the record.
@@ -69,6 +72,7 @@ final class BulkIndexRequest {
   private static final String WITH_LEASE_PROPERTY = "withLease";
   private static final String METADATA_PROPERTY = "metadata";
   private static final String KIND_PROPERTY = "kind";
+  private static final String STORAGE_ORDINAL_KEY_PROPERTY = "storageOrdinalKey";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -193,17 +197,28 @@ final class BulkIndexRequest {
     ELEMENT_TYPE_PROPERTY,
     BUSINESS_ID_PROPERTY,
     LEASE_TOKEN_PROPERTY,
-    SECRET_REFERENCES_PROPERTY
+    SECRET_REFERENCES_PROPERTY,
+    STORAGE_ORDINAL_KEY_PROPERTY
   })
   private static final class JobMixin {}
 
   @JsonIgnoreProperties({WITH_LEASE_PROPERTY})
   private static final class JobBatchMixin {}
 
-  /** Shared by record values that only need to strip {@code businessId} for previous versions. */
-  @JsonIgnoreProperties({BUSINESS_ID_PROPERTY})
+  /**
+   * Shared by record values that need to strip {@code businessId} and {@code storageOrdinalKey} for
+   * previous versions.
+   */
+  @JsonIgnoreProperties({BUSINESS_ID_PROPERTY, STORAGE_ORDINAL_KEY_PROPERTY})
   private static final class BusinessIdMixin {}
 
   @JsonIgnoreProperties({METADATA_PROPERTY, KIND_PROPERTY, SECRET_REFERENCES_PROPERTY})
   private static final class ClusterVariableMixin {}
+
+  /**
+   * The storage ordinal key is only used to route a record's document to its storage location; it
+   * must not be stored in the document itself.
+   */
+  @JsonIgnoreProperties({STORAGE_ORDINAL_KEY_PROPERTY})
+  private static final class StorageOrdinalKeyMixin {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -92,7 +93,19 @@ final class BulkIndexRequestTest {
     recordAsMap.remove("agent");
     recordAsMap.remove("requestChannelType");
     recordAsMap.remove("requestToolName");
+    // the storage ordinal key is stripped from every record value during serialization; it can
+    // appear at any nesting level (e.g. embedded job records), so remove it recursively
+    removeStorageOrdinalKeys(recordAsMap);
     return MAPPER.writeValueAsBytes(recordAsMap).length;
+  }
+
+  private static void removeStorageOrdinalKeys(final Object node) {
+    if (node instanceof final Map<?, ?> map) {
+      map.remove("storageOrdinalKey");
+      map.values().forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+    } else if (node instanceof final Collection<?> collection) {
+      collection.forEach(BulkIndexRequestTest::removeStorageOrdinalKeys);
+    }
   }
 
   @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -35,6 +35,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
@@ -66,12 +67,13 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public AgentHistoryRecord() {
-    super(24);
+    super(25);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
@@ -374,6 +376,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public AgentHistoryRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agentinstance/AgentInstanceRecord.java
@@ -49,6 +49,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
@@ -76,13 +77,14 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(21);
+    super(22);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
@@ -322,6 +324,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
     elementInstanceKeysProp.add().setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -19,15 +20,20 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     implements BatchOperationChunkRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_ITEMS_LIST = "items";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final ArrayProperty<BatchOperationItem> itemsProp =
       new ArrayProperty<>(PROP_ITEMS_LIST, BatchOperationItem::new);
 
   public BatchOperationChunkRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemsProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
+        .declareProperty(itemsProp);
   }
 
   @Override
@@ -38,6 +44,16 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   public BatchOperationChunkRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationChunkRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -54,6 +70,7 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
 
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setItems(record.getItems());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
@@ -31,6 +32,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     implements BatchOperationCreationRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_BATCH_OPERATION_TYPE = "batchOperationType";
   public static final String PROP_ENTITY_FILTER = "entityFilter";
   public static final String PROP_MIGRATION_PLAN = "migrationPlan";
@@ -42,6 +44,8 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public static final String PROP_FOLLOWUP_COMMAND = "followUpCommand";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
       new EnumProperty<>(PROP_BATCH_OPERATION_TYPE, BatchOperationType.class);
   private final BinaryProperty entityFilterProp =
@@ -64,8 +68,9 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
       new ObjectProperty<>(PROP_FOLLOWUP_COMMAND, new NestedRecord());
 
   public BatchOperationCreationRecord() {
-    super(10);
+    super(11);
     declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(entityFilterProp)
         .declareProperty(migrationPlanProp)
@@ -85,6 +90,16 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public BatchOperationCreationRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -193,6 +208,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
 
   public BatchOperationCreationRecord wrap(final BatchOperationCreationRecord record) {
     batchOperationKeyProp.setValue(record.getBatchOperationKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     batchOperationTypeProp.setValue(record.getBatchOperationType());
     entityFilterProp.setValue(record.getEntityFilterBuffer());
     migrationPlanProp.getValue().wrap(record.getMigrationPlan());

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -19,15 +20,20 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
     implements BatchOperationExecutionRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_ITEM_KEY_LIST = "itemKeys";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final ArrayProperty<LongValue> itemKeysProp =
       new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
 
   public BatchOperationExecutionRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
+        .declareProperty(itemKeysProp);
   }
 
   @Override
@@ -38,6 +44,16 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   public BatchOperationExecutionRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationExecutionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -54,6 +70,7 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
 
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setItemKeys(record.getItemKeys());
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationInitializationRecord.java
@@ -19,10 +19,13 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
     implements BatchOperationInitializationRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_SEARCH_RESULT_CURSOR_KEY = "searchResultCursor";
   public static final String PROP_SEARCH_QUERY_PAGE_SIZE = "searchQueryPageSize";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
 
   private final StringProperty searchResultCursorProp =
       new StringProperty(PROP_SEARCH_RESULT_CURSOR_KEY, "");
@@ -30,8 +33,9 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
       new IntegerProperty(PROP_SEARCH_QUERY_PAGE_SIZE, 0);
 
   public BatchOperationInitializationRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(searchResultCursorProp)
         .declareProperty(searchQueryPageSize);
   }
@@ -44,6 +48,16 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
   public BatchOperationInitializationRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationInitializationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -71,6 +85,7 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
 
   public void wrap(final BatchOperationInitializationRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setSearchResultCursor(record.getSearchResultCursor());
     setSearchQueryPageSize(record.getSearchQueryPageSize());
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationItem.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
@@ -18,12 +19,15 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
       new LongProperty("processInstanceKey", -1);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty("rootProcessInstanceKey", -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
 
   public BatchOperationItem() {
-    super(3);
+    super(4);
     declareProperty(itemKeyProperty)
         .declareProperty(processInstanceKeyProperty)
-        .declareProperty(rootProcessInstanceKeyProperty);
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   public BatchOperationItem(
@@ -64,10 +68,21 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
     return this;
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
+  }
+
   public BatchOperationItem wrap(final BatchOperationItemValue value) {
     setItemKey(value.getItemKey());
     setProcessInstanceKey(value.getProcessInstanceKey());
     setRootProcessInstanceKey(value.getRootProcessInstanceKey());
+    setStorageOrdinalKey(value.getStorageOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationLifecycleManagementRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -18,15 +19,19 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
     implements BatchOperationLifecycleManagementRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
 
   private final ArrayProperty<BatchOperationError> errorsProp =
       new ArrayProperty<>("errors", BatchOperationError::new);
 
   public BatchOperationLifecycleManagementRecord() {
-    super(2);
+    super(3);
     declareProperty(batchOperationKeyProp);
+    declareProperty(storageOrdinalKeyProp);
     declareProperty(errorsProp);
   }
 
@@ -42,9 +47,20 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
     return this;
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationLifecycleManagementRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
   public BatchOperationLifecycleManagementRecord wrap(
       final BatchOperationLifecycleManagementRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setErrors(record.getErrors().stream().map(BatchOperationError.class::cast).toList());
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationPartitionLifecycleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationPartitionLifecycleRecord.java
@@ -17,17 +17,21 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
     implements BatchOperationPartitionLifecycleRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_SOURCE_PARTITION_ID = "sourcePartitionId";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final IntegerProperty sourcePartitionIdProp =
       new IntegerProperty(PROP_SOURCE_PARTITION_ID, -1);
   private final ObjectProperty<BatchOperationError> errorProp =
       new ObjectProperty<>("error", new BatchOperationError());
 
   public BatchOperationPartitionLifecycleRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp);
+    declareProperty(storageOrdinalKeyProp);
     declareProperty(sourcePartitionIdProp);
     declareProperty(errorProp);
   }
@@ -40,6 +44,16 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
   public BatchOperationPartitionLifecycleRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationPartitionLifecycleRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -66,6 +80,7 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
   public BatchOperationPartitionLifecycleRecord wrap(
       final BatchOperationPartitionLifecycleRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setSourcePartitionId(record.getSourcePartitionId());
     setError(record.getError());
     return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/conditional/ConditionalSubscriptionRecord.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -42,6 +43,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   // default to -1 for root level start events
@@ -64,11 +66,13 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ConditionalSubscriptionRecord() {
-    super(13);
+    super(14);
     declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -81,6 +85,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(variableEventsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(elementTypeProp);
   }
 
@@ -97,6 +102,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     setVariableEvents(record.getVariableEvents());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     elementTypeProp.setValue(record.getElementType());
   }
 
@@ -266,6 +272,16 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
 
   public ConditionalSubscriptionRecord setRootProcessInstanceKey(final long key) {
     rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -62,10 +62,11 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty businessIdProp = new StringProperty("businessId", "");
 
   public DecisionEvaluationRecord() {
-    super(19);
+    super(20);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -84,6 +85,7 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
         .declareProperty(failedDecisionIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -365,6 +367,16 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.incident;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
@@ -43,6 +44,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   private static final StringValue PROCESS_DEFINITION_PATH_KEY =
       new StringValue("processDefinitionPath");
   private static final StringValue CALLING_ELEMENT_PATH_KEY = new StringValue("callingElementPath");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final EnumProperty<ErrorType> errorTypeProp =
       new EnumProperty<>(ERROR_TYPE_KEY, ErrorType.class, ErrorType.UNKNOWN);
@@ -52,6 +54,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final LongProperty processInstanceKeyProp =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final LongProperty elementInstanceKeyProp =
       new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
@@ -67,12 +71,13 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new ArrayProperty<>(CALLING_ELEMENT_PATH_KEY, IntegerValue::new);
 
   public IncidentRecord() {
-    super(13);
+    super(14);
     declareProperty(errorTypeProp)
         .declareProperty(errorMessageProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(jobKeyProp)
@@ -89,6 +94,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     bpmnProcessIdProp.setValue(record.getBpmnProcessIdBuffer());
     processDefinitionKeyProp.setValue(record.getProcessDefinitionKey());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     elementIdProp.setValue(record.getElementIdBuffer());
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     jobKeyProp.setValue(record.getJobKey());
@@ -279,6 +285,16 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public IncidentRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -100,6 +100,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private static final StringValue LEASE_TOKEN_KEY = new StringValue("leaseToken");
@@ -149,6 +150,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
   private final StringProperty leaseTokenProp = new StringProperty(LEASE_TOKEN_KEY, EMPTY_STRING);
@@ -156,7 +159,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new ArrayProperty<>(SECRET_REFERENCES_KEY, JobSecretReference::new);
 
   public JobRecord() {
-    super(30);
+    super(31);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -183,6 +186,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(priorityProp)
         .declareProperty(businessIdProp)
         .declareProperty(leaseTokenProp)
@@ -217,6 +221,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     priorityProp.setValue(record.getPriority());
     businessIdProp.setValue(record.getBusinessIdBuffer());
     leaseTokenProp.setValue(record.getLeaseTokenBuffer());
@@ -612,6 +617,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @JsonIgnore
   public DirectBuffer getLeaseTokenBuffer() {
     return leaseTokenProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public JobRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
@@ -36,6 +36,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
@@ -52,10 +53,12 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageCorrelationRecord() {
-    super(10);
+    super(11);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(variablesProp)
@@ -65,6 +68,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
         .declareProperty(requestStreamIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -74,6 +78,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
     setProcessInstanceKey(record.getProcessInstanceKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setBusinessId(record.getBusinessIdBuffer());
   }
 
@@ -200,5 +205,15 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public MessageCorrelationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -43,6 +44,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
@@ -62,11 +64,13 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public MessageSubscriptionRecord() {
-    super(14);
+    super(15);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -80,6 +84,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(businessIdProp)
         .declareProperty(elementIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(elementTypeProp);
   }
 
@@ -97,6 +102,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBusinessId(record.getBusinessIdBuffer());
     setElementId(record.getElementIdBuffer());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setElementType(record.getElementType());
   }
 
@@ -278,5 +284,15 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -44,6 +44,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
@@ -64,12 +65,14 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ProcessMessageSubscriptionRecord() {
-    super(15);
+    super(16);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -83,6 +86,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
         .declareProperty(elementTypeProp);
   }
@@ -101,6 +105,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setBusinessId(record.getBusinessIdBuffer());
     setElementType(record.getElementType());
   }
@@ -288,5 +293,15 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -33,14 +34,18 @@ public final class ProcessEventRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProperty =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
+
   public ProcessEventRecord() {
-    super(6);
+    super(7);
     declareProperty(scopeKeyProperty)
         .declareProperty(targetElementIdProperty)
         .declareProperty(variablesProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
-        .declareProperty(tenantIdProperty);
+        .declareProperty(tenantIdProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   public ProcessEventRecord wrap(final ProcessEventRecord record) {
@@ -50,6 +55,7 @@ public final class ProcessEventRecord extends UnifiedRecordValue
     processDefinitionKeyProperty.setValue(record.getProcessDefinitionKey());
     processInstanceKeyProperty.setValue(record.getProcessInstanceKey());
     tenantIdProperty.setValue(record.getTenantId());
+    storageOrdinalKeyProperty.setValue(record.getStorageOrdinalKey());
 
     return this;
   }
@@ -121,6 +127,16 @@ public final class ProcessEventRecord extends UnifiedRecordValue
 
   public ProcessEventRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessEventRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
@@ -36,12 +37,16 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
    */
   private final LongProperty indexProperty = new LongProperty("index", -1L);
 
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
+
   public ProcessInstanceBatchRecord() {
-    super(4);
+    super(5);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(batchElementInstanceKeyProperty)
-        .declareProperty(indexProperty);
+        .declareProperty(indexProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -88,5 +93,15 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
     return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBufferedCommandRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBufferedCommandRecord.java
@@ -35,6 +35,7 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
   private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
@@ -48,19 +49,22 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
   private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
 
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
   public ProcessInstanceBufferedCommandRecord() {
-    super(7);
+    super(8);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(commandKeyProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
-        .declareProperty(commandValueProperty);
+        .declareProperty(commandValueProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -173,6 +177,16 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
 
     commandValue.write(valueBuffer, 0);
     commandValueProperty.getValue().read(commandValueReader.wrap(valueBuffer, 0, encodedLength));
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBusinessIdRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBusinessIdRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -25,6 +26,7 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
@@ -36,16 +38,19 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   public ProcessInstanceBusinessIdRecord() {
-    super(6);
+    super(7);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(businessIdProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(bpmnProcessIdProperty);
   }
@@ -88,6 +93,16 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
   public ProcessInstanceBusinessIdRecord setRootProcessInstanceKey(
       final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -47,6 +47,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue TAGS_KEY = new StringValue("tags");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
@@ -71,10 +72,12 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceCreationRecord() {
-    super(12);
+    super(13);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -86,6 +89,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(businessIdProperty);
   }
 
@@ -292,5 +296,15 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProperty.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceCreationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceMigrationRecord.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -31,6 +32,7 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringValue("mappingInstructions");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
@@ -47,17 +49,20 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   public ProcessInstanceMigrationRecord() {
-    super(7);
+    super(8);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(bpmnProcessIdProperty);
   }
@@ -153,6 +158,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   public ProcessInstanceMigrationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -37,6 +38,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new StringValue("activatedElementInstanceKeys");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
@@ -64,9 +66,11 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceModificationRecord() {
-    super(9);
+    super(10);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
@@ -74,6 +78,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .declareProperty(activatedElementInstanceKeys)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(bpmnProcessIdProperty);
   }
@@ -251,6 +256,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
 
   public ProcessInstanceModificationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -58,6 +58,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
+  public static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
@@ -97,10 +98,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY, -1L);
 
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
+
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceRecord() {
-    super(17);
+    super(18);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -117,6 +121,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -133,6 +138,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     parentElementInstanceKeyProp.setValue(record.getParentElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     businessIdProp.setValue(record.getBusinessId());
   }
 
@@ -348,6 +354,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
     bpmnProcessIdProp.setValue(directBuffer);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -40,6 +40,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  public static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -53,9 +54,11 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceResultRecord() {
-    super(8);
+    super(9);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -63,7 +66,8 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(variablesProperty)
         .declareProperty(tagsProperty)
-        .declareProperty(businessIdProperty);
+        .declareProperty(businessIdProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -174,6 +178,16 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
 
   public ProcessInstanceResultRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceResultRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/RuntimeInstructionRecord.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -25,13 +26,16 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1);
   private final StringProperty tenantIdProperty = new StringProperty("tenantId", "");
   private final StringProperty elementIdProperty = new StringProperty("elementId", "");
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
 
   public RuntimeInstructionRecord() {
-    super(4);
+    super(5);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(tenantIdProperty)
-        .declareProperty(elementIdProperty);
+        .declareProperty(elementIdProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -77,5 +81,15 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProperty.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public RuntimeInstructionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.resource;
 
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -27,6 +28,7 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue DELETE_HISTORY_KEY = new StringValue("deleteHistory");
   private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
+  private static final StringValue STORAGE_ORDINAL_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BATCH_OPERATION_TYPE = new StringValue("batchOperationType");
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
   private static final StringValue RESOURCE_ID = new StringValue("resourceId");
@@ -35,6 +37,7 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
   private final BooleanProperty deleteHistoryProp = new BooleanProperty(DELETE_HISTORY_KEY, false);
   private final LongProperty batchOperationKeyProp = new LongProperty(BATCH_OPERATION_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty(STORAGE_ORDINAL_KEY, 0);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
       new EnumProperty<>(
           BATCH_OPERATION_TYPE,
@@ -45,11 +48,12 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID, "");
 
   public ResourceDeletionRecord() {
-    super(7);
+    super(8);
     declareProperty(resourceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deleteHistoryProp)
         .declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(resourceIdProp);
@@ -127,6 +131,16 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   public ResourceDeletionRecord setBatchOperationKey(final long batchOperationKey) {
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ResourceDeletionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -35,6 +36,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BPMN_ELEMENT_TYPE_KEY = new StringValue("bpmnElementType");
 
   private final LongProperty processDefinitionKeyProp =
@@ -50,11 +52,13 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> bpmnElementTypeProp =
       new EnumProperty<>(BPMN_ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public SignalSubscriptionRecord() {
-    super(9);
+    super(10);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)
@@ -63,6 +67,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnElementTypeProp);
   }
 
@@ -75,6 +80,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
     tenantIdProp.setValue(record.getTenantId());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     bpmnElementTypeProp.setValue(record.getBpmnElementType());
   }
 
@@ -188,6 +194,16 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
 
   public SignalSubscriptionRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public SignalSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
@@ -34,13 +34,14 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(
           new StringValue("elementType"), BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public TimerRecord() {
-    super(10);
+    super(11);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
@@ -49,6 +50,7 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(elementTypeProp);
   }
@@ -155,6 +157,16 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
 
   public TimerRecord setElementType(final BpmnElementType elementType) {
     elementTypeProp.setValue(elementType);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public TimerRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -58,6 +58,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue VARIABLES_VALUE = new StringValue(VARIABLES);
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_VALUE =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_VALUE = new StringValue("storageOrdinalKey");
 
   /**
    * Defines the mapping between names of attributes that may be modified (updated or corrected) and
@@ -111,6 +112,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_VALUE, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_VALUE, 0);
   private final StringProperty businessIdProp = new StringProperty("businessId", EMPTY_STRING);
 
   /**
@@ -156,7 +159,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(26);
+    super(27);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -182,6 +185,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(tagsProp)
         .declareProperty(listenersConfigKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -212,6 +216,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     setTags(record.getTags());
     listenersConfigKeyProp.setValue(record.getListenersConfigKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     businessIdProp.setValue(record.getBusinessIdBuffer());
   }
 
@@ -811,6 +816,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord resetChangedAttributes() {
     changedAttributesProp.reset();
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public UserTaskRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -36,6 +37,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue SOURCE_KEY = new StringValue("source");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -48,6 +50,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final ObjectProperty<VariableSourceRecord> sourceProp =
       new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
 
@@ -58,7 +62,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private String cachedJsonValue;
 
   public VariableRecord() {
-    super(9);
+    super(10);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
@@ -67,6 +71,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(sourceProp);
   }
 
@@ -195,6 +200,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public VariableRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2237,6 +2237,7 @@ final class JsonSerializableToJsonTest {
         "DecisionEvaluationRecord",
         (Supplier<UnifiedRecordValue>)
             () -> {
+              final int storageOrdinalKey = 9;
               final var record =
                   new DecisionEvaluationRecord()
                       .setDecisionKey(1L)
@@ -2256,7 +2257,8 @@ final class JsonSerializableToJsonTest {
                       .setEvaluationFailureMessage("evaluation-failure-message")
                       .setFailedDecisionId("failed-decision-id")
                       .setRootProcessInstanceKey(6L)
-                      .setBusinessId("business-id");
+                      .setBusinessId("business-id")
+                      .setStorageOrdinalKey(storageOrdinalKey);
 
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
@@ -2339,7 +2341,8 @@ final class JsonSerializableToJsonTest {
                   "failedDecisionId":"failed-decision-id",
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 6,
-                  "businessId": "business-id"
+                  "businessId": "business-id",
+                  "storageOrdinalKey": 9
                 }
                 """
       },
@@ -2349,6 +2352,7 @@ final class JsonSerializableToJsonTest {
         "DecisionEvaluationRecord",
         (Supplier<UnifiedRecordValue>)
             () -> {
+              final int storageOrdinalKey = 10;
               final var record =
                   new DecisionEvaluationRecord()
                       .setDecisionKey(1L)
@@ -2369,7 +2373,8 @@ final class JsonSerializableToJsonTest {
                       .setFailedDecisionId("failed-decision-id")
                       .setTenantId("tenant-test")
                       .setRootProcessInstanceKey(6L)
-                      .setBusinessId("business-id");
+                      .setBusinessId("business-id")
+                      .setStorageOrdinalKey(storageOrdinalKey);
 
               final var evaluatedDecisionRecord = record.evaluatedDecisions().add();
               evaluatedDecisionRecord
@@ -2453,7 +2458,8 @@ final class JsonSerializableToJsonTest {
                   "failedDecisionId":"failed-decision-id",
                   "tenantId": "tenant-test",
                   "rootProcessInstanceKey": 6,
-                  "businessId": "business-id"
+                  "businessId": "business-id",
+                  "storageOrdinalKey": 10
                 }
                 """
       },
@@ -2486,7 +2492,8 @@ final class JsonSerializableToJsonTest {
                   "failedDecisionId":"",
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
-                  "businessId": ""
+                  "businessId": "",
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -2696,6 +2703,7 @@ final class JsonSerializableToJsonTest {
             () -> {
               final var resourceKey = 1L;
               final var batchOperationKey = 2L;
+              final int storageOrdinalKey = 3;
 
               return new ResourceDeletionRecord()
                   .setResourceKey(resourceKey)
@@ -2704,7 +2712,8 @@ final class JsonSerializableToJsonTest {
                   .setBatchOperationKey(batchOperationKey)
                   .setBatchOperationType(BatchOperationType.DELETE_PROCESS_INSTANCE)
                   .setResourceType(ResourceType.PROCESS_DEFINITION)
-                  .setResourceId("foo");
+                  .setResourceId("foo")
+                  .setStorageOrdinalKey(storageOrdinalKey);
             },
         """
                 {
@@ -2714,7 +2723,8 @@ final class JsonSerializableToJsonTest {
                   "batchOperationKey": 2,
                   "batchOperationType": "DELETE_PROCESS_INSTANCE",
                   "resourceType": "PROCESS_DEFINITION",
-                  "resourceId": "foo"
+                  "resourceId": "foo",
+                  "storageOrdinalKey": 3
                 }
                 """
       },
@@ -2736,7 +2746,8 @@ final class JsonSerializableToJsonTest {
                   "batchOperationKey": -1,
                   "batchOperationType": "DELETE_PROCESS_INSTANCE",
                   "resourceType": "UNKNOWN",
-                  "resourceId": ""
+                  "resourceId": "",
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -4179,7 +4190,8 @@ final class JsonSerializableToJsonTest {
                     "valueType": "NULL_VAL",
                     "intent": "UNKNOWN",
                     "recordValue": null
-                  }
+                  },
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -4247,7 +4259,8 @@ final class JsonSerializableToJsonTest {
                         HistoryDeletionIntent.DELETE,
                         new HistoryDeletionRecord()
                             .setResourceKey(1)
-                            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION)),
+                            .setResourceType(HistoryDeletionType.PROCESS_DEFINITION))
+                    .setStorageOrdinalKey(11),
         """
                 {
                    "batchOperationKey": 12345,
@@ -4312,7 +4325,8 @@ final class JsonSerializableToJsonTest {
                         "tenantId": "<default>",
                         "decisionDefinitionId": ""
                       }
-                    }
+                    },
+                    "storageOrdinalKey": 11
                  }
                 """
       },
@@ -4331,7 +4345,8 @@ final class JsonSerializableToJsonTest {
                     .setBatchOperationType(BatchOperationType.UPDATE_JOB)
                     .setEntityFilter(toMessagePack("{'type': 'myJobType'}"))
                     .setJobUpdatePlan(
-                        new BatchOperationJobUpdatePlan().setPriority(80).setRetries(5)),
+                        new BatchOperationJobUpdatePlan().setPriority(80).setRetries(5))
+                    .setStorageOrdinalKey(12),
         """
                 {
                   "batchOperationKey": 12345,
@@ -4348,7 +4363,8 @@ final class JsonSerializableToJsonTest {
                     "valueType": "NULL_VAL",
                     "intent": "UNKNOWN",
                     "recordValue": null
-                  }
+                  },
+                  "storageOrdinalKey": 12
                 }
                 """
       },
@@ -4364,7 +4380,8 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "batchOperationKey": 12345,
-                  "items": []
+                  "items": [],
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -4384,8 +4401,10 @@ final class JsonSerializableToJsonTest {
                             new BatchOperationItem()
                                 .setItemKey(1L)
                                 .setProcessInstanceKey(2L)
-                                .setRootProcessInstanceKey(3L),
-                            new BatchOperationItem().setItemKey(2L).setProcessInstanceKey(2L))),
+                                .setRootProcessInstanceKey(3L)
+                                .setStorageOrdinalKey(13),
+                            new BatchOperationItem().setItemKey(2L).setProcessInstanceKey(2L)))
+                    .setStorageOrdinalKey(14),
         """
                 {
                   "items": [
@@ -4393,18 +4412,21 @@ final class JsonSerializableToJsonTest {
                       "itemKey": 1,
                       "processInstanceKey": 2,
                       "rootProcessInstanceKey": 3,
+                      "storageOrdinalKey": 13,
                       "empty": false,
-                      "encodedLength": 54
+                      "encodedLength": 73
                     },
                     {
                       "itemKey": 2,
                       "processInstanceKey": 2,
                       "rootProcessInstanceKey": -1,
+                      "storageOrdinalKey": 0,
                       "empty": false,
-                      "encodedLength": 54
+                      "encodedLength": 73
                     }
                   ],
-                  "batchOperationKey": 12345
+                  "batchOperationKey": 12345,
+                  "storageOrdinalKey": 14
                 }
                 """
       },
@@ -4419,11 +4441,13 @@ final class JsonSerializableToJsonTest {
             () ->
                 new BatchOperationExecutionRecord()
                     .setBatchOperationKey(12345L)
-                    .setItemKeys(Set.of(1L, 2L)),
+                    .setItemKeys(Set.of(1L, 2L))
+                    .setStorageOrdinalKey(15),
         """
                 {
                   "batchOperationKey": 12345,
-                  "itemKeys": [1, 2]
+                  "itemKeys": [1, 2],
+                  "storageOrdinalKey": 15
                 }
                 """
       },
@@ -4439,7 +4463,8 @@ final class JsonSerializableToJsonTest {
         """
                 {
                   "batchOperationKey": 12345,
-                  "itemKeys": []
+                  "itemKeys": [],
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -4451,11 +4476,15 @@ final class JsonSerializableToJsonTest {
       {
         "BatchOperationLifecycleManagementRecord",
         (Supplier<BatchOperationLifecycleManagementRecord>)
-            () -> new BatchOperationLifecycleManagementRecord().setBatchOperationKey(12345L),
+            () ->
+                new BatchOperationLifecycleManagementRecord()
+                    .setBatchOperationKey(12345L)
+                    .setStorageOrdinalKey(16),
         """
                 {
                   "batchOperationKey": 12345,
-                  "errors":[]
+                  "errors":[],
+                  "storageOrdinalKey": 16
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -716,6 +716,7 @@ final class JsonSerializableToJsonTest {
               final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
               final var processDefinitionPath = List.of(101L, 102L);
               final var callingElementPath = List.of(12345, 67890);
+              final int storageOrdinalKey = 5;
               return new IncidentRecord()
                   .setElementInstanceKey(elementInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
@@ -728,7 +729,8 @@ final class JsonSerializableToJsonTest {
                   .setVariableScopeKey(elementInstanceKey)
                   .setElementInstancePath(elementInstancePath)
                   .setProcessDefinitionPath(processDefinitionPath)
-                  .setCallingElementPath(callingElementPath);
+                  .setCallingElementPath(callingElementPath)
+                  .setStorageOrdinalKey(storageOrdinalKey);
             },
         """
                 {
@@ -745,7 +747,8 @@ final class JsonSerializableToJsonTest {
                   "elementInstancePath":[[101, 102], [103, 104]],
                   "processDefinitionPath": [101, 102],
                   "callingElementPath": [12345, 67890],
-                  "rootProcessInstanceKey": 101
+                  "rootProcessInstanceKey": 101,
+                  "storageOrdinalKey": 5
                 }
                 """
       },
@@ -772,7 +775,8 @@ final class JsonSerializableToJsonTest {
                   "elementInstancePath":[],
                   "processDefinitionPath":[],
                   "callingElementPath":[],
-                  "rootProcessInstanceKey": -1
+                  "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -808,6 +812,7 @@ final class JsonSerializableToJsonTest {
               final int processDefinitionVersion = 12;
               final int processInstanceKey = 1234;
               final int rootProcessInstanceKey = 4321;
+              final int storageOrdinalKey = 7;
               final String activityId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
@@ -858,6 +863,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessDefinitionVersion(processDefinitionVersion)
                   .setProcessInstanceKey(processInstanceKey)
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setStorageOrdinalKey(storageOrdinalKey)
                   .setElementId(wrapString(activityId))
                   .setElementType(BpmnElementType.SERVICE_TASK)
                   .setElementInstanceKey(activityInstanceKey)
@@ -907,6 +913,7 @@ final class JsonSerializableToJsonTest {
                       "timeout": -1,
                       "tenantId": "<default>",
                       "rootProcessInstanceKey": 4321,
+                      "storageOrdinalKey": 7,
                       "changedAttributes": ["bar", "foo"],
                       "tags": ["tag1", "tag2"],
                       "jobToUserTaskMigration": true,
@@ -1003,6 +1010,7 @@ final class JsonSerializableToJsonTest {
               final int processDefinitionVersion = 12;
               final int processInstanceKey = 1234;
               final int rootProcessInstanceKey = 4321;
+              final int storageOrdinalKey = 7;
               final String elementId = "activity";
               final BpmnElementType elementType = BpmnElementType.SERVICE_TASK;
               final int activityInstanceKey = 123;
@@ -1065,6 +1073,7 @@ final class JsonSerializableToJsonTest {
                       .setResult(result)
                       .setTags(Set.of("tag1", "tag2"))
                       .setRootProcessInstanceKey(rootProcessInstanceKey)
+                      .setStorageOrdinalKey(storageOrdinalKey)
                       .setIsJobToUserTaskMigration(true)
                       .setPriority(42)
                       .setBusinessId("biz-42")
@@ -1105,6 +1114,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": 14,
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 4321,
+                  "storageOrdinalKey": 7,
                   "tags": ["tag1", "tag2"],
                   "jobToUserTaskMigration": true,
                   "changedAttributes": ["bar", "foo"],
@@ -1191,6 +1201,7 @@ final class JsonSerializableToJsonTest {
                   "timeout": -1,
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "tags": [],
                   "jobToUserTaskMigration": false,
                   "changedAttributes": [],
@@ -1256,6 +1267,7 @@ final class JsonSerializableToJsonTest {
                   "customHeaders": {},
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "tags": [],
                   "jobToUserTaskMigration": false,
                   "changedAttributes": [],
@@ -1453,6 +1465,7 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 6L;
               final String correlationKey = "key";
               final long messageKey = 3L;
+              final int storageOrdinalKey = 8;
 
               return new MessageSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -1466,6 +1479,7 @@ final class JsonSerializableToJsonTest {
                   .setBusinessId("biz-42")
                   .setElementId("catch-1")
                   .setRootProcessInstanceKey(99L)
+                  .setStorageOrdinalKey(storageOrdinalKey)
                   .setElementType(BpmnElementType.RECEIVE_TASK);
             },
         """
@@ -1485,6 +1499,7 @@ final class JsonSerializableToJsonTest {
                   "businessId": "biz-42",
                   "elementId": "catch-1",
                   "rootProcessInstanceKey": 99,
+                  "storageOrdinalKey": 8,
                   "elementType": "RECEIVE_TASK"
                 }
                 """
@@ -1519,6 +1534,7 @@ final class JsonSerializableToJsonTest {
                   "businessId": "",
                   "elementId": "",
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "elementType": "UNSPECIFIED"
                 }
                 """
@@ -1542,6 +1558,7 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 444;
               final String correlationKey = "key";
               final long rootProcessInstanceKey = 5678L;
+              final int storageOrdinalKey = 8;
 
               return new ProcessMessageSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -1556,6 +1573,7 @@ final class JsonSerializableToJsonTest {
                   .setElementId(wrapString("A"))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
                   .setBusinessId("biz-42")
+                  .setStorageOrdinalKey(storageOrdinalKey)
                   .setElementType(BpmnElementType.RECEIVE_TASK);
             },
         """
@@ -1575,6 +1593,7 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 5678,
                   "businessId": "biz-42",
+                  "storageOrdinalKey": 8,
                   "elementType": "RECEIVE_TASK"
                 }
                 """
@@ -1611,6 +1630,7 @@ final class JsonSerializableToJsonTest {
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
                   "businessId": "",
+                  "storageOrdinalKey": 0,
                   "elementType": "UNSPECIFIED"
                 }
                 """
@@ -1631,6 +1651,7 @@ final class JsonSerializableToJsonTest {
               final int elementInstanceKey = 567;
               final String handlerNodeId = "node1";
               final int repetitions = 3;
+              final int storageOrdinalKey = 4;
 
               return new TimerRecord()
                   .setDueDate(dueDate)
@@ -1638,7 +1659,8 @@ final class JsonSerializableToJsonTest {
                   .setTargetElementId(wrapString(handlerNodeId))
                   .setRepetitions(repetitions)
                   .setProcessInstanceKey(processInstanceKey)
-                  .setProcessDefinitionKey(processDefinitionKey);
+                  .setProcessDefinitionKey(processDefinitionKey)
+                  .setStorageOrdinalKey(storageOrdinalKey);
             },
         """
                 {
@@ -1652,6 +1674,7 @@ final class JsonSerializableToJsonTest {
                   "rootProcessInstanceKey": -1,
                   "bpmnProcessId": "",
                   "elementId": "node1",
+                  "storageOrdinalKey": 4,
                   "elementType": "UNSPECIFIED"
                 }
                 """
@@ -1673,6 +1696,7 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 4;
               final String bpmnProcessId = "process";
               final long rootProcessInstanceKey = 5;
+              final int storageOrdinalKey = 6;
               final VariableSourceRecord source = VariableSourceRecord.api();
 
               return new VariableRecord()
@@ -1683,7 +1707,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setSource(source)
-                  .setRootProcessInstanceKey(rootProcessInstanceKey);
+                  .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setStorageOrdinalKey(storageOrdinalKey);
             },
         """
                 {
@@ -1695,6 +1720,7 @@ final class JsonSerializableToJsonTest {
                   "value": "1",
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 5,
+                  "storageOrdinalKey": 6,
                   "elementInstanceKey": 3,
                   "source": {
                     "type":"API"
@@ -1715,6 +1741,7 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 4;
               final String bpmnProcessId = "process";
               final long rootProcessInstanceKey = 5;
+              final int storageOrdinalKey = 6;
               final VariableSourceRecord source = VariableSourceRecord.api();
 
               return new VariableRecord()
@@ -1726,7 +1753,8 @@ final class JsonSerializableToJsonTest {
                   .setBpmnProcessId(wrapString(bpmnProcessId))
                   .setSource(source)
                   .setTenantId("tenant-test")
-                  .setRootProcessInstanceKey(rootProcessInstanceKey);
+                  .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setStorageOrdinalKey(storageOrdinalKey);
             },
         """
                 {
@@ -1738,6 +1766,7 @@ final class JsonSerializableToJsonTest {
                   "value": "1",
                   "tenantId": "tenant-test",
                   "rootProcessInstanceKey": 5,
+                  "storageOrdinalKey": 6,
                   "elementInstanceKey": 3,
                   "source": {
                     "type":"API"
@@ -1812,6 +1841,7 @@ final class JsonSerializableToJsonTest {
               final int version = 1;
               final long instanceKey = 2L;
               final long rootProcessInstanceKey = 3L;
+              final int storageOrdinalKey = 6;
               final String businessId = "business-id-456";
 
               return new ProcessInstanceCreationRecord()
@@ -1827,6 +1857,7 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(instanceKey)
                   .setTags(Set.of("tag1", "tag2"))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setStorageOrdinalKey(storageOrdinalKey)
                   .setBusinessId(businessId);
             },
         """
@@ -1848,6 +1879,7 @@ final class JsonSerializableToJsonTest {
                   "runtimeInstructions": [],
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 3,
+                  "storageOrdinalKey": 6,
                   "businessId": "business-id-456",
                   "elementInstanceKey": -1
                 }
@@ -1874,6 +1906,7 @@ final class JsonSerializableToJsonTest {
                   "runtimeInstructions": [],
                   "tags": [],
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "businessId": "",
                   "elementInstanceKey": -1
                 }
@@ -1895,6 +1928,7 @@ final class JsonSerializableToJsonTest {
               final var ancestorScopeKey = 3L;
               final var variableInstructionElementId = "sub-process";
               final var rootProcessInstanceKey = 4L;
+              final var storageOrdinalKey = 6;
               final var processDefinitionKey = 5L;
               final var bpmnProcessId = "bpmnProcessId";
 
@@ -1925,6 +1959,7 @@ final class JsonSerializableToJsonTest {
                                   .setElementId(variableInstructionElementId))
                           .addAncestorScopeKeys(Set.of(key, ancestorScopeKey)))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setStorageOrdinalKey(storageOrdinalKey)
                   .setProcessDefinitionKey(processDefinitionKey)
                   .setBpmnProcessId(bpmnProcessId);
             },
@@ -1963,6 +1998,7 @@ final class JsonSerializableToJsonTest {
                   "ancestorScopeKeys": [1,3],
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": 4,
+                  "storageOrdinalKey": 6,
                   "processDefinitionKey": 5,
                   "bpmnProcessId": "bpmnProcessId",
                   "elementInstanceKey": -1
@@ -1988,6 +2024,7 @@ final class JsonSerializableToJsonTest {
                   "ancestorScopeKeys": [],
                   "tenantId": "<default>",
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "processDefinitionKey": -1,
                   "bpmnProcessId": "",
                   "elementInstanceKey": -1
@@ -2015,6 +2052,7 @@ final class JsonSerializableToJsonTest {
               final var processDefinitionPath = List.of(101L, 102L);
               final var callingElementPath = List.of(12345, 67890);
               final var rootProcessInstanceKey = 9999L;
+              final var storageOrdinalKey = 6;
               final var businessId = "business-id-123";
 
               return new ProcessInstanceRecord()
@@ -2033,6 +2071,7 @@ final class JsonSerializableToJsonTest {
                   .setCallingElementPath(callingElementPath)
                   .setTags(Set.of("tag1", "tag2"))
                   .setRootProcessInstanceKey(rootProcessInstanceKey)
+                  .setStorageOrdinalKey(storageOrdinalKey)
                   .setBusinessId(businessId);
             },
         """
@@ -2053,6 +2092,7 @@ final class JsonSerializableToJsonTest {
                   "callingElementPath": [12345, 67890],
                   "tags": ["tag1", "tag2"],
                   "rootProcessInstanceKey": 9999,
+                  "storageOrdinalKey": 6,
                   "businessId": "business-id-123",
                   "elementInstanceKey": -1
                 }
@@ -2085,6 +2125,7 @@ final class JsonSerializableToJsonTest {
                   "callingElementPath": [],
                   "tags": [],
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "businessId": "",
                   "elementInstanceKey": -1
                 }
@@ -2888,6 +2929,7 @@ final class JsonSerializableToJsonTest {
                   "commandKey": 5678,
                   "valueType": "PROCESS_INSTANCE",
                   "intent": "ACTIVATE_ELEMENT",
+                  "storageOrdinalKey": 0,
                   "commandValue": {
                     "bpmnProcessId": "",
                     "version": -1,
@@ -2905,6 +2947,7 @@ final class JsonSerializableToJsonTest {
                     "callingElementPath": [],
                     "tags": [],
                     "rootProcessInstanceKey": -1,
+                    "storageOrdinalKey": 0,
                     "businessId": "",
                     "elementInstanceKey": -1
                   }
@@ -2929,6 +2972,7 @@ final class JsonSerializableToJsonTest {
                   "commandKey": -1,
                   "valueType": "NULL_VAL",
                   "intent": "UNKNOWN",
+                  "storageOrdinalKey": 0,
                   "commandValue": null
                 }
                 """
@@ -2947,14 +2991,16 @@ final class JsonSerializableToJsonTest {
                     .setProcessInstanceKey(123L)
                     .setProcessDefinitionKey(234L)
                     .setBatchElementInstanceKey(456L)
-                    .setIndex(10L),
+                    .setIndex(10L)
+                    .setStorageOrdinalKey(9),
         """
                 {
                   "processInstanceKey": 123,
                   "processDefinitionKey": 234,
                   "batchElementInstanceKey": 456,
                   "index": 10,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "storageOrdinalKey": 9
                 }
                 """
       },
@@ -2977,7 +3023,8 @@ final class JsonSerializableToJsonTest {
                   "processDefinitionKey": -1,
                   "batchElementInstanceKey": 456,
                   "index": -1,
-                  "tenantId": "<default>"
+                  "tenantId": "<default>",
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -3016,6 +3063,7 @@ final class JsonSerializableToJsonTest {
                     .setDeniedReason("Reason to deny lifecycle transition")
                     .setListenersConfigKey(42L)
                     .setRootProcessInstanceKey(4321L)
+                    .setStorageOrdinalKey(7)
                     .setBusinessId("order-4711"),
         """
                 {
@@ -3048,6 +3096,7 @@ final class JsonSerializableToJsonTest {
                   "deniedReason": "Reason to deny lifecycle transition",
                   "listenersConfigKey": 42,
                   "rootProcessInstanceKey": 4321,
+                  "storageOrdinalKey": 7,
                   "businessId": "order-4711"
                 }
                 """
@@ -3088,6 +3137,7 @@ final class JsonSerializableToJsonTest {
                   "deniedReason": "",
                   "listenersConfigKey": -1,
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "businessId": ""
                 }
                 """
@@ -3133,6 +3183,7 @@ final class JsonSerializableToJsonTest {
                   "deniedReason": "",
                   "listenersConfigKey": -1,
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "businessId": ""
                 }
                 """
@@ -3162,6 +3213,7 @@ final class JsonSerializableToJsonTest {
                         new ProcessInstanceMigrationMappingInstruction()
                             .setTargetElementId("targetId3"))
                     .setRootProcessInstanceKey(321L)
+                    .setStorageOrdinalKey(6)
                     .setProcessDefinitionKey(234L)
                     .setBpmnProcessId("bpmnProcessId"),
         """
@@ -3180,6 +3232,7 @@ final class JsonSerializableToJsonTest {
                     "targetElementId": "targetId3"
                   }],
                   "rootProcessInstanceKey": 321,
+                  "storageOrdinalKey": 6,
                   "processDefinitionKey": 234,
                   "bpmnProcessId": "bpmnProcessId",
                   "elementInstanceKey": -1
@@ -3206,6 +3259,7 @@ final class JsonSerializableToJsonTest {
                   "targetProcessDefinitionKey": 456,
                   "mappingInstructions": [],
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "processDefinitionKey": -1,
                   "bpmnProcessId": "",
                   "elementInstanceKey": -1
@@ -3235,6 +3289,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey": 123,
                   "businessId": "order-42",
                   "rootProcessInstanceKey": 321,
+                  "storageOrdinalKey": 0,
                   "processDefinitionKey": 234,
                   "bpmnProcessId": "bpmnProcessId",
                   "elementInstanceKey": -1
@@ -3257,6 +3312,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey": 123,
                   "businessId": "",
                   "rootProcessInstanceKey": -1,
+                  "storageOrdinalKey": 0,
                   "processDefinitionKey": -1,
                   "bpmnProcessId": "",
                   "elementInstanceKey": -1
@@ -3343,6 +3399,7 @@ final class JsonSerializableToJsonTest {
               final long messageKey = 2L;
               final long requestId = 3L;
               final int requestStreamId = 4;
+              final int storageOrdinalKey = 6;
 
               return new MessageCorrelationRecord()
                   .setCorrelationKey(correlationKey)
@@ -3354,7 +3411,8 @@ final class JsonSerializableToJsonTest {
                   .setRequestId(requestId)
                   .setRequestStreamId(requestStreamId)
                   .setProcessDefinitionKey(5L)
-                  .setBusinessId("biz-42");
+                  .setBusinessId("biz-42")
+                  .setStorageOrdinalKey(storageOrdinalKey);
             },
         """
                 {
@@ -3369,7 +3427,8 @@ final class JsonSerializableToJsonTest {
                   "requestId": 3,
                   "requestStreamId": 4,
                   "processDefinitionKey": 5,
-                  "businessId": "biz-42"
+                  "businessId": "biz-42",
+                  "storageOrdinalKey": 6
                 }
                 """
       },
@@ -3626,7 +3685,8 @@ final class JsonSerializableToJsonTest {
                   "requestId": -1,
                   "requestStreamId": -1,
                   "processDefinitionKey": -1,
-                  "businessId": ""
+                  "businessId": "",
+                  "storageOrdinalKey": 0
                 }
                 """
       },
@@ -4519,13 +4579,15 @@ final class JsonSerializableToJsonTest {
                     .setProcessInstanceKey(12345L)
                     .setProcessDefinitionKey(6L)
                     .setTenantId("tenant_1")
-                    .setElementId("element_1"),
+                    .setElementId("element_1")
+                    .setStorageOrdinalKey(3),
         """
       {
         "tenantId": "tenant_1",
         "elementId": "element_1",
         "processInstanceKey": 12345,
-        "processDefinitionKey": 6
+        "processDefinitionKey": 6,
+        "storageOrdinalKey": 3
       }
       """
       },
@@ -4540,7 +4602,8 @@ final class JsonSerializableToJsonTest {
         "tenantId": "",
         "elementId": "",
         "processInstanceKey": -1,
-        "processDefinitionKey": -1
+        "processDefinitionKey": -1,
+        "storageOrdinalKey": 0
       }
       """
       },
@@ -4609,6 +4672,7 @@ final class JsonSerializableToJsonTest {
                     .setVariableEvents(List.of("CREATED", "UPDATED"))
                     .setInterrupting(true)
                     .setRootProcessInstanceKey(999L)
+                    .setStorageOrdinalKey(7)
                     .setElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT),
         """
                 {
@@ -4624,6 +4688,7 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId":"process-1",
                   "processDefinitionKey":456,
                   "rootProcessInstanceKey":999,
+                  "storageOrdinalKey":7,
                   "elementType":"INTERMEDIATE_CATCH_EVENT"
                 }
                 """
@@ -4651,6 +4716,7 @@ final class JsonSerializableToJsonTest {
                   "bpmnProcessId":"",
                   "processDefinitionKey":-1,
                   "rootProcessInstanceKey":-1,
+                  "storageOrdinalKey":0,
                   "elementType":"UNSPECIFIED"
                 }
                 """
@@ -5087,7 +5153,8 @@ final class JsonSerializableToJsonTest {
                               new AgentInstanceTool()
                                   .setName("MCP_ocr___scan_document")
                                   .setElementId("MCP_ocr")))
-                      .setChangedAttributes(List.of("status", "metrics"));
+                      .setChangedAttributes(List.of("status", "metrics"))
+                      .setStorageOrdinalKey(11);
               record
                   .getDefinition()
                   .setModel("gpt-4o")
@@ -5132,7 +5199,8 @@ final class JsonSerializableToJsonTest {
           "jobKey": -1,
           "jobLease": "",
           "loopIteration": 0,
-          "history": []
+          "history": [],
+          "storageOrdinalKey": 11
         }
         """
       },
@@ -5161,7 +5229,8 @@ final class JsonSerializableToJsonTest {
           "jobKey": -1,
           "jobLease": "",
           "loopIteration": 0,
-          "history": []
+          "history": [],
+          "storageOrdinalKey": 0
         }
         """
       },
@@ -5255,9 +5324,11 @@ final class JsonSerializableToJsonTest {
               "provider": "openai",
               "limits": { "maxTokens": 8000, "maxModelCalls": 10, "maxToolCalls": 20 },
               "changedAttributes": [],
-              "duplicate": true
+              "duplicate": true,
+              "storageOrdinalKey": 0
             }
-          ]
+          ],
+          "storageOrdinalKey": 0
         }
         """
       },
@@ -5278,7 +5349,8 @@ final class JsonSerializableToJsonTest {
                       .setLoopIteration(3)
                       .setRole(AgentHistoryRole.ASSISTANT)
                       .setProducedAt(1748860800000L)
-                      .setBpmnProcessId("process");
+                      .setBpmnProcessId("process")
+                      .setStorageOrdinalKey(10);
               record.addContent(
                   new AgentHistoryMessageContent()
                       .setContentType(AgentHistoryContentType.TEXT)
@@ -5392,7 +5464,8 @@ final class JsonSerializableToJsonTest {
           "provider": "",
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
           "changedAttributes": [],
-          "duplicate": false
+          "duplicate": false,
+          "storageOrdinalKey": 10
         }
         """
       },
@@ -5483,7 +5556,8 @@ final class JsonSerializableToJsonTest {
           "provider": "",
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
           "changedAttributes": [],
-          "duplicate": false
+          "duplicate": false,
+          "storageOrdinalKey": 0
         }
         """
       },
@@ -5515,7 +5589,8 @@ final class JsonSerializableToJsonTest {
           "provider": "",
           "limits": { "maxTokens": -1, "maxModelCalls": -1, "maxToolCalls": -1 },
           "changedAttributes": [],
-          "duplicate": false
+          "duplicate": false,
+          "storageOrdinalKey": 0
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2659,6 +2659,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey":-1,
                   "processDefinitionKey":22334,
                   "rootProcessInstanceKey":-1,
+                  "storageOrdinalKey":0,
                   "bpmnProcessId": "process",
                   "tenantId": "acme"
                 }
@@ -2687,6 +2688,7 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey":-1,
                   "processDefinitionKey":22334,
                   "rootProcessInstanceKey":-1,
+                  "storageOrdinalKey":0,
                   "bpmnProcessId":"",
                   "tenantId": "<default>"
                 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -35,6 +35,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
@@ -66,12 +67,13 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public AgentHistoryRecord() {
-    super(24);
+    super(25);
     declareProperty(agentHistoryKeyProp)
         .declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
@@ -374,6 +376,16 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
 
   public AgentHistoryRecord setBpmnProcessId(final String bpmnProcessId) {
     bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public AgentHistoryRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentInstanceRecord.golden
@@ -49,6 +49,7 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
@@ -76,13 +77,14 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
       new ArrayProperty<>("history", AgentHistoryRecord::new);
 
   public AgentInstanceRecord() {
-    super(21);
+    super(22);
     declareProperty(agentInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(elementInstanceKeysProp)
         .declareProperty(elementIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processDefinitionVersionProp)
@@ -322,6 +324,16 @@ public final class AgentInstanceRecord extends UnifiedRecordValue
 
   public AgentInstanceRecord addElementInstanceKey(final long elementInstanceKey) {
     elementInstanceKeysProp.add().setValue(elementInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public AgentInstanceRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationChunkRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationChunkRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
@@ -19,15 +20,20 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     implements BatchOperationChunkRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_ITEMS_LIST = "items";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final ArrayProperty<BatchOperationItem> itemsProp =
       new ArrayProperty<>(PROP_ITEMS_LIST, BatchOperationItem::new);
 
   public BatchOperationChunkRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemsProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
+        .declareProperty(itemsProp);
   }
 
   @Override
@@ -38,6 +44,16 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   public BatchOperationChunkRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationChunkRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -54,6 +70,7 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
 
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setItems(record.getItems());
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationCreationRecord.golden
@@ -11,6 +11,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.value.IntegerValue;
@@ -31,6 +32,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
     implements BatchOperationCreationRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_BATCH_OPERATION_TYPE = "batchOperationType";
   public static final String PROP_ENTITY_FILTER = "entityFilter";
   public static final String PROP_MIGRATION_PLAN = "migrationPlan";
@@ -42,6 +44,8 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public static final String PROP_FOLLOWUP_COMMAND = "followUpCommand";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
       new EnumProperty<>(PROP_BATCH_OPERATION_TYPE, BatchOperationType.class);
   private final BinaryProperty entityFilterProp =
@@ -64,8 +68,9 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
       new ObjectProperty<>(PROP_FOLLOWUP_COMMAND, new NestedRecord());
 
   public BatchOperationCreationRecord() {
-    super(10);
+    super(11);
     declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(entityFilterProp)
         .declareProperty(migrationPlanProp)
@@ -85,6 +90,16 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
   public BatchOperationCreationRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -193,6 +208,7 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
 
   public BatchOperationCreationRecord wrap(final BatchOperationCreationRecord record) {
     batchOperationKeyProp.setValue(record.getBatchOperationKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     batchOperationTypeProp.setValue(record.getBatchOperationType());
     entityFilterProp.setValue(record.getEntityFilterBuffer());
     migrationPlanProp.getValue().wrap(record.getMigrationPlan());

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationExecutionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationExecutionRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -19,15 +20,20 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
     implements BatchOperationExecutionRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_ITEM_KEY_LIST = "itemKeys";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final ArrayProperty<LongValue> itemKeysProp =
       new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
 
   public BatchOperationExecutionRecord() {
-    super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
+        .declareProperty(itemKeysProp);
   }
 
   @Override
@@ -38,6 +44,16 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   public BatchOperationExecutionRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationExecutionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -54,6 +70,7 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
 
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setItemKeys(record.getItemKeys());
     return this;
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationInitializationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationInitializationRecord.golden
@@ -19,10 +19,13 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
     implements BatchOperationInitializationRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_SEARCH_RESULT_CURSOR_KEY = "searchResultCursor";
   public static final String PROP_SEARCH_QUERY_PAGE_SIZE = "searchQueryPageSize";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
 
   private final StringProperty searchResultCursorProp =
       new StringProperty(PROP_SEARCH_RESULT_CURSOR_KEY, "");
@@ -30,8 +33,9 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
       new IntegerProperty(PROP_SEARCH_QUERY_PAGE_SIZE, 0);
 
   public BatchOperationInitializationRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(searchResultCursorProp)
         .declareProperty(searchQueryPageSize);
   }
@@ -44,6 +48,16 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
   public BatchOperationInitializationRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationInitializationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -71,6 +85,7 @@ public final class BatchOperationInitializationRecord extends UnifiedRecordValue
 
   public void wrap(final BatchOperationInitializationRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setSearchResultCursor(record.getSearchResultCursor());
     setSearchQueryPageSize(record.getSearchQueryPageSize());
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationItem.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationItem.golden
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue.BatchOperationItemValue;
@@ -18,12 +19,15 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
       new LongProperty("processInstanceKey", -1);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty("rootProcessInstanceKey", -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
 
   public BatchOperationItem() {
-    super(3);
+    super(4);
     declareProperty(itemKeyProperty)
         .declareProperty(processInstanceKeyProperty)
-        .declareProperty(rootProcessInstanceKeyProperty);
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   public BatchOperationItem(
@@ -64,10 +68,21 @@ public final class BatchOperationItem extends ObjectValue implements BatchOperat
     return this;
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public BatchOperationItem setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
+  }
+
   public BatchOperationItem wrap(final BatchOperationItemValue value) {
     setItemKey(value.getItemKey());
     setProcessInstanceKey(value.getProcessInstanceKey());
     setRootProcessInstanceKey(value.getRootProcessInstanceKey());
+    setStorageOrdinalKey(value.getStorageOrdinalKey());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationLifecycleManagementRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationLifecycleManagementRecord.golden
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
 
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationLifecycleManagementRecordValue;
@@ -18,15 +19,19 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
     implements BatchOperationLifecycleManagementRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
 
   private final ArrayProperty<BatchOperationError> errorsProp =
       new ArrayProperty<>("errors", BatchOperationError::new);
 
   public BatchOperationLifecycleManagementRecord() {
-    super(2);
+    super(3);
     declareProperty(batchOperationKeyProp);
+    declareProperty(storageOrdinalKeyProp);
     declareProperty(errorsProp);
   }
 
@@ -42,9 +47,20 @@ public final class BatchOperationLifecycleManagementRecord extends UnifiedRecord
     return this;
   }
 
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationLifecycleManagementRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
+  }
+
   public BatchOperationLifecycleManagementRecord wrap(
       final BatchOperationLifecycleManagementRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setErrors(record.getErrors().stream().map(BatchOperationError.class::cast).toList());
     return this;
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationPartitionLifecycleRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/BatchOperationPartitionLifecycleRecord.golden
@@ -17,17 +17,21 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
     implements BatchOperationPartitionLifecycleRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_STORAGE_ORDINAL_KEY = "storageOrdinalKey";
   public static final String PROP_SOURCE_PARTITION_ID = "sourcePartitionId";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(PROP_STORAGE_ORDINAL_KEY, 0);
   private final IntegerProperty sourcePartitionIdProp =
       new IntegerProperty(PROP_SOURCE_PARTITION_ID, -1);
   private final ObjectProperty<BatchOperationError> errorProp =
       new ObjectProperty<>("error", new BatchOperationError());
 
   public BatchOperationPartitionLifecycleRecord() {
-    super(3);
+    super(4);
     declareProperty(batchOperationKeyProp);
+    declareProperty(storageOrdinalKeyProp);
     declareProperty(sourcePartitionIdProp);
     declareProperty(errorProp);
   }
@@ -40,6 +44,16 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
   public BatchOperationPartitionLifecycleRecord setBatchOperationKey(final Long batchOperationKey) {
     batchOperationKeyProp.reset();
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public BatchOperationPartitionLifecycleRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 
@@ -66,6 +80,7 @@ public final class BatchOperationPartitionLifecycleRecord extends UnifiedRecordV
   public BatchOperationPartitionLifecycleRecord wrap(
       final BatchOperationPartitionLifecycleRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setSourcePartitionId(record.getSourcePartitionId());
     setError(record.getError());
     return this;

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ConditionalSubscriptionRecord.golden
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -42,6 +43,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   // default to -1 for root level start events
@@ -64,11 +66,13 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ConditionalSubscriptionRecord() {
-    super(13);
+    super(14);
     declareProperty(scopeKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -81,6 +85,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(variableEventsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(elementTypeProp);
   }
 
@@ -97,6 +102,7 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
     setVariableEvents(record.getVariableEvents());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     elementTypeProp.setValue(record.getElementType());
   }
 
@@ -266,6 +272,16 @@ public class ConditionalSubscriptionRecord extends UnifiedRecordValue
 
   public ConditionalSubscriptionRecord setRootProcessInstanceKey(final long key) {
     rootProcessInstanceKeyProp.setValue(key);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ConditionalSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/DecisionEvaluationRecord.golden
@@ -62,10 +62,11 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty businessIdProp = new StringProperty("businessId", "");
 
   public DecisionEvaluationRecord() {
-    super(19);
+    super(20);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
@@ -84,6 +85,7 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
         .declareProperty(failedDecisionIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -365,6 +367,16 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
 
   public DecisionEvaluationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public DecisionEvaluationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IncidentRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/IncidentRecord.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.incident;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
@@ -43,6 +44,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   private static final StringValue PROCESS_DEFINITION_PATH_KEY =
       new StringValue("processDefinitionPath");
   private static final StringValue CALLING_ELEMENT_PATH_KEY = new StringValue("callingElementPath");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final EnumProperty<ErrorType> errorTypeProp =
       new EnumProperty<>(ERROR_TYPE_KEY, ErrorType.class, ErrorType.UNKNOWN);
@@ -52,6 +54,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final LongProperty processInstanceKeyProp =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final LongProperty elementInstanceKeyProp =
       new LongProperty(ELEMENT_INSTANCE_KEY_KEY, -1L);
@@ -67,12 +71,13 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new ArrayProperty<>(CALLING_ELEMENT_PATH_KEY, IntegerValue::new);
 
   public IncidentRecord() {
-    super(13);
+    super(14);
     declareProperty(errorTypeProp)
         .declareProperty(errorMessageProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(jobKeyProp)
@@ -89,6 +94,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     bpmnProcessIdProp.setValue(record.getBpmnProcessIdBuffer());
     processDefinitionKeyProp.setValue(record.getProcessDefinitionKey());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     elementIdProp.setValue(record.getElementIdBuffer());
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     jobKeyProp.setValue(record.getJobKey());
@@ -279,6 +285,16 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public IncidentRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -100,6 +100,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private static final StringValue LEASE_TOKEN_KEY = new StringValue("leaseToken");
@@ -149,6 +150,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
   private final StringProperty leaseTokenProp = new StringProperty(LEASE_TOKEN_KEY, EMPTY_STRING);
@@ -156,7 +159,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new ArrayProperty<>(SECRET_REFERENCES_KEY, JobSecretReference::new);
 
   public JobRecord() {
-    super(30);
+    super(31);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -183,6 +186,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(priorityProp)
         .declareProperty(businessIdProp)
         .declareProperty(leaseTokenProp)
@@ -217,6 +221,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     priorityProp.setValue(record.getPriority());
     businessIdProp.setValue(record.getBusinessIdBuffer());
     leaseTokenProp.setValue(record.getLeaseTokenBuffer());
@@ -612,6 +617,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @JsonIgnore
   public DirectBuffer getLeaseTokenBuffer() {
     return leaseTokenProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public JobRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageCorrelationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageCorrelationRecord.golden
@@ -36,6 +36,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
@@ -52,10 +53,12 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty processDefinitionKeyProp =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public MessageCorrelationRecord() {
-    super(10);
+    super(11);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(variablesProp)
@@ -65,6 +68,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
         .declareProperty(requestStreamIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -74,6 +78,7 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
     setProcessInstanceKey(record.getProcessInstanceKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setBusinessId(record.getBusinessIdBuffer());
   }
 
@@ -200,5 +205,15 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public MessageCorrelationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/MessageSubscriptionRecord.golden
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -43,6 +44,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue ELEMENT_ID_KEY = new StringValue("elementId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
   private final LongProperty processInstanceKeyProp = new LongProperty(PROCESS_INSTANCE_KEY_KEY);
@@ -62,11 +64,13 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty elementIdProp = new StringProperty(ELEMENT_ID_KEY, "");
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public MessageSubscriptionRecord() {
-    super(14);
+    super(15);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(processDefinitionKeyProp)
@@ -80,6 +84,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(businessIdProp)
         .declareProperty(elementIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(elementTypeProp);
   }
 
@@ -97,6 +102,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBusinessId(record.getBusinessIdBuffer());
     setElementId(record.getElementIdBuffer());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setElementType(record.getElementType());
   }
 
@@ -278,5 +284,15 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessEventRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessEventRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -33,14 +34,18 @@ public final class ProcessEventRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProperty =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
+
   public ProcessEventRecord() {
-    super(6);
+    super(7);
     declareProperty(scopeKeyProperty)
         .declareProperty(targetElementIdProperty)
         .declareProperty(variablesProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
-        .declareProperty(tenantIdProperty);
+        .declareProperty(tenantIdProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   public ProcessEventRecord wrap(final ProcessEventRecord record) {
@@ -50,6 +55,7 @@ public final class ProcessEventRecord extends UnifiedRecordValue
     processDefinitionKeyProperty.setValue(record.getProcessDefinitionKey());
     processInstanceKeyProperty.setValue(record.getProcessInstanceKey());
     tenantIdProperty.setValue(record.getTenantId());
+    storageOrdinalKeyProperty.setValue(record.getStorageOrdinalKey());
 
     return this;
   }
@@ -121,6 +127,16 @@ public final class ProcessEventRecord extends UnifiedRecordValue
 
   public ProcessEventRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessEventRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBatchRecord.golden
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
@@ -36,12 +37,16 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
    */
   private final LongProperty indexProperty = new LongProperty("index", -1L);
 
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
+
   public ProcessInstanceBatchRecord() {
-    super(4);
+    super(5);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(batchElementInstanceKeyProperty)
-        .declareProperty(indexProperty);
+        .declareProperty(indexProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -88,5 +93,15 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
   public String getTenantId() {
     // todo(#13774): replace dummy implementation
     return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBatchRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBufferedCommandRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBufferedCommandRecord.golden
@@ -35,6 +35,7 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
   private static final StringValue VALUE_TYPE_KEY = new StringValue("valueType");
   private static final StringValue INTENT_KEY = new StringValue("intent");
   private static final StringValue COMMAND_VALUE_KEY = new StringValue("commandValue");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final LongProperty processInstanceKeyProperty =
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
@@ -48,19 +49,22 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
   private final IntegerProperty intentProperty = new IntegerProperty(INTENT_KEY, Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
       new ObjectProperty<>(COMMAND_VALUE_KEY, new UnifiedRecordValue(10));
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
 
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
   public ProcessInstanceBufferedCommandRecord() {
-    super(7);
+    super(8);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(commandKeyProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
-        .declareProperty(commandValueProperty);
+        .declareProperty(commandValueProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -173,6 +177,16 @@ public final class ProcessInstanceBufferedCommandRecord extends UnifiedRecordVal
 
     commandValue.write(valueBuffer, 0);
     commandValueProperty.getValue().read(commandValueReader.wrap(valueBuffer, 0, encodedLength));
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBufferedCommandRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBusinessIdRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBusinessIdRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -25,6 +26,7 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
@@ -36,16 +38,19 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   public ProcessInstanceBusinessIdRecord() {
-    super(6);
+    super(7);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(businessIdProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(bpmnProcessIdProperty);
   }
@@ -88,6 +93,16 @@ public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
   public ProcessInstanceBusinessIdRecord setRootProcessInstanceKey(
       final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceCreationRecord.golden
@@ -47,6 +47,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   private static final StringValue TAGS_KEY = new StringValue("tags");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
@@ -71,10 +72,12 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceCreationRecord() {
-    super(12);
+    super(13);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -86,6 +89,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(tagsProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(businessIdProperty);
   }
 
@@ -292,5 +296,15 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProperty.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceCreationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceMigrationRecord.golden
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -31,6 +32,7 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringValue("mappingInstructions");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
@@ -47,17 +49,20 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final LongProperty processDefinitionKeyProperty =
       new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
 
   public ProcessInstanceMigrationRecord() {
-    super(7);
+    super(8);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(targetProcessDefinitionKeyProperty)
         .declareProperty(mappingInstructionsProperty)
         .declareProperty(tenantIdProperty)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(bpmnProcessIdProperty);
   }
@@ -153,6 +158,16 @@ public final class ProcessInstanceMigrationRecord extends UnifiedRecordValue
 
   public ProcessInstanceMigrationRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceMigrationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceModificationRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -37,6 +38,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new StringValue("activatedElementInstanceKeys");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue PROCESS_DEFINITION_KEY_KEY =
       new StringValue("processDefinitionKey");
   private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
@@ -64,9 +66,11 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new ArrayProperty<>(ACTIVATED_ELEMENT_INSTANCE_KEYS_KEY, LongValue::new);
   private final LongProperty rootProcessInstanceKeyProperty =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceModificationRecord() {
-    super(9);
+    super(10);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)
@@ -74,6 +78,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
         .declareProperty(activatedElementInstanceKeys)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(storageOrdinalKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(bpmnProcessIdProperty);
   }
@@ -251,6 +256,16 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
 
   public ProcessInstanceModificationRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceModificationRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceRecord.golden
@@ -58,6 +58,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
+  public static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
@@ -97,10 +98,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY, -1L);
 
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
+
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
   public ProcessInstanceRecord() {
-    super(17);
+    super(18);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -117,6 +121,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -133,6 +138,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     parentElementInstanceKeyProp.setValue(record.getParentElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     businessIdProp.setValue(record.getBusinessId());
   }
 
@@ -348,6 +354,16 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
     bpmnProcessIdProp.setValue(directBuffer);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceResultRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceResultRecord.golden
@@ -40,6 +40,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   public static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   public static final StringValue TAGS_KEY = new StringValue("tags");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  public static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final LongProperty processDefinitionKeyProperty =
@@ -53,9 +54,11 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
   private final ArrayProperty<StringValue> tagsProperty =
       new ArrayProperty<>(TAGS_KEY, StringValue::new);
   private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
 
   public ProcessInstanceResultRecord() {
-    super(8);
+    super(9);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -63,7 +66,8 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProperty)
         .declareProperty(variablesProperty)
         .declareProperty(tagsProperty)
-        .declareProperty(businessIdProperty);
+        .declareProperty(businessIdProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -174,6 +178,16 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
 
   public ProcessInstanceResultRecord setTenantId(final String tenantId) {
     tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public ProcessInstanceResultRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessMessageSubscriptionRecord.golden
@@ -44,6 +44,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue ELEMENT_TYPE_KEY = new StringValue("elementType");
 
@@ -64,12 +65,14 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public ProcessMessageSubscriptionRecord() {
-    super(15);
+    super(16);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
@@ -83,6 +86,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(elementIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp)
         .declareProperty(elementTypeProp);
   }
@@ -101,6 +105,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
     setElementId(record.getElementIdBuffer());
     setTenantId(record.getTenantId());
     setRootProcessInstanceKey(record.getRootProcessInstanceKey());
+    setStorageOrdinalKey(record.getStorageOrdinalKey());
     setBusinessId(record.getBusinessIdBuffer());
     setElementType(record.getElementType());
   }
@@ -288,5 +293,15 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ProcessMessageSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceDeletionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ResourceDeletionRecord.golden
@@ -9,6 +9,7 @@ package io.camunda.zeebe.protocol.impl.record.value.resource;
 
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -27,6 +28,7 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue DELETE_HISTORY_KEY = new StringValue("deleteHistory");
   private static final StringValue BATCH_OPERATION_KEY = new StringValue("batchOperationKey");
+  private static final StringValue STORAGE_ORDINAL_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BATCH_OPERATION_TYPE = new StringValue("batchOperationType");
   private static final StringValue RESOURCE_TYPE = new StringValue("resourceType");
   private static final StringValue RESOURCE_ID = new StringValue("resourceId");
@@ -35,6 +37,7 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp = new StringProperty(TENANT_ID_KEY, "");
   private final BooleanProperty deleteHistoryProp = new BooleanProperty(DELETE_HISTORY_KEY, false);
   private final LongProperty batchOperationKeyProp = new LongProperty(BATCH_OPERATION_KEY, -1);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty(STORAGE_ORDINAL_KEY, 0);
   private final EnumProperty<BatchOperationType> batchOperationTypeProp =
       new EnumProperty<>(
           BATCH_OPERATION_TYPE,
@@ -45,11 +48,12 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private final StringProperty resourceIdProp = new StringProperty(RESOURCE_ID, "");
 
   public ResourceDeletionRecord() {
-    super(7);
+    super(8);
     declareProperty(resourceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(deleteHistoryProp)
         .declareProperty(batchOperationKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(resourceIdProp);
@@ -127,6 +131,16 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
 
   public ResourceDeletionRecord setBatchOperationKey(final long batchOperationKey) {
     batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public ResourceDeletionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RuntimeInstructionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/RuntimeInstructionRecord.golden
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -25,13 +26,16 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1);
   private final StringProperty tenantIdProperty = new StringProperty("tenantId", "");
   private final StringProperty elementIdProperty = new StringProperty("elementId", "");
+  private final IntegerProperty storageOrdinalKeyProperty =
+      new IntegerProperty("storageOrdinalKey", 0);
 
   public RuntimeInstructionRecord() {
-    super(4);
+    super(5);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(tenantIdProperty)
-        .declareProperty(elementIdProperty);
+        .declareProperty(elementIdProperty)
+        .declareProperty(storageOrdinalKeyProperty);
   }
 
   @Override
@@ -77,5 +81,15 @@ public class RuntimeInstructionRecord extends UnifiedRecordValue
   @JsonIgnore
   public DirectBuffer getElementIdBuffer() {
     return elementIdProperty.getValue();
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProperty.getValue();
+  }
+
+  public RuntimeInstructionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProperty.setValue(storageOrdinalKey);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/SignalSubscriptionRecord.golden
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -35,6 +36,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
   private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
   private static final StringValue BPMN_ELEMENT_TYPE_KEY = new StringValue("bpmnElementType");
 
   private final LongProperty processDefinitionKeyProp =
@@ -50,11 +52,13 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1L);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final EnumProperty<BpmnElementType> bpmnElementTypeProp =
       new EnumProperty<>(BPMN_ELEMENT_TYPE_KEY, BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public SignalSubscriptionRecord() {
-    super(9);
+    super(10);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)
@@ -63,6 +67,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnElementTypeProp);
   }
 
@@ -75,6 +80,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
     tenantIdProp.setValue(record.getTenantId());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     bpmnElementTypeProp.setValue(record.getBpmnElementType());
   }
 
@@ -188,6 +194,16 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
 
   public SignalSubscriptionRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public SignalSubscriptionRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/TimerRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/TimerRecord.golden
@@ -34,13 +34,14 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty("rootProcessInstanceKey", -1L);
+  private final IntegerProperty storageOrdinalKeyProp = new IntegerProperty("storageOrdinalKey", 0);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
   private final EnumProperty<BpmnElementType> elementTypeProp =
       new EnumProperty<>(
           new StringValue("elementType"), BpmnElementType.class, BpmnElementType.UNSPECIFIED);
 
   public TimerRecord() {
-    super(10);
+    super(11);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
@@ -49,6 +50,7 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(elementTypeProp);
   }
@@ -155,6 +157,16 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
 
   public TimerRecord setElementType(final BpmnElementType elementType) {
     elementTypeProp.setValue(elementType);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public TimerRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/UserTaskRecord.golden
@@ -58,6 +58,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue VARIABLES_VALUE = new StringValue(VARIABLES);
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_VALUE =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue STORAGE_ORDINAL_KEY_VALUE = new StringValue("storageOrdinalKey");
 
   /**
    * Defines the mapping between names of attributes that may be modified (updated or corrected) and
@@ -111,6 +112,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_VALUE, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_VALUE, 0);
   private final StringProperty businessIdProp = new StringProperty("businessId", EMPTY_STRING);
 
   /**
@@ -156,7 +159,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty listenersConfigKeyProp = new LongProperty("listenersConfigKey", -1L);
 
   public UserTaskRecord() {
-    super(26);
+    super(27);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsListProp)
@@ -182,6 +185,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(tagsProp)
         .declareProperty(listenersConfigKeyProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(businessIdProp);
   }
 
@@ -212,6 +216,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     setTags(record.getTags());
     listenersConfigKeyProp.setValue(record.getListenersConfigKey());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
+    storageOrdinalKeyProp.setValue(record.getStorageOrdinalKey());
     businessIdProp.setValue(record.getBusinessIdBuffer());
   }
 
@@ -811,6 +816,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord resetChangedAttributes() {
     changedAttributesProp.reset();
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public UserTaskRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/VariableRecord.golden
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -36,6 +37,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
   private static final StringValue SOURCE_KEY = new StringValue("source");
+  private static final StringValue STORAGE_ORDINAL_KEY_KEY = new StringValue("storageOrdinalKey");
 
   private final StringProperty nameProp = new StringProperty(NAME_KEY);
   private final BinaryProperty valueProp = new BinaryProperty(VALUE_KEY);
@@ -48,6 +50,8 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final IntegerProperty storageOrdinalKeyProp =
+      new IntegerProperty(STORAGE_ORDINAL_KEY_KEY, 0);
   private final ObjectProperty<VariableSourceRecord> sourceProp =
       new ObjectProperty<>(SOURCE_KEY, new VariableSourceRecord());
 
@@ -58,7 +62,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private String cachedJsonValue;
 
   public VariableRecord() {
-    super(9);
+    super(10);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)
@@ -67,6 +71,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(tenantIdProp)
         .declareProperty(rootProcessInstanceKeyProp)
+        .declareProperty(storageOrdinalKeyProp)
         .declareProperty(sourceProp);
   }
 
@@ -195,6 +200,16 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
 
   public VariableRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public int getStorageOrdinalKey() {
+    return storageOrdinalKeyProp.getValue();
+  }
+
+  public VariableRecord setStorageOrdinalKey(final int storageOrdinalKey) {
+    storageOrdinalKeyProp.setValue(storageOrdinalKey);
     return this;
   }
 }

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -546,7 +546,10 @@ public final class ProtocolFactory {
         // as we have nested types in our protocol, let's give a generous depth here, but let's
         // still limit it to avoid errors/issues with nested collections
         .randomizationDepth(8)
-        .excludeField(excludedRecordFields);
+        .excludeField(excludedRecordFields)
+        // force the default ordinal so random records will always target the main index and
+        // not ordinal indexes (unless we need to verify that in tests)
+        .randomize(field -> field.getName().equals("storageOrdinalKey"), () -> 0);
   }
 
   private <T extends RecordValue> Record<T> generateImmutableRecord(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -38,7 +38,7 @@ public interface BatchOperationChunkRecordValue extends BatchOperationRelated, R
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutableBatchOperationItemValue.Builder.class)
-  interface BatchOperationItemValue {
+  interface BatchOperationItemValue extends StorageOrdinalKeyRelated {
     long getItemKey();
 
     long getProcessInstanceKey();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.protocol.record.value;
 
 /** Marks a record as related to a batch operation. */
-public interface BatchOperationRelated {
+public interface BatchOperationRelated extends StorageOrdinalKeyRelated {
 
   /**
    * @return the key of the batch operation aka operation reference key

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DecisionEvaluationRecordValue.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableDecisionEvaluationRecordValue.Builder.class)
 public interface DecisionEvaluationRecordValue
-    extends RecordValue, RecordValueWithVariables, TenantOwned {
+    extends RecordValue, RecordValueWithVariables, StorageOrdinalKeyRelated, TenantOwned {
 
   /**
    * @return the key of the evaluated decision

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -39,6 +39,7 @@ public interface MessageSubscriptionRecordValue
   /**
    * @return the element instance key tied to the subscription
    */
+  @Override
   long getElementInstanceKey();
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRelated.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
-public interface ProcessInstanceRelated {
+public interface ProcessInstanceRelated extends StorageOrdinalKeyRelated {
 
   /**
    * @return the key of the corresponding process instance

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/StorageOrdinalKeyRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/StorageOrdinalKeyRelated.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/**
+ * Marks a record value that carries a storage ordinal key.
+ *
+ * <p>A storage ordinal groups entities with a well-defined lifetime (e.g. process instances,
+ * standalone decision instances - anything that is archived today) so that their data can be stored
+ * together and disposed of together. The engine assigns the currently active ordinal to a root
+ * process instance when it is created; all dependent records (child instances, jobs, variables,
+ * incidents, etc.) inherit the ordinal of their root instance. Once assigned, the ordinal of a root
+ * process instance never changes.
+ *
+ * <p>Exporters use this key to route a record's document to the storage location (e.g. an
+ * ordinal-suffixed index) of its ordinal. Once every entity in an ordinal has completed and the
+ * retention period has elapsed, the ordinal's storage location can be deleted as a whole, removing
+ * the need to archive (i.e. move) documents of completed instances.
+ *
+ * <p>Ordinals are monotonically increasing numbers, with a few reserved values:
+ *
+ * <ul>
+ *   <li>{@code 0} — the main (non-ordinal) index of the record type. Used while ordinal-based
+ *       storage is disabled, and for instances that predate the feature; such records keep being
+ *       written to the main index and remain subject to archiving.
+ *   <li>{@code 1..1000} — reserved for special allocations (e.g. fixed ordinal pools or recovery).
+ *   <li>{@code 1001+} — regular ordinals assigned by the engine.
+ * </ul>
+ */
+public interface StorageOrdinalKeyRelated {
+
+  /**
+   * @return the ordinal this record belongs to; {@code 0} means the record must be stored in the
+   *     main index (either a legacy record or explicitly forced); {@code -1} means the record is
+   *     not ordinal-controlled
+   */
+  int getStorageOrdinalKey();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TimerRecordValue.java
@@ -45,6 +45,7 @@ public interface TimerRecordValue
   /**
    * @return the key of the related element instance.
    */
+  @Override
   long getElementInstanceKey();
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/WaitStateRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/WaitStateRelated.java
@@ -16,7 +16,7 @@
 package io.camunda.zeebe.protocol.record.value;
 
 /** Marks a record value that carries the identifying fields of a waiting-state element. */
-public interface WaitStateRelated {
+public interface WaitStateRelated extends StorageOrdinalKeyRelated {
 
   /**
    * @return the key of the root process instance, or {@code -1L} if not set.

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilderTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/BufferedTaskResultBuilderTest.java
@@ -40,7 +40,7 @@ class BufferedTaskResultBuilderTest {
   @Test
   void canAppendRecords() {
     final var cache = Mockito.mock(StagedScheduledCommandCache.class);
-    final var builder = new BufferedTaskResultBuilder((count, size) -> size < 1000, cache);
+    final var builder = new BufferedTaskResultBuilder((count, size) -> size < 1200, cache);
 
     final var records =
         List.of(
@@ -49,7 +49,7 @@ class BufferedTaskResultBuilderTest {
             new ProcessInstanceCreationRecord());
 
     assertThat(builder.canAppendRecords(records, FollowUpCommandMetadata.empty()))
-        .isTrue(); // size should be 801
+        .isTrue(); // size should be 1011
   }
 
   @Test
@@ -66,6 +66,6 @@ class BufferedTaskResultBuilderTest {
             new ProcessInstanceCreationRecord());
 
     assertThat(builder.canAppendRecords(records, FollowUpCommandMetadata.empty()))
-        .isFalse(); // size should be 1335
+        .isFalse(); // size should be 1685
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 469]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 488]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 470);
+    final var recordBatch = new RecordBatch((count, size) -> size < 489);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);


### PR DESCRIPTION
## Description

Add the `storageOrdinalKey` field to all records that directly or indirectly implement the `ProcessInstanceRelated`, `BatchOperationRelated`, and `DecisionEvaluationRecordValue` interfaces.

This change only adds the field, sets a default value, and updates all relevant places, such as the `.wrap()` method. 

The value is not set anywhere yet; the actual functionality will be implemented in a later PR.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57154 
