### PR TITLE
feat: stub MembershipPort for Optimize CSL adoption

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeCamundaSecurityConfig.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.optimize.rest.security.csl;
 
+import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityAutoConfiguration;
 import io.camunda.security.spring.spi.OidcAuthenticationEntryPoint;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -46,14 +46,20 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 public class OptimizeCamundaSecurityConfig {
 
   @Bean
-  @ConditionalOnMissingBean
   public SecurityPathPort securityPathPort() {
     return new OptimizeSecurityPathAdapter();
   }
 
+  /**
+   * Stub membership port CSL's claim converters depend on; see {@link OptimizeMembershipAdapter}.
+   */
+  @Bean
+  public MembershipPort membershipPort() {
+    return new OptimizeMembershipAdapter();
+  }
+
   /** Overrides CSL's default OIDC entry point; see {@link OptimizeOidcAuthenticationEntryPoint}. */
   @Bean
-  @ConditionalOnMissingBean
   public OidcAuthenticationEntryPoint oidcAuthenticationEntryPoint(
       final ClientRegistrationRepository clientRegistrationRepository) {
     return new OptimizeOidcAuthenticationEntryPoint(

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeMembershipAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeMembershipAdapter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import io.camunda.security.core.port.out.MembershipPort;
+import io.camunda.security.core.port.out.MembershipQuery;
+import java.util.List;
+
+/**
+ * Stub {@link MembershipPort} for Optimize's CSL wiring: CSL's lazy claim converters require a
+ * {@code MembershipPort} bean to build their chains, and CSL ships no default.
+ *
+ * <p>Optimize has no live group/role/tenant membership feature to preserve, so every lookup returns
+ * an empty list — matching the behaviour of the legacy setup, which resolved no memberships either.
+ */
+public final class OptimizeMembershipAdapter implements MembershipPort {
+
+  @Override
+  public List<String> mappingRuleIds(final MembershipQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public List<String> groupIds(final MembershipQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public List<String> roleIds(final MembershipQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public List<String> tenantIds(final MembershipQuery query) {
+    return List.of();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/CslSecurityChainSelectionTest.java
@@ -20,6 +20,7 @@ import io.camunda.optimize.service.security.SessionService;
 import io.camunda.optimize.service.security.UserIdMigrationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
+import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.LazyInitializationBeanFactoryPostProcessor;
@@ -115,6 +116,8 @@ class CslSecurityChainSelectionTest {
               assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
               assertThat(context.getBean(SecurityPathPort.class))
                   .isInstanceOf(OptimizeSecurityPathAdapter.class);
+              assertThat(context.getBean(MembershipPort.class))
+                  .isInstanceOf(OptimizeMembershipAdapter.class);
             });
   }
 
@@ -140,6 +143,8 @@ class CslSecurityChainSelectionTest {
               assertThat(context).doesNotHaveBean(CCSaaSSecurityConfigurerAdapter.class);
               assertThat(context).doesNotHaveBean(CCSaasAuth0WebSecurityConfig.class);
               assertThat(context).hasSingleBean(OptimizeCamundaSecurityConfig.class);
+              assertThat(context.getBean(MembershipPort.class))
+                  .isInstanceOf(OptimizeMembershipAdapter.class);
             });
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeMembershipAdapterTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeMembershipAdapterTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.core.port.out.MembershipPort.PrincipalType;
+import io.camunda.security.core.port.out.MembershipQuery;
+import java.util.Map;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class OptimizeMembershipAdapterTest {
+
+  private final OptimizeMembershipAdapter membershipAdapter = new OptimizeMembershipAdapter();
+
+  @ParameterizedTest
+  @EnumSource(PrincipalType.class)
+  void shouldReturnEmptyMembershipForAnyPrincipal(final PrincipalType principalType) {
+    // given
+    final MembershipQuery query =
+        new MembershipQuery(Map.of("sub", "someone"), "someone", principalType);
+
+    // when / then
+    assertThat(membershipAdapter.mappingRuleIds(query)).isEmpty();
+    assertThat(membershipAdapter.groupIds(query)).isEmpty();
+    assertThat(membershipAdapter.roleIds(query)).isEmpty();
+    assertThat(membershipAdapter.tenantIds(query)).isEmpty();
+  }
+}


### PR DESCRIPTION
Closes #58478

Optimize's opt-in CSL security wiring (introduced in #58501) reuses CSL's stateful OIDC webapp chain. CSL's lazy claim converters take a `MembershipPort` as a constructor dependency and CSL ships **no default**, so the chain fails to build unless the host registers one.

Optimize has no live group/role/tenant membership feature to preserve (see the investigation on #58478), so this adds a **pure stub**: `OptimizeMembershipAdapter` returns no memberships for any principal, matching the legacy setup which resolved none either.

It is registered as a plain `@Bean MembershipPort` in `OptimizeCamundaSecurityConfig`. The host beans in that class are intentionally **unconditional**: Optimize is the terminal host, so nothing downstream overrides them, and the `@ConditionalOnMissingBean` convention belongs on the library side. CSL's own default `OidcAuthenticationEntryPoint` carries `@ConditionalOnMissingBean` and backs off when the host provides one, and CSL ships no default for `SecurityPathPort` or `MembershipPort`, so the host beans are always the definitive ones. This PR therefore also drops the `@ConditionalOnMissingBean` that was previously on the `SecurityPathPort` and `OidcAuthenticationEntryPoint` beans, removing a latent registration-order dependency. The whole class stays gated by `@ConditionalOnProperty(optimize.security.csl.enabled=true)`, so these beans only exist in CSL mode.

### Acceptance criteria
- [x] `MembershipPort` bean registered when `optimize.security.csl.enabled=true`
- [x] Returns empty membership (no groups/roles/tenants)
- [x] Enabling CSL mode starts the context cleanly for CCSM and CCSaaS: covered by the enabled-flag cases in `CslSecurityChainSelectionTest` (`hasNotFailed()` + stub bean present). Full chain-build verification under a real servlet context is tracked in #58480.
- [x] Unit test asserts empty membership for any principal (`OptimizeMembershipAdapterTest`, parameterized over `PrincipalType`)
