### PR TITLE
fix: start timeout when the first `null` configuration is received

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Metadata.java
+++ b/configuration/src/main/java/io/camunda/configuration/Metadata.java
@@ -39,6 +39,12 @@ public class Metadata {
   /** The number of nodes to which a cluster topology is gossiped. */
   private int gossipFanout = ClusterConfigurationGossiperConfig.DEFAULT_GOSSIP_FANOUT;
 
+  /**
+   * The maximum time to wait for a sync response with an initialized configuration before falling
+   * back to generating a new configuration from the static configuration.
+   */
+  private Duration bootstrapTimeout = ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT;
+
   public Duration getSyncDelay() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
         PREFIX + ".sync-delay", syncDelay, Duration.class, SUPPORTED, LEGACY_SYNC_DELAY_PROPERTIES);
@@ -80,5 +86,13 @@ public class Metadata {
 
   public void setSyncInitializerDelay(final Duration delay) {
     syncInitializerDelay = delay;
+  }
+
+  public Duration getBootstrapTimeout() {
+    return bootstrapTimeout;
+  }
+
+  public void setBootstrapTimeout(final Duration bootstrapTimeout) {
+    this.bootstrapTimeout = bootstrapTimeout;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -578,9 +578,10 @@ public class BrokerBasedPropertiesOverride {
     final var syncTimeout = metadata.getSyncRequestTimeout();
     final var gossipFanout = metadata.getGossipFanout();
     final var syncInitializerDelay = metadata.getSyncInitializerDelay();
+    final var bootstrapTimeout = metadata.getBootstrapTimeout();
     final var configManagerGossipConfig =
         new ClusterConfigurationGossiperConfig(
-            syncDelay, syncTimeout, gossipFanout, syncInitializerDelay);
+            syncDelay, syncTimeout, gossipFanout, syncInitializerDelay, bootstrapTimeout);
     override.getCluster().setConfigManager(new ConfigManagerCfg(configManagerGossipConfig));
   }
 

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -22,6 +22,7 @@ cluster.membership.probe-interval
 cluster.membership.probe-timeout
 cluster.membership.suspect-probes
 cluster.membership.sync-interval
+cluster.metadata.bootstrap-timeout
 cluster.metadata.gossip-fanout
 cluster.metadata.sync-delay
 cluster.metadata.sync-initializer-delay

--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -55,7 +55,8 @@ public class DynamicClusterServices {
         gossiperConfig.getSyncDelay(),
         gossiperConfig.getSyncRequestTimeout(),
         gossiperConfig.getGossipFanout(),
-        gossiperConfig.getSyncInitializerDelay());
+        gossiperConfig.getSyncInitializerDelay(),
+        gossiperConfig.getBootstrapTimeout());
   }
 
   @Bean

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -677,7 +677,8 @@ final class SystemContextTest {
                 Duration.ofSeconds(10).negated(),
                 Duration.ofSeconds(10).negated(),
                 -1,
-                Duration.ofSeconds(1)));
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(30)));
     clusterCfg.setConfigManager(invalidconfigManagerCfg);
 
     // when
@@ -702,7 +703,11 @@ final class SystemContextTest {
     final var invalidConfigManagerCfg =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(0), Duration.ofSeconds(0), 0, Duration.ofSeconds(1)));
+                Duration.ofSeconds(0),
+                Duration.ofSeconds(0),
+                0,
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(30)));
     clusterCfg.setConfigManager(invalidConfigManagerCfg);
 
     // when
@@ -727,7 +732,11 @@ final class SystemContextTest {
     final var invalidDynamicConfig =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(1), Duration.ofSeconds(1), 1, Duration.ofSeconds(1)));
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(1),
+                1,
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(30)));
     clusterCfg.setConfigManager(invalidDynamicConfig);
 
     // when

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -177,7 +177,11 @@ public final class ClusterCfgTest {
         .isEqualTo(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(10), Duration.ofSeconds(30), 10, Duration.ofSeconds(1))));
+                    Duration.ofSeconds(10),
+                    Duration.ofSeconds(30),
+                    10,
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(30))));
   }
 
   @Test
@@ -199,7 +203,11 @@ public final class ClusterCfgTest {
         .isEqualTo(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(6), 6, Duration.ofSeconds(1))));
+                    Duration.ofSeconds(5),
+                    Duration.ofSeconds(6),
+                    6,
+                    Duration.ofSeconds(1),
+                    Duration.ofSeconds(30))));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -351,17 +351,14 @@ public interface ClusterConfigurationInitializer {
         scheduleRetry();
       } else if (configuration == null) {
         LOGGER.trace("Received null cluster configuration from {}. Will retry.", memberId);
+        // A null response (e.g. from a gateway member, which never gossips an explicit
+        // uninitialized configuration) must still count towards the bootstrap timeout. Otherwise
+        // a cluster with only such members would poll forever without ever falling back.
+        armBootstrapTimeout();
         scheduleRetry();
       } else if (configuration.isUninitialized()) {
         LOGGER.trace("Cluster configuration is uninitialized in {}", memberId);
-
-        // start timeout after first uninitialized
-        if (bootstrapTimeoutTimer == null && uninitializedMembers.isEmpty()) {
-          bootstrapTimeoutTimer =
-              executor.schedule(
-                  bootstrapTimeout,
-                  () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
-        }
+        armBootstrapTimeout();
         uninitializedMembers.add(memberId);
         final var members = knownMembersToSync.get();
         if (uninitializedMembers.containsAll(members)
@@ -398,6 +395,15 @@ public interface ClusterConfigurationInitializer {
         initialized.complete(ClusterConfiguration.uninitialized());
         cancelBootstrapTimeout();
         clusterConfigurationUpdateNotifier.removeUpdateListener(this);
+      }
+    }
+
+    private void armBootstrapTimeout() {
+      if (bootstrapTimeoutTimer == null) {
+        bootstrapTimeoutTimer =
+            executor.schedule(
+                bootstrapTimeout,
+                () -> completeAsUninitialized("sync timeout (%s)".formatted(bootstrapTimeout)));
       }
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -259,7 +259,6 @@ public interface ClusterConfigurationInitializer {
       implements ClusterConfigurationInitializer, ClusterConfigurationUpdateListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SyncInitializer.class);
-    private static final Duration DEFAULT_BOOTSTRAP_TIMEOUT = Duration.ofSeconds(30);
     private final Duration syncDelay;
     private final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier;
     private final ActorFuture<ClusterConfiguration> initialized;
@@ -271,21 +270,6 @@ public interface ClusterConfigurationInitializer {
     private ScheduledTimer bootstrapTimeoutTimer;
     private final ConcurrencyControl executor;
     private final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester;
-
-    public SyncInitializer(
-        final Duration syncDelay,
-        final ClusterConfigurationUpdateNotifier clusterConfigurationUpdateNotifier,
-        final Supplier<List<MemberId>> knownMembersToSync,
-        final ConcurrencyControl executor,
-        final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester) {
-      this(
-          syncDelay,
-          clusterConfigurationUpdateNotifier,
-          knownMembersToSync,
-          executor,
-          syncRequester,
-          DEFAULT_BOOTSTRAP_TIMEOUT);
-    }
 
     SyncInitializer(
         final Duration syncDelay,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -138,7 +138,8 @@ public final class ClusterConfigurationManagerService
                 clusterConfigurationGossiper,
                 otherKnownMembers,
                 managerActor,
-                clusterConfigurationGossiper::queryClusterConfiguration))
+                clusterConfigurationGossiper::queryClusterConfiguration,
+                gossiperConfig.bootstrapTimeout()))
         .orThen(
             new GossipInitializer(
                 clusterConfigurationGossiper,
@@ -170,7 +171,8 @@ public final class ClusterConfigurationManagerService
                 clusterConfigurationGossiper,
                 otherKnownMembers,
                 managerActor,
-                clusterConfigurationGossiper::queryClusterConfiguration))
+                clusterConfigurationGossiper::queryClusterConfiguration,
+                gossiperConfig.bootstrapTimeout()))
         .orThen(new StaticInitializer(staticConfiguration))
         .andThen(
             new ExporterStateInitializer(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
@@ -14,30 +14,35 @@ public record ClusterConfigurationGossiperConfig(
     Duration syncDelay,
     Duration syncRequestTimeout,
     Integer gossipFanout,
-    Duration syncInitializerDelay) {
+    Duration syncInitializerDelay,
+    Duration bootstrapTimeout) {
 
   public static final Duration DEFAULT_SYNC_DELAY = Duration.ofSeconds(10);
   public static final Duration DEFAULT_SYNC_INITIALIZER_DELAY = Duration.ofSeconds(5);
   public static final Duration DEFAULT_SYNC_REQUEST_TIMEOUT = Duration.ofSeconds(2);
   public static final int DEFAULT_GOSSIP_FANOUT = 2;
+  public static final Duration DEFAULT_BOOTSTRAP_TIMEOUT = Duration.ofSeconds(30);
 
   public static final ClusterConfigurationGossiperConfig DEFAULT =
       new ClusterConfigurationGossiperConfig(
           DEFAULT_SYNC_DELAY,
           DEFAULT_SYNC_REQUEST_TIMEOUT,
           DEFAULT_GOSSIP_FANOUT,
-          DEFAULT_SYNC_INITIALIZER_DELAY);
+          DEFAULT_SYNC_INITIALIZER_DELAY,
+          DEFAULT_BOOTSTRAP_TIMEOUT);
 
   public ClusterConfigurationGossiperConfig(
       final Duration syncDelay,
       final Duration syncRequestTimeout,
       final Integer gossipFanout,
-      final Duration syncInitializerDelay) {
+      final Duration syncInitializerDelay,
+      final Duration bootstrapTimeout) {
     this.syncDelay = Optional.ofNullable(syncDelay).orElse(DEFAULT_SYNC_DELAY);
     this.syncRequestTimeout =
         Optional.ofNullable(syncRequestTimeout).orElse(DEFAULT_SYNC_REQUEST_TIMEOUT);
     this.gossipFanout = Optional.ofNullable(gossipFanout).orElse(DEFAULT_GOSSIP_FANOUT);
     this.syncInitializerDelay =
         Optional.ofNullable(syncInitializerDelay).orElse(DEFAULT_SYNC_INITIALIZER_DELAY);
+    this.bootstrapTimeout = Optional.ofNullable(bootstrapTimeout).orElse(DEFAULT_BOOTSTRAP_TIMEOUT);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -339,6 +339,94 @@ final class ClusterConfigurationInitializerTest {
     assertThatClusterTopology(initializeFuture.join()).isInitialized();
   }
 
+  @Test
+  void shouldCompleteImmediatelyWithNoKnownMembersToSync() {
+    // given - a single-node cluster: the coordinator has no other members to sync with
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofSeconds(5),
+            new TestClusterConfigurationNotifier(),
+            List::of,
+            new TestConcurrencyControl(),
+            id -> {
+              throw new AssertionError("should not query any member when the cluster has none");
+            });
+
+    // when
+    final var initializeFuture = initializer.initialize();
+
+    // then - completes immediately as uninitialized so the coordinator falls back to
+    // StaticInitializer, without waiting on anyone (including itself)
+    assertThat(initializeFuture.isDone()).isTrue();
+    assertThatClusterTopology(initializeFuture.join()).isUninitialized();
+  }
+
+  @Test
+  void shouldFallBackToUninitializedAfterBootstrapTimeoutWhenMemberOnlyEverReturnsNull() {
+    // given - a member that always answers with null, e.g. a gateway member which is part of
+    // cluster membership but never gossips an explicit uninitialized configuration
+    final var nullRespondingMember = MemberId.from("gateway-0");
+    final var concurrencyControl = new TestConcurrencyControl(true);
+    final var bootstrapTimeout = Duration.ofSeconds(1);
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofMillis(50),
+            new TestClusterConfigurationNotifier(),
+            () -> List.of(nullRespondingMember),
+            concurrencyControl,
+            ignored -> CompletableActorFuture.completed(null),
+            bootstrapTimeout);
+
+    // when
+    final var initializeFuture = initializer.initialize();
+
+    // then - stays pending while only null responses are received
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // when - retries run and the bootstrap timeout elapses
+    concurrencyControl.runAll();
+
+    // then - falls back to uninitialized instead of polling forever, since a member that only
+    // ever returns null never contributes to the "all members confirmed uninitialized" check
+    assertThatClusterTopology(initializeFuture.join()).isUninitialized();
+  }
+
+  @Test
+  void shouldConvergeQuicklyWhenAllMembersEventuallyConfirmUninitialized() {
+    // given - a 3-node cluster (this member + 2 peers); one peer hasn't yet reached the gossip
+    // stage on the first poll (returns null), the other already confirms uninitialized
+    final var slowMember = MemberId.from("1");
+    final var fastMember = MemberId.from("2");
+    final var slowMemberCalls = new AtomicInteger();
+    final Function<MemberId, ActorFuture<ClusterConfiguration>> syncRequester =
+        id -> {
+          if (id.equals(slowMember)) {
+            return slowMemberCalls.getAndIncrement() == 0
+                ? CompletableActorFuture.completed(null)
+                : CompletableActorFuture.completed(ClusterConfiguration.uninitialized());
+          }
+          return CompletableActorFuture.completed(ClusterConfiguration.uninitialized());
+        };
+    final var concurrencyControl = new TestConcurrencyControl(true);
+    final var bootstrapTimeout = Duration.ofSeconds(30);
+    final var initializer =
+        new SyncInitializer(
+            Duration.ofMillis(50),
+            new TestClusterConfigurationNotifier(),
+            () -> List.of(slowMember, fastMember),
+            concurrencyControl,
+            syncRequester,
+            bootstrapTimeout);
+
+    // when
+    final var initializeFuture = initializer.initialize();
+    assertThat(initializeFuture.isDone()).isFalse();
+
+    // then - converges within a single retry round, well before the 30s bootstrap timeout
+    concurrencyControl.runAll();
+    assertThatClusterTopology(initializeFuture.join()).isUninitialized();
+  }
+
   private ClusterConfigurationInitializer getStaticInitializer() {
     final var member = MemberId.from("10");
     return new StaticInitializer(getStaticConfiguration(member, Set.of(member)));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.GossipIni
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.InitializerError.PersistedConfigurationIsBroken;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.SyncInitializer;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -159,7 +160,8 @@ final class ClusterConfigurationInitializerTest {
             new TestClusterConfigurationNotifier(),
             () -> knownMembers,
             new TestConcurrencyControl(true),
-            syncRequester);
+            syncRequester,
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -190,7 +192,8 @@ final class ClusterConfigurationInitializerTest {
             new TestClusterConfigurationNotifier(),
             () -> knownMembers,
             concurrencyControl,
-            syncRequester);
+            syncRequester,
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -220,7 +223,8 @@ final class ClusterConfigurationInitializerTest {
             new TestClusterConfigurationNotifier(),
             () -> List.of(uninitializedMember, initializedMember),
             new TestConcurrencyControl(true),
-            syncResponses::get);
+            syncResponses::get,
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -326,7 +330,8 @@ final class ClusterConfigurationInitializerTest {
             new TestClusterConfigurationNotifier(),
             () -> List.of(unreachableMember, recoveringMember),
             concurrencyControl,
-            syncRequester);
+            syncRequester,
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
     // when - first round: one member fails, the other is uninitialized -> stays pending
     final var initializeFuture = initializer.initialize();
@@ -350,7 +355,8 @@ final class ClusterConfigurationInitializerTest {
             new TestConcurrencyControl(),
             id -> {
               throw new AssertionError("should not query any member when the cluster has none");
-            });
+            },
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
     // when
     final var initializeFuture = initializer.initialize();
@@ -562,7 +568,8 @@ final class ClusterConfigurationInitializerTest {
               new TestClusterConfigurationNotifier(),
               () -> knownMembers,
               new TestConcurrencyControl(true),
-              syncRequester);
+              syncRequester,
+              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
       final var initializer =
           new FileInitializer(topologyFile, new ProtoBufSerializer()).orThen(syncInitializer);
@@ -592,7 +599,8 @@ final class ClusterConfigurationInitializerTest {
               new TestClusterConfigurationNotifier(),
               () -> knownMembers,
               concurrencyControl,
-              syncRequester);
+              syncRequester,
+              ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
 
       final var initializer =
           new FileInitializer(topologyFile, new ProtoBufSerializer())

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -318,7 +318,11 @@ class ClusterConfigurationManagementIntegrationTest {
             cluster.getCommunicationService(),
             cluster.getMembershipService(),
             new ClusterConfigurationGossiperConfig(
-                Duration.ofSeconds(1), Duration.ofMillis(100), 2, Duration.ofSeconds(1)),
+                Duration.ofSeconds(1),
+                Duration.ofMillis(100),
+                2,
+                Duration.ofSeconds(1),
+                Duration.ofSeconds(5)),
             new NoopClusterChangeExecutor(),
             meterRegistry);
     return new TestNode(cluster, service);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -62,7 +62,11 @@ final class ClusterConfigurationGossiperTest {
     // given
     final var config =
         new ClusterConfigurationGossiperConfig(
-            Duration.ofMillis(100), Duration.ofSeconds(1), 0, Duration.ofSeconds(1));
+            Duration.ofMillis(100),
+            Duration.ofSeconds(1),
+            0,
+            Duration.ofSeconds(1),
+            ClusterConfigurationGossiperConfig.DEFAULT_BOOTSTRAP_TIMEOUT);
     node1 =
         new TestGossiper(
             createClusterNode(clusterNodes.get(0), clusterNodes), config, topologyMetrics);

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -48,7 +48,11 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(30), 6, Duration.ofSeconds(5))));
+                    Duration.ofSeconds(5),
+                    Duration.ofSeconds(30),
+                    6,
+                    Duration.ofSeconds(5),
+                    Duration.ofSeconds(30))));
     CUSTOM_CFG
         .getSecurity()
         .setEnabled(true)
@@ -198,7 +202,11 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    Duration.ofSeconds(5), Duration.ofSeconds(5), 4, Duration.ofSeconds(5))));
+                    Duration.ofSeconds(5),
+                    Duration.ofSeconds(5),
+                    4,
+                    Duration.ofSeconds(5),
+                    Duration.ofSeconds(30))));
     expected.getThreads().setManagementThreads(32);
     expected
         .getSecurity()

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -14,6 +14,7 @@ import io.camunda.configuration.Partitioning.Scheme;
 import io.camunda.configuration.Zone;
 import io.camunda.configuration.ZoneAware;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,7 @@ import java.util.stream.IntStream;
 public final class TestClusterBuilder {
 
   public static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+  private static final Duration MULTI_ZONE_BOOTSTRAP_TIMEOUT = Duration.ofSeconds(15);
 
   private String name = DEFAULT_CLUSTER_NAME;
 
@@ -391,6 +393,9 @@ public final class TestClusterBuilder {
         .getPartitioning()
         .setZoneAware(
             new ZoneAware(IntStream.range(0, zoneCount).mapToObj(this::zoneConfig).toList()));
+    // cross-zone gossip during bootstrap needs more headroom than the 5s default used for
+    // single-zone test clusters
+    cluster.getMetadata().setBootstrapTimeout(MULTI_ZONE_BOOTSTRAP_TIMEOUT);
   }
 
   private Zone zoneConfig(final int zoneIndex) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -438,6 +438,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     metadata.setSyncInitializerDelay(Duration.ofMillis(500));
     metadata.setSyncDelay(Duration.ofMillis(500));
     metadata.setSyncRequestTimeout(Duration.ofMillis(500));
+    metadata.setBootstrapTimeout(Duration.ofSeconds(5));
 
     // Set raft defaults - disable flushing for faster tests
     unifiedConfig.getCluster().getRaft().setFlushEnabled(false);


### PR DESCRIPTION
## Description
In PR #58321 we changed how SyncInitializer works, by waiting for one member to report uninitialized before starting the timeout.
However, there are edge cases (like when there's just 1 broker and 1 gateway) that make the SyncInitializer never start when the other member always return a null configuration.
Brokers return `uninitialized` when they can't read the file from disk, so the problem is mostly when there's just 1 broker and 1 gateway.

The timeout is now configurable as well, so it can be shortened in tests:
- generally set to 5s
- When a TestCluster is multi zone then 15s


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #58321 
