### PR TITLE
ci: retry docker login in setup-build to survive transient registry auth failures

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -266,7 +266,7 @@ runs:
       timeout_seconds: 60
       shell: bash
       command: |
-        echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+        printf '%s' "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
   - name: Logs on to Harbor
     # Harbor login is disabled for fork PRs
     if: >-
@@ -282,7 +282,7 @@ runs:
       timeout_seconds: 60
       shell: bash
       command: |
-        echo "${DOCKER_PASSWORD}" | docker login registry.camunda.cloud \
+        printf '%s' "${DOCKER_PASSWORD}" | docker login registry.camunda.cloud \
           --username "${DOCKER_USERNAME}" --password-stdin
   - name: Logs on to Minimus
     # Minimus login is disabled for fork PRs
@@ -298,7 +298,7 @@ runs:
       timeout_seconds: 60
       shell: bash
       command: |
-        echo "${DOCKER_PASSWORD}" | docker login reg.mini.dev \
+        printf '%s' "${DOCKER_PASSWORD}" | docker login reg.mini.dev \
           --username minimus --password-stdin
   - name: Authenticate to GCS build-cache
     # GCS build-cache auth is disabled for fork PRs (no Vault access)

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -256,30 +256,50 @@ runs:
         inputs.dockerhub == 'true' ||
         inputs.dockerhub-readonly == 'true'
       )
-    uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    env:
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.dockerhub-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.dockerhub-token }}
     with:
-      username: ${{ steps.secrets.outputs.dockerhub-username }}
-      password: ${{ steps.secrets.outputs.dockerhub-token }}
+      max_attempts: 3
+      retry_wait_seconds: 10
+      timeout_seconds: 60
+      shell: bash
+      command: |
+        echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
   - name: Logs on to Harbor
     # Harbor login is disabled for fork PRs
     if: >-
       steps.is-fork.outputs.is-fork != 'true' &&
       inputs.harbor == 'true'
-    uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    env:
+      DOCKER_USERNAME: ${{ steps.secrets.outputs.ci-account-username }}
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.ci-account-password }}
     with:
-      registry: registry.camunda.cloud
-      username: ${{ steps.secrets.outputs.ci-account-username }}
-      password: ${{ steps.secrets.outputs.ci-account-password }}
+      max_attempts: 3
+      retry_wait_seconds: 10
+      timeout_seconds: 60
+      shell: bash
+      command: |
+        echo "${DOCKER_PASSWORD}" | docker login registry.camunda.cloud \
+          --username "${DOCKER_USERNAME}" --password-stdin
   - name: Logs on to Minimus
     # Minimus login is disabled for fork PRs
     if: >-
       steps.is-fork.outputs.is-fork != 'true' &&
       inputs.minimus == 'true'
-    uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+    uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+    env:
+      DOCKER_PASSWORD: ${{ steps.secrets.outputs.minimus-token }}
     with:
-      registry: reg.mini.dev
-      username: minimus
-      password: ${{ steps.secrets.outputs.minimus-token }}
+      max_attempts: 3
+      retry_wait_seconds: 10
+      timeout_seconds: 60
+      shell: bash
+      command: |
+        echo "${DOCKER_PASSWORD}" | docker login reg.mini.dev \
+          --username minimus --password-stdin
   - name: Authenticate to GCS build-cache
     # GCS build-cache auth is disabled for fork PRs (no Vault access)
     if: >-


### PR DESCRIPTION
## Description

Jobs on `main` intermittently fail during `./.github/actions/setup-build` because DockerHub's auth endpoint (`auth.docker.io`) resets or times out the token exchange performed by `docker login` — e.g. [`context deadline exceeded`](https://github.com/camunda/camunda/actions/runs/30007959151/job/89209713289) and `connection reset by peer`. `docker/login-action` has no built-in retry, so a single transient blip fails the whole job (and cascades into misleading "Build output file does not exist" errors downstream).

This wraps each login (DockerHub, Harbor, Minimus) in `nick-fields/retry` (3 attempts, 10s wait, 60s per attempt) — the retry idiom already established in this repo (see `.github/actions/npm-ci-with-retry`).

**Security:** the password is passed via an env var and piped through `--password-stdin`, so it is never interpolated into the logged command nor exposed in the process list; `nick-fields/retry` does not echo the command or run with `set -x`, and Vault-sourced secrets stay masked.

**Compatibility:** the only behavioral difference from `docker/login-action` is the loss of its automatic post-job `docker logout`, which is immaterial on ephemeral CI runners.

**Scope:** this hardens the `docker login` step only. The separate buildkit base-image-pull token reset seen in `build-platform-docker` (e.g. [this run](https://github.com/camunda/camunda/actions/runs/30000093256/job/89183984558)) is an upstream buildkit gap — its authorizer does not wrap the token request in the retry handler that already covers blob/manifest fetches — and is out of scope here.

## Checklist

- [ ] Enable backports when necessary (see [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

n/a