### PR TITLE
ci: load-test: fix for "Detect changed versions" workflow

### DIFF
--- a/.github/scripts/load-test-detect-versions-changed.sh
+++ b/.github/scripts/load-test-detect-versions-changed.sh
@@ -1,45 +1,49 @@
 #!/bin/bash
 # owner: @camunda/reliability-testing
+#
+# Detects which load-tests/setup/<version> folders changed compared to the PR's base branch
+# and emits a GitHub Actions matrix (as the `matrix` step output) listing the versions to test.
+# If the load-test workflows themselves changed, all versions are included.
 
 set -o nounset
+set -o errexit
+set -o pipefail
 
 GITHUB_BASE_REF="${GITHUB_BASE_REF:-main}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
 
 PARENT="origin/${GITHUB_BASE_REF}"
 
-echo "⏳ Finding versions changed compared to ${PARENT}..."
+# version orchestration-tag setup-path
+VERSIONS=(
+    "main SNAPSHOT load-tests/setup/main/"
+    "stable-89 8.9-SNAPSHOT load-tests/setup/stable-89/"
+    "stable-88 8.8-SNAPSHOT load-tests/setup/stable-88/"
+    "stable-87 8.7-SNAPSHOT load-tests/setup/stable-87/"
+)
+
+echo "Finding versions changed compared to ${PARENT}..."
 
 changed="$(git diff --name-only "${PARENT}...HEAD")"
 
 run_all=false
-if echo "$changed" | grep -qE '\.github/workflows/camunda-load-test'; then
+if grep -qE '\.github/workflows/camunda-load-test' <<<"$changed"; then
+    echo "⇒ Load-test workflow changed, running all versions..."
     run_all=true
 fi
 
 matrix_entries=()
-
-if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/main/'; then
-    echo "✅ Version 'main' changed..."
-    matrix_entries+=('{"version":"main","orchestration-tag":"SNAPSHOT"}')
-fi
-
-if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-89/'; then
-    echo "✅ Version 8.9 changed..."
-    matrix_entries+=('{"version":"stable-89","orchestration-tag":"8.9-SNAPSHOT"}')
-fi
-if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
-    echo "✅ Version 8.8 changed..."
-    matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
-fi
-if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-87/'; then
-    echo "✅ Version 8.7 changed..."
-    matrix_entries+=('{"version":"stable-87","orchestration-tag":"8.7-SNAPSHOT"}')
-fi
+for entry in "${VERSIONS[@]}"; do
+    read -r version tag path <<<"$entry"
+    if [[ "$run_all" == "true" ]] || grep -qF "$path" <<<"$changed"; then
+        echo "⇒ Version '${version}' changed..."
+        matrix_entries+=("{\"version\":\"${version}\",\"orchestration-tag\":\"${tag}\"}")
+    fi
+done
 
 # Default: run main if nothing specific was detected
 if [[ ${#matrix_entries[@]} -eq 0 ]]; then
-    echo "✅ Version 'main' will be run as default because no specific version was detected..."
+    echo "⇒ Version 'main' will be run as default because no specific version was detected..."
     matrix_entries+=('{"version":"main","orchestration-tag":"SNAPSHOT"}')
 fi
 

--- a/.github/scripts/load-test-detect-versions-changed.sh
+++ b/.github/scripts/load-test-detect-versions-changed.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# owner: @camunda/reliability-testing
+
+set -o nounset
+
+GITHUB_BASE_REF="${GITHUB_BASE_REF:-main}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+PARENT="origin/${GITHUB_BASE_REF}"
+
+echo "⏳ Finding versions changed compared to ${PARENT}..."
+
+changed="$(git diff --name-only "${PARENT}...HEAD")"
+
+run_all=false
+if echo "$changed" | grep -qE '\.github/workflows/camunda-load-test'; then
+    run_all=true
+fi
+
+matrix_entries=()
+
+if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/main/'; then
+    echo "✅ Version 'main' changed..."
+    matrix_entries+=('{"version":"main","orchestration-tag":"SNAPSHOT"}')
+fi
+
+if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-89/'; then
+    echo "✅ Version 8.9 changed..."
+    matrix_entries+=('{"version":"stable-89","orchestration-tag":"8.9-SNAPSHOT"}')
+fi
+if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
+    echo "✅ Version 8.8 changed..."
+    matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
+fi
+if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-87/'; then
+    echo "✅ Version 8.7 changed..."
+    matrix_entries+=('{"version":"stable-87","orchestration-tag":"8.7-SNAPSHOT"}')
+fi
+
+# Default: run main if nothing specific was detected
+if [[ ${#matrix_entries[@]} -eq 0 ]]; then
+    echo "✅ Version 'main' will be run as default because no specific version was detected..."
+    matrix_entries+=('{"version":"main","orchestration-tag":"SNAPSHOT"}')
+fi
+
+joined=$(IFS=,; echo "${matrix_entries[*]}")
+echo "matrix={\"include\":[${joined}]}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/camunda-load-test-smoke-dispatch.yml
+++ b/.github/workflows/camunda-load-test-smoke-dispatch.yml
@@ -38,39 +38,7 @@ jobs:
           persist-credentials: false
       - id: detect
         name: Detect which setup versions changed
-        run: |
-          changed=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
-
-          run_all=false
-          if echo "$changed" | grep -qE '\.github/workflows/camunda-load-test'; then
-            run_all=true
-          fi
-
-          matrix_entries=()
-
-          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/main/'; then
-            matrix_entries+=('{"version":"main","orchestration-tag":"SNAPSHOT"}')
-          fi
-          #
-          # Commented out versions - will be added as soon as we have target version support
-          #
-          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-89/'; then
-            matrix_entries+=('{"version":"stable-89","orchestration-tag":"8.9-SNAPSHOT"}')
-          fi
-          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-88/'; then
-            matrix_entries+=('{"version":"stable-88","orchestration-tag":"8.8-SNAPSHOT"}')
-          fi
-          if [[ "$run_all" == "true" ]] || echo "$changed" | grep -q 'load-tests/setup/stable-87/'; then
-            matrix_entries+=('{"version":"stable-87","orchestration-tag":"8.7-SNAPSHOT"}')
-          fi
-
-          # Default: run main if nothing specific was detected
-          if [[ ${#matrix_entries[@]} -eq 0 ]]; then
-            matrix_entries+=('{"version":"main","orchestration-tag":"SNAPSHOT"}')
-          fi
-
-          joined=$(IFS=,; echo "${matrix_entries[*]}")
-          echo "matrix={\"include\":[${joined}]}" >> "$GITHUB_OUTPUT"
+        run: ./.github/scripts/load-test-detect-versions-changed.sh
 
   smoke:
     name: Smoke (${{ matrix.version }})


### PR DESCRIPTION
## Description

This workflow sometimes doesn't correctly detect changed versions and defaults to "main" ; it also fails with mysterious "echo: write error: Broken pipe" errors.

Example https://github.com/camunda/camunda/actions/runs/29936559706/job/89058925911?pr=58435#logs
<img width="852" height="194" alt="image" src="https://github.com/user-attachments/assets/1fade3e1-639b-47b1-be74-f54bc5c02903" />

This job has several problems:

1. No clear mention what the script ran with as inputs
2. No clear what the script is doing internally (no logs)

To help investigation, this:

1. Extracts the script into a dedicated script to be callable from a developer's machine
2. Adds some logs to make it easier to see what's happening
3. The second commit rewrites the script to remove the original "broken pipe" error by replacing `echo "$changed" | grep ...` by `grep ... <<<"$changed"`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/pull/58278#issuecomment-5067533869
