### PR TITLE
feat: agentic tool-calls tile footnote and L1 heat map reorder

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -109,6 +109,9 @@ public class AgenticControlDashboardService {
       "agenticFailureRateByVersionDescription";
   public static final String KPI_TOOL_CALLS_NAME = "agenticKpiToolCallsName";
   public static final String KPI_TOOL_CALLS_DESCRIPTION = "agenticKpiToolCallsDescription";
+  public static final String KPI_TOOL_CALLS_FOOTNOTE = "agenticKpiToolCallsFootnote";
+  public static final String KPI_TOOL_CALLS_FOOTNOTE_KEY =
+      "agenticControl.report." + KPI_TOOL_CALLS_FOOTNOTE;
 
   public static final String TOOL_CALLS_HEATMAP_NAME = "agenticToolCallsHeatmapName";
   public static final String TOOL_CALLS_HEATMAP_DESCRIPTION = "agenticToolCallsHeatmapDescription";
@@ -723,7 +726,11 @@ public class AgenticControlDashboardService {
         KPI_TOOL_CALLS_REPORT_ID,
         new PositionDto(0, 6),
         new DimensionDto(18, 2),
-        Map.of(TILE_CONFIG_SECTION, TILE_SECTION_RELIABILITY_AND_TOOL_CALLS));
+        Map.of(
+            TILE_CONFIG_SECTION,
+            TILE_SECTION_RELIABILITY_AND_TOOL_CALLS,
+            TILE_CONFIG_FOOTNOTE,
+            KPI_TOOL_CALLS_FOOTNOTE_KEY));
   }
 
   // Per-flow-node tool-call counts rendered as a process diagram heat map. Only visible when a

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -768,7 +768,9 @@ public class AgenticControlDashboardService {
         null);
     return buildTile(
         TOOL_CALLS_HEATMAP_REPORT_ID,
-        new PositionDto(0, 14),
+        // Top of the reliability-and-tool-calls section: the smallest y in the section, so the
+        // grid's vertical compaction floats it above the number tiles.
+        new PositionDto(0, 0),
         new DimensionDto(18, 4),
         Map.of(
             TILE_CONFIG_VISIBLE_IN_L1_ONLY,
@@ -814,7 +816,9 @@ public class AgenticControlDashboardService {
         null);
     return buildTile(
         DURATION_HEATMAP_REPORT_ID,
-        new PositionDto(0, 14),
+        // Top of the duration section: the smallest y in the section, so the grid's vertical
+        // compaction floats it above the percentile and stability tiles.
+        new PositionDto(0, 0),
         new DimensionDto(18, 4),
         Map.of(TILE_CONFIG_VISIBLE_IN_L1_ONLY, true, TILE_CONFIG_SECTION, TILE_SECTION_DURATION));
   }

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1613,6 +1613,7 @@
       "agenticFailureRateByVersionDescription": "Prozentsatz der abgeschlossenen agentischen Prozessinstanzen mit einem gelösten Vorfall, aufgeschlüsselt nach Prozessdefinitionsversion.",
       "agenticKpiToolCallsName": "Tool-Aufrufe gesamt",
       "agenticKpiToolCallsDescription": "Gesamtzahl der Tool-Aufrufe durch Agenten in abgeschlossenen agentischen Prozessinstanzen im gewählten Zeitraum.",
+      "agenticKpiToolCallsFootnote": "Ein anhaltender Anstieg der Tool-Aufrufe ohne entsprechenden Anstieg der Ausführungen kann auf Schleifen oder ineffiziente Tool-Nutzung hindeuten. Untersuchen Sie die Prozesse und Prozessknoten, die den Anstieg verursachen.",
       "agenticToolCallsHeatmapName": "Tool-Aufrufe je Prozessknoten",
       "agenticToolCallsHeatmapDescription": "Gesamtzahl der Tool-Aufrufe je Prozessknoten über abgeschlossene agentische Prozessinstanzen, als Heatmap auf dem Prozessdiagramm dargestellt.",
       "agenticDurationHeatmapName": "Dauer je Prozessknoten",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1613,6 +1613,7 @@
       "agenticFailureRateByVersionDescription": "Percentage of completed agentic process instances that encountered a resolved incident, broken down by process definition version.",
       "agenticKpiToolCallsName": "Total tool calls",
       "agenticKpiToolCallsDescription": "Total number of tool calls made by agents in completed agentic process instances in the selected period.",
+      "agenticKpiToolCallsFootnote": "A sustained rise in tool calls without a matching rise in executions can signal looping or inefficient tool use. Investigate the processes and flow nodes driving the increase.",
       "agenticToolCallsHeatmapName": "Tool calls per flow node",
       "agenticToolCallsHeatmapDescription": "Total tool calls made per flow node across completed agentic process instances, shown as a heat map overlay on the process diagram.",
       "agenticDurationHeatmapName": "Duration per flow node",

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -928,7 +928,7 @@ public class AgenticControlDashboardServiceTest {
         tileById(saved, AgenticControlDashboardService.TOOL_CALLS_HEATMAP_REPORT_ID);
 
     assertThat(heatmapTile.getPosition().getX()).isZero();
-    assertThat(heatmapTile.getPosition().getY()).isEqualTo(14);
+    assertThat(heatmapTile.getPosition().getY()).isZero();
     assertThat(heatmapTile.getDimensions().getWidth()).isEqualTo(18);
     assertThat(heatmapTile.getDimensions().getHeight()).isEqualTo(4);
     assertThat(heatmapTile.getConfiguration())
@@ -1022,7 +1022,7 @@ public class AgenticControlDashboardServiceTest {
         tileById(saved, AgenticControlDashboardService.DURATION_HEATMAP_REPORT_ID);
 
     assertThat(heatmapTile.getPosition().getX()).isZero();
-    assertThat(heatmapTile.getPosition().getY()).isEqualTo(14);
+    assertThat(heatmapTile.getPosition().getY()).isZero();
     assertThat(heatmapTile.getDimensions().getWidth()).isEqualTo(18);
     assertThat(heatmapTile.getDimensions().getHeight()).isEqualTo(4);
     assertThat(heatmapTile.getConfiguration())

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -854,7 +854,12 @@ public class AgenticControlDashboardServiceTest {
 
     final DashboardReportTileDto toolCallsTile = toolCallsTiles.getFirst();
     assertThat(toolCallsTile.getConfiguration())
-        .isEqualTo(Map.of("section", "reliabilityAndToolCalls"));
+        .isEqualTo(
+            Map.of(
+                "section",
+                "reliabilityAndToolCalls",
+                "footnote",
+                AgenticControlDashboardService.KPI_TOOL_CALLS_FOOTNOTE_KEY));
     assertThat(toolCallsTile.getDimensions().getWidth()).isEqualTo(18);
     assertThat(toolCallsTile.getDimensions().getHeight()).isEqualTo(2);
   }


### PR DESCRIPTION
## What?
Two small Agentic Control Plane tweaks: add an interpretation footnote to the **Total tool calls** tile, and move the two **L1 heat maps** (tool-calls, duration) to the top of their sections.

## Why?
The tool-calls number had no guidance on how to read it or when to act; the heat maps were buried at the bottom of their sections.

## How?
Footnote reuses the existing per-tile footnote mechanism (backend config + `en`/`de` strings, no frontend change). Heat maps get the smallest `y` in their section so the grid's vertical compaction floats them to the top — no other tile moves.

Closes #58433
