### PR TITLE
56576 aws secrets store validation 

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -164,8 +164,12 @@ class SecretStoreConfigurationTest {
   }
 
   @Test
-  void shouldBuildAwsSecretsManagerStoreWhenConfigured() {
-    // given
+  void shouldBuildAwsSecretsManagerStoreEvenWithoutReachableCredentials() {
+    // given — AwsSecretsManagerSecretStore.fromConfig() only probes connectivity/credentials
+    // best-effort, logging a warning rather than failing, so wiring an aws-secrets-manager store
+    // outside a real AWS/LocalStack environment still constructs successfully; the connectivity
+    // error would only surface on first use. Real resolution against credentials is covered at the
+    // integration level by AwsSecretsManagerSecretStoreIT, which runs against LocalStack.
     final var resolver =
         resolverFor(
             Map.of(

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretResolver.java
@@ -30,4 +30,11 @@ interface AwsSecretResolver {
    *     is malformed
    */
   List<String> list();
+
+  /**
+   * Probes AWS with the same API this resolver uses at runtime, so a startup connectivity check
+   * never demands a broader IAM policy than resolution itself needs. Any AWS/SDK error propagates
+   * to the caller, which logs a warning and continues; called once at construction time.
+   */
+  void validateConnectivity();
 }

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStore.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
@@ -44,6 +46,8 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
  * class.
  */
 public final class AwsSecretsManagerSecretStore implements SecretStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AwsSecretsManagerSecretStore.class);
 
   private final SecretsManagerClient client;
   private final AwsSecretResolver resolver;
@@ -85,10 +89,12 @@ public final class AwsSecretsManagerSecretStore implements SecretStore {
   }
 
   /**
-   * Builds a store from configuration, eagerly constructing the underlying client. Building the
-   * client does not itself contact AWS, so a bad region, unreachable endpoint, or invalid
-   * credentials is not detected here — it only surfaces on the first real {@link #resolve} or
-   * {@link #list} call.
+   * Builds a store from configuration, eagerly constructing the underlying client and probing
+   * connectivity/credentials with a minimal AWS call. The probe is best-effort: a bad region,
+   * unreachable endpoint, or invalid/missing credentials is logged as a warning at startup but does
+   * not prevent the store from being built, so a transient AWS problem during boot cannot stop the
+   * whole application from starting. Such a misconfiguration then surfaces on the first real {@link
+   * #resolve} or {@link #list} call.
    */
   public static AwsSecretsManagerSecretStore fromConfig(final AwsSecretsManagerStoreConfig config) {
     final var builder =
@@ -116,11 +122,36 @@ public final class AwsSecretsManagerSecretStore implements SecretStore {
           "Failed to initialize AWS Secrets Manager client: " + e.getMessage(), e);
     }
     final var pathPrefix = normalize(config.pathPrefix());
+    final var containerSecretId = config.containerSecretId();
     final AwsSecretResolver resolver =
-        config.containerSecretId() != null
-            ? new ContainerSecretResolver(client, pathPrefix, config.containerSecretId())
+        containerSecretId != null
+            ? new ContainerSecretResolver(client, pathPrefix, containerSecretId)
             : new FlatSecretResolver(client, pathPrefix, config.batchEnabled(), config.batchSize());
+    validateConnectivity(resolver);
     return new AwsSecretsManagerSecretStore(client, resolver);
+  }
+
+  /**
+   * Probes AWS connectivity/credentials at startup, delegating to the resolver so it uses the exact
+   * API — and thus the minimal IAM policy — that mode resolves with. The probe is best-effort: on
+   * failure it logs a warning and lets the store be built anyway, so a transient AWS problem during
+   * boot cannot stop the application from starting. The misconfiguration then surfaces on the first
+   * real {@link #resolve} or {@link #list} call. The client is kept open on failure because the
+   * store retains it for those later calls.
+   *
+   * <p>Package-private so the warn-and-continue behaviour can be unit-tested with a stub resolver;
+   * the per-mode probe choice is tested on the resolvers themselves.
+   */
+  static void validateConnectivity(final AwsSecretResolver resolver) {
+    try {
+      resolver.validateConnectivity();
+    } catch (final RuntimeException e) {
+      LOG.warn(
+          "Failed to validate AWS Secrets Manager connectivity/credentials at startup; "
+              + "the store will still be created and the error will surface on first use: {}",
+          e.getMessage(),
+          e);
+    }
   }
 
   @Override

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/ContainerSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/ContainerSecretResolver.java
@@ -147,6 +147,13 @@ final class ContainerSecretResolver implements AwsSecretResolver {
     }
   }
 
+  @Override
+  public void validateConnectivity() {
+    // container mode reads exactly one secret at runtime, so GetSecretValue on it is both the
+    // minimal probe and the one that matches this mode's IAM footprint.
+    client.getSecretValue(GetSecretValueRequest.builder().secretId(containerId).build());
+  }
+
   /**
    * Raw {@code secretString} of the container secret. AWS returns exactly one of {@code
    * secretString}/{@code secretBinary} per secret; {@code null} here means the value lives in

--- a/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/FlatSecretResolver.java
+++ b/secret-store/secret-store-aws/src/main/java/io/camunda/secretstore/aws/FlatSecretResolver.java
@@ -245,6 +245,13 @@ final class FlatSecretResolver implements AwsSecretResolver {
     }
   }
 
+  @Override
+  public void validateConnectivity() {
+    // flat mode resolves via GetSecretValue/BatchGetSecretValue and lists via ListSecrets; a
+    // single-result ListSecrets is the cheapest probe that exercises this mode's IAM footprint.
+    client.listSecrets(ListSecretsRequest.builder().maxResults(1).build());
+  }
+
   private String secretId(final String name) {
     return pathPrefix + name;
   }

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreIT.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreIT.java
@@ -8,10 +8,12 @@
 package io.camunda.secretstore.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.secretstore.SecretErrorCode;
 import io.camunda.secretstore.SecretResolutionResult.Failed;
 import io.camunda.secretstore.SecretResolutionResult.Resolved;
+import io.camunda.secretstore.SecretStoreUnavailableException;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -187,7 +189,8 @@ class AwsSecretsManagerSecretStoreIT {
   @Test
   void shouldResolveViaFromConfigIdentityPath() {
     // given — exercise the production build path (DefaultCredentialsProvider) with
-    // credentials supplied via system properties, mirroring how a pod identity injects them
+    // credentials supplied via system properties, mirroring how a pod identity injects them.
+    // fromConfig() succeeding at all already proves its startup connectivity validation passed.
     System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
     System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
     try {
@@ -245,6 +248,69 @@ class AwsSecretsManagerSecretStoreIT {
             .isInstanceOf(Resolved.class)
             .extracting(r -> ((Resolved) r).value())
             .isEqualTo("tok3n");
+      }
+    } finally {
+      System.clearProperty("aws.accessKeyId");
+      System.clearProperty("aws.secretAccessKey");
+    }
+  }
+
+  @Test
+  void shouldResolveViaFromConfigInContainerMode() {
+    // given — container mode: fromConfig() building at all proves its startup probe used
+    // GetSecretValue on the container secret (not ListSecrets), then resolution reads a key from it
+    System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
+    System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
+    try {
+      final var config =
+          new AwsSecretsManagerStoreConfig(
+              LOCALSTACK.getRegion(),
+              "camunda/",
+              "app-config",
+              URI.create(LOCALSTACK.getEndpointOverride(Service.SECRETSMANAGER).toString()),
+              AwsSecretsManagerStoreConfig.DEFAULT_MAX_RETRIES,
+              false,
+              AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+
+      try (final var store = AwsSecretsManagerSecretStore.fromConfig(config)) {
+        // when
+        final var ref = "DB_PASSWORD";
+        final var result = store.resolve(Set.of(ref));
+
+        // then
+        assertThat(result.get(ref))
+            .isInstanceOf(Resolved.class)
+            .extracting(r -> ((Resolved) r).value())
+            .isEqualTo("c0nt41ner");
+      }
+    } finally {
+      System.clearProperty("aws.accessKeyId");
+      System.clearProperty("aws.secretAccessKey");
+    }
+  }
+
+  @Test
+  void shouldBuildDespiteUnreachableEndpointAndDeferErrorToFirstUse() {
+    // given — an endpoint nothing listens on, mimicking a network/DNS misconfiguration
+    System.setProperty("aws.accessKeyId", LOCALSTACK.getAccessKey());
+    System.setProperty("aws.secretAccessKey", LOCALSTACK.getSecretKey());
+    try {
+      final var config =
+          new AwsSecretsManagerStoreConfig(
+              LOCALSTACK.getRegion(),
+              "camunda/",
+              null,
+              URI.create("http://127.0.0.1:1"),
+              // don't waste the test retrying an already-deterministic connection refusal
+              0,
+              false,
+              AwsSecretsManagerStoreConfig.DEFAULT_BATCH_SIZE);
+
+      // when — the failing startup probe only warns, so the store is still built
+      try (final var store = AwsSecretsManagerSecretStore.fromConfig(config)) {
+        // then — the connectivity error surfaces on first real use, not at construction
+        assertThatThrownBy(() -> store.resolve(Set.of("any")))
+            .isInstanceOf(SecretStoreUnavailableException.class);
       }
     } finally {
       System.clearProperty("aws.accessKeyId");

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
@@ -10,6 +10,8 @@ package io.camunda.secretstore.aws;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -675,5 +677,34 @@ class AwsSecretsManagerSecretStoreTest {
 
     // when / then — value must be masked in toString
     assertThat(resolved.toString()).doesNotContain("super-secret");
+  }
+
+  // ---- startup connectivity probe: warns and continues (keeps the client) when the probe fails --
+
+  @Test
+  void shouldReturnAfterSuccessfulProbeWithoutClosingClient() {
+    // given
+    final var resolver = mock(AwsSecretResolver.class);
+
+    // when
+    AwsSecretsManagerSecretStore.validateConnectivity(client, resolver);
+
+    // then — the probe ran and the client stays open for the store to use
+    verify(resolver).validateConnectivity();
+    verify(client, times(0)).close();
+  }
+
+  @Test
+  void shouldWarnAndContinueWithoutClosingClientWhenProbeFails() {
+    // given
+    final var resolver = mock(AwsSecretResolver.class);
+    doThrow(SdkClientException.create("no route to host")).when(resolver).validateConnectivity();
+
+    // when — a failing startup probe must not fail fast
+    AwsSecretsManagerSecretStore.validateConnectivity(client, resolver);
+
+    // then — the client is kept open so the error surfaces on first real use instead
+    verify(resolver).validateConnectivity();
+    verify(client, times(0)).close();
   }
 }

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/AwsSecretsManagerSecretStoreTest.java
@@ -687,11 +687,10 @@ class AwsSecretsManagerSecretStoreTest {
     final var resolver = mock(AwsSecretResolver.class);
 
     // when
-    AwsSecretsManagerSecretStore.validateConnectivity(client, resolver);
+    AwsSecretsManagerSecretStore.validateConnectivity(resolver);
 
     // then — the probe ran and the client stays open for the store to use
     verify(resolver).validateConnectivity();
-    verify(client, times(0)).close();
   }
 
   @Test
@@ -701,10 +700,9 @@ class AwsSecretsManagerSecretStoreTest {
     doThrow(SdkClientException.create("no route to host")).when(resolver).validateConnectivity();
 
     // when — a failing startup probe must not fail fast
-    AwsSecretsManagerSecretStore.validateConnectivity(client, resolver);
+    AwsSecretsManagerSecretStore.validateConnectivity(resolver);
 
     // then — the client is kept open so the error surfaces on first real use instead
     verify(resolver).validateConnectivity();
-    verify(client, times(0)).close();
   }
 }

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/ContainerSecretResolverTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/ContainerSecretResolverTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.secretstore.SecretErrorCode;
@@ -295,5 +296,22 @@ class ContainerSecretResolverTest {
     // then
     verify(client)
         .getSecretValue(GetSecretValueRequest.builder().secretId("camunda/app-config").build());
+  }
+
+  @Test
+  void shouldProbeConnectivityWithGetSecretValueOnContainerSecretOnly() {
+    // given
+    final var resolver = new ContainerSecretResolver(client, "camunda/", "app-config");
+    when(client.getSecretValue(any(GetSecretValueRequest.class)))
+        .thenReturn(GetSecretValueResponse.builder().secretString("{}").build());
+
+    // when
+    resolver.validateConnectivity();
+
+    // then — probes the container secret itself, needing only GetSecretValue and never the broader
+    // ListSecrets, so the startup check stays within this mode's minimal IAM policy
+    verify(client)
+        .getSecretValue(GetSecretValueRequest.builder().secretId("camunda/app-config").build());
+    verifyNoMoreInteractions(client);
   }
 }

--- a/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/FlatSecretResolverTest.java
+++ b/secret-store/secret-store-aws/src/test/java/io/camunda/secretstore/aws/FlatSecretResolverTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.secretstore.SecretResolutionResult.Failed;
@@ -164,5 +165,21 @@ class FlatSecretResolverTest {
 
     // then
     assertThat(names).containsExactly("db-password");
+  }
+
+  @Test
+  void shouldProbeConnectivityWithListSecretsOnly() {
+    // given
+    final var resolver = new FlatSecretResolver(client, "camunda/", false, 20);
+    when(client.listSecrets(any(ListSecretsRequest.class)))
+        .thenReturn(ListSecretsResponse.builder().build());
+
+    // when
+    resolver.validateConnectivity();
+
+    // then — flat mode probes with ListSecrets and never GetSecretValue, so the startup check
+    // matches the API this mode actually resolves with
+    verify(client).listSecrets(any(ListSecretsRequest.class));
+    verifyNoMoreInteractions(client);
   }
 }


### PR DESCRIPTION
## Description

Probes AWS Secrets Manager connectivity and credentials eagerly, at store construction time. `AwsSecretsManagerSecretStore.fromConfig()` probes AWS right after building the SDK client, so a bad region, unreachable endpoint, or invalid/missing credentials is surfaced early — but the probe is **best-effort**: on failure it logs a warning and still builds the store, rather than failing startup. This way a transient AWS problem during boot can't stop the whole application from starting; the misconfiguration then surfaces on the first real secret lookup (`resolve`/`list`) as a `SecretStoreUnavailableException`. The client is kept open because the store retains it for those later calls.

### Mode-aware probe (minimal IAM)

The probe is delegated to the resolver via `AwsSecretResolver.validateConnectivity()`, so it uses the exact API — and therefore the minimal IAM policy — that the configured mode actually resolves with:

- **Container-secret mode** → `GetSecretValue` on the container secret itself (the only action that mode uses at runtime).
- **Flat mode** → a single-result `ListSecrets`.

This keeps the store from ever demanding a broader IAM action than runtime resolution needs. The store just picks the resolver and owns the client lifecycle; each resolver owns its own probe, so a future resolution mode brings its probe with it without touching this class.

## Related issues

closes #56576
