### PR TITLE
refactor: continue engine tenant-check sweep onto CslAuthorizationCheck.checkTenant() (Inc 4 / #556)

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -370,8 +370,7 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         bpmnBehaviors,
         permissionsBehavior,
-        claimsConverter,
-        securityConfig,
+        cslCheck,
         processDefinitionMetrics);
     addSignalBroadcastProcessors(
         typedRecordProcessors,
@@ -801,8 +800,7 @@ public final class EngineProcessors {
       final CommandDistributionBehavior commandDistributionBehavior,
       final BpmnBehaviors bpmnBehaviors,
       final PermissionsBehavior permissionsBehavior,
-      final LazyTokenClaimsConverter claimsConverter,
-      final EngineSecurityConfig securityConfig,
+      final CslAuthorizationCheck cslCheck,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     final var resourceDeletionProcessor =
         new ResourceDeletionDeleteProcessor(
@@ -812,8 +810,7 @@ public final class EngineProcessors {
             commandDistributionBehavior,
             bpmnBehaviors,
             permissionsBehavior,
-            claimsConverter,
-            securityConfig,
+            cslCheck,
             processDefinitionMetrics);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -92,14 +92,16 @@ public class ConditionalEvaluationEvaluateProcessor
   public void processRecord(final TypedRecord<ConditionalEvaluationRecord> command) {
     final var record = command.getValue();
 
+    final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final var tenantCheck =
-        cslCheck.checkTenant(
-            command,
-            record.getTenantId(),
+        cslCheck.checkTenants(
+            List.of(record.getTenantId()),
+            authorizedTenants,
             record,
-            new Rejection(
-                RejectionType.FORBIDDEN,
-                USER_NOT_ASSIGNED_TO_TENANT_MESSAGE.formatted(record.getTenantId())));
+            () ->
+                new Rejection(
+                    RejectionType.FORBIDDEN,
+                    USER_NOT_ASSIGNED_TO_TENANT_MESSAGE.formatted(record.getTenantId())));
     if (tenantCheck.isLeft()) {
       final var rejection = tenantCheck.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -94,7 +94,7 @@ public class ConditionalEvaluationEvaluateProcessor
 
     final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final var tenantCheck =
-        cslCheck.checkTenants(
+        cslCheck.checkTenantsRequiringPrincipal(
             List.of(record.getTenantId()),
             authorizedTenants,
             record,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenantsResolver;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -157,6 +158,34 @@ public final class CslAuthorizationCheck {
       return Either.right(value);
     }
     if (resolveAuthorizedTenants(authorizations).isAuthorizedForTenantId(tenantId)) {
+      return Either.right(value);
+    }
+    return Either.left(notAssignedRejection);
+  }
+
+  /**
+   * Like {@link #checkTenant} but for command sites that must verify membership across a list of
+   * tenant IDs at once (e.g. a job-batch activation command targeting multiple explicit tenants),
+   * using {@link AuthorizedTenants#isAuthorizedForTenantIds}. Shares the same skip-logic as {@link
+   * #checkTenant}.
+   *
+   * @param notAssignedRejection the rejection to return when the principal is not assigned to all
+   *     of {@code tenantIds}
+   */
+  public <T> Either<Rejection, T> checkTenants(
+      final TypedRecord<?> command,
+      final List<String> tenantIds,
+      final T value,
+      final Rejection notAssignedRejection) {
+    if (!securityConfig.isMultiTenancyChecksEnabled()) {
+      return Either.right(value);
+    }
+    final var authorizations = command.getAuthorizations();
+    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
+        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
+      return Either.right(value);
+    }
+    if (resolveAuthorizedTenants(authorizations).isAuthorizedForTenantIds(tenantIds)) {
       return Either.right(value);
     }
     return Either.left(notAssignedRejection);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -175,13 +175,14 @@ public final class CslAuthorizationCheck {
   }
 
   /**
-   * Like {@link #checkTenant} but for command sites that call the tenant check directly, with no
+   * Rejects a claims-free caller outright: unlike {@link #checkTenant}, this method has no
+   * no-principal skip. Use it only for command sites that call the tenant check directly, with no
    * preceding {@link #check}, and that verify membership across a list of tenant IDs at once, using
    * {@link AuthorizedTenants#isAuthorizedForTenantIds}.
    *
-   * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip: without a
-   * preceding {@link #check} to reject a claims-free command first, that skip would silently
-   * authorize a claims-free caller for every tenant it names instead of rejecting it.
+   * <p>Without a preceding {@link #check} to reject a claims-free command first, sharing {@link
+   * #checkTenant}'s no-principal skip here would silently authorize a claims-free caller for every
+   * tenant it names instead of rejecting it — hence the guarantee is deliberate, not an oversight.
    *
    * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} and a
    * lazy {@code Supplier<Rejection>} rather than resolving internally and building the rejection
@@ -195,7 +196,7 @@ public final class CslAuthorizationCheck {
    * @param notAssignedRejection supplies the rejection to return when the principal is not assigned
    *     to all of {@code tenantIds}; only invoked on that failure path
    */
-  public <T> Either<Rejection, T> checkTenants(
+  public <T> Either<Rejection, T> checkTenantsRequiringPrincipal(
       final List<String> tenantIds,
       final AuthorizedTenants authorizedTenants,
       final T value,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -178,27 +178,18 @@ public final class CslAuthorizationCheck {
    * list of tenant IDs at once ({@code JobBatchActivateProcessor}), using {@link
    * AuthorizedTenants#isAuthorizedForTenantIds}.
    *
-   * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip. Unlike {@link
-   * #checkTenant}'s callers, {@code JobBatchActivateProcessor} is
+   * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip: that site is
    * {@code @ExcludeAuthorizationCheck} and calls this method directly with no preceding {@link
-   * #check} to have already rejected a no-principal, authorizations-enabled command — so skipping
-   * here would silently authorize a claims-free caller for every tenant it names. This matches the
-   * site's own pre-CSL-migration behavior (a direct {@code isAuthorizedForTenantIds} call with no
-   * skip-logic at all), which this method restores after an intermediate migration in this PR
-   * temporarily introduced the skip and regressed it.
+   * #check}, so skipping here would silently authorize a claims-free caller for every tenant it
+   * names. This restores the site's pre-CSL-migration behavior after an intermediate migration in
+   * this PR temporarily introduced the skip and regressed it.
    *
-   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants}
-   * instead of resolving it internally, and a lazy {@code Supplier<Rejection>} instead of an eager
-   * {@link Rejection} — its one caller (the highest-throughput command in the engine) already
-   * resolves tenants once per command and must not pay for a second resolution or eager
-   * message-building on every activation.
-   *
-   * <p>The supplier is only invoked when {@code isAuthorizedForTenantIds} returns {@code false},
-   * which never happens for an anonymous principal ({@link
-   * io.camunda.zeebe.engine.processing.identity.AnonymouslyAuthorizedTenants#isAuthorizedForTenantIds}
-   * always returns {@code true}) — so a rejection supplier that calls {@code
-   * authorizedTenants.getAuthorizedTenantIds()} is always safe to invoke here, unlike calling it
-   * unconditionally as a method argument (which previously crashed for anonymous callers).
+   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} and a
+   * lazy {@code Supplier<Rejection>} rather than resolving internally and building the rejection
+   * eagerly — its one caller resolves tenants once per command already and shouldn't pay twice or
+   * build a message on the happy path. The supplier is only invoked on rejection, which never
+   * happens for an anonymous principal, so it's always safe to call {@code
+   * authorizedTenants.getAuthorizedTenantIds()} inside it.
    *
    * @param authorizedTenants the tenants the command's principal is authorized for, as resolved by
    *     {@link #resolveAuthorizedTenants} from the same command's claims

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,6 +136,14 @@ public final class CslAuthorizationCheck {
    * requirement against). Otherwise the authorized tenants are resolved from the command's claims
    * (anonymous access is authorized for every tenant) and {@code tenantId} must be among them.
    *
+   * <p>This no-principal skip is load-bearing: most callers reach this method via {@link
+   * #checkAuthorizationAndTenant}, which already ran {@link #check} first — when authorizations are
+   * enabled, {@code check} itself rejects a no-principal command before this method ever runs; when
+   * authorizations are disabled, letting a claims-free command through here (e.g. deployment/process
+   * lifecycle commands issued without an explicit user, common in tests and tooling) is the
+   * established, relied-upon behavior. Do not remove this skip without auditing every caller,
+   * direct and via {@link #checkAuthorizationAndTenant} — see camunda-security-library#556.
+   *
    * <p>Callers own the rejection semantics: {@code notAssignedRejection} carries the {@link
    * io.camunda.zeebe.protocol.record.RejectionType} — {@code FORBIDDEN} to signal "not assigned to
    * tenant", or {@code NOT_FOUND} to mask an existing resource — and the message.
@@ -164,31 +173,49 @@ public final class CslAuthorizationCheck {
   }
 
   /**
-   * Like {@link #checkTenant} but for command sites that must verify membership across a list of
-   * tenant IDs at once (e.g. a job-batch activation command targeting multiple explicit tenants),
-   * using {@link AuthorizedTenants#isAuthorizedForTenantIds}. Shares the same skip-logic as {@link
-   * #checkTenant}.
+   * Like {@link #checkTenant} but for the one command site that must verify membership across a
+   * list of tenant IDs at once ({@code JobBatchActivateProcessor}), using {@link
+   * AuthorizedTenants#isAuthorizedForTenantIds}.
    *
-   * @param notAssignedRejection the rejection to return when the principal is not assigned to all
-   *     of {@code tenantIds}
+   * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip. Unlike {@link
+   * #checkTenant}'s callers, {@code JobBatchActivateProcessor} is {@code @ExcludeAuthorizationCheck}
+   * and calls this method directly with no preceding {@link #check} to have already rejected a
+   * no-principal, authorizations-enabled command — so skipping here would silently authorize a
+   * claims-free caller for every tenant it names. This matches the site's own pre-CSL-migration
+   * behavior (a direct {@code isAuthorizedForTenantIds} call with no skip-logic at all), which this
+   * method restores after an intermediate migration in this PR temporarily introduced the skip and
+   * regressed it.
+   *
+   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} instead
+   * of resolving it internally, and a lazy {@code Supplier<Rejection>} instead of an eager {@link
+   * Rejection} — its one caller (the highest-throughput command in the engine) already resolves
+   * tenants once per command and must not pay for a second resolution or eager message-building on
+   * every activation.
+   *
+   * <p>The supplier is only invoked when {@code isAuthorizedForTenantIds} returns {@code false},
+   * which never happens for an anonymous principal ({@link
+   * io.camunda.zeebe.engine.processing.identity.AnonymouslyAuthorizedTenants#isAuthorizedForTenantIds}
+   * always returns {@code true}) — so a rejection supplier that calls {@code
+   * authorizedTenants.getAuthorizedTenantIds()} is always safe to invoke here, unlike calling it
+   * unconditionally as a method argument (which previously crashed for anonymous callers).
+   *
+   * @param authorizedTenants the tenants the command's principal is authorized for, as resolved by
+   *     {@link #resolveAuthorizedTenants} from the same command's claims
+   * @param notAssignedRejection supplies the rejection to return when the principal is not assigned
+   *     to all of {@code tenantIds}; only invoked on that failure path
    */
   public <T> Either<Rejection, T> checkTenants(
-      final TypedRecord<?> command,
       final List<String> tenantIds,
+      final AuthorizedTenants authorizedTenants,
       final T value,
-      final Rejection notAssignedRejection) {
+      final Supplier<Rejection> notAssignedRejection) {
     if (!securityConfig.isMultiTenancyChecksEnabled()) {
       return Either.right(value);
     }
-    final var authorizations = command.getAuthorizations();
-    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
-        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
+    if (authorizedTenants.isAuthorizedForTenantIds(tenantIds)) {
       return Either.right(value);
     }
-    if (resolveAuthorizedTenants(authorizations).isAuthorizedForTenantIds(tenantIds)) {
-      return Either.right(value);
-    }
-    return Either.left(notAssignedRejection);
+    return Either.left(notAssignedRejection.get());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -139,10 +139,11 @@ public final class CslAuthorizationCheck {
    * <p>This no-principal skip is load-bearing: most callers reach this method via {@link
    * #checkAuthorizationAndTenant}, which already ran {@link #check} first — when authorizations are
    * enabled, {@code check} itself rejects a no-principal command before this method ever runs; when
-   * authorizations are disabled, letting a claims-free command through here (e.g. deployment/process
-   * lifecycle commands issued without an explicit user, common in tests and tooling) is the
-   * established, relied-upon behavior. Do not remove this skip without auditing every caller,
-   * direct and via {@link #checkAuthorizationAndTenant} — see camunda-security-library#556.
+   * authorizations are disabled, letting a claims-free command through here (e.g.
+   * deployment/process lifecycle commands issued without an explicit user, common in tests and
+   * tooling) is the established, relied-upon behavior. Do not remove this skip without auditing
+   * every caller, direct and via {@link #checkAuthorizationAndTenant} — see
+   * camunda-security-library#556.
    *
    * <p>Callers own the rejection semantics: {@code notAssignedRejection} carries the {@link
    * io.camunda.zeebe.protocol.record.RejectionType} — {@code FORBIDDEN} to signal "not assigned to
@@ -178,19 +179,19 @@ public final class CslAuthorizationCheck {
    * AuthorizedTenants#isAuthorizedForTenantIds}.
    *
    * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip. Unlike {@link
-   * #checkTenant}'s callers, {@code JobBatchActivateProcessor} is {@code @ExcludeAuthorizationCheck}
-   * and calls this method directly with no preceding {@link #check} to have already rejected a
-   * no-principal, authorizations-enabled command — so skipping here would silently authorize a
-   * claims-free caller for every tenant it names. This matches the site's own pre-CSL-migration
-   * behavior (a direct {@code isAuthorizedForTenantIds} call with no skip-logic at all), which this
-   * method restores after an intermediate migration in this PR temporarily introduced the skip and
-   * regressed it.
+   * #checkTenant}'s callers, {@code JobBatchActivateProcessor} is
+   * {@code @ExcludeAuthorizationCheck} and calls this method directly with no preceding {@link
+   * #check} to have already rejected a no-principal, authorizations-enabled command — so skipping
+   * here would silently authorize a claims-free caller for every tenant it names. This matches the
+   * site's own pre-CSL-migration behavior (a direct {@code isAuthorizedForTenantIds} call with no
+   * skip-logic at all), which this method restores after an intermediate migration in this PR
+   * temporarily introduced the skip and regressed it.
    *
-   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} instead
-   * of resolving it internally, and a lazy {@code Supplier<Rejection>} instead of an eager {@link
-   * Rejection} — its one caller (the highest-throughput command in the engine) already resolves
-   * tenants once per command and must not pay for a second resolution or eager message-building on
-   * every activation.
+   * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants}
+   * instead of resolving it internally, and a lazy {@code Supplier<Rejection>} instead of an eager
+   * {@link Rejection} — its one caller (the highest-throughput command in the engine) already
+   * resolves tenants once per command and must not pay for a second resolution or eager
+   * message-building on every activation.
    *
    * <p>The supplier is only invoked when {@code isAuthorizedForTenantIds} returns {@code false},
    * which never happens for an anonymous principal ({@link

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -136,14 +136,15 @@ public final class CslAuthorizationCheck {
    * requirement against). Otherwise the authorized tenants are resolved from the command's claims
    * (anonymous access is authorized for every tenant) and {@code tenantId} must be among them.
    *
-   * <p>This no-principal skip is load-bearing: most callers reach this method via {@link
-   * #checkAuthorizationAndTenant}, which already ran {@link #check} first — when authorizations are
-   * enabled, {@code check} itself rejects a no-principal command before this method ever runs; when
-   * authorizations are disabled, letting a claims-free command through here (e.g.
-   * deployment/process lifecycle commands issued without an explicit user, common in tests and
-   * tooling) is the established, relied-upon behavior. Do not remove this skip without auditing
-   * every caller, direct and via {@link #checkAuthorizationAndTenant} — see
-   * camunda-security-library#556.
+   * <p>This no-principal skip is load-bearing: every caller runs {@link #check} first — either
+   * directly, composed via {@link #checkAuthorizationAndTenant}, or (for the sole remaining direct
+   * caller) via an equivalent {@code check(...).flatMap(v -> checkTenant(...))} of its own — before
+   * this method is ever reached. When authorizations are enabled, {@code check} itself rejects a
+   * no-principal command before this method runs; when authorizations are disabled, letting a
+   * claims-free command through here (e.g. deployment/process lifecycle commands issued without an
+   * explicit user, common in tests and tooling) is the established, relied-upon behavior. Do not
+   * call this method directly without a preceding {@link #check}, and do not remove this skip
+   * without auditing every caller.
    *
    * <p>Callers own the rejection semantics: {@code notAssignedRejection} carries the {@link
    * io.camunda.zeebe.protocol.record.RejectionType} — {@code FORBIDDEN} to signal "not assigned to
@@ -174,22 +175,20 @@ public final class CslAuthorizationCheck {
   }
 
   /**
-   * Like {@link #checkTenant} but for the one command site that must verify membership across a
-   * list of tenant IDs at once ({@code JobBatchActivateProcessor}), using {@link
-   * AuthorizedTenants#isAuthorizedForTenantIds}.
+   * Like {@link #checkTenant} but for command sites that call the tenant check directly, with no
+   * preceding {@link #check}, and that verify membership across a list of tenant IDs at once, using
+   * {@link AuthorizedTenants#isAuthorizedForTenantIds}.
    *
-   * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip: that site is
-   * {@code @ExcludeAuthorizationCheck} and calls this method directly with no preceding {@link
-   * #check}, so skipping here would silently authorize a claims-free caller for every tenant it
-   * names. This restores the site's pre-CSL-migration behavior after an intermediate migration in
-   * this PR temporarily introduced the skip and regressed it.
+   * <p>Deliberately does <b>not</b> share {@link #checkTenant}'s no-principal skip: without a
+   * preceding {@link #check} to reject a claims-free command first, that skip would silently
+   * authorize a claims-free caller for every tenant it names instead of rejecting it.
    *
    * <p>Also unlike {@link #checkTenant}, takes an already-resolved {@link AuthorizedTenants} and a
    * lazy {@code Supplier<Rejection>} rather than resolving internally and building the rejection
-   * eagerly — its one caller resolves tenants once per command already and shouldn't pay twice or
-   * build a message on the happy path. The supplier is only invoked on rejection, which never
-   * happens for an anonymous principal, so it's always safe to call {@code
-   * authorizedTenants.getAuthorizedTenantIds()} inside it.
+   * eagerly — callers that already resolved tenants for the same command don't pay to resolve
+   * twice, and the rejection message is only built on the rejected path. The supplier is only
+   * invoked on rejection, which never happens for an anonymous principal, so it's always safe to
+   * call {@code authorizedTenants.getAuthorizedTenantIds()} inside it.
    *
    * @param authorizedTenants the tenants the command's principal is authorized for, as resolved by
    *     {@link #resolveAuthorizedTenants} from the same command's claims

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheck.java
@@ -175,10 +175,12 @@ public final class CslAuthorizationCheck {
   }
 
   /**
-   * Rejects a claims-free caller outright: unlike {@link #checkTenant}, this method has no
-   * no-principal skip. Use it only for command sites that call the tenant check directly, with no
-   * preceding {@link #check}, and that verify membership across a list of tenant IDs at once, using
-   * {@link AuthorizedTenants#isAuthorizedForTenantIds}.
+   * Unlike {@link #checkTenant}, this method has no no-principal skip: a claims-free caller is
+   * rejected for every tenant it names, rather than vacuously authorized. (The
+   * multi-tenancy-disabled and anonymous-caller skips still apply, same as {@link #checkTenant}.)
+   * Use it only for command sites that call the tenant check directly, with no preceding {@link
+   * #check}, and that verify membership across a list of tenant IDs at once, using {@link
+   * AuthorizedTenants#isAuthorizedForTenantIds}.
    *
    * <p>Without a preceding {@link #check} to reject a claims-free command first, sharing {@link
    * #checkTenant}'s no-principal skip here would silently authorize a claims-free caller for every

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -152,7 +152,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private Either<Rejection, Void> validateTenantAuthorization(
       final JobBatchRecord value, final AuthorizedTenants authorizedTenantIds) {
     final var tenantIds = resolveProvidedTenantIds(value);
-    return cslCheck.checkTenants(
+    return cslCheck.checkTenantsRequiringPrincipal(
         tenantIds,
         authorizedTenantIds,
         null,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -140,7 +140,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
     // Skip tenant authorization check when using ASSIGNED filter
     if (TenantFilter.PROVIDED.equals(value.getTenantFilter())) {
-      final var tenantAuthResult = validateTenantAuthorization(record, value, authorizedTenantIds);
+      final var tenantAuthResult = validateTenantAuthorization(value, authorizedTenantIds);
       if (tenantAuthResult.isLeft()) {
         return tenantAuthResult;
       }
@@ -150,25 +150,17 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   }
 
   private Either<Rejection, Void> validateTenantAuthorization(
-      final TypedRecord<JobBatchRecord> record,
-      final JobBatchRecord value,
-      final AuthorizedTenants authorizedTenantIds) {
+      final JobBatchRecord value, final AuthorizedTenants authorizedTenantIds) {
     final var tenantIds = resolveProvidedTenantIds(value);
-    // Rejection is a method argument, so it's always evaluated eagerly, even when checkTenants
-    // ends up allowing the request; getAuthorizedTenantIds() throws for an anonymous principal, so
-    // it can't be called unconditionally here.
-    final var authorizedTenantIdsForMessage =
-        authorizedTenantIds.isAnonymous()
-            ? List.of()
-            : authorizedTenantIds.getAuthorizedTenantIds();
     return cslCheck.checkTenants(
-        record,
         tenantIds,
+        authorizedTenantIds,
         null,
-        new Rejection(
-            RejectionType.UNAUTHORIZED,
-            "Expected to activate job batch for tenants '%s', but user is not authorized. Authorized tenants are '%s'"
-                .formatted(tenantIds, authorizedTenantIdsForMessage)));
+        () ->
+            new Rejection(
+                RejectionType.UNAUTHORIZED,
+                "Expected to activate job batch for tenants '%s', but user is not authorized. Authorized tenants are '%s'"
+                    .formatted(tenantIds, authorizedTenantIds.getAuthorizedTenantIds())));
   }
 
   private Either<Rejection, Void> validateCommandFields(final JobBatchRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -119,6 +119,15 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       return authorizedTenantIds.getAuthorizedTenantIds();
     }
 
+    return resolveProvidedTenantIds(value);
+  }
+
+  // An empty PROVIDED tenant-ID list is treated as "the default tenant" both here and in
+  // validateTenantAuthorization, so the tenant-authorization check and the tenants actually used
+  // for activation can never diverge (isAuthorizedForTenantIds([]) is vacuously true, so checking
+  // the raw empty list would silently authorize a caller not actually assigned to the default
+  // tenant).
+  private List<String> resolveProvidedTenantIds(final JobBatchRecord value) {
     final var providedTenantIds = value.getTenantIds();
     return providedTenantIds.isEmpty()
         ? List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
@@ -144,7 +153,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final TypedRecord<JobBatchRecord> record,
       final JobBatchRecord value,
       final AuthorizedTenants authorizedTenantIds) {
-    final var tenantIds = value.getTenantIds();
+    final var tenantIds = resolveProvidedTenantIds(value);
     // Rejection is a method argument, so it's always evaluated eagerly, even when checkTenants
     // ends up allowing the request; getAuthorizedTenantIds() throws for an anonymous principal, so
     // it can't be called unconditionally here.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -131,7 +131,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
     // Skip tenant authorization check when using ASSIGNED filter
     if (TenantFilter.PROVIDED.equals(value.getTenantFilter())) {
-      final var tenantAuthResult = validateTenantAuthorization(value, authorizedTenantIds);
+      final var tenantAuthResult = validateTenantAuthorization(record, value, authorizedTenantIds);
       if (tenantAuthResult.isLeft()) {
         return tenantAuthResult;
       }
@@ -141,18 +141,25 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   }
 
   private Either<Rejection, Void> validateTenantAuthorization(
-      final JobBatchRecord record, final AuthorizedTenants authorizedTenantIds) {
-    final var tenantIds = record.getTenantIds();
-
-    if (!authorizedTenantIds.isAuthorizedForTenantIds(tenantIds)) {
-      return Either.left(
-          new Rejection(
-              RejectionType.UNAUTHORIZED,
-              "Expected to activate job batch for tenants '%s', but user is not authorized. Authorized tenants are '%s'"
-                  .formatted(tenantIds, authorizedTenantIds.getAuthorizedTenantIds())));
-    }
-
-    return Either.right(null);
+      final TypedRecord<JobBatchRecord> record,
+      final JobBatchRecord value,
+      final AuthorizedTenants authorizedTenantIds) {
+    final var tenantIds = value.getTenantIds();
+    // Rejection is a method argument, so it's always evaluated eagerly, even when checkTenants
+    // ends up allowing the request; getAuthorizedTenantIds() throws for an anonymous principal, so
+    // it can't be called unconditionally here.
+    final var authorizedTenantIdsForMessage =
+        authorizedTenantIds.isAnonymous()
+            ? List.of()
+            : authorizedTenantIds.getAuthorizedTenantIds();
+    return cslCheck.checkTenants(
+        record,
+        tenantIds,
+        null,
+        new Rejection(
+            RejectionType.UNAUTHORIZED,
+            "Expected to activate job batch for tenants '%s', but user is not authorized. Authorized tenants are '%s'"
+                .formatted(tenantIds, authorizedTenantIdsForMessage)));
   }
 
   private Either<Rejection, Void> validateCommandFields(final JobBatchRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -113,13 +113,20 @@ public final class MessageCorrelationCorrelateProcessor
 
     // Check tenant authorization if not an internal command
     if (!command.isInternalCommand()) {
-      final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
-      if (!authorizedTenants.isAuthorizedForTenantId(messageCorrelationRecord.getTenantId())) {
-        final var message =
-            "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
-                .formatted(messageCorrelationRecord.getTenantId());
-        rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
-        responseWriter.writeRejectedResponseOnCommand(command, RejectionType.FORBIDDEN, message);
+      final var tenantCheck =
+          cslCheck.checkTenant(
+              command,
+              messageCorrelationRecord.getTenantId(),
+              messageCorrelationRecord,
+              new Rejection(
+                  RejectionType.FORBIDDEN,
+                  "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
+                      .formatted(messageCorrelationRecord.getTenantId())));
+      if (tenantCheck.isLeft()) {
+        final var rejection = tenantCheck.getLeft();
+        rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+        responseWriter.writeRejectedResponseOnCommand(
+            command, rejection.type(), rejection.reason());
         return;
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -113,15 +114,17 @@ public final class MessageCorrelationCorrelateProcessor
 
     // Check tenant authorization if not an internal command
     if (!command.isInternalCommand()) {
+      final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
       final var tenantCheck =
-          cslCheck.checkTenant(
-              command,
-              messageCorrelationRecord.getTenantId(),
+          cslCheck.checkTenants(
+              List.of(messageCorrelationRecord.getTenantId()),
+              authorizedTenants,
               messageCorrelationRecord,
-              new Rejection(
-                  RejectionType.FORBIDDEN,
-                  "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
-                      .formatted(messageCorrelationRecord.getTenantId())));
+              () ->
+                  new Rejection(
+                      RejectionType.FORBIDDEN,
+                      "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
+                          .formatted(messageCorrelationRecord.getTenantId())));
       if (tenantCheck.isLeft()) {
         final var rejection = tenantCheck.getLeft();
         rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -116,7 +116,7 @@ public final class MessageCorrelationCorrelateProcessor
     if (!command.isInternalCommand()) {
       final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
       final var tenantCheck =
-          cslCheck.checkTenants(
+          cslCheck.checkTenantsRequiringPrincipal(
               List.of(messageCorrelationRecord.getTenantId()),
               authorizedTenants,
               messageCorrelationRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -14,9 +14,6 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.camunda.search.filter.DecisionInstanceFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.configuration.EngineSecurityConfig;
-import io.camunda.security.core.authz.LazyTokenClaimsConverter;
-import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.metrics.ProcessDefinitionMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
@@ -24,8 +21,8 @@ import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManag
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenantsAdapter;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -105,8 +102,7 @@ public class ResourceDeletionDeleteProcessor
   private final CatchEventBehavior catchEventBehavior;
   private final StartEventSubscriptions startEventSubscriptions;
   private final PermissionsBehavior permissionsBehavior;
-  private final LazyTokenClaimsConverter claimsConverter;
-  private final EngineSecurityConfig securityConfig;
+  private final CslAuthorizationCheck cslCheck;
   private final StartEventSubscriptionManager startEventSubscriptionManager;
   private final FormState formState;
   private final ResourceState resourceState;
@@ -120,8 +116,7 @@ public class ResourceDeletionDeleteProcessor
       final CommandDistributionBehavior commandDistributionBehavior,
       final BpmnBehaviors bpmnBehaviors,
       final PermissionsBehavior permissionsBehavior,
-      final LazyTokenClaimsConverter claimsConverter,
-      final EngineSecurityConfig securityConfig,
+      final CslAuthorizationCheck cslCheck,
       final ProcessDefinitionMetrics processDefinitionMetrics) {
     stateWriter = writers.state();
     commandWriter = writers.command();
@@ -136,8 +131,7 @@ public class ResourceDeletionDeleteProcessor
     bannedInstanceState = processingState.getBannedInstanceState();
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     this.permissionsBehavior = permissionsBehavior;
-    this.claimsConverter = claimsConverter;
-    this.securityConfig = securityConfig;
+    this.cslCheck = cslCheck;
     startEventSubscriptionManager =
         new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
     startEventSubscriptions =
@@ -580,9 +574,9 @@ public class ResourceDeletionDeleteProcessor
       final TypedRecord<ResourceDeletionRecord> command) {
     final String tenantId = command.getValue().getTenantId();
     if (tenantId.isEmpty()) {
-      return determineAuthorizedTenants(command);
+      return cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
     }
-    final var userTenants = determineAuthorizedTenants(command);
+    final var userTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
     if (!userTenants.isAuthorizedForTenantId(tenantId)) {
       throw new NoSuchResourceException(command.getValue().getResourceKey());
     }
@@ -635,21 +629,6 @@ public class ResourceDeletionDeleteProcessor
   private void setTenantId(
       final TypedRecord<ResourceDeletionRecord> command, final String tenantId) {
     command.getValue().setTenantId(tenantId);
-  }
-
-  private AuthorizedTenants determineAuthorizedTenants(final TypedRecord<?> command) {
-    final var authorizations = command.getAuthorizations();
-    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
-      return AuthorizedTenants.ANONYMOUS;
-    }
-    if (!securityConfig.isMultiTenancyChecksEnabled()) {
-      return AuthorizedTenants.DEFAULT_TENANTS;
-    }
-    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
-        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
-      return new AuthenticatedAuthorizedTenants(List.of());
-    }
-    return new AuthorizedTenantsAdapter(claimsConverter.convert(authorizations));
   }
 
   private void checkAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -572,11 +572,11 @@ public class ResourceDeletionDeleteProcessor
 
   private AuthorizedTenants getAuthorizedTenants(
       final TypedRecord<ResourceDeletionRecord> command) {
+    final var userTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
     final String tenantId = command.getValue().getTenantId();
     if (tenantId.isEmpty()) {
-      return cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
+      return userTenants;
     }
-    final var userTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
     if (!userTenants.isAuthorizedForTenantId(tenantId)) {
       throw new NoSuchResourceException(command.getValue().getResourceKey());
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.engine.processing.signal;
 
 import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.exception.ForbiddenException;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -96,13 +96,20 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
 
     // Check tenant authorization if not an internal command
     if (isAuthNeeded) {
-      final var authorizedTenants = determineAuthorizedTenants(command);
-      if (!authorizedTenants.isAuthorizedForTenantId(signalRecord.getTenantId())) {
-        final var message =
-            "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
-                .formatted(signalRecord.getTenantId());
-        rejectionWriter.appendRejection(command, RejectionType.FORBIDDEN, message);
-        responseWriter.writeRejectedResponseOnCommand(command, RejectionType.FORBIDDEN, message);
+      final var tenantCheck =
+          cslCheck.checkTenant(
+              command,
+              signalRecord.getTenantId(),
+              signalRecord,
+              new Rejection(
+                  RejectionType.FORBIDDEN,
+                  "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
+                      .formatted(signalRecord.getTenantId())));
+      if (tenantCheck.isLeft()) {
+        final var rejection = tenantCheck.getLeft();
+        rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+        responseWriter.writeRejectedResponseOnCommand(
+            command, rejection.type(), rejection.reason());
         return;
       }
     }
@@ -141,10 +148,6 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     final var isAuthNeeded = !(command.getAuthInfo().getFormat() == AuthDataFormat.PRE_AUTHORIZED);
     triggerSignal(command, command.getKey(), isAuthNeeded);
     commandDistributionBehavior.acknowledgeCommand(command);
-  }
-
-  private AuthorizedTenants determineAuthorizedTenants(final TypedRecord<SignalRecord> command) {
-    return cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
   }
 
   private void checkAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -98,7 +98,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     if (isAuthNeeded) {
       final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
       final var tenantCheck =
-          cslCheck.checkTenants(
+          cslCheck.checkTenantsRequiringPrincipal(
               List.of(signalRecord.getTenantId()),
               authorizedTenants,
               signalRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -96,15 +96,17 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
 
     // Check tenant authorization if not an internal command
     if (isAuthNeeded) {
+      final var authorizedTenants = cslCheck.resolveAuthorizedTenants(command.getAuthorizations());
       final var tenantCheck =
-          cslCheck.checkTenant(
-              command,
-              signalRecord.getTenantId(),
+          cslCheck.checkTenants(
+              List.of(signalRecord.getTenantId()),
+              authorizedTenants,
               signalRecord,
-              new Rejection(
-                  RejectionType.FORBIDDEN,
-                  "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
-                      .formatted(signalRecord.getTenantId())));
+              () ->
+                  new Rejection(
+                      RejectionType.FORBIDDEN,
+                      "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
+                          .formatted(signalRecord.getTenantId())));
       if (tenantCheck.isLeft()) {
         final var rejection = tenantCheck.getLeft();
         rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
@@ -11,9 +11,9 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
@@ -308,8 +308,7 @@ public class ConditionalEvaluationAuthorizationTest {
     // given — a command carrying no username/clientId claim at all (not anonymous either); this
     // is the shape an unauthenticated gateway deployment would produce, and must be rejected
     // rather than vacuously authorized for the tenant now that multi-tenancy is enabled
-    final var authInfo = new AuthInfo();
-    authInfo.setClaims(Map.of());
+    final var authInfo = AuthorizationUtil.getClaimsFreeAuthInfo();
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationAuthorizationTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
@@ -300,6 +301,27 @@ public class ConditionalEvaluationAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(secondProcessId));
+  }
+
+  @Test
+  public void shouldRejectWhenNoPrincipalClaimAndMultiTenancyEnabled() {
+    // given — a command carrying no username/clientId claim at all (not anonymous either); this
+    // is the shape an unauthenticated gateway deployment would produce, and must be rejected
+    // rather than vacuously authorized for the tenant now that multi-tenancy is enabled
+    final var authInfo = new AuthInfo();
+    authInfo.setClaims(Map.of());
+
+    // when
+    final var rejection =
+        engine
+            .conditionalEvaluation()
+            .withVariables(Map.of("x", 100, "y", 1))
+            .expectRejection()
+            .evaluate(authInfo);
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    assertThat(rejection.getRejectionReason()).contains("user is not assigned to this tenant");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
@@ -181,6 +181,85 @@ final class CslAuthorizationCheckTest {
     verifyNoInteractions(claimsConverter, authCheckPort);
   }
 
+  @Test
+  void shouldSkipTenantsCheckWhenMultiTenancyDisabled() {
+    // given — multi-tenancy checks disabled
+    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, false);
+    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
+
+    // when
+    final var result =
+        cslCheck.checkTenants(command, List.of("tenant-a", "tenant-b"), "ok", rejection);
+
+    // then — no tenant resolution happens; the claims converter is never invoked
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+    verifyNoInteractions(claimsConverter, authCheckPort);
+  }
+
+  @Test
+  void shouldAllowWhenPrincipalIsAssignedToAllTenants() {
+    // given — multi-tenancy on and a principal assigned to tenant-a and tenant-b
+    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
+    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
+    when(authentication.anonymousUser()).thenReturn(false);
+    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a", "tenant-b"));
+    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
+        .thenReturn(authentication);
+
+    // when
+    final var result =
+        cslCheck.checkTenants(
+            command,
+            List.of("tenant-a", "tenant-b"),
+            "ok",
+            new Rejection(RejectionType.UNAUTHORIZED, "denied"));
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+  }
+
+  @Test
+  void shouldRejectWhenPrincipalIsNotAssignedToAllTenants() {
+    // given — multi-tenancy on and a principal assigned only to tenant-a
+    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
+    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
+    when(authentication.anonymousUser()).thenReturn(false);
+    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a"));
+    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
+        .thenReturn(authentication);
+    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized for tenant-b");
+
+    // when — tenant-b is requested in addition to tenant-a
+    final var result =
+        cslCheck.checkTenants(command, List.of("tenant-a", "tenant-b"), "ok", rejection);
+
+    // then — the caller-supplied rejection is returned verbatim
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo(rejection);
+  }
+
+  @Test
+  void shouldAllowAnonymousUserForAnyTenants() {
+    // given — multi-tenancy on but the request is anonymous
+    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
+    when(command.getAuthorizations())
+        .thenReturn(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
+
+    // when
+    final var result =
+        cslCheck.checkTenants(
+            command,
+            List.of("tenant-a", "tenant-b"),
+            "ok",
+            new Rejection(RejectionType.UNAUTHORIZED, "denied"));
+
+    // then — anonymous access is authorized for every tenant; no claims conversion needed
+    assertThat(result.isRight()).isTrue();
+    verifyNoInteractions(claimsConverter, authCheckPort);
+  }
+
   private CslAuthorizationCheck cslCheck(
       final boolean authorizationsEnabled, final boolean multiTenancyChecksEnabled) {
     final var securityConfig =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
@@ -20,7 +20,9 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRejectionMapper;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.List;
@@ -182,6 +184,27 @@ final class CslAuthorizationCheckTest {
   }
 
   @Test
+  void shouldSkipTenantCheckWhenNoIdentityClaims() {
+    // given — multi-tenancy on but the command carries neither a username nor a clientId claim;
+    // most callers reach checkTenant via checkAuthorizationAndTenant, which already runs `check`
+    // first and rejects a no-principal command when authorizations are enabled — so by the time
+    // checkTenant sees a no-principal command, either authorizations are disabled (and this skip
+    // is the established behavior many callers rely on) or the command was already rejected
+    // upstream
+    final var cslCheck = cslCheck(/* authorizationsEnabled= */ false, true);
+    when(command.getAuthorizations()).thenReturn(Map.of());
+    final var rejection = new Rejection(RejectionType.FORBIDDEN, "not assigned");
+
+    // when
+    final var result = cslCheck.checkTenant(command, "tenant-a", "ok", rejection);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isEqualTo("ok");
+    verifyNoInteractions(claimsConverter);
+  }
+
+  @Test
   void shouldSkipTenantsCheckWhenMultiTenancyDisabled() {
     // given — multi-tenancy checks disabled
     final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, false);
@@ -189,31 +212,28 @@ final class CslAuthorizationCheckTest {
 
     // when
     final var result =
-        cslCheck.checkTenants(command, List.of("tenant-a", "tenant-b"), "ok", rejection);
+        cslCheck.checkTenants(
+            List.of("tenant-a", "tenant-b"), AuthorizedTenants.ANONYMOUS, "ok", () -> rejection);
 
-    // then — no tenant resolution happens; the claims converter is never invoked
+    // then
     assertThat(result.isRight()).isTrue();
     assertThat(result.get()).isEqualTo("ok");
-    verifyNoInteractions(claimsConverter, authCheckPort);
   }
 
   @Test
   void shouldAllowWhenPrincipalIsAssignedToAllTenants() {
-    // given — multi-tenancy on and a principal assigned to tenant-a and tenant-b
+    // given — a principal pre-resolved as assigned to tenant-a and tenant-b
     final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
-    when(authentication.anonymousUser()).thenReturn(false);
-    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a", "tenant-b"));
-    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
-        .thenReturn(authentication);
+    final var authorizedTenants =
+        new AuthenticatedAuthorizedTenants(List.of("tenant-a", "tenant-b"));
 
     // when
     final var result =
         cslCheck.checkTenants(
-            command,
             List.of("tenant-a", "tenant-b"),
+            authorizedTenants,
             "ok",
-            new Rejection(RejectionType.UNAUTHORIZED, "denied"));
+            () -> new Rejection(RejectionType.UNAUTHORIZED, "denied"));
 
     // then
     assertThat(result.isRight()).isTrue();
@@ -222,18 +242,15 @@ final class CslAuthorizationCheckTest {
 
   @Test
   void shouldRejectWhenPrincipalIsNotAssignedToAllTenants() {
-    // given — multi-tenancy on and a principal assigned only to tenant-a
+    // given — a principal pre-resolved as assigned only to tenant-a
     final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    when(command.getAuthorizations()).thenReturn(Map.of(Authorization.AUTHORIZED_USERNAME, "user"));
-    when(authentication.anonymousUser()).thenReturn(false);
-    when(authentication.authenticatedTenantIds()).thenReturn(List.of("tenant-a"));
-    when(claimsConverter.resolve(Map.of(Authorization.AUTHORIZED_USERNAME, "user")))
-        .thenReturn(authentication);
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of("tenant-a"));
     final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized for tenant-b");
 
     // when — tenant-b is requested in addition to tenant-a
     final var result =
-        cslCheck.checkTenants(command, List.of("tenant-a", "tenant-b"), "ok", rejection);
+        cslCheck.checkTenants(
+            List.of("tenant-a", "tenant-b"), authorizedTenants, "ok", () -> rejection);
 
     // then — the caller-supplied rejection is returned verbatim
     assertThat(result.isLeft()).isTrue();
@@ -242,22 +259,37 @@ final class CslAuthorizationCheckTest {
 
   @Test
   void shouldAllowAnonymousUserForAnyTenants() {
-    // given — multi-tenancy on but the request is anonymous
+    // given — the pre-resolved tenants represent an anonymous caller
     final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
-    when(command.getAuthorizations())
-        .thenReturn(Map.of(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
 
     // when
     final var result =
         cslCheck.checkTenants(
-            command,
             List.of("tenant-a", "tenant-b"),
+            AuthorizedTenants.ANONYMOUS,
             "ok",
-            new Rejection(RejectionType.UNAUTHORIZED, "denied"));
+            () -> new Rejection(RejectionType.UNAUTHORIZED, "denied"));
 
-    // then — anonymous access is authorized for every tenant; no claims conversion needed
+    // then — anonymous access is authorized for every tenant
     assertThat(result.isRight()).isTrue();
-    verifyNoInteractions(claimsConverter, authCheckPort);
+  }
+
+  @Test
+  void shouldRejectWhenNoPrincipalAssignedToAnyTenants() {
+    // given — a pre-resolved empty-tenant set (what AuthorizedTenantsResolver returns for a
+    // no-principal, non-anonymous command when multi-tenancy is enabled); the rejection supplier
+    // must be safely callable here since the check failed for a non-anonymous result
+    final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, true);
+    final var authorizedTenants = new AuthenticatedAuthorizedTenants(List.of());
+    final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
+
+    // when
+    final var result =
+        cslCheck.checkTenants(List.of("tenant-a"), authorizedTenants, "ok", () -> rejection);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo(rejection);
   }
 
   private CslAuthorizationCheck cslCheck(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
@@ -214,7 +214,7 @@ final class CslAuthorizationCheckTest {
 
     // when
     final var result =
-        cslCheck.checkTenants(
+        cslCheck.checkTenantsRequiringPrincipal(
             List.of("tenant-a", "tenant-b"),
             new AuthenticatedAuthorizedTenants(List.of()),
             "ok",
@@ -234,7 +234,7 @@ final class CslAuthorizationCheckTest {
 
     // when
     final var result =
-        cslCheck.checkTenants(
+        cslCheck.checkTenantsRequiringPrincipal(
             List.of("tenant-a", "tenant-b"),
             authorizedTenants,
             "ok",
@@ -254,7 +254,7 @@ final class CslAuthorizationCheckTest {
 
     // when — tenant-b is requested in addition to tenant-a
     final var result =
-        cslCheck.checkTenants(
+        cslCheck.checkTenantsRequiringPrincipal(
             List.of("tenant-a", "tenant-b"), authorizedTenants, "ok", () -> rejection);
 
     // then — the caller-supplied rejection is returned verbatim
@@ -269,7 +269,7 @@ final class CslAuthorizationCheckTest {
 
     // when
     final var result =
-        cslCheck.checkTenants(
+        cslCheck.checkTenantsRequiringPrincipal(
             List.of("tenant-a", "tenant-b"),
             AuthorizedTenants.ANONYMOUS,
             "ok",
@@ -290,7 +290,8 @@ final class CslAuthorizationCheckTest {
 
     // when
     final var result =
-        cslCheck.checkTenants(List.of("tenant-a"), authorizedTenants, "ok", () -> rejection);
+        cslCheck.checkTenantsRequiringPrincipal(
+            List.of("tenant-a"), authorizedTenants, "ok", () -> rejection);
 
     // then
     assertThat(result.isLeft()).isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/authorization/CslAuthorizationCheckTest.java
@@ -206,14 +206,19 @@ final class CslAuthorizationCheckTest {
 
   @Test
   void shouldSkipTenantsCheckWhenMultiTenancyDisabled() {
-    // given — multi-tenancy checks disabled
+    // given — multi-tenancy checks disabled, and a non-anonymous, empty authorized-tenants set
+    // that would fail isAuthorizedForTenantIds if the multi-tenancy gate didn't short-circuit
+    // first — so a pass here can only be explained by the gate, not by trivial authorization
     final var cslCheck = cslCheck(/* authorizationsEnabled= */ true, false);
     final var rejection = new Rejection(RejectionType.UNAUTHORIZED, "not authorized");
 
     // when
     final var result =
         cslCheck.checkTenants(
-            List.of("tenant-a", "tenant-b"), AuthorizedTenants.ANONYMOUS, "ok", () -> rejection);
+            List.of("tenant-a", "tenant-b"),
+            new AuthenticatedAuthorizedTenants(List.of()),
+            "ok",
+            () -> rejection);
 
     // then
     assertThat(result.isRight()).isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -10,15 +10,22 @@ package io.camunda.zeebe.engine.processing.job;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantFilter;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -48,6 +55,7 @@ public class JobBatchActivateAuthorizationTest {
           .withIdentitySetup()
           .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
@@ -60,6 +68,7 @@ public class JobBatchActivateAuthorizationTest {
   @Test
   public void shouldBeAuthorizedToActivateAllJobsWithDefaultUser() {
     // given
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
@@ -82,10 +91,12 @@ public class JobBatchActivateAuthorizationTest {
   @Test
   public void shouldBeAuthorizedToActivateMultipleJobsWithUser() {
     // given
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
@@ -107,10 +118,12 @@ public class JobBatchActivateAuthorizationTest {
   @Test
   public void shouldBeAuthorizedToActivateSingleJobWithUser() {
     // given
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
@@ -131,10 +144,12 @@ public class JobBatchActivateAuthorizationTest {
   @Test
   public void shouldNotActivateJobsWithUnauthorizedUser() {
     // given
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
 
     // when
     final var response =
@@ -142,6 +157,63 @@ public class JobBatchActivateAuthorizationTest {
 
     // then
     assertThat(response.getValue().getJobs()).isEmpty();
+  }
+
+  @Test
+  public void shouldRejectWhenUserNotAuthorizedForProvidedTenants() {
+    // given
+    final String tenant = "restricted-tenant";
+
+    engine.tenant().newTenant().withTenantId(tenant).withName("Restricted Tenant").create();
+
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+
+    // when
+    final var rejection =
+        engine
+            .jobs()
+            .withType(JOB_TYPE)
+            .withMaxJobsToActivate(2)
+            .withTenantFilter(TenantFilter.PROVIDED)
+            .withTenantIds(List.of(tenant))
+            .expectRejection()
+            .activate(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.UNAUTHORIZED);
+    assertThat(rejection.getRejectionReason())
+        .contains("Expected to activate job batch for tenants")
+        .contains("but user is not authorized");
+  }
+
+  @Test
+  public void shouldActivateEmptyBatchForAnonymousCallerWithProvidedTenantFilter() {
+    // given
+    final var authInfo =
+        AuthorizationUtil.getAuthInfoWithClaim(Authorization.AUTHORIZED_ANONYMOUS_USER, true);
+
+    // when
+    final var response =
+        engine
+            .jobs()
+            .withType("nonExistentJobType")
+            .withMaxJobsToActivate(2)
+            .withTenantFilter(TenantFilter.PROVIDED)
+            .withTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .activate(authInfo);
+
+    // then
+    assertThat(response.getValue().getJobs()).isEmpty();
+  }
+
+  private void assignUserToTenant(final String tenantId, final String username) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -188,6 +188,32 @@ public class JobBatchActivateAuthorizationTest {
   }
 
   @Test
+  public void shouldRejectWhenUserNotAssignedToDefaultTenantAndNoTenantsProvided() {
+    // given
+    final var user = createUser();
+    addPermissionsToUser(
+        user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE_PROCESS_INSTANCE);
+
+    // when
+    // no tenant IDs provided: an empty list must not vacuously pass tenant authorization for the
+    // default tenant that determineTenantIds() would otherwise default to
+    final var rejection =
+        engine
+            .jobs()
+            .withType(JOB_TYPE)
+            .withMaxJobsToActivate(2)
+            .withTenantFilter(TenantFilter.PROVIDED)
+            .expectRejection()
+            .activate(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.UNAUTHORIZED);
+    assertThat(rejection.getRejectionReason())
+        .contains("Expected to activate job batch for tenants")
+        .contains("but user is not authorized");
+  }
+
+  @Test
   public void shouldActivateEmptyBatchForAnonymousCallerWithProvidedTenantFilter() {
     // given
     final var authInfo =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -239,8 +238,7 @@ public class JobBatchActivateAuthorizationTest {
     // given — a command carrying no username/clientId claim at all (not anonymous either); this is
     // the shape an unauthenticated gateway deployment would produce, and must be rejected rather
     // than vacuously authorized for the tenant now that multi-tenancy is enabled
-    final var authInfo = new AuthInfo();
-    authInfo.setClaims(Map.of());
+    final var authInfo = AuthorizationUtil.getClaimsFreeAuthInfo();
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -231,6 +232,29 @@ public class JobBatchActivateAuthorizationTest {
 
     // then
     assertThat(response.getValue().getJobs()).isEmpty();
+  }
+
+  @Test
+  public void shouldRejectWhenNoPrincipalClaimAndMultiTenancyEnabled() {
+    // given — a command carrying no username/clientId claim at all (not anonymous either); this is
+    // the shape an unauthenticated gateway deployment would produce, and must be rejected rather
+    // than vacuously authorized for the tenant now that multi-tenancy is enabled
+    final var authInfo = new AuthInfo();
+    authInfo.setClaims(Map.of());
+
+    // when
+    final var rejection =
+        engine
+            .jobs()
+            .withType(JOB_TYPE)
+            .withMaxJobsToActivate(2)
+            .withTenantFilter(TenantFilter.PROVIDED)
+            .withTenantIds(List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+            .expectRejection()
+            .activate(authInfo);
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.UNAUTHORIZED);
   }
 
   private void assignUserToTenant(final String tenantId, final String username) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -22,7 +22,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -54,6 +56,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
           .withIdentitySetup()
           .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
@@ -65,6 +68,8 @@ public class MessageCorrelationCorrelateAuthorizationTest {
 
   @Before
   public void before() {
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
+
     engine
         .deployment()
         .withXmlResource(
@@ -112,6 +117,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
     final var correlationKey = UUID.randomUUID().toString();
     createProcessInstance(correlationKey);
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE_PROCESS_INSTANCE);
 
@@ -137,6 +143,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
     final var correlationKey = UUID.randomUUID().toString();
     createProcessInstance(correlationKey);
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
 
     // when
     final var rejection =
@@ -177,6 +184,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   public void shouldBeAuthorizedToCorrelateMessageToStartEventWithUser() {
     // given
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
@@ -202,6 +210,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   public void shouldBeUnauthorizedToCorrelateMessageToStartEventIfNoPermissions() {
     // given
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     final var correlationKey = "test";
 
     // when
@@ -228,6 +237,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
     final var correlationKey = UUID.randomUUID().toString();
     createProcessInstance(correlationKey);
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user,
         AuthorizationResourceType.PROCESS_DEFINITION,
@@ -264,6 +274,50 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(unauthorizedProcessId));
+  }
+
+  @Test
+  public void shouldRejectWhenUserNotAssignedToTenant() {
+    // given
+    final String tenant = "restricted-tenant";
+    final String tenantProcessId = "tenantProcessId";
+
+    engine.tenant().newTenant().withTenantId(tenant).withName("Restricted Tenant").create();
+    assignUserToTenant(tenant, DEFAULT_USER.getUsername());
+
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.CREATE_PROCESS_INSTANCE,
+        tenantProcessId);
+
+    engine
+        .deployment()
+        .withXmlResource(
+            "tenant-process.bpmn",
+            Bpmn.createExecutableProcess(tenantProcessId)
+                .startEvent()
+                .message(m -> m.name(START_MSG_NAME))
+                .endEvent()
+                .done())
+        .withTenantId(tenant)
+        .deploy(DEFAULT_USER.getUsername());
+
+    // when
+    final var rejection =
+        engine
+            .messageCorrelation()
+            .withName(START_MSG_NAME)
+            .withCorrelationKey("")
+            .withTenantId(tenant)
+            .expectRejection()
+            .correlate(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    assertThat(rejection.getRejectionReason()).contains("user is not assigned to this tenant");
   }
 
   private UserRecordValue createUser() {
@@ -311,6 +365,15 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         .ofBpmnProcessId(PROCESS_ID)
         .withVariable(CORRELATION_KEY_VARIABLE, correlationKey)
         .create(DEFAULT_USER.getUsername());
+  }
+
+  private void assignUserToTenant(final String tenantId, final String username) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
   }
 
   private void assertNoMessagePublishedOrCorrelated(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.engine.processing.message;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
@@ -283,8 +283,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
     // is the shape an unauthenticated gateway deployment would produce, and must be rejected
     // rather than vacuously authorized for the tenant now that multi-tenancy is enabled
     final var correlationKey = "";
-    final var authInfo = new AuthInfo();
-    authInfo.setClaims(Map.of());
+    final var authInfo = AuthorizationUtil.getClaimsFreeAuthInfo();
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
@@ -274,6 +275,29 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(unauthorizedProcessId));
+  }
+
+  @Test
+  public void shouldRejectWhenNoPrincipalClaimAndMultiTenancyEnabled() {
+    // given — a command carrying no username/clientId claim at all (not anonymous either); this
+    // is the shape an unauthenticated gateway deployment would produce, and must be rejected
+    // rather than vacuously authorized for the tenant now that multi-tenancy is enabled
+    final var correlationKey = "";
+    final var authInfo = new AuthInfo();
+    authInfo.setClaims(Map.of());
+
+    // when
+    final var rejection =
+        engine
+            .messageCorrelation()
+            .withName(START_MSG_NAME)
+            .withCorrelationKey(correlationKey)
+            .expectRejection()
+            .correlate(authInfo);
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    assertThat(rejection.getRejectionReason()).contains("user is not assigned to this tenant");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -18,7 +18,9 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -47,6 +49,7 @@ public class SignalBroadcastAuthorizationTest {
           .withIdentitySetup()
           .withAuthorizationsEnabled(true)
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withMultiTenancyChecksEnabled(true)
           .withSecurityConfig(
               cfg -> {
                 final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
@@ -58,6 +61,8 @@ public class SignalBroadcastAuthorizationTest {
 
   @Before
   public void before() {
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, DEFAULT_USER.getUsername());
+
     engine
         .deployment()
         .withXmlResource(
@@ -95,6 +100,7 @@ public class SignalBroadcastAuthorizationTest {
     // given
     createProcessInstance();
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.CREATE_PROCESS_INSTANCE);
     addPermissionsToUser(
@@ -116,6 +122,7 @@ public class SignalBroadcastAuthorizationTest {
     // given
     createProcessInstance();
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
 
     // when
     final var rejection =
@@ -135,6 +142,7 @@ public class SignalBroadcastAuthorizationTest {
     // given
     createProcessInstance();
     final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
     addPermissionsToUser(
         user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.CREATE_PROCESS_INSTANCE);
 
@@ -148,6 +156,55 @@ public class SignalBroadcastAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
+  }
+
+  @Test
+  public void shouldRejectWhenUserNotAssignedToTenant() {
+    // given
+    final String tenant = "restricted-tenant";
+    final String tenantProcessId = "tenantProcessId";
+
+    engine.tenant().newTenant().withTenantId(tenant).withName("Restricted Tenant").create();
+    assignUserToTenant(tenant, DEFAULT_USER.getUsername());
+
+    final var user = createUser();
+    assignUserToTenant(TenantOwned.DEFAULT_TENANT_IDENTIFIER, user.getUsername());
+    addPermissionsToUser(
+        user, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.CREATE_PROCESS_INSTANCE);
+
+    engine
+        .deployment()
+        .withXmlResource(
+            "tenant-process.bpmn",
+            Bpmn.createExecutableProcess(tenantProcessId)
+                .startEvent()
+                .signal(s -> s.name(SIGNAL_NAME))
+                .endEvent()
+                .done())
+        .withTenantId(tenant)
+        .deploy(DEFAULT_USER.getUsername());
+
+    // when
+    final var rejection =
+        engine
+            .signal()
+            .withSignalName(SIGNAL_NAME)
+            .withTenantId(tenant)
+            .expectRejection()
+            .broadcast(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    assertThat(rejection.getRejectionReason()).contains("user is not assigned to this tenant");
+  }
+
+  private void assignUserToTenant(final String tenantId, final String username) {
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
@@ -156,6 +157,24 @@ public class SignalBroadcastAuthorizationTest {
         .hasRejectionReason(
             "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
                 .formatted(PROCESS_ID));
+  }
+
+  @Test
+  public void shouldRejectWhenNoPrincipalClaimAndMultiTenancyEnabled() {
+    // given — a command carrying no username/clientId claim at all (not anonymous either); this
+    // is the shape an unauthenticated gateway deployment would produce, and must be rejected
+    // rather than vacuously authorized for the tenant now that multi-tenancy is enabled
+    createProcessInstance();
+    final var authInfo = new AuthInfo();
+    authInfo.setClaims(Map.of());
+
+    // when
+    final var rejection =
+        engine.signal().withSignalName(SIGNAL_NAME).expectRejection().broadcast(authInfo);
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.FORBIDDEN);
+    assertThat(rejection.getRejectionReason()).contains("user is not assigned to this tenant");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -11,9 +11,9 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
@@ -165,8 +165,7 @@ public class SignalBroadcastAuthorizationTest {
     // is the shape an unauthenticated gateway deployment would produce, and must be rejected
     // rather than vacuously authorized for the tenant now that multi-tenancy is enabled
     createProcessInstance();
-    final var authInfo = new AuthInfo();
-    authInfo.setClaims(Map.of());
+    final var authInfo = AuthorizationUtil.getClaimsFreeAuthInfo();
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
@@ -62,4 +62,10 @@ public class AuthorizationUtil {
             List.of(authorizedTenantIds)));
     return auth;
   }
+
+  public static AuthInfo getClaimsFreeAuthInfo() {
+    final var auth = new AuthInfo();
+    auth.setClaims(Map.of());
+    return auth;
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ConditionalEvaluationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ConditionalEvaluationClient.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalEvaluationRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
@@ -78,6 +79,13 @@ public class ConditionalEvaluationClient {
     final long position =
         writer.writeCommand(
             ConditionalEvaluationIntent.EVALUATE, username, conditionalEvaluationRecord);
+    return expectation.apply(position);
+  }
+
+  public Record<ConditionalEvaluationRecordValue> evaluate(final AuthInfo authorizations) {
+    final long position =
+        writer.writeCommand(
+            ConditionalEvaluationIntent.EVALUATE, conditionalEvaluationRecord, authorizations);
     return expectation.apply(position);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util.client;
 
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 import java.util.function.BiFunction;
 
 public final class JobActivationClient {
@@ -160,6 +162,20 @@ public final class JobActivationClient {
     final long position =
         writer.writeCommandOnPartition(
             partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord, username);
+
+    return expectation.apply(partitionId, position);
+  }
+
+  public Record<JobBatchRecordValue> activate(final AuthInfo authorizations) {
+    final long position =
+        writer.writeCommandOnPartition(
+            partitionId,
+            r ->
+                r.intent(JobBatchIntent.ACTIVATE)
+                    .event(jobBatchRecord)
+                    .authorizations(authorizations)
+                    .requestId(new Random().nextLong())
+                    .requestStreamId(new Random().nextInt()));
 
     return expectation.apply(partitionId, position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.function.BiFunction;
 
 public final class JobActivationClient {
@@ -174,8 +173,8 @@ public final class JobActivationClient {
                 r.intent(JobBatchIntent.ACTIVATE)
                     .event(jobBatchRecord)
                     .authorizations(authorizations)
-                    .requestId(new Random().nextLong())
-                    .requestStreamId(new Random().nextInt()));
+                    .requestId(1L)
+                    .requestStreamId(1));
 
     return expectation.apply(partitionId, position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util.client;
 
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.record.Record;
@@ -144,6 +145,27 @@ public final class MessageCorrelationClient {
     final var position =
         writer.writeCommandOnPartition(
             partitionId, MessageCorrelationIntent.CORRELATE, messageCorrelationRecord, username);
+    return expectation.apply(
+        new Message(messageCorrelationRecord.getCorrelationKey(), position, partitionId));
+  }
+
+  public Record<MessageCorrelationRecordValue> correlate(final AuthInfo authorizations) {
+
+    if (partitionId == NOT_SET) {
+      partitionId =
+          SubscriptionUtil.getSubscriptionPartitionId(
+              messageCorrelationRecord.getCorrelationKeyBuffer(), partitionCount);
+    }
+
+    final var position =
+        writer.writeCommandOnPartition(
+            partitionId,
+            r ->
+                r.intent(MessageCorrelationIntent.CORRELATE)
+                    .event(messageCorrelationRecord)
+                    .authorizations(authorizations)
+                    .requestId(1L)
+                    .requestStreamId(1));
     return expectation.apply(
         new Message(messageCorrelationRecord.getCorrelationKey(), position, partitionId));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.record.Record;
@@ -88,6 +89,11 @@ public class SignalClient {
 
   public Record<SignalRecordValue> broadcastWithMetadata(final String username) {
     final long position = writer.writeCommand(1, 1, SignalIntent.BROADCAST, signalRecord, username);
+    return expectation.apply(position);
+  }
+
+  public Record<SignalRecordValue> broadcast(final AuthInfo authorizations) {
+    final long position = writer.writeCommand(SignalIntent.BROADCAST, signalRecord, authorizations);
     return expectation.apply(position);
   }
 }


### PR DESCRIPTION
## Summary

Continues the engine-side sweep from camunda-security-library#556 ("Unify tenant check + RBAC
authorization check", part of Inc 4 / #402): migrating hand-rolled tenant-check call sites onto
`CslAuthorizationCheck` (added in 776481c27ab, rolled out to six sites in bc0765e7fa9).

Of the 18 total tenant-check sites in the engine, 10 were already migrated. This PR handles the 3
remaining sites that fit the `checkTenant`/`checkTenants` shape:

1. **`MessageCorrelationCorrelateProcessor`**, **`SignalBroadcastProcessor`**, and
   **`ConditionalEvaluationEvaluateProcessor`** — migrated onto `checkTenants()` (plural), the
   variant for direct callers with no preceding `check()` call. All three call the tenant check
   directly rather than reaching it via `checkAuthorizationAndTenant`, so they need the variant
   that deliberately omits `checkTenant()`'s no-principal skip: `checkTenants()` takes an
   already-resolved `AuthorizedTenants` (so callers that resolved tenants for the same command
   don't pay to resolve twice) and a lazy `Supplier<Rejection>` (so the rejection message is only
   built on the rejected path). Each site's own `isInternalCommand()`/`isAuthNeeded` guard is
   preserved untouched — `checkTenants()` doesn't fold that concern in.
   `ConditionalEvaluationEvaluateProcessor` predates this PR (migrated in an earlier commit) but
   shares the identical bug shape; it's gateway-only with no internal/claims-free path to protect,
   but fixing it makes `checkTenant`'s "every caller runs `check()` first" invariant true
   repo-wide instead of true-with-exceptions.
2. **`JobBatchActivateProcessor`** — the original site needing `checkTenants()` (list-based
   `isAuthorizedForTenantIds`, `UNAUTHORIZED` rejection instead of `FORBIDDEN`/`NOT_FOUND`).
3. **`ResourceDeletionDeleteProcessor`** — a narrower dedup, not a `checkTenant`-family migration:
   this file hand-rolled its own copy of `AuthorizedTenantsResolver.resolve`'s logic via
   `LazyTokenClaimsConverter.convert(...)` instead of the centralized
   `cslCheck.resolveAuthorizedTenants(...)`. Confirmed via bytecode inspection of
   `camunda-security-library-core:0.1.0-alpha57` that `resolve(claims)` is a one-line delegation to
   `convert(claims)` — so this is a pure, verified dedup. The tenant gate itself stays
   exception-based (`NoSuchResourceException` → `NOT_FOUND`), since `ForbiddenException` hardcodes
   `FORBIDDEN` and can't carry that masking semantic — forcing an `Either`-based migration here
   would fight the file's established idiom rather than simplify it.

**Not purely behavior-preserving for (1) and (2)**: `checkTenants()` deliberately does **not** skip
claims-free commands the way `checkTenant()` does. Review found that `SignalBroadcastProcessor`,
`MessageCorrelationCorrelateProcessor`, and `ConditionalEvaluationEvaluateProcessor` (and originally
`JobBatchActivateProcessor`) all called the tenant check directly with no preceding `check()`, so a
claims-free, non-anonymous command (multi-tenancy enabled, authorizations disabled) was silently
authorized for every tenant it named instead of being rejected. Routing them through the skip-free
`checkTenants()` restores each site's pre-CSL-migration `FORBIDDEN`/`UNAUTHORIZED` rejection.

## Explicitly out of scope (documented, not migrated)

Three further sites named in the issue were investigated and found unsuitable for
`checkTenant`-style migration:

- **`BpmnJobActivationBehavior.isAuthorized`**: migrating would invert its `!isAnonymous()` guard —
  `checkTenant` allows on claim-absence (how anonymous requests look), but this site requires
  anonymous job-worker streams to get zero jobs under the `ASSIGNED` tenant filter. Forcing this
  through `checkTenant` would be an authorization regression, not a refactor.
- **`JobCommandPreconditionValidator`, `UserTaskCommandPreconditionValidator`,
  `IncidentResolveProcessor`** (+ `DbJobState`/`DbUserTaskState`/`DbIncidentState`): these already
  route through the centralized `resolveAuthorizedTenants`; the actual tenant comparison is a
  lookup-time NOT_FOUND-masking pattern inside the state layer (tenantId unknown until the by-key
  lookup resolves), architecturally distinct from `checkTenant`'s command-level gate. Migrating
  would require threading `CslAuthorizationCheck`/`Rejection`/`Either` into the state layer, which
  currently has zero dependency on those processing-layer types — a disproportionate layering
  violation for this sweep.

The CSL-level part of [#556](https://github.com/camunda/camunda-security-library/issues/556) (giving `RequiredAuthorization` a tenant dimension) is a
`camunda-security-library` change and out of scope for this repo; the issue itself describes the two
pieces as decoupled and independently mergeable.

Part of camunda-security-library#556

## Test plan

- [x] `./mvnw verify -pl zeebe/engine -Dtest=CslAuthorizationCheckTest,MessageCorrelationCorrelateAuthorizationTest,SignalBroadcastAuthorizationTest,ConditionalEvaluationAuthorizationTest,JobBatchActivateAuthorizationTest -DskipTests=false -DskipITs -Dquickly` — 44/44 passing
- [x] `./mvnw verify -pl zeebe/engine -Dtest=ResourceDeletionTest,ResourceDeletionAuthorizationTest,ResourceDeletionMultiPartitionTest,ResourceDeletionRejectionTest,TenantAwareResourceDeletionTest -DskipTests=false -DskipITs -Dquickly` — 64/64 passing (confirms the `ResourceDeletionDeleteProcessor` dedup is behavior-preserving)
- [x] `./mvnw verify -pl zeebe/engine -Dtest='Signal*,MessageCorrelation*,ConditionalEvaluation*' -DskipTests=false -DskipITs -Dquickly` — 189/189 passing (no regressions in the processors whose tenant-check behavior changed)
- [x] `./mvnw install -Dquickly -T1C` — full repo still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
