### PR TITLE
fix: keep replicating to removed Raft members until the new configuration commits

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java
@@ -245,7 +245,13 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
    * @return true if the given member is part of the cluster, false otherwise
    */
   public boolean isMember(final MemberId memberId) {
-    return localMember.memberId().equals(memberId) || remoteMemberContexts.containsKey(memberId);
+    // Configuration-derived rather than context-derived: remoteMemberContexts keeps a removed
+    // member alive as a replication target until the removal commits (see updateConfiguration),
+    // but such a member must not become a valid leadership-transfer target (its only caller,
+    // LeaderRole.onTransfer) during that window - membership-blind votes could actually elect it
+    // into a configuration that no longer includes it.
+    return localMember.memberId().equals(memberId)
+        || (configuration != null && configuration.hasMember(memberId));
   }
 
   /**
@@ -363,6 +369,13 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     updateConfiguration(configuration);
     final var newType = localMember.getType();
     if (initialType.ordinal() < newType.ordinal()) {
+      // Promotions transition at append, unlike demotions/removals which transition at commit
+      // (see commitCurrentConfiguration). Delaying PASSIVE->ACTIVE to commit has a liveness
+      // counterexample: if the promoted member holds the longest log and the leader dies before
+      // C-new commits, C-new's majority may require the promoted member's vote, and the
+      // log-up-to-date check (dissertation §4.1) makes every other member unelectable - so it
+      // must be able to stand for election under its appended configuration. Likewise, deferring
+      // INACTIVE->PASSIVE would stall log catch-up, since only PassiveRole accepts appends.
       raft.transition(localMember.getType());
     }
 
@@ -382,14 +395,32 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
       localMember.update(Type.INACTIVE, time);
     }
 
-    // Close and remove contexts which are not needed anymore
     final var membersToRemove =
         remoteMemberContexts.values().stream()
             .map(RaftMemberContext::getMember)
             .filter(Predicate.not(membersInNewConfiguration::contains))
             .toList();
-    for (final var member : membersToRemove) {
-      removeMemberContext(member);
+    if (configuration.force()) {
+      // A forced configuration is authoritative without waiting for a commit: the orchestrator
+      // that issues it (ReconfigurationHelper.triggerForceConfigure) wins its election before this
+      // server would ever reach commitCurrentConfiguration, so deferring pruning to commit would
+      // keep presumably-dead members as replication targets of the new leader.
+      for (final var member : membersToRemove) {
+        removeMemberContext(member);
+      }
+    } else {
+      // raft.pdf §6: servers removed by a reconfiguration may only be shut down once the new
+      // configuration commits. Keep their contexts and replication targets alive here - they are
+      // fully pruned in commitCurrentConfiguration() once the outcome is decided - so the leader
+      // keeps replicating and heartbeating to a removed member while its fate is still undecided,
+      // keeping it reachable and its election timer quiet. Only the active-voting bookkeeping,
+      // which election/quorum logic reads at append time, is updated immediately.
+      for (final var member : membersToRemove) {
+        final var context = remoteMemberContexts.get(member.memberId());
+        if (context != null && remoteActiveMembers.remove(context)) {
+          hasRemoteActiveMembers = !remoteActiveMembers.isEmpty();
+        }
+      }
     }
 
     // Add or update contexts for members in the new configuration
@@ -451,6 +482,22 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     final var storedConfiguration = raft.getMetaStore().loadConfiguration();
     if (storedConfiguration == null || storedConfiguration.index() < configuration.index()) {
       raft.getMetaStore().storeConfiguration(configuration);
+    }
+
+    // Members kept alive as replication targets while the configuration was appended but not yet
+    // committed (see updateConfiguration) can finally be shut down now (raft.pdf §6). This is
+    // idempotent reconciliation: a forced configuration is already pruned by the time this runs,
+    // and every caller (the commit-index hook, an already-committed configure(), the initial
+    // config, PassiveRole/InactiveRole onConfigure, force-configure) may invoke this repeatedly for
+    // the same configuration.
+    final var membersInConfiguration = configuration.allMembers();
+    final var membersToRemove =
+        remoteMemberContexts.values().stream()
+            .map(RaftMemberContext::getMember)
+            .filter(Predicate.not(membersInConfiguration::contains))
+            .toList();
+    for (final var member : membersToRemove) {
+      removeMemberContext(member);
     }
 
     // Apply the configuration to the local server state.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java
@@ -113,6 +113,10 @@ public final class RaftMemberContext {
     open = false;
     member.close();
     closeReader();
+    if (snapshotChunkReader != null) {
+      snapshotChunkReader.close();
+      snapshotChunkReader = null;
+    }
   }
 
   public boolean isOpen() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -17,9 +17,12 @@ import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftPartitionConfig;
+import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.RaftResponse.Status;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.TestRaftProtocolFactory;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.roles.LeaderRole;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
@@ -29,6 +32,7 @@ import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,7 +47,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
@@ -114,6 +123,13 @@ final class ReconfigurationTest {
 
   private RaftServer createServer(
       final Path dir, final ClusterMembershipService membershipService) {
+    return createServer(dir, membershipService, config -> {});
+  }
+
+  private RaftServer createServer(
+      final Path dir,
+      final ClusterMembershipService membershipService,
+      final Consumer<RaftPartitionConfig> configCustomizer) {
     final var memberId = membershipService.getLocalMember().id();
     final var protocol = protocolFactory.newServerProtocol(memberId);
     final var storage =
@@ -122,15 +138,17 @@ final class ReconfigurationTest {
             .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
             .withMaxSegmentSize(1024 * 10)
             .build();
+    final var partitionConfig =
+        new RaftPartitionConfig()
+            .setElectionTimeout(Duration.ofMillis(500))
+            .setHeartbeatInterval(Duration.ofMillis(100));
+    configCustomizer.accept(partitionConfig);
     final var server =
         RaftServer.builder(memberId)
             .withMembershipService(membershipService)
             .withProtocol(protocol)
             .withStorage(storage)
-            .withPartitionConfig(
-                new RaftPartitionConfig()
-                    .setElectionTimeout(Duration.ofMillis(500))
-                    .setHeartbeatInterval(Duration.ofMillis(100)))
+            .withPartitionConfig(partitionConfig)
             .withMeterRegistry(meterRegistry)
             .build();
     servers.add(server);
@@ -760,6 +778,131 @@ final class ReconfigurationTest {
       // then -- remaining three can elect a leader and commit entries
       final var leader = awaitLeader(m1, m2);
       assertThat(appendEntry(leader).commit()).succeedsWithin(Duration.ofSeconds(1));
+    }
+
+    /**
+     * Pins existing behavior against regression: a removed leader steps down only once the removal
+     * commits, not as soon as it is appended. Role transitions for demotions/removals are driven by
+     * the commit-index hook in {@code RaftContext#setCommitIndex}, not by the append-time
+     * membership bookkeeping in {@code RaftClusterContext#updateConfiguration} - so a leaving
+     * leader keeps leading and replicating for as long as the removal is uncommitted.
+     */
+    @Test
+    void removedLeaderStepsDownAtCommitNotAtAppend(@TempDir final Path tmp) {
+      // given - a cluster with 3 members and a long quorum response timeout, so the leader does
+      // not suspect a network partition and step down early while this test deliberately holds
+      // back one member's acknowledgement of the final configuration
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+      // A held-back follower is not the only one affected while the removal is uncommitted: any
+      // *other* follower that catches up to the removing configuration entry stops recognizing
+      // the (about-to-be-removed) leader via RaftClusterContext#getMember, because that lookup is
+      // backed by remoteMemberContexts, which is pruned at append time on unfixed code. Its
+      // election timer then never gets reset by further heartbeats from that leader, and it calls
+      // its own election after one electionTimeout. Widen the election timeout so that neither
+      // follower's timer fires within this test's observation window.
+      final Consumer<RaftPartitionConfig> testTimeouts =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+          };
+
+      final var m1 =
+          createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3), testTimeouts);
+      final var m2 =
+          createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3), testTimeouts);
+      final var m3 =
+          createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2), testTimeouts);
+
+      CompletableFuture.allOf(
+              m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+          .join();
+      awaitLeader(m1, m2, m3);
+      final var leader = getLeaderServer(List.of(m1, m2, m3)).orElseThrow();
+      final var leaderId = MemberId.from(leader.name());
+      final var followers = Stream.of(m1, m2, m3).filter(s -> s != leader).toList();
+      final var heldBackFollower = followers.get(0);
+      final var heldBackFollowerId = MemberId.from(heldBackFollower.name());
+
+      // when - the leader leaves. The final, non-joint configuration is identifiable by an empty
+      // oldMembers (the joint configuration that precedes it always carries the current members
+      // as oldMembers); once the leader starts disseminating it to one follower, drop entry-
+      // carrying appends to that follower, so its match index can never reach the new
+      // configuration's index and the removal can never commit. Empty heartbeats keep flowing so
+      // the follower is not falsely suspected unreachable and does not call an election itself.
+      // Every append exchange (to either follower) is delayed by a few milliseconds: the in-memory
+      // test protocol otherwise completes them fast enough that a follower which keeps
+      // acknowledging immediately refuels another full round of appends to every member (see
+      // LeaderAppender#recordHeartbeat -> sendHeartbeats), busy-looping the single raft actor
+      // thread. A few milliseconds is negligible against this test's assertions, which all operate
+      // on a scale of several heartbeat intervals or more.
+      final var holdBackCommit = new AtomicBoolean(false);
+      final var leaderProtocol = (TestRaftServerProtocol) leader.getContext().getProtocol();
+      leaderProtocol.interceptRequest(
+          ConfigureRequest.class,
+          (receiver, request) -> {
+            // oldMembers().isEmpty() alone is not enough to identify C-new: the *initial*
+            // configuration is also non-joint and could resurface here as a retried/straggler
+            // ConfigureRequest after this interceptor is registered (e.g. after a dropped
+            // configure response, or a term bump). Requiring that the leaving leader is
+            // already excluded from the new members uniquely identifies the final,
+            // post-joint-consensus configuration.
+            if (receiver.equals(heldBackFollowerId)
+                && request.oldMembers().isEmpty()
+                && request.newMembers().stream()
+                    .noneMatch(member -> member.memberId().equals(leaderId))) {
+              holdBackCommit.set(true);
+            }
+          });
+      leaderProtocol.interceptDelivery(
+          VersionedAppendRequest.class,
+          (receiver, request) -> {
+            final var result = new CompletableFuture<Void>();
+            CompletableFuture.runAsync(
+                () -> {
+                  if (receiver.equals(heldBackFollowerId)
+                      && holdBackCommit.get()
+                      && !request.entries().isEmpty()) {
+                    result.completeExceptionally(new ConnectException());
+                  } else {
+                    result.complete(null);
+                  }
+                },
+                CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
+            return result;
+          });
+
+      final var leaveFuture = leader.leave();
+
+      // then - while the final configuration is appended but held back from committing, the
+      // removed leader keeps leading and heartbeating instead of stepping down immediately
+      Awaitility.await("the final configuration is appended but not yet committed")
+          .until(holdBackCommit::get);
+      Awaitility.await("the leader keeps leading while the removal is uncommitted")
+          .during(Duration.ofMillis(800))
+          .until(leader::isLeader);
+      assertThat(leaveFuture).isNotDone();
+
+      // when - the configuration is allowed to commit
+      holdBackCommit.set(false);
+
+      // then - only now does the removed leader step down, the leave completes, and the
+      // remaining members elect a new leader among themselves
+      assertThat(leaveFuture).succeedsWithin(Duration.ofSeconds(10));
+      Awaitility.await("the removed leader has stepped down to inactive")
+          .untilAsserted(
+              () ->
+                  assertThat(leader.cluster().getLocalMember().getType())
+                      .isEqualTo(RaftMember.Type.INACTIVE));
+      awaitLeader(followers.toArray(RaftServer[]::new));
+      final var expected =
+          followers.stream().map(server -> server.cluster().getLocalMember()).toList();
+      assertThat(followers)
+          .allSatisfy(
+              member ->
+                  assertThat(member.cluster().getMembers())
+                      .containsExactlyInAnyOrderElementsOf(expected));
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -49,9 +49,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -778,6 +777,129 @@ final class ReconfigurationTest {
       // then -- remaining three can elect a leader and commit entries
       final var leader = awaitLeader(m1, m2);
       assertThat(appendEntry(leader).commit()).succeedsWithin(Duration.ofSeconds(1));
+    }
+
+    /**
+     * The discriminating test for <a href="https://github.com/camunda/camunda/issues/57390">
+     * #57390</a>: a leaving member must keep receiving appends/heartbeats for as long as its
+     * removal is appended but not yet committed, so its election timer stays quiet and it stays
+     * reachable while the outcome is still undecided. Red on unfixed code, where {@code
+     * RaftClusterContext#updateConfiguration} prunes the leaving member's context - and thus its
+     * place in the leader's replication targets - as soon as the removal is appended.
+     */
+    @Test
+    void leavingMemberKeepsReceivingAppendsUntilConfigurationCommits(@TempDir final Path tmp) {
+      // given - a cluster with 3 members and generous timeouts, so holding one follower's ack of
+      // the final configuration back for an extended window doesn't itself disrupt the leader or
+      // the leaving member (see removedLeaderStepsDownAtCommitNotAtAppend for why)
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+      final var id3 = MemberId.from("3");
+      final Consumer<RaftPartitionConfig> testTimeouts =
+          config -> {
+            config.setMaxQuorumResponseTimeout(Duration.ofSeconds(60));
+            config.setElectionTimeout(Duration.ofSeconds(3));
+          };
+
+      final var m1 =
+          createServer(tmp, StaticClusterMembershipService.of(id1, id2, id3), testTimeouts);
+      final var m2 =
+          createServer(tmp, StaticClusterMembershipService.of(id2, id1, id3), testTimeouts);
+      final var m3 =
+          createServer(tmp, StaticClusterMembershipService.of(id3, id1, id2), testTimeouts);
+
+      CompletableFuture.allOf(
+              m1.bootstrap(id1, id2, id3), m2.bootstrap(id1, id2, id3), m3.bootstrap(id1, id2, id3))
+          .join();
+      awaitLeader(m1, m2, m3);
+      final var leader = getLeaderServer(List.of(m1, m2, m3)).orElseThrow();
+      final var followers = Stream.of(m1, m2, m3).filter(s -> s != leader).toList();
+      final var leaving = followers.get(0);
+      final var leavingId = MemberId.from(leaving.name());
+      final var quorumFollower = followers.get(1);
+      final var quorumFollowerId = MemberId.from(quorumFollower.name());
+
+      // when - a follower (not the leader) leaves. The final, non-joint configuration is
+      // identifiable by an empty oldMembers; once the leader starts disseminating it to the other
+      // follower (the one whose ack the new configuration's quorum needs), drop entry-carrying
+      // appends to it, so the removal can never commit. Every append exchange is delayed by a few
+      // milliseconds, for the same reason as in removedLeaderStepsDownAtCommitNotAtAppend: the
+      // in-memory test protocol otherwise completes exchanges fast enough that a member which
+      // keeps acknowledging immediately refuels another full round of appends to every member,
+      // busy-looping the single raft actor thread - which would also corrupt this test's own
+      // append counter for the leaving member.
+      final var holdBackCommit = new AtomicBoolean(false);
+      final var appendsToLeavingMember = new AtomicInteger();
+      final var leaderProtocol = (TestRaftServerProtocol) leader.getContext().getProtocol();
+      leaderProtocol.interceptRequest(
+          ConfigureRequest.class,
+          (receiver, request) -> {
+            // oldMembers().isEmpty() alone is not enough to identify C-new: the *initial*
+            // configuration is also non-joint and could resurface here as a retried/straggler
+            // ConfigureRequest after this interceptor is registered (e.g. after a dropped
+            // configure response, or a term bump). Requiring that the leaving member is
+            // already excluded from the new members uniquely identifies the final,
+            // post-joint-consensus configuration.
+            if (receiver.equals(quorumFollowerId)
+                && request.oldMembers().isEmpty()
+                && request.newMembers().stream()
+                    .noneMatch(member -> member.memberId().equals(leavingId))) {
+              holdBackCommit.set(true);
+            }
+          });
+      leaderProtocol.interceptDelivery(
+          VersionedAppendRequest.class,
+          (receiver, request) -> {
+            if (receiver.equals(leavingId)) {
+              appendsToLeavingMember.incrementAndGet();
+            }
+            final var result = new CompletableFuture<Void>();
+            CompletableFuture.runAsync(
+                () -> {
+                  if (receiver.equals(quorumFollowerId)
+                      && holdBackCommit.get()
+                      && !request.entries().isEmpty()) {
+                    result.completeExceptionally(new ConnectException());
+                  } else {
+                    result.complete(null);
+                  }
+                },
+                CompletableFuture.delayedExecutor(20, TimeUnit.MILLISECONDS));
+            return result;
+          });
+
+      final var leaveFuture = leaving.leave();
+
+      // then - while the final configuration is appended but held back from committing, the
+      // leaving member keeps receiving appends across several heartbeat intervals, and neither
+      // the leave nor the leader's own leadership resolves
+      Awaitility.await("the final configuration is appended but not yet committed")
+          .until(holdBackCommit::get);
+      final var appendsAtHoldBack = appendsToLeavingMember.get();
+      Awaitility.await("the leaving member keeps receiving appends")
+          .atMost(Duration.ofSeconds(5))
+          .until(() -> appendsToLeavingMember.get() >= appendsAtHoldBack + 5);
+      assertThat(leader.isLeader()).isTrue();
+      assertThat(leaveFuture).isNotDone();
+
+      // when - the configuration is allowed to commit
+      holdBackCommit.set(false);
+
+      // then - the leave completes, the leaving member's context is torn down everywhere, and it
+      // stops receiving appends
+      assertThat(leaveFuture).succeedsWithin(Duration.ofSeconds(10));
+      final var remaining = List.of(leader, quorumFollower);
+      final var expected =
+          remaining.stream().map(server -> server.cluster().getLocalMember()).toList();
+      Awaitility.await("the leaving member's context is removed everywhere")
+          .untilAsserted(
+              () ->
+                  assertThat(remaining)
+                      .allSatisfy(
+                          member ->
+                              assertThat(member.cluster().getMembers())
+                                  .containsExactlyInAnyOrderElementsOf(expected)));
+      assertThat(leader.getContext().getCluster().getMemberContext(leavingId)).isNull();
     }
 
     /**

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -109,7 +109,7 @@ final class RaftClusterContextTest {
   }
 
   @Test
-  void shouldRemoveContextsOnReconfiguration() {
+  void shouldKeepRemovedMembersAsReplicationTargetsUntilCommit() {
     // given -- stored configuration that contains all members
     final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
     final var remoteMembers =
@@ -123,15 +123,75 @@ final class RaftClusterContextTest {
     final var context = new RaftClusterContext(localMember.memberId(), raft);
     context.bootstrap(List.of()).join();
 
-    // when -- reconfigure with a new configuration only contains the local member
+    // when -- an uncommitted configuration is appended that drops both remote members (the mock
+    // RaftContext's commit index stays at its default of 0, below the new configuration's index)
     context.configure(new Configuration(2, 1, Instant.now().toEpochMilli(), List.of(localMember)));
 
-    // then -- new configuration is used
+    // then -- append-time membership bookkeeping already reflects the new configuration
     assertThat(context.getLocalMember().memberId()).isEqualTo(MemberId.from("1"));
-    assertThat(context.inJointConsensus()).isFalse();
     assertThat(context.getMembers()).containsExactly(localMember);
     assertThat(context.isSingleMemberCluster()).isTrue();
     assertThat(context.getVotingMembers()).isEmpty();
+    assertThat(remoteMembers).noneMatch(member -> context.isMember(member.memberId()));
+
+    // but -- the removed members are kept alive as replication targets until the removal commits
+    assertThat(
+            context.getReplicationTargets().stream()
+                .map(RaftMemberContext::getMember)
+                .map(RaftMember.class::cast))
+        .containsExactlyInAnyOrderElementsOf(remoteMembers);
+    assertThat(remoteMembers)
+        .allSatisfy(member -> assertThat(context.getMemberContext(member.memberId())).isNotNull());
+  }
+
+  @Test
+  void shouldRemoveContextsWhenConfigurationCommits() {
+    // given -- an uncommitted configuration that drops both remote members
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var remoteMembers =
+        List.<RaftMember>of(
+            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+    final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
+
+    final var raft =
+        raftWithStoredConfiguration(new Configuration(1, 1, Instant.now().toEpochMilli(), members));
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+    context.configure(new Configuration(2, 1, Instant.now().toEpochMilli(), List.of(localMember)));
+
+    // when -- the configuration commits
+    context.commitCurrentConfiguration();
+
+    // then -- the removed members' contexts are finally closed and removed
+    assertThat(context.getReplicationTargets()).isEmpty();
+    assertThat(remoteMembers)
+        .noneMatch(member -> context.isMember(member.memberId()))
+        .allSatisfy(member -> assertThat(context.getMember(member.memberId())).isNull())
+        .allSatisfy(member -> assertThat(context.getMemberContext(member.memberId())).isNull());
+  }
+
+  @Test
+  void shouldRemoveContextsImmediatelyOnForcedConfiguration() {
+    // given -- stored configuration that contains all members
+    final var localMember = new DefaultRaftMember(new MemberId("1"), Type.ACTIVE, Instant.now());
+    final var remoteMembers =
+        List.<RaftMember>of(
+            new DefaultRaftMember(new MemberId("2"), Type.ACTIVE, Instant.now()),
+            new DefaultRaftMember(new MemberId("3"), Type.ACTIVE, Instant.now()));
+    final var members = Stream.concat(Stream.of(localMember), remoteMembers.stream()).toList();
+
+    final var raft =
+        raftWithStoredConfiguration(new Configuration(1, 1, Instant.now().toEpochMilli(), members));
+    final var context = new RaftClusterContext(localMember.memberId(), raft);
+    context.bootstrap(List.of()).join();
+
+    // when -- a forced configuration drops both remote members, without ever committing
+    context.configure(
+        new Configuration(
+            2, 1, Instant.now().toEpochMilli(), List.of(localMember), List.of(), true));
+
+    // then -- the removed members' contexts are pruned immediately, at apply time
     assertThat(context.getReplicationTargets()).isEmpty();
     assertThat(remoteMembers)
         .noneMatch(member -> context.isMember(member.memberId()))

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftMemberContextTest.java
@@ -20,6 +20,7 @@ import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
@@ -294,6 +295,20 @@ final class RaftMemberContextTest {
     assertThat(context.getSnapshotReplicationLag()).isZero();
     assertThat(context.getSnapshotChunkBytesInFlight()).isZero();
     assertThat(context.getReplicationLagBytes()).isZero();
+  }
+
+  @Test
+  void shouldCloseSnapshotChunkReaderOnClose() {
+    // given
+    final var context = newContext();
+    final var snapshotChunkReader = mock(SnapshotChunkReader.class);
+    context.setSnapshotChunkReader(snapshotChunkReader);
+
+    // when
+    context.close();
+
+    // then
+    verify(snapshotChunkReader).close();
   }
 
   private RaftMemberContext newContext() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -461,6 +461,30 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
                 .thenCompose(ignore -> CompletableFuture.completedFuture(listener)));
   }
 
+  /**
+   * Intercepts the delivery of a request to a specific receiver, with the receiver's member id as
+   * the first argument. If the interceptor returns a failed future, the request is not delivered to
+   * the receiver. Otherwise, the request is forwarded to the receiver. Unlike the other overloads,
+   * this combines receiver visibility with the ability to block the request, which the {@link
+   * Consumer}/{@link BiConsumer} variants cannot do and the {@link Function} variant cannot see the
+   * receiver for. Named distinctly from {@code interceptRequest} rather than added as another
+   * overload: a same-arity {@link BiConsumer} overload already exists, and javac's overload
+   * resolution for implicitly-typed two-arg lambdas can find call sites ambiguous between the two
+   * even when only one is structurally compatible with the lambda body.
+   */
+  public <T> void interceptDelivery(
+      final Class<T> requestType,
+      final BiFunction<MemberId, T, CompletableFuture<Void>> interceptor) {
+    interceptors.put(
+        requestType,
+        (request, listener) -> {
+          final var receiver = listener != null ? listener.memberId : memberId;
+          return interceptor
+              .apply(receiver, (T) request)
+              .thenCompose(ignore -> CompletableFuture.completedFuture(listener));
+        });
+  }
+
   public <T extends RaftResponse> void interceptResponse(
       final Class<T> responseType, final ResponseInterceptor<T> interceptor) {
     responseInterceptors.put(responseType, interceptor);


### PR DESCRIPTION
Closes #57390. Part of the #57386 fix-package epic; builds on #58080, #58099 and #58304, all merged to main.

## Problem

raft.pdf §6: servers removed by a reconfiguration may only be shut down once the new configuration commits. `RaftClusterContext` already respected this for role transitions — a removed leader steps down at commit, not at append (pinned by a new test in this PR) — but `updateConfiguration()` pruned a removed member's context, and with it its place in the leader's replication targets, as soon as the removal was appended. A leaving member therefore stopped receiving appends/heartbeats before its removal committed: its election timer could fire (a disruptive election while the outcome was still undecided), and it became unreachable if the removal never committed (e.g. the leader failing over before a quorum acknowledged it).

## Fix

Split pruning into two phases: at [append](https://github.com/camunda/camunda/blob/b9f61419f0f3129110a439e6e4bccb2f8a4d3c71/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java#L404-L426), a removed member only leaves the active-voting bookkeeping that election/quorum logic reads at append time (safe because #58080 made quorum arithmetic configuration-derived); its context and replication target survive until [`commitCurrentConfiguration()` prunes them](https://github.com/camunda/camunda/blob/b9f61419f0f3129110a439e6e4bccb2f8a4d3c71/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java#L486-L501), once the outcome is decided. A forced configuration is authoritative without a commit, so it keeps pruning immediately at apply time. [`isMember()` becomes configuration-derived](https://github.com/camunda/camunda/blob/b9f61419f0f3129110a439e6e4bccb2f8a4d3c71/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftClusterContext.java#L245-L256) instead of context-derived, so a kept-alive leaving member cannot become a leadership-transfer target during the append→commit window (with #58099's membership-blind votes it could actually get elected into a configuration that excludes it).

Drive-by: [`RaftMemberContext#close()` now also closes the `SnapshotChunkReader`](https://github.com/camunda/camunda/blob/b9f61419f0f3129110a439e6e4bccb2f8a4d3c71/zeebe/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/RaftMemberContext.java#L112-L120) set by an in-flight snapshot install — a pre-existing leak that this change makes more likely to be hit, since in-flight installs to a removed member are now a normal occurrence.

## Deviation from the issue text

The leaving member does not reliably learn the commit index via heartbeats — the leader prunes at commit, before a post-commit heartbeat round. Its clean shutdown is driven by the `LeaveResponse` sent when the removal commits, same as today, matching canonical raft (the post-commit disruption window is §4.2.3 leader-stickiness territory, out of scope here).

## Known residual (out of scope)

If the removed member itself restarts during the append→commit window, its bootstrap unconditionally transitions it to INACTIVE after recovering the appended configuration, so it stops answering polls/votes/appends even though the removal could still be lost. Fixing this means commit-gating the bootstrap transition, left as a follow-up.

