### PR TITLE
fix: bound and retry individual snyk calls in Zeebe Snyk scan

### DIFF
--- a/.github/actions/frontend-sbom-snyk/action.yml
+++ b/.github/actions/frontend-sbom-snyk/action.yml
@@ -92,7 +92,38 @@ runs:
       env:
         SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
       run: |
-        snyk sbom test \
+        # Bounds the `snyk` call so a single stuck/slow call to the Snyk API cannot consume the
+        # whole job's timeout (see INC-6630 for the same class of issue with unbounded external
+        # network calls in CI).
+        #
+        # snyk exit codes: 0 = no issues, 1 = vulnerabilities found (a valid result),
+        # 2 = error / re-run recommended, 3 = no supported projects. `timeout` returns 124 when
+        # it kills a stuck call. Only 2 and 124 are transient, so we retry those and pass every
+        # other code straight through - retrying a legitimate vuln finding (1) would needlessly
+        # double every scan that has findings and defeat the purpose of this bound.
+        function runSnykWithRetry() {
+          local maxAttempts=2
+          local perAttemptTimeoutSecs=120
+          local retryDelaySecs=10
+          local attempt=1
+
+          while true; do
+            local status=0
+            timeout "${perAttemptTimeoutSecs}s" snyk "$@" || status=$?
+            if [ "${status}" -ne 2 ] && [ "${status}" -ne 124 ]; then
+              return "${status}"
+            fi
+            if [ "${attempt}" -ge "${maxAttempts}" ]; then
+              echo "::error::snyk $* still failing after ${maxAttempts} attempts (exit ${status})"
+              return "${status}"
+            fi
+            echo "snyk $* transient failure (exit ${status}), retry ${attempt}/${maxAttempts} in ${retryDelaySecs}s..."
+            sleep "${retryDelaySecs}"
+            attempt=$((attempt + 1))
+          done
+        }
+
+        runSnykWithRetry sbom test \
           --file="${{ inputs.sbom-file }}" \
           --org="${{ inputs.snyk-org }}" \
           --severity-threshold="${{ inputs.severity-threshold }}"

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -212,6 +212,30 @@ jobs:
             fi
           }
 
+          # Bounds each individual `snyk` call so a single stuck/slow call to the Snyk API cannot
+          # consume the whole job's 15m timeout and take the remaining projects down with it (see
+          # INC-6630 for the same class of issue with unbounded external network calls in CI).
+          function runSnykWithRetry() {
+            local maxAttempts=2
+            local perAttemptTimeoutSecs=120
+            local retryDelaySecs=10
+            local attempt=1
+
+            while true; do
+              if timeout "${perAttemptTimeoutSecs}s" snyk "$@"; then
+                return 0
+              fi
+              local status=$?
+              if [ "${attempt}" -ge "${maxAttempts}" ]; then
+                echo "::error::snyk $* failed after ${maxAttempts} attempts (exit ${status})"
+                return "${status}"
+              fi
+              echo "snyk $* failed or timed out (attempt ${attempt}/${maxAttempts}), retrying in ${retryDelaySecs}s..."
+              sleep "${retryDelaySecs}"
+              attempt=$((attempt + 1))
+            done
+          }
+
           # Print out command if debug logging is enabled
           set -x
 
@@ -224,14 +248,14 @@ jobs:
             PROJECT_NAME="zeebe(${TARGET}):${project}/pom.xml"
             ensureExists "${project}/pom.xml"
             # shellcheck disable=SC2153
-            snyk "${SNYK_COMMAND}" --file="${project}/pom.xml" "'--project-name=${PROJECT_NAME}'" "${SNYK_ARGS}" "$(output "${SARIF}" "${project/\//-}")" || exitCode=1
+            runSnykWithRetry "${SNYK_COMMAND}" --file="${project}/pom.xml" "'--project-name=${PROJECT_NAME}'" "${SNYK_ARGS}" "$(output "${SARIF}" "${project/\//-}")" || exitCode=1
           done
 
           # The `container` command does not yet support setting a target reference, as this is a beta
           # feature at the moment. It's added here anyway for now, and hopefully support will come soon.
           PROJECT_NAME="zeebe(${TARGET}):camunda.Dockerfile"
           ensureExists "camunda.Dockerfile"
-          snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" --file=camunda.Dockerfile "'--project-name=${PROJECT_NAME}'" "${SNYK_ARGS}" "$(output "${SARIF}" 'docker')" || exitCode=1
+          runSnykWithRetry container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" --file=camunda.Dockerfile "'--project-name=${PROJECT_NAME}'" "${SNYK_ARGS}" "$(output "${SARIF}" 'docker')" || exitCode=1
 
           # Only fail if we entirely failed to parse the projects
           if [[ $exitCode -gt 1 ]]; then

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -228,8 +228,8 @@ jobs:
             local attempt=1
 
             while true; do
-              timeout "${perAttemptTimeoutSecs}s" snyk "$@"
-              local status=$?
+              local status=0
+              timeout "${perAttemptTimeoutSecs}s" snyk "$@" || status=$?
               if [ "${status}" -ne 2 ] && [ "${status}" -ne 124 ]; then
                 return "${status}"
               fi

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -215,6 +215,12 @@ jobs:
           # Bounds each individual `snyk` call so a single stuck/slow call to the Snyk API cannot
           # consume the whole job's 15m timeout and take the remaining projects down with it (see
           # INC-6630 for the same class of issue with unbounded external network calls in CI).
+          #
+          # snyk exit codes: 0 = no issues, 1 = vulnerabilities found (a valid result),
+          # 2 = error / re-run recommended, 3 = no supported projects. `timeout` returns 124 when
+          # it kills a stuck call. Only 2 and 124 are transient, so we retry those and pass every
+          # other code straight through - retrying a legitimate vuln finding (1) would needlessly
+          # double every scan that has findings and defeat the purpose of this bound.
           function runSnykWithRetry() {
             local maxAttempts=2
             local perAttemptTimeoutSecs=120
@@ -222,15 +228,16 @@ jobs:
             local attempt=1
 
             while true; do
-              if timeout "${perAttemptTimeoutSecs}s" snyk "$@"; then
-                return 0
-              fi
+              timeout "${perAttemptTimeoutSecs}s" snyk "$@"
               local status=$?
-              if [ "${attempt}" -ge "${maxAttempts}" ]; then
-                echo "::error::snyk $* failed after ${maxAttempts} attempts (exit ${status})"
+              if [ "${status}" -ne 2 ] && [ "${status}" -ne 124 ]; then
                 return "${status}"
               fi
-              echo "snyk $* failed or timed out (attempt ${attempt}/${maxAttempts}), retrying in ${retryDelaySecs}s..."
+              if [ "${attempt}" -ge "${maxAttempts}" ]; then
+                echo "::error::snyk $* still failing after ${maxAttempts} attempts (exit ${status})"
+                return "${status}"
+              fi
+              echo "snyk $* transient failure (exit ${status}), retry ${attempt}/${maxAttempts} in ${retryDelaySecs}s..."
               sleep "${retryDelaySecs}"
               attempt=$((attempt + 1))
             done


### PR DESCRIPTION
## Description

Run [30014534124](https://github.com/camunda/camunda/actions/runs/30014534124) on `main` got cancelled: the `Run Snyk` step in `.github/workflows/zeebe-snyk.yml` loops 9 sequential `snyk` calls (8 Java projects + 1 container scan) with no per-call bound. One slow/stuck call silently consumed the whole job's 15m timeout and took the other 8 scans down with it. That cascaded through the `check-results` merge-queue gate, which in turn skipped the snapshot artifact/Docker-image deploy jobs — matching the `base-branch-unsuccessful-job` alert.

Compared against the job's own recent history: baseline runs finished in 6-9 min, so this was an anomalous slowdown, not a systemic capacity issue.

This wraps each `snyk` invocation in the loop with a 120s per-attempt timeout and one retry (10s backoff) — the same bounded-retry idiom already used elsewhere in this repo for flaky external network calls (see [INC-6630](https://camunda.slack.com/archives/C0BKE2AV5V2) / [#58548](https://github.com/camunda/camunda/pull/58548), which hardened `docker login` against transient DockerHub auth failures the same day). `nick-fields/retry` itself can't wrap a single command inside a bash loop without restructuring the step into a matrix, so this reproduces the same bound+retry behavior inline in bash instead — same idiom already used in `camunda-load-test.yml`'s Docker-image validation retry loop.

Validated locally: actionlint and conftest pass on the changed workflow; a temporary act-testing harness (`test-zeebe-snyk.yml`, not part of this PR) confirmed the retry/timeout wrapper recovers from a transient failure and bounds a stuck call instead of hanging.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

N/A