### PR TITLE
fix: zone was not passed correctly in Member

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -56,7 +56,7 @@ public class Member extends Node {
   }
 
   protected Member(final MemberId id, final Address address) {
-    this(id, 0L, address, null, null, null, new Properties());
+    this(id, 0L, address, id.zone(), null, null, new Properties());
   }
 
   protected Member(
@@ -149,7 +149,7 @@ public class Member extends Node {
    * @return the member
    */
   public static Member member(final MemberId memberId, final Address address) {
-    return builder(memberId).withAddress(address).build();
+    return builder(memberId).withAddress(address).withZoneId(memberId.zone()).build();
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.utils.net.Address;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+final class MemberTest {
+
+  private static final Address ADDRESS = Address.from("localhost", 26502);
+
+  @Test
+  void shouldPropagateZoneFromMemberIdWhenBuildingZonedMemberViaFactory() {
+    // given
+    final var memberId = MemberId.from("us-east", 0);
+
+    // when
+    final var member = Member.member(memberId, ADDRESS);
+
+    // then
+    assertThat(member.zone()).isEqualTo("us-east");
+  }
+
+  @Test
+  void shouldBuildBareMemberViaFactoryWhenMemberIdHasNoZone() {
+    // given
+    final var memberId = MemberId.from(0);
+
+    // when / then
+    assertThatNoException().isThrownBy(() -> Member.member(memberId, ADDRESS));
+    assertThat(Member.member(memberId, ADDRESS).zone()).isNull();
+  }
+
+  @Test
+  void shouldBuildViaConfigConstructorWhenZoneMatchesMemberId() {
+    // given
+    final var memberId = MemberId.from("us-east", 0);
+    final var config = new MemberConfig().setId(memberId).setZoneId("us-east").setAddress(ADDRESS);
+
+    // when
+    final var member = new Member(config);
+
+    // then
+    assertThat(member.id()).isEqualTo(memberId);
+    assertThat(member.zone()).isEqualTo("us-east");
+  }
+
+  @Test
+  void shouldThrowViaConfigConstructorWhenZoneDoesNotMatchMemberId() {
+    // given
+    final var memberId = MemberId.from("us-east", 0);
+    final var config = new MemberConfig().setId(memberId).setZoneId("eu-west");
+
+    // when / then
+    assertThatThrownBy(() -> new Member(config)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldDeriveZoneFromMemberIdViaTwoArgConstructor() {
+    // given
+    final var memberId = MemberId.from("us-east", 0);
+
+    // when
+    final var member = new Member(memberId, ADDRESS);
+
+    // then
+    assertThat(member.id()).isEqualTo(memberId);
+    assertThat(member.zone()).isEqualTo("us-east");
+  }
+
+  @Test
+  void shouldBuildBareMemberViaTwoArgConstructorWhenMemberIdHasNoZone() {
+    // given
+    final var memberId = MemberId.from(0);
+
+    // when
+    final var member = new Member(memberId, ADDRESS);
+
+    // then
+    assertThat(member.zone()).isNull();
+  }
+
+  @Test
+  void shouldSetAllFieldsViaFullConstructorWhenZoneMatchesMemberId() {
+    // given
+    final var memberId = MemberId.from("us-east", 0);
+    final var properties = new Properties();
+    properties.setProperty("k", "v");
+
+    // when
+    final var member = new Member(memberId, 3L, ADDRESS, "us-east", "rack-1", "host-1", properties);
+
+    // then
+    assertThat(member.id()).isEqualTo(memberId);
+    assertThat(member.nodeVersion()).isEqualTo(3L);
+    assertThat(member.zone()).isEqualTo("us-east");
+    assertThat(member.rack()).isEqualTo("rack-1");
+    assertThat(member.host()).isEqualTo("host-1");
+    assertThat(member.properties()).isEqualTo(properties);
+  }
+
+  @Test
+  void shouldThrowViaFullConstructorWhenZoneDoesNotMatchMemberId() {
+    // given
+    final var memberId = MemberId.from("us-east", 0);
+
+    // when / then
+    assertThatThrownBy(
+            () -> new Member(memberId, 0L, ADDRESS, "eu-west", null, null, new Properties()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
## Description

Member constructor was not setting `zone` correctly. Same for a MemberBuilder method.

There were no tests for `Member` so I created it for the constructors.



## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
