### PR TITLE
test: automate P1 wait-state regression cases in orchestration-cluster e2e suite

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.waitstates-isolated.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.waitstates-isolated.yml
@@ -1,55 +1,80 @@
-# Standalone, throwaway environment for the wait-states flag-off scenarios
-# (P1-API-2, P1-UI-3): proving `camunda.data.wait-states.enabled=false`
-# disables both indexing and the Operate UI/API surface requires a broker
-# that was booted with the flag off from the start — the shared, long-running
-# `camunda` container every other test in this suite depends on always boots
-# with the default (`enabled=true`). Deliberately NOT part of
-# docker-compose.yml — brought up and torn down around these tests via
-# utils/dockerComposeControl.ts. Modeled on
-# docker-compose.analytics-isolated.yml's isolated-stack pattern, but with a
-# single service variant (there is no "isolated flag-on" test — every other
-# wait-state case already runs flag-on against the shared stack).
+# Standalone environment for testing camunda.data.wait-states.enabled=false —
+# the shared stack in docker-compose.yml always boots with it on. Mirrors the
+# main `elasticsearch`/`camunda` services (renamed, re-ported), plus
+# CAMUNDA_DATA_WAIT_STATES_ENABLED=false. Skips
+# `env_file: envs/.env.database.${DATABASE}` since its hostnames assume a
+# container literally named `elasticsearch`. Brought up/down via
+# utils/dockerComposeControl.ts.
 #
 # Usage:
 #   docker compose -f config/docker-compose.yml -f config/docker-compose.waitstates-isolated.yml \
-#     -p waitstates-isolated up -d --no-deps camunda-waitstates-isolated-off
+#     -p waitstates-isolated up -d --no-deps camunda-waitstates-isolated-off elasticsearch-waitstates-isolated
 #   docker compose -f config/docker-compose.yml -f config/docker-compose.waitstates-isolated.yml \
 #     -p waitstates-isolated down
 
 services:
+  elasticsearch-waitstates-isolated:
+    container_name: elasticsearch-waitstates-isolated
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION:-8.19.16}
+    environment:
+      - discovery.type=single-node
+      - cluster.name=elasticsearch-waitstates-isolated
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - 'ES_JAVA_OPTS=-Xms1024m -Xmx1024m'
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - '29200:9200'
+      - '29300:9300'
+    networks:
+      - zeebe_network
+
   camunda-waitstates-isolated-off:
     container_name: camunda-waitstates-isolated-off
     image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}
     environment:
-      JAVA_TOOL_OPTIONS: '-Xms512m -Xmx1g'
-      ZEEBE_BROKER_NETWORK_HOST: camunda-waitstates-isolated-off
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-e2e-test,consolidated-auth,tasklist,broker,operate,admin}
-      CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: 'false'
-      CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: 'true'
-      CAMUNDA_SECURITY_AUTHENTICATION_METHOD: BASIC
-      CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED: 'false'
-      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME: demo
-      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD: demo
-      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME: Demo
-      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL: demo@example.com
-      CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
-      CAMUNDA_LICENSE_KEY: ${CAMUNDA_LICENSE_KEY:-local-test-license-key}
-      # H2 in-memory storage — this throwaway broker only needs to prove the
-      # wait-state surface is absent, not exercise a real secondary store.
-      CAMUNDA_DATA_SECONDARY_STORAGE_TYPE: rdbms
-      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL: jdbc:h2:mem:camunda
-      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_USERNAME: sa
-      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_PASSWORD: ''
-      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_AUTO_DDL: 'true'
-      # The entire point of this variant: wait-state tracking explicitly off.
-      # Property is camunda.data.wait-states.enabled — Spring's relaxed
-      # binding maps the hyphen in "wait-states" to an underscore just like
-      # "secondary-storage" becomes SECONDARY_STORAGE above, so this is
-      # WAIT_STATES, not WAITSTATES.
-      CAMUNDA_DATA_WAIT_STATES_ENABLED: 'false'
+      - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx1g'
+      - ZEEBE_BROKER_NETWORK_HOST=camunda-waitstates-isolated-off
+      - CAMUNDA_MODE=${CAMUNDA_MODE:-}
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-e2e-test,consolidated-auth,tasklist,broker,operate,admin}
+      - CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
+      - CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=true
+      - CAMUNDA_SECURITY_AUTHENTICATION_METHOD=BASIC
+      - CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=false
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME=demo
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD=demo
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME=Demo
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL=demo@example.com
+      - CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0=demo
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_1_USERNAME=lisa
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_1_PASSWORD=lisa
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_1_NAME=lisa
+      - CAMUNDA_SECURITY_INITIALIZATION_USERS_1_EMAIL=lisa@example.com
+      - CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_1=lisa
+      - CAMUNDA_DATA_SECONDARY_STORAGE_TYPE=elasticsearch
+      - CAMUNDA_DATA_SECONDARY_STORAGE_ELASTICSEARCH_URL=http://elasticsearch-waitstates-isolated:9200
+      - CAMUNDA_DATA_SECONDARYSTORAGE_ELASTICSEARCH_WAITFORIMPORTERS=false
+      - CAMUNDA_TASKLIST_V2_MODE_ENABLED=${CAMUNDA_TASKLIST_V2_MODE_ENABLED:-true}
+      # Audit log configuration
+      - CAMUNDA_DATA_AUDITLOG_ENABLED=true
+      - CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_0=ADMIN
+      - CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_1=DEPLOYED_RESOURCES
+      - CAMUNDA_DATA_AUDITLOG_USER_CATEGORIES_2=USER_TASKS
+      - CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_0=VARIABLE
+      - CAMUNDA_DATA_AUDITLOG_USER_EXCLUDES_1=BATCH
+      - CAMUNDA_DATA_AUDITLOG_CLIENT_CATEGORIES_0=ADMIN
+      - CAMUNDA_DATA_AUDITLOG_CLIENT_EXCLUDES_0=PROCESS_INSTANCE
+      - CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true
+      # camunda.data.wait-states.enabled -> WAIT_STATES (not WAITSTATES)
+      - CAMUNDA_DATA_WAIT_STATES_ENABLED=false
     ports:
       - '29080:8080'
       - '29600:9600'
       - '29650:26500'
     networks:
       - zeebe_network
+    depends_on:
+      - elasticsearch-waitstates-isolated

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.waitstates-isolated.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.waitstates-isolated.yml
@@ -1,0 +1,55 @@
+# Standalone, throwaway environment for the wait-states flag-off scenarios
+# (P1-API-2, P1-UI-3): proving `camunda.data.wait-states.enabled=false`
+# disables both indexing and the Operate UI/API surface requires a broker
+# that was booted with the flag off from the start — the shared, long-running
+# `camunda` container every other test in this suite depends on always boots
+# with the default (`enabled=true`). Deliberately NOT part of
+# docker-compose.yml — brought up and torn down around these tests via
+# utils/dockerComposeControl.ts. Modeled on
+# docker-compose.analytics-isolated.yml's isolated-stack pattern, but with a
+# single service variant (there is no "isolated flag-on" test — every other
+# wait-state case already runs flag-on against the shared stack).
+#
+# Usage:
+#   docker compose -f config/docker-compose.yml -f config/docker-compose.waitstates-isolated.yml \
+#     -p waitstates-isolated up -d --no-deps camunda-waitstates-isolated-off
+#   docker compose -f config/docker-compose.yml -f config/docker-compose.waitstates-isolated.yml \
+#     -p waitstates-isolated down
+
+services:
+  camunda-waitstates-isolated-off:
+    container_name: camunda-waitstates-isolated-off
+    image: ${CAMUNDA_DOCKER_IMAGE:-camunda/camunda:SNAPSHOT}
+    environment:
+      JAVA_TOOL_OPTIONS: '-Xms512m -Xmx1g'
+      ZEEBE_BROKER_NETWORK_HOST: camunda-waitstates-isolated-off
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-e2e-test,consolidated-auth,tasklist,broker,operate,admin}
+      CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI: 'false'
+      CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED: 'true'
+      CAMUNDA_SECURITY_AUTHENTICATION_METHOD: BASIC
+      CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED: 'false'
+      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_USERNAME: demo
+      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_PASSWORD: demo
+      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_NAME: Demo
+      CAMUNDA_SECURITY_INITIALIZATION_USERS_0_EMAIL: demo@example.com
+      CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_USERS_0: demo
+      CAMUNDA_LICENSE_KEY: ${CAMUNDA_LICENSE_KEY:-local-test-license-key}
+      # H2 in-memory storage — this throwaway broker only needs to prove the
+      # wait-state surface is absent, not exercise a real secondary store.
+      CAMUNDA_DATA_SECONDARY_STORAGE_TYPE: rdbms
+      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_URL: jdbc:h2:mem:camunda
+      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_USERNAME: sa
+      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_PASSWORD: ''
+      CAMUNDA_DATA_SECONDARY_STORAGE_RDBMS_AUTO_DDL: 'true'
+      # The entire point of this variant: wait-state tracking explicitly off.
+      # Property is camunda.data.wait-states.enabled — Spring's relaxed
+      # binding maps the hyphen in "wait-states" to an underscore just like
+      # "secondary-storage" becomes SECONDARY_STORAGE above, so this is
+      # WAIT_STATES, not WAITSTATES.
+      CAMUNDA_DATA_WAIT_STATES_ENABLED: 'false'
+    ports:
+      - '29080:8080'
+      - '29600:9600'
+      - '29650:26500'
+    networks:
+      - zeebe_network

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -150,12 +150,7 @@ export class OperateDiagramPage {
       .getByTestId('state-overlay-active');
   }
 
-  /**
-   * The waiting-state diagram badge is a dedicated component
-   * (`WaitingStateOverlay`, testid `waiting-state-overlay`), separate from
-   * the `state-overlay-{state}` family above — it is not one of
-   * `verifyStateOverlay`'s states.
-   */
+  // Dedicated WaitingStateOverlay component, not part of the state-overlay-{state} family above.
   getWaitingOverlay(elementId: string): Locator {
     return this.page
       .locator(`[data-container-id="${elementId}"]`)

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDiagramPage.ts
@@ -150,6 +150,18 @@ export class OperateDiagramPage {
       .getByTestId('state-overlay-active');
   }
 
+  /**
+   * The waiting-state diagram badge is a dedicated component
+   * (`WaitingStateOverlay`, testid `waiting-state-overlay`), separate from
+   * the `state-overlay-{state}` family above — it is not one of
+   * `verifyStateOverlay`'s states.
+   */
+  getWaitingOverlay(elementId: string): Locator {
+    return this.page
+      .locator(`[data-container-id="${elementId}"]`)
+      .getByTestId('waiting-state-overlay');
+  }
+
   async verifyFlowNodeMetadata(
     elementId: string,
     options: {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -40,6 +40,7 @@ class OperateProcessInstancePage {
   readonly listenersTabButton: Locator;
   readonly detailsTabButton: Locator;
   readonly jobPriorityValue: Locator;
+  readonly waitingStatus: Locator;
   readonly variablesTabButton: Locator;
   readonly operationsLogTabButton: Locator;
   readonly operationsLogTable: Locator;
@@ -182,6 +183,7 @@ class OperateProcessInstancePage {
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Details$/i});
     this.jobPriorityValue = page.getByTestId('job-priority');
+    this.waitingStatus = page.getByTestId('waiting-status');
     this.variablesTabButton = page
       .getByLabel('Process Instance Bottom Panel Tabs')
       .getByRole('link', {name: /^Variables$/i});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/conditionalIntermediateCatchEvent.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/conditionalIntermediateCatchEvent.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_condWaitState" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="conditionalIntermediateCatchEventProcess" name="Conditional Intermediate Catch Event Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="conditional-catch" />
+    <bpmn:intermediateCatchEvent id="conditional-catch" name="Wait For Condition">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1">
+        <bpmn:extensionElements>
+          <zeebe:conditionalFilter variableEvents="create, update" />
+        </bpmn:extensionElements>
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">=x &gt; 10</bpmn:condition>
+      </bpmn:conditionalEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="conditional-catch" targetRef="Event_End" />
+    <bpmn:endEvent id="Event_End">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="conditionalIntermediateCatchEventProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_conditional_catch_di" bpmnElement="conditional-catch">
+        <dc:Bounds x="272" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="250" y="145" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_End_di" bpmnElement="Event_End">
+        <dc:Bounds x="362" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="272" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="308" y="120" />
+        <di:waypoint x="362" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/highCardinalityMultiInstance.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/highCardinalityMultiInstance.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_highCardinality" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="highCardinalityMultiInstance" name="High Cardinality Multi Instance" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="wait_task" />
+    <bpmn:serviceTask id="wait_task" name="Wait Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="highCardinalityWaitTask" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=item" target="item" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=items" inputElement="item" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="wait_task" targetRef="Event_End" />
+    <bpmn:endEvent id="Event_End">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="highCardinalityMultiInstance">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_wait_task_di" bpmnElement="wait_task">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_End_di" bpmnElement="Event_End">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/timerIntermediateCatchEvent.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/timerIntermediateCatchEvent.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_timerWaitState" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.10.0">
+  <bpmn:process id="timerIntermediateCatchEventProcess" name="Timer Intermediate Catch Event Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="timer-catch" />
+    <bpmn:intermediateCatchEvent id="timer-catch" name="Wait For Timer">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">=duration</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="timer-catch" targetRef="Event_End" />
+    <bpmn:endEvent id="Event_End">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="timerIntermediateCatchEventProcess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_timer_catch_di" bpmnElement="timer-catch">
+        <dc:Bounds x="272" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="255" y="145" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_End_di" bpmnElement="Event_End">
+        <dc:Bounds x="362" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="272" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="308" y="120" />
+        <di:waypoint x="362" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts
@@ -14,15 +14,6 @@ import {
   stopIsolatedEnvironment,
 } from '../../../../../utils/dockerComposeControl';
 
-// The flag-on baseline (a process reaching a wait state gets indexed and is
-// searchable) is already the behavior every other wait-state-search test in
-// this suite relies on, running against the shared stack — which always
-// boots with camunda.data.wait-states.enabled=true. This spec only proves
-// the flag-off half, which needs a broker booted with the flag off from the
-// start (see config/docker-compose.waitstates-isolated.yml). Dev's own
-// WaitStateConfigurationTest / WaitStatesTest already prove config
-// propagation at the unit level — this proves the full-stack outcome.
-
 const ISOLATED_BASE_URL =
   process.env.WAITSTATES_ISOLATED_BASE_URL ?? 'http://localhost:29080';
 const authHeader = `Basic ${encode('demo:demo')}`;
@@ -90,10 +81,7 @@ test.describe.serial('Wait States Flag Off', () => {
     });
 
     await test.step('Confirm the wait state was never indexed', async () => {
-      // Give the exporter every opportunity to have indexed something if the
-      // flag were somehow not honored — a fixed wait, not a retry-until-found
-      // loop, since we're asserting an absence, not waiting for eventual
-      // presence.
+      // Fixed wait, not a retry loop — asserting an absence, not eventual presence.
       await new Promise((resolve) => setTimeout(resolve, 15_000));
 
       const res = await request.post(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {readFileSync} from 'node:fs';
+import {test, expect, request as playwrightRequest} from '@playwright/test';
+import {encode} from '../../../../../utils/http';
+import {
+  startIsolatedEnvironmentWaitStatesOff,
+  stopIsolatedEnvironment,
+} from '../../../../../utils/dockerComposeControl';
+
+// The flag-on baseline (a process reaching a wait state gets indexed and is
+// searchable) is already the behavior every other wait-state-search test in
+// this suite relies on, running against the shared stack — which always
+// boots with camunda.data.wait-states.enabled=true. This spec only proves
+// the flag-off half, which needs a broker booted with the flag off from the
+// start (see config/docker-compose.waitstates-isolated.yml). Dev's own
+// WaitStateConfigurationTest / WaitStatesTest already prove config
+// propagation at the unit level — this proves the full-stack outcome.
+
+const ISOLATED_BASE_URL =
+  process.env.WAITSTATES_ISOLATED_BASE_URL ?? 'http://localhost:29080';
+const authHeader = `Basic ${encode('demo:demo')}`;
+
+test.describe.serial('Wait States Flag Off', () => {
+  test.setTimeout(5 * 60 * 1000);
+
+  test.beforeAll(async () => {
+    await startIsolatedEnvironmentWaitStatesOff();
+
+    const context = await playwrightRequest.newContext();
+    try {
+      await expect(async () => {
+        const res = await context.get(`${ISOLATED_BASE_URL}/v2/topology`, {
+          headers: {Authorization: authHeader},
+        });
+        expect(res.status()).toBe(200);
+      }).toPass({intervals: [2_000, 5_000, 10_000], timeout: 120_000});
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  test.afterAll(async () => {
+    await stopIsolatedEnvironment();
+  });
+
+  test('wait-states/search returns no rows for an instance that would otherwise be waiting on a job', async ({
+    request,
+  }) => {
+    let processInstanceKey = '';
+
+    await test.step('Deploy a process and start an instance', async () => {
+      const bpmn = readFileSync(
+        './resources/simpleServiceTaskProcess.bpmn',
+        'utf-8',
+      );
+      const deployRes = await request.post(
+        `${ISOLATED_BASE_URL}/v2/deployments`,
+        {
+          headers: {Authorization: authHeader},
+          multipart: {
+            resources: {
+              name: 'simpleServiceTaskProcess.bpmn',
+              mimeType: 'application/xml',
+              buffer: Buffer.from(bpmn),
+            },
+          },
+        },
+      );
+      expect(deployRes.status()).toBe(200);
+
+      const createRes = await request.post(
+        `${ISOLATED_BASE_URL}/v2/process-instances`,
+        {
+          headers: {
+            Authorization: authHeader,
+            'Content-Type': 'application/json',
+          },
+          data: {processDefinitionId: 'simpleServiceTaskProcess'},
+        },
+      );
+      expect(createRes.status()).toBe(200);
+      processInstanceKey = (await createRes.json()).processInstanceKey;
+    });
+
+    await test.step('Confirm the wait state was never indexed', async () => {
+      // Give the exporter every opportunity to have indexed something if the
+      // flag were somehow not honored — a fixed wait, not a retry-until-found
+      // loop, since we're asserting an absence, not waiting for eventual
+      // presence.
+      await new Promise((resolve) => setTimeout(resolve, 15_000));
+
+      const res = await request.post(
+        `${ISOLATED_BASE_URL}/v2/element-instances/wait-states/search`,
+        {
+          headers: {
+            Authorization: authHeader,
+            'Content-Type': 'application/json',
+          },
+          data: {filter: {processInstanceKey}},
+        },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(0);
+      expect(body.items).toHaveLength(0);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts
@@ -80,24 +80,29 @@ test.describe.serial('Wait States Flag Off', () => {
       processInstanceKey = (await createRes.json()).processInstanceKey;
     });
 
-    await test.step('Confirm the wait state was never indexed', async () => {
-      // Fixed wait, not a retry loop — asserting an absence, not eventual presence.
-      await new Promise((resolve) => setTimeout(resolve, 15_000));
-
-      const res = await request.post(
-        `${ISOLATED_BASE_URL}/v2/element-instances/wait-states/search`,
-        {
-          headers: {
-            Authorization: authHeader,
-            'Content-Type': 'application/json',
+    await test.step('Confirm the wait state stays unindexed over a 15s observation window', async () => {
+      const checkEmpty = async () => {
+        const res = await request.post(
+          `${ISOLATED_BASE_URL}/v2/element-instances/wait-states/search`,
+          {
+            headers: {
+              Authorization: authHeader,
+              'Content-Type': 'application/json',
+            },
+            data: {filter: {processInstanceKey}},
           },
-          data: {filter: {processInstanceKey}},
-        },
-      );
-      expect(res.status()).toBe(200);
-      const body = await res.json();
-      expect(body.page.totalItems).toBe(0);
-      expect(body.items).toHaveLength(0);
+        );
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.page.totalItems).toBe(0);
+        expect(body.items).toHaveLength(0);
+      };
+
+      const deadline = Date.now() + 15_000;
+      do {
+        await checkEmpty();
+        await new Promise((resolve) => setTimeout(resolve, 3_000));
+      } while (Date.now() < deadline);
     });
   });
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
@@ -16,23 +16,10 @@ import {
   createProcessInstanceWithManyWaitingTokens,
 } from '@requestHelpers';
 
-// camunda/camunda#56239: `wait-states/search` was found to silently truncate
-// results for a single element with a large number of concurrently active
-// tokens (no indication anything was cut). It was resolved by adding a
-// dedicated aggregated statistics endpoint
-// (GET /process-instances/{key}/statistics/wait-states, thoroughly covered
-// by dev's own ProcessInstanceWaitStateStatisticsIT — do not re-test that
-// here) for the diagram overlay count.
-//
-// Verified live against a real cluster before writing these assertions
-// (an earlier draft of this spec assumed the issue's "capped at 1000"
-// wording described `wait-states/search` itself — it doesn't): the default
-// page size is the standard 100, `page.totalItems` always reports the true
-// match count (not capped), and an explicit `page.limit` well above 1000
-// returns every item with no server-side ceiling. So the actual regression
-// to guard is data-completeness for a large single-element cardinality:
-// nothing errors, the true count is reported, and every token is reachable
-// either via an explicit limit or by paging through with the cursor.
+// camunda/camunda#56239: verified live there's no 1000-item cap on this
+// endpoint — default page size is 100, page.totalItems is always the true
+// count, and page.limit above 1000 returns everything. Guards
+// data-completeness for large single-element cardinality instead.
 
 test.describe
   .parallel('Wait State Search — Large Single-Element Cardinality', () => {
@@ -106,9 +93,6 @@ test.describe
         res,
       );
       const body = await res.json();
-      // The default page size is the standard 100 — not the full 1200 —
-      // but totalItems must still report the true, uncapped count so the
-      // caller knows there is more to fetch.
       expect(body.items).toHaveLength(100);
       expect(body.page.totalItems).toBe(tokenCount);
       expect(

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
@@ -16,11 +16,6 @@ import {
   createProcessInstanceWithManyWaitingTokens,
 } from '@requestHelpers';
 
-// camunda/camunda#56239: verified live there's no 1000-item cap on this
-// endpoint — default page size is 100, page.totalItems is always the true
-// count, and page.limit above 1000 returns everything. Guards
-// data-completeness for large single-element cardinality instead.
-
 test.describe
   .parallel('Wait State Search — Large Single-Element Cardinality', () => {
   const processInstanceKeys: string[] = [];

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {cancelProcessInstance} from '../../../../utils/zeebeClient';
+import {buildUrl, jsonHeaders, assertStatusCode} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {extendedAssertionOptions} from '../../../../utils/constants';
+import {
+  WAIT_STATES_SEARCH_ENDPOINT,
+  createProcessInstanceWithManyWaitingTokens,
+} from '@requestHelpers';
+
+// camunda/camunda#56239: `wait-states/search` was found to silently truncate
+// results for a single element with a large number of concurrently active
+// tokens (no indication anything was cut). It was resolved by adding a
+// dedicated aggregated statistics endpoint
+// (GET /process-instances/{key}/statistics/wait-states, thoroughly covered
+// by dev's own ProcessInstanceWaitStateStatisticsIT — do not re-test that
+// here) for the diagram overlay count.
+//
+// Verified live against a real cluster before writing these assertions
+// (an earlier draft of this spec assumed the issue's "capped at 1000"
+// wording described `wait-states/search` itself — it doesn't): the default
+// page size is the standard 100, `page.totalItems` always reports the true
+// match count (not capped), and an explicit `page.limit` well above 1000
+// returns every item with no server-side ceiling. So the actual regression
+// to guard is data-completeness for a large single-element cardinality:
+// nothing errors, the true count is reported, and every token is reachable
+// either via an explicit limit or by paging through with the cursor.
+
+test.describe
+  .parallel('Wait State Search — Large Single-Element Cardinality', () => {
+  const processInstanceKeys: string[] = [];
+
+  test.afterAll(async () => {
+    for (const key of processInstanceKeys) {
+      await cancelProcessInstance(key);
+    }
+  });
+
+  test('returns every waiting token when the count is small', async ({
+    request,
+  }) => {
+    const tokenCount = 50;
+    const instance =
+      await createProcessInstanceWithManyWaitingTokens(tokenCount);
+    processInstanceKeys.push(instance.processInstanceKey);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: instance.processInstanceKey,
+            elementId: 'wait_task',
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: WAIT_STATES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.items).toHaveLength(tokenCount);
+      expect(body.page.totalItems).toBe(tokenCount);
+    }).toPass(extendedAssertionOptions);
+  });
+
+  test('reports the true count and never errors when a single element has far more waiting tokens than the default page size', async ({
+    request,
+  }) => {
+    const tokenCount = 1200;
+    const instance =
+      await createProcessInstanceWithManyWaitingTokens(tokenCount);
+    processInstanceKeys.push(instance.processInstanceKey);
+
+    const firstPage: Record<string, unknown> = {};
+    await expect(async () => {
+      const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: instance.processInstanceKey,
+            elementId: 'wait_task',
+          },
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: WAIT_STATES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      // The default page size is the standard 100 — not the full 1200 —
+      // but totalItems must still report the true, uncapped count so the
+      // caller knows there is more to fetch.
+      expect(body.items).toHaveLength(100);
+      expect(body.page.totalItems).toBe(tokenCount);
+      expect(
+        body.page.endCursor,
+        `Received JSON: ${JSON.stringify(body)}`,
+      ).toBeTruthy();
+      firstPage.body = body;
+    }).toPass(extendedAssertionOptions);
+
+    const body = firstPage.body as {
+      items: Array<{elementInstanceKey: string}>;
+      page: {endCursor: string};
+    };
+
+    await test.step('every token is retrievable in one call via an explicit page.limit', async () => {
+      const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: instance.processInstanceKey,
+            elementId: 'wait_task',
+          },
+          page: {limit: tokenCount},
+        },
+      });
+      await assertStatusCode(res, 200);
+      const bodyAll = await res.json();
+      expect(bodyAll.items).toHaveLength(tokenCount);
+      expect(bodyAll.page.totalItems).toBe(tokenCount);
+    });
+
+    await test.step('the remainder beyond the first page is reachable via the cursor', async () => {
+      const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {
+            processInstanceKey: instance.processInstanceKey,
+            elementId: 'wait_task',
+          },
+          page: {after: body.page.endCursor},
+        },
+      });
+      await assertStatusCode(res, 200);
+      const nextPageBody = await res.json();
+      expect(nextPageBody.items.length).toBeGreaterThan(0);
+      const firstPageKeys = new Set(
+        body.items.map((item) => item.elementInstanceKey),
+      );
+      const overlap = nextPageBody.items.filter(
+        (item: {elementInstanceKey: string}) =>
+          firstPageKeys.has(item.elementInstanceKey),
+      );
+      expect(overlap).toHaveLength(0);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts
@@ -144,3 +144,46 @@ test.describe
     });
   });
 });
+
+test.describe
+  .parallel('Wait State Statistics — Large Single-Element Cardinality', () => {
+  const processInstanceKeys: string[] = [];
+
+  test.afterAll(async () => {
+    for (const key of processInstanceKeys) {
+      await cancelProcessInstance(key);
+    }
+  });
+
+  test('reports the true waitingCount for an element with far more waiting tokens than the search endpoint returns in one page', async ({
+    request,
+  }) => {
+    const tokenCount = 1200;
+    const instance =
+      await createProcessInstanceWithManyWaitingTokens(tokenCount);
+    processInstanceKeys.push(instance.processInstanceKey);
+
+    await expect(async () => {
+      const res = await request.get(
+        buildUrl(
+          '/process-instances/{processInstanceKey}/statistics/wait-states',
+          {processInstanceKey: instance.processInstanceKey},
+        ),
+        {headers: jsonHeaders()},
+      );
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: '/process-instances/{processInstanceKey}/statistics/wait-states',
+          method: 'GET',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].elementId).toBe('wait_task');
+      expect(body.items[0].waitingCount).toBe(tokenCount);
+    }).toPass(extendedAssertionOptions);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '@playwright/test';
+import {cancelProcessInstance} from '../../../../utils/zeebeClient';
+import {
+  buildUrl,
+  jsonHeaders,
+  assertBadRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+} from '../../../../utils/http';
+import {validateResponse} from '../../../../json-body-assertions';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {
+  WAIT_STATES_SEARCH_ENDPOINT,
+  createProcessInstanceWaitingOnJob,
+} from '@requestHelpers';
+
+// Per-type filter/sort/pagination correctness across all six wait-state
+// types is already exhaustively covered by dev's acceptance ITs
+// (qa/acceptance-tests/.../it/waitstate/WaitState*IT.java, it/client/
+// WaitStateSearchIT.java) and by the Java client's
+// SearchElementInstanceWaitStatesTest. This spec only fills the black-box
+// request-validation gap dev's controller unit test doesn't reach (it
+// covers just an empty body and one filter). Malformed-body / enum-violation
+// cases will be auto-generated once this endpoint lands in
+// v2-stateless-tests/request-validation-test-generator's regenerated specs —
+// they are intentionally not hand-duplicated here.
+
+test.describe.parallel('Wait State Search Validation', () => {
+  const processInstanceKeys: string[] = [];
+
+  test.afterAll(async () => {
+    for (const key of processInstanceKeys) {
+      await cancelProcessInstance(key);
+    }
+  });
+
+  test('finds a wait state by processInstanceKey with sort and pagination applied', async ({
+    request,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnJob();
+    processInstanceKeys.push(instance.processInstanceKey);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {processInstanceKey: instance.processInstanceKey},
+          sort: [{field: 'elementId'}],
+          page: {limit: 10},
+        },
+      });
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {
+          path: WAIT_STATES_SEARCH_ENDPOINT,
+          method: 'POST',
+          status: '200',
+        },
+        res,
+      );
+      const body = await res.json();
+      expect(body.page.totalItems).toBe(1);
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].processInstanceKey).toBe(
+        instance.processInstanceKey,
+      );
+      expect(body.items[0].details.waitStateType).toBe('JOB');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('rejects an unknown filter field with 400', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          filter: {invalidField: 'someValue'},
+        },
+      });
+      await assertBadRequest(
+        res,
+        'Request property [filter.invalidField] cannot be parsed',
+      );
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('returns an empty result, not an error, for a well-formed filter matching nothing', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {processInstanceKey: '9999999999999999'},
+      },
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: WAIT_STATES_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    const body = await res.json();
+    expect(body.page.totalItems).toBe(0);
+    expect(body.items).toHaveLength(0);
+  });
+
+  // eslint-disable-next-line playwright/expect-expect
+  test('rejects an unauthenticated request with 401', async ({request}) => {
+    const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+      headers: {},
+      data: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts
@@ -22,17 +22,6 @@ import {
   createProcessInstanceWaitingOnJob,
 } from '@requestHelpers';
 
-// Per-type filter/sort/pagination correctness across all six wait-state
-// types is already exhaustively covered by dev's acceptance ITs
-// (qa/acceptance-tests/.../it/waitstate/WaitState*IT.java, it/client/
-// WaitStateSearchIT.java) and by the Java client's
-// SearchElementInstanceWaitStatesTest. This spec only fills the black-box
-// request-validation gap dev's controller unit test doesn't reach (it
-// covers just an empty body and one filter). Malformed-body / enum-violation
-// cases will be auto-generated once this endpoint lands in
-// v2-stateless-tests/request-validation-test-generator's regenerated specs —
-// they are intentionally not hand-duplicated here.
-
 test.describe.parallel('Wait State Search Validation', () => {
   const processInstanceKeys: string[] = [];
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
@@ -26,14 +26,6 @@ import {
   findUserTask,
 } from '@requestHelpers';
 
-// Dev already covers per-type add/update/remove lifecycle and negative
-// (start/boundary not tracked) cases at the acceptance-test layer across
-// ES/OS/RDBMS (qa/acceptance-tests/.../it/waitstate/*IT.java). This spec
-// covers the two gaps dev's tests don't reach: the real, unmocked Operate UI
-// rendering path (regression for the #54983 Zod/OpenAPI-drift crash) and the
-// full lifecycle through the actual exporter delete path — dev's own
-// Playwright coverage here is mocked/static.
-
 let jobInstance: {processInstanceKey: string};
 let messageInstance: {processInstanceKey: string};
 let signalInstance: {processInstanceKey: string};
@@ -149,9 +141,6 @@ test.describe('Wait State Details Tab', () => {
   test('does not show a wait reason for a completed, non-waiting element', async ({
     operateProcessInstancePage,
   }) => {
-    // The start event on any of these instances completed immediately and is
-    // not itself a wait state — the Details tab must render cleanly with no
-    // waiting section, not crash into the global error boundary.
     await operateProcessInstancePage.gotoProcessInstancePage({
       id: jobInstance.processInstanceKey,
     });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
@@ -1,0 +1,390 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {cancelProcessInstance, setVariables} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {buildUrl, jsonHeaders, assertStatusCode} from 'utils/http';
+import {
+  createProcessInstanceWaitingOnJob,
+  createProcessInstanceWaitingOnMessage,
+  createProcessInstanceWaitingOnSignal,
+  createProcessInstanceWaitingOnUserTask,
+  createProcessInstanceWaitingOnTimer,
+  createProcessInstanceWaitingOnCondition,
+  activateJobsByType,
+  completeJob,
+  completeUserTask,
+  findUserTask,
+} from '@requestHelpers';
+
+// Dev already covers per-type add/update/remove lifecycle and negative
+// (start/boundary not tracked) cases at the acceptance-test layer across
+// ES/OS/RDBMS (qa/acceptance-tests/.../it/waitstate/*IT.java). This spec
+// covers the two gaps dev's tests don't reach: the real, unmocked Operate UI
+// rendering path (regression for the #54983 Zod/OpenAPI-drift crash) and the
+// full lifecycle through the actual exporter delete path — dev's own
+// Playwright coverage here is mocked/static.
+
+let jobInstance: {processInstanceKey: string};
+let messageInstance: {processInstanceKey: string};
+let signalInstance: {processInstanceKey: string};
+let userTaskInstance: {processInstanceKey: string};
+let timerInstance: {processInstanceKey: string};
+let conditionInstance: {processInstanceKey: string};
+
+const persistentInstanceKeys: string[] = [];
+
+test.beforeAll(async () => {
+  jobInstance = await createProcessInstanceWaitingOnJob();
+  messageInstance = await createProcessInstanceWaitingOnMessage();
+  signalInstance = await createProcessInstanceWaitingOnSignal();
+  userTaskInstance = await createProcessInstanceWaitingOnUserTask();
+  // Long duration — this instance is only used to assert the Details tab
+  // renders correctly; it must not fire mid-suite.
+  timerInstance = await createProcessInstanceWaitingOnTimer('PT1H');
+  conditionInstance = await createProcessInstanceWaitingOnCondition();
+
+  persistentInstanceKeys.push(
+    jobInstance.processInstanceKey,
+    messageInstance.processInstanceKey,
+    signalInstance.processInstanceKey,
+    userTaskInstance.processInstanceKey,
+    timerInstance.processInstanceKey,
+    conditionInstance.processInstanceKey,
+  );
+});
+
+test.afterAll(async () => {
+  for (const key of persistentInstanceKeys) {
+    await cancelProcessInstance(key);
+  }
+});
+
+test.describe('Wait State Details Tab', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('shows the JOB wait reason without crashing', async ({
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: jobInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem('task', true);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+  });
+
+  test('shows the MESSAGE wait reason without crashing', async ({
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: messageInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem('Event_1idbbd5', true);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+  });
+
+  test('shows the SIGNAL wait reason without crashing', async ({
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: signalInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem(/receive test signal/i);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+  });
+
+  test('shows the USER_TASK wait reason without crashing', async ({
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: userTaskInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem(/test user task api/i);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+  });
+
+  test('shows the TIMER wait reason without crashing', async ({
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: timerInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem(/wait for timer/i);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+  });
+
+  test('shows the CONDITIONAL wait reason without crashing', async ({
+    operateProcessInstancePage,
+  }) => {
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: conditionInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem(/wait for condition/i);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+  });
+
+  test('does not show a wait reason for a completed, non-waiting element', async ({
+    operateProcessInstancePage,
+  }) => {
+    // The start event on any of these instances completed immediately and is
+    // not itself a wait state — the Details tab must render cleanly with no
+    // waiting section, not crash into the global error boundary.
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: jobInstance.processInstanceKey,
+    });
+    await operateProcessInstancePage.clickTreeItem('StartEvent_1', true);
+    await operateProcessInstancePage.clickDetailsTab();
+    await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toBeHidden();
+  });
+});
+
+test.describe('Wait State Lifecycle', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('JOB wait indicator clears once the job is completed', async ({
+    page,
+    request,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnJob();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(operateDiagramPage.getWaitingOverlay('task')).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const jobs = await activateJobsByType(
+      request,
+      'task',
+      instance.processInstanceKey,
+    );
+    expect(jobs.length).toBe(1);
+    await completeJob(request, jobs[0].jobKey);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateDiagramPage.getWaitingOverlay('task')).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('MESSAGE wait indicator clears once the message is published', async ({
+    page,
+    request,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnMessage();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(
+      operateDiagramPage.getWaitingOverlay('Event_1idbbd5'),
+    ).toBeVisible({timeout: 30_000});
+
+    const res = await request.post(buildUrl('/messages/publication'), {
+      headers: jsonHeaders(),
+      data: {name: 'Message_143t419', correlationKey: '143419'},
+    });
+    await assertStatusCode(res, 200);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDiagramPage.getWaitingOverlay('Event_1idbbd5'),
+        ).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('SIGNAL wait indicator clears once the signal is broadcast', async ({
+    page,
+    request,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnSignal();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(
+      operateDiagramPage.getWaitingOverlay('Event_Test_Signal'),
+    ).toBeVisible({timeout: 30_000});
+
+    const res = await request.post(buildUrl('/signals/broadcast'), {
+      headers: jsonHeaders(),
+      data: {signalName: 'Signal_220k2ur'},
+    });
+    await assertStatusCode(res, 200);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDiagramPage.getWaitingOverlay('Event_Test_Signal'),
+        ).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('USER_TASK wait indicator clears once the user task is completed', async ({
+    page,
+    request,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnUserTask();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(
+      operateDiagramPage.getWaitingOverlay('test_user_task_api'),
+    ).toBeVisible({timeout: 30_000});
+
+    const userTaskKey = await findUserTask(
+      request,
+      instance.processInstanceKey,
+      'CREATED',
+    );
+    const completeRes = await completeUserTask(request, userTaskKey);
+    expect(completeRes.status()).toBe(204);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDiagramPage.getWaitingOverlay('test_user_task_api'),
+        ).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('TIMER wait indicator clears once the timer fires', async ({
+    page,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnTimer('PT2S');
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(
+      operateDiagramPage.getWaitingOverlay('timer-catch'),
+    ).toBeVisible({timeout: 30_000});
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDiagramPage.getWaitingOverlay('timer-catch'),
+        ).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+      maxRetries: 6,
+    });
+  });
+
+  test('CONDITIONAL wait indicator clears once the condition is met', async ({
+    page,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnCondition();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(
+      operateDiagramPage.getWaitingOverlay('conditional-catch'),
+    ).toBeVisible({timeout: 30_000});
+
+    await setVariables(instance.processInstanceKey, {x: 42});
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(
+          operateDiagramPage.getWaitingOverlay('conditional-catch'),
+        ).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+
+  test('wait indicator disappears when the instance is canceled while waiting', async ({
+    page,
+    operateProcessInstancePage,
+    operateDiagramPage,
+  }) => {
+    const instance = await createProcessInstanceWaitingOnJob();
+
+    await operateProcessInstancePage.gotoProcessInstancePage({
+      id: instance.processInstanceKey,
+    });
+    await expect(operateDiagramPage.getWaitingOverlay('task')).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await cancelProcessInstance(instance.processInstanceKey);
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(operateDiagramPage.getWaitingOverlay('task')).toBeHidden();
+      },
+      onFailure: async () => {
+        await page.reload();
+      },
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
@@ -313,7 +313,7 @@ test.describe('Wait State Lifecycle', () => {
     operateProcessInstancePage,
     operateDiagramPage,
   }) => {
-    const instance = await createProcessInstanceWaitingOnTimer('PT2S');
+    const instance = await createProcessInstanceWaitingOnTimer('PT10S');
 
     await operateProcessInstancePage.gotoProcessInstancePage({
       id: instance.processInstanceKey,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStates.spec.ts
@@ -80,7 +80,9 @@ test.describe('Wait State Details Tab', () => {
     });
     await operateProcessInstancePage.clickTreeItem('task', true);
     await operateProcessInstancePage.clickDetailsTab();
-    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toContainText(
+      'Waiting for job: task',
+    );
   });
 
   test('shows the MESSAGE wait reason without crashing', async ({
@@ -91,7 +93,9 @@ test.describe('Wait State Details Tab', () => {
     });
     await operateProcessInstancePage.clickTreeItem('Event_1idbbd5', true);
     await operateProcessInstancePage.clickDetailsTab();
-    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toContainText(
+      'Waiting for message: Message_143t419',
+    );
   });
 
   test('shows the SIGNAL wait reason without crashing', async ({
@@ -102,7 +106,9 @@ test.describe('Wait State Details Tab', () => {
     });
     await operateProcessInstancePage.clickTreeItem(/receive test signal/i);
     await operateProcessInstancePage.clickDetailsTab();
-    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toContainText(
+      'Waiting for signal: Signal_220k2ur',
+    );
   });
 
   test('shows the USER_TASK wait reason without crashing', async ({
@@ -113,7 +119,9 @@ test.describe('Wait State Details Tab', () => {
     });
     await operateProcessInstancePage.clickTreeItem(/test user task api/i);
     await operateProcessInstancePage.clickDetailsTab();
-    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toContainText(
+      'Waiting for task completion',
+    );
   });
 
   test('shows the TIMER wait reason without crashing', async ({
@@ -124,7 +132,9 @@ test.describe('Wait State Details Tab', () => {
     });
     await operateProcessInstancePage.clickTreeItem(/wait for timer/i);
     await operateProcessInstancePage.clickDetailsTab();
-    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toContainText(
+      /Waiting for timer/,
+    );
   });
 
   test('shows the CONDITIONAL wait reason without crashing', async ({
@@ -135,7 +145,9 @@ test.describe('Wait State Details Tab', () => {
     });
     await operateProcessInstancePage.clickTreeItem(/wait for condition/i);
     await operateProcessInstancePage.clickDetailsTab();
-    await expect(operateProcessInstancePage.waitingStatus).toBeVisible();
+    await expect(operateProcessInstancePage.waitingStatus).toContainText(
+      'Waiting for condition',
+    );
   });
 
   test('does not show a wait reason for a completed, non-waiting element', async ({

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStatesFlagOff.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStatesFlagOff.spec.ts
@@ -16,14 +16,6 @@ import {
   stopIsolatedEnvironment,
 } from 'utils/dockerComposeControl';
 
-// The flag-on case (waiting indicators + Details tab wait reason render, and
-// the FE issues a wait-states/search request) is already exercised against
-// the shared, default stack by every test in processInstanceWaitStates.spec.ts
-// — the default stack always boots with camunda.data.wait-states.enabled=true.
-// This spec only needs the negative, flag-off half, which requires a broker
-// booted with the flag off from the start (see
-// config/docker-compose.waitstates-isolated.yml).
-
 const ISOLATED_BASE_URL =
   process.env.WAITSTATES_ISOLATED_BASE_URL ?? 'http://localhost:29080';
 const authHeader = `Basic ${encode('demo:demo')}`;
@@ -101,10 +93,6 @@ test.describe.serial('Wait States Flag Off', () => {
     });
 
     await test.step('Log in against the isolated stack', async () => {
-      // Set via the page's own browser-context request API so the response's
-      // Set-Cookie header lands in the same context page.goto() will use —
-      // the worker-scoped loginState fixture only authenticates against the
-      // shared stack's CORE_APPLICATION_URL, not this isolated broker.
       const loginRes = await page
         .context()
         .request.post(`${ISOLATED_BASE_URL}/login`, {
@@ -121,9 +109,6 @@ test.describe.serial('Wait States Flag Off', () => {
 
       await expect(page.getByTestId('waiting-state-overlay')).toBeHidden();
 
-      // The Details tab only appears once a specific element is selected —
-      // select the waiting service task before opening it, matching every
-      // other Operate spec's convention (e.g. processInstanceJobPriority.spec.ts).
       await page.getByRole('treeitem', {name: 'task', exact: true}).click();
       const detailsTabButton = page
         .getByLabel('Process Instance Bottom Panel Tabs')

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStatesFlagOff.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStatesFlagOff.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {readFileSync} from 'node:fs';
+import {test} from 'fixtures';
+import {expect, request as playwrightRequest} from '@playwright/test';
+import {encode} from 'utils/http';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {
+  startIsolatedEnvironmentWaitStatesOff,
+  stopIsolatedEnvironment,
+} from 'utils/dockerComposeControl';
+
+// The flag-on case (waiting indicators + Details tab wait reason render, and
+// the FE issues a wait-states/search request) is already exercised against
+// the shared, default stack by every test in processInstanceWaitStates.spec.ts
+// — the default stack always boots with camunda.data.wait-states.enabled=true.
+// This spec only needs the negative, flag-off half, which requires a broker
+// booted with the flag off from the start (see
+// config/docker-compose.waitstates-isolated.yml).
+
+const ISOLATED_BASE_URL =
+  process.env.WAITSTATES_ISOLATED_BASE_URL ?? 'http://localhost:29080';
+const authHeader = `Basic ${encode('demo:demo')}`;
+
+test.describe.serial('Wait States Flag Off', () => {
+  test.setTimeout(5 * 60 * 1000);
+
+  test.beforeAll(async () => {
+    await startIsolatedEnvironmentWaitStatesOff();
+
+    const context = await playwrightRequest.newContext();
+    try {
+      await expect(async () => {
+        const res = await context.get(`${ISOLATED_BASE_URL}/v2/topology`, {
+          headers: {Authorization: authHeader},
+        });
+        expect(res.status()).toBe(200);
+      }).toPass({intervals: [2_000, 5_000, 10_000], timeout: 120_000});
+    } finally {
+      await context.dispose();
+    }
+  });
+
+  test.afterAll(async () => {
+    await stopIsolatedEnvironment();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('no waiting indicators render and no wait-states/search request fires when the flag is off', async ({
+    page,
+  }) => {
+    let processInstanceKey = '';
+
+    await test.step('Deploy a process and start an instance that would otherwise wait on a job', async () => {
+      const bpmn = readFileSync(
+        './resources/simpleServiceTaskProcess.bpmn',
+        'utf-8',
+      );
+      const deployRes = await page
+        .context()
+        .request.post(`${ISOLATED_BASE_URL}/v2/deployments`, {
+          headers: {Authorization: authHeader},
+          multipart: {
+            resources: {
+              name: 'simpleServiceTaskProcess.bpmn',
+              mimeType: 'application/xml',
+              buffer: Buffer.from(bpmn),
+            },
+          },
+        });
+      expect(deployRes.status()).toBe(200);
+
+      const createRes = await page
+        .context()
+        .request.post(`${ISOLATED_BASE_URL}/v2/process-instances`, {
+          headers: {
+            Authorization: authHeader,
+            'Content-Type': 'application/json',
+          },
+          data: {processDefinitionId: 'simpleServiceTaskProcess'},
+        });
+      expect(createRes.status()).toBe(200);
+      processInstanceKey = (await createRes.json()).processInstanceKey;
+    });
+
+    const waitStatesRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('/wait-states/search')) {
+        waitStatesRequests.push(req.url());
+      }
+    });
+
+    await test.step('Log in against the isolated stack', async () => {
+      // Set via the page's own browser-context request API so the response's
+      // Set-Cookie header lands in the same context page.goto() will use —
+      // the worker-scoped loginState fixture only authenticates against the
+      // shared stack's CORE_APPLICATION_URL, not this isolated broker.
+      const loginRes = await page
+        .context()
+        .request.post(`${ISOLATED_BASE_URL}/login`, {
+          form: {username: 'demo', password: 'demo'},
+        });
+      expect(loginRes.ok()).toBe(true);
+    });
+
+    await test.step('Open the process instance and confirm no waiting UI or query', async () => {
+      await page.goto(
+        `${ISOLATED_BASE_URL}/operate/processes/${processInstanceKey}`,
+      );
+      await expect(page.getByTestId('instance-header')).toBeVisible();
+
+      await expect(page.getByTestId('waiting-state-overlay')).toBeHidden();
+
+      // The Details tab only appears once a specific element is selected —
+      // select the waiting service task before opening it, matching every
+      // other Operate spec's convention (e.g. processInstanceJobPriority.spec.ts).
+      await page.getByRole('treeitem', {name: 'task', exact: true}).click();
+      const detailsTabButton = page
+        .getByLabel('Process Instance Bottom Panel Tabs')
+        .getByRole('link', {name: /^Details$/i});
+      await detailsTabButton.click();
+      await expect(page.getByTestId('instance-header')).toBeVisible();
+      await expect(page.getByTestId('waiting-status')).toBeHidden();
+
+      expect(waitStatesRequests).toHaveLength(0);
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStatesFlagOff.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceWaitStatesFlagOff.spec.ts
@@ -107,7 +107,9 @@ test.describe.serial('Wait States Flag Off', () => {
       );
       await expect(page.getByTestId('instance-header')).toBeVisible();
 
-      await expect(page.getByTestId('waiting-state-overlay')).toBeHidden();
+      await expect(
+        page.getByTestId('waiting-state-overlay').first(),
+      ).toBeHidden();
 
       await page.getByRole('treeitem', {name: 'task', exact: true}).click();
       const detailsTabButton = page

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
@@ -12,9 +12,6 @@ import path from 'node:path';
 
 const execAsync = promisify(exec);
 
-// Resolved against the CWD Playwright is invoked from (the suite's project
-// root), matching how other specs in this repo reference relative paths
-// (e.g. deployWithSubstitutions('./resources/*.bpmn')).
 const CONFIG_DIR = path.resolve(process.cwd(), 'config');
 const COMPOSE_FILES = [
   '-f',
@@ -24,16 +21,14 @@ const COMPOSE_FILES = [
 ];
 const PROJECT_NAME = 'waitstates-isolated';
 
-// Combining docker-compose.yml with the isolated override means Compose
-// validates the *entire* merged service graph up front — including the
-// shared `camunda` service's `depends_on: [${DATABASE}]` — even when
-// targeting only the isolated service with --no-deps. DATABASE just needs
-// any valid value to satisfy that validation; the isolated service doesn't
-// use it itself (it runs its own in-memory H2, see
-// config/docker-compose.waitstates-isolated.yml).
+// Merging docker-compose.yml pulls in the shared `camunda` service's
+// `depends_on: [${DATABASE}]`, which Compose validates even though we only
+// target the isolated services. DATABASE must be a literal service name
+// (postgres/elasticsearch/opensearch) — forwarding process.env.DATABASE
+// verbatim breaks when it's e.g. "RDBMS", so hardcode a valid one.
 const COMPOSE_ENV = {
   ...process.env,
-  DATABASE: (process.env.DATABASE ?? 'elasticsearch').toLowerCase(),
+  DATABASE: 'elasticsearch',
 };
 
 function composeCommand(args: string[]): string {
@@ -42,13 +37,6 @@ function composeCommand(args: string[]): string {
   );
 }
 
-/**
- * Brings up the isolated environment with wait-state tracking disabled
- * (`camunda.data.wait-states.enabled=false`) — for the tests proving the
- * feature is fully off (no indexing, no UI surface) when the flag is off.
- * Every other wait-state test runs flag-on against the shared stack, so
- * there is no matching "with wait states" isolated variant here.
- */
 export async function startIsolatedEnvironmentWaitStatesOff(): Promise<void> {
   await execAsync(
     composeCommand([
@@ -56,6 +44,7 @@ export async function startIsolatedEnvironmentWaitStatesOff(): Promise<void> {
       '-d',
       '--no-deps',
       'camunda-waitstates-isolated-off',
+      'elasticsearch-waitstates-isolated',
     ]),
     {cwd: CONFIG_DIR, env: COMPOSE_ENV},
   );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {exec} from 'node:child_process';
+import {promisify} from 'node:util';
+import path from 'node:path';
+
+const execAsync = promisify(exec);
+
+// Resolved against the CWD Playwright is invoked from (the suite's project
+// root), matching how other specs in this repo reference relative paths
+// (e.g. deployWithSubstitutions('./resources/*.bpmn')).
+const CONFIG_DIR = path.resolve(process.cwd(), 'config');
+const COMPOSE_FILES = [
+  '-f',
+  'docker-compose.yml',
+  '-f',
+  'docker-compose.waitstates-isolated.yml',
+];
+const PROJECT_NAME = 'waitstates-isolated';
+
+// Combining docker-compose.yml with the isolated override means Compose
+// validates the *entire* merged service graph up front — including the
+// shared `camunda` service's `depends_on: [${DATABASE}]` — even when
+// targeting only the isolated service with --no-deps. DATABASE just needs
+// any valid value to satisfy that validation; the isolated service doesn't
+// use it itself (it runs its own in-memory H2, see
+// config/docker-compose.waitstates-isolated.yml).
+const COMPOSE_ENV = {
+  ...process.env,
+  DATABASE: (process.env.DATABASE ?? 'elasticsearch').toLowerCase(),
+};
+
+function composeCommand(args: string[]): string {
+  return ['docker compose', ...COMPOSE_FILES, '-p', PROJECT_NAME, ...args].join(
+    ' ',
+  );
+}
+
+/**
+ * Brings up the isolated environment with wait-state tracking disabled
+ * (`camunda.data.wait-states.enabled=false`) — for the tests proving the
+ * feature is fully off (no indexing, no UI surface) when the flag is off.
+ * Every other wait-state test runs flag-on against the shared stack, so
+ * there is no matching "with wait states" isolated variant here.
+ */
+export async function startIsolatedEnvironmentWaitStatesOff(): Promise<void> {
+  await execAsync(
+    composeCommand([
+      'up',
+      '-d',
+      '--no-deps',
+      'camunda-waitstates-isolated-off',
+    ]),
+    {cwd: CONFIG_DIR, env: COMPOSE_ENV},
+  );
+}
+
+/** Tears down the isolated wait-states environment. Safe to call even if it was never started. */
+export async function stopIsolatedEnvironment(): Promise<void> {
+  await execAsync(composeCommand(['down', '-v']), {
+    cwd: CONFIG_DIR,
+    env: COMPOSE_ENV,
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/dockerComposeControl.ts
@@ -9,8 +9,44 @@
 import {exec} from 'node:child_process';
 import {promisify} from 'node:util';
 import path from 'node:path';
+import {mkdirSync, rmSync} from 'node:fs';
+import os from 'node:os';
 
 const execAsync = promisify(exec);
+
+// The Operate spec and the API spec both drive this same isolated stack
+// (same project name, same host ports) and can be scheduled concurrently in
+// different Playwright workers/projects. mkdirSync is atomic, so this acts
+// as a cross-process mutex: only one caller can be mid-lifecycle
+// (start...stop) at a time; a second caller blocks in startIsolatedEnvironmentWaitStatesOff()
+// until the first one's stopIsolatedEnvironment() releases the lock.
+const LOCK_DIR = path.join(os.tmpdir(), 'waitstates-isolated.lock');
+const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+const LOCK_RETRY_MS = 1_000;
+
+async function acquireLock(): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      mkdirSync(LOCK_DIR);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+      if (Date.now() - start > LOCK_TIMEOUT_MS) {
+        throw new Error(
+          `Timed out after ${LOCK_TIMEOUT_MS}ms waiting for the wait-states isolated-stack lock (${LOCK_DIR})`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
+    }
+  }
+}
+
+function releaseLock(): void {
+  rmSync(LOCK_DIR, {recursive: true, force: true});
+}
 
 const CONFIG_DIR = path.resolve(process.cwd(), 'config');
 const COMPOSE_FILES = [
@@ -38,6 +74,7 @@ function composeCommand(args: string[]): string {
 }
 
 export async function startIsolatedEnvironmentWaitStatesOff(): Promise<void> {
+  await acquireLock();
   await execAsync(
     composeCommand([
       'up',
@@ -50,10 +87,14 @@ export async function startIsolatedEnvironmentWaitStatesOff(): Promise<void> {
   );
 }
 
-/** Tears down the isolated wait-states environment. Safe to call even if it was never started. */
+/** Tears down the isolated wait-states environment and releases the lock. Safe to call even if it was never started. */
 export async function stopIsolatedEnvironment(): Promise<void> {
-  await execAsync(composeCommand(['down', '-v']), {
-    cwd: CONFIG_DIR,
-    env: COMPOSE_ENV,
-  });
+  try {
+    await execAsync(composeCommand(['down', '-v']), {
+      cwd: CONFIG_DIR,
+      env: COMPOSE_ENV,
+    });
+  } finally {
+    releaseLock();
+  }
 }

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/index.ts
@@ -124,3 +124,17 @@ export {
   getVariablesByName,
   getVariablesByPatterns,
 } from './optimize-variable-requestHelpers';
+export {
+  WAIT_STATES_SEARCH_ENDPOINT,
+  type WaitStateItem,
+  type WaitStateSearchResponse,
+  searchWaitStatesByFilter,
+  waitForWaitState,
+  createProcessInstanceWaitingOnJob,
+  createProcessInstanceWaitingOnMessage,
+  createProcessInstanceWaitingOnSignal,
+  createProcessInstanceWaitingOnUserTask,
+  createProcessInstanceWaitingOnTimer,
+  createProcessInstanceWaitingOnCondition,
+  createProcessInstanceWithManyWaitingTokens,
+} from './wait-state-requestHelpers';

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/wait-state-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/wait-state-requestHelpers.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {APIRequestContext} from 'playwright-core';
+import {expect} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../http';
+import {defaultAssertionOptions} from '../constants';
+import {validateResponse} from '../../json-body-assertions';
+import {createSingleInstance, deploy} from '../zeebeClient';
+
+export const WAIT_STATES_SEARCH_ENDPOINT =
+  '/element-instances/wait-states/search';
+
+export interface WaitStateItem {
+  rootProcessInstanceKey: string;
+  processInstanceKey: string;
+  elementInstanceKey: string;
+  elementId: string;
+  elementType: string;
+  bpmnProcessId: string;
+  tenantId: string;
+  // waitStateType lives inside `details`, alongside per-type fields
+  // (jobKey, messageName, etc.) — confirmed against a live response, not
+  // a top-level field.
+  details: {waitStateType: string; [key: string]: unknown};
+  [key: string]: unknown;
+}
+
+export interface WaitStateSearchResponse {
+  items: WaitStateItem[];
+  page: {
+    totalItems: number;
+    hasMoreTotalItems?: boolean;
+    startCursor?: string | null;
+    endCursor?: string | null;
+  };
+}
+
+/**
+ * Polls `wait-states/search` until it returns a 200 with a validated shape.
+ * Does not assert on item count — callers assert that themselves, since some
+ * negative cases (e.g. flag disabled, unknown key) expect zero items.
+ */
+export async function searchWaitStatesByFilter(
+  request: APIRequestContext,
+  filter: Record<string, unknown>,
+  options: {page?: Record<string, unknown>; auth?: string} = {},
+): Promise<WaitStateSearchResponse> {
+  const result: Record<string, unknown> = {};
+  await expect(async () => {
+    const res = await request.post(buildUrl(WAIT_STATES_SEARCH_ENDPOINT), {
+      headers: jsonHeaders(options.auth),
+      data: {filter, ...(options.page ? {page: options.page} : {})},
+    });
+    await assertStatusCode(res, 200);
+    await validateResponse(
+      {
+        path: WAIT_STATES_SEARCH_ENDPOINT,
+        method: 'POST',
+        status: '200',
+      },
+      res,
+    );
+    result.body = await res.json();
+  }).toPass(defaultAssertionOptions);
+  return result.body as WaitStateSearchResponse;
+}
+
+/**
+ * Waits until `wait-states/search` reports at least one row for the given
+ * process instance — absorbs exporter/indexing lag between instance
+ * creation and the wait-state row becoming searchable.
+ */
+export async function waitForWaitState(
+  request: APIRequestContext,
+  processInstanceKey: string,
+): Promise<WaitStateItem> {
+  const result: Record<string, unknown> = {};
+  await expect(async () => {
+    const body = await searchWaitStatesByFilter(request, {processInstanceKey});
+    expect(
+      body.items.length,
+      `Received JSON: ${JSON.stringify(body)}`,
+    ).toBeGreaterThan(0);
+    result.item = body.items[0];
+  }).toPass(defaultAssertionOptions);
+  return result.item as WaitStateItem;
+}
+
+/** JOB wait state: a service task whose type is never claimed by a worker. */
+export async function createProcessInstanceWaitingOnJob(): Promise<{
+  processInstanceKey: string;
+}> {
+  await deploy(['./resources/simpleServiceTaskProcess.bpmn']);
+  return createSingleInstance('simpleServiceTaskProcess', 1);
+}
+
+/** MESSAGE wait state: a receive task with a literal correlation key. */
+export async function createProcessInstanceWaitingOnMessage(): Promise<{
+  processInstanceKey: string;
+}> {
+  await deploy(['./resources/messageCatchEvent1.bpmn']);
+  return createSingleInstance('messageCatchEvent1', 1);
+}
+
+/** SIGNAL wait state: an intermediate catch event subscribed to Signal_220k2ur. */
+export async function createProcessInstanceWaitingOnSignal(): Promise<{
+  processInstanceKey: string;
+}> {
+  await deploy(['./resources/signal_broadcast_test_process.bpmn']);
+  return createSingleInstance('signal_broadcast_test_process', 1, {
+    orderId: '123',
+  });
+}
+
+/** USER_TASK wait state. */
+export async function createProcessInstanceWaitingOnUserTask(): Promise<{
+  processInstanceKey: string;
+}> {
+  await deploy(['./resources/user_task_api_test_process.bpmn']);
+  return createSingleInstance('user_task_api_test_process', 1);
+}
+
+/**
+ * TIMER wait state. `duration` is an ISO-8601 duration (e.g. `PT2S` for a
+ * short-lived timer that resolves on its own, `PT1H` for one that stays
+ * waiting for the duration of a test).
+ */
+export async function createProcessInstanceWaitingOnTimer(
+  duration: string,
+): Promise<{processInstanceKey: string}> {
+  await deploy(['./resources/timerIntermediateCatchEvent.bpmn']);
+  return createSingleInstance('timerIntermediateCatchEventProcess', 1, {
+    duration,
+  });
+}
+
+/**
+ * CONDITIONAL wait state. Starts with `x=1` (condition `x > 10` unmet).
+ * Resolve by calling `setVariables(processInstanceKey, {x: 42})` — the same
+ * mechanism dev's own WaitStateConditionalIT uses to re-trigger evaluation.
+ */
+export async function createProcessInstanceWaitingOnCondition(): Promise<{
+  processInstanceKey: string;
+}> {
+  await deploy(['./resources/conditionalIntermediateCatchEvent.bpmn']);
+  return createSingleInstance('conditionalIntermediateCatchEventProcess', 1, {
+    x: 1,
+  });
+}
+
+/**
+ * High-cardinality multi-instance JOB wait state, all on the same
+ * elementId, for cap-behavior testing. Never claimed by a worker — the
+ * `highCardinalityWaitTask` job type is dedicated to this resource.
+ */
+export async function createProcessInstanceWithManyWaitingTokens(
+  tokenCount: number,
+): Promise<{processInstanceKey: string}> {
+  await deploy(['./resources/highCardinalityMultiInstance.bpmn']);
+  return createSingleInstance('highCardinalityMultiInstance', 1, {
+    items: Array.from({length: tokenCount}, (_, i) => i),
+  });
+}

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/wait-state-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/wait-state-requestHelpers.ts
@@ -24,9 +24,6 @@ export interface WaitStateItem {
   elementType: string;
   bpmnProcessId: string;
   tenantId: string;
-  // waitStateType lives inside `details`, alongside per-type fields
-  // (jobKey, messageName, etc.) — confirmed against a live response, not
-  // a top-level field.
   details: {waitStateType: string; [key: string]: unknown};
   [key: string]: unknown;
 }
@@ -41,11 +38,6 @@ export interface WaitStateSearchResponse {
   };
 }
 
-/**
- * Polls `wait-states/search` until it returns a 200 with a validated shape.
- * Does not assert on item count — callers assert that themselves, since some
- * negative cases (e.g. flag disabled, unknown key) expect zero items.
- */
 export async function searchWaitStatesByFilter(
   request: APIRequestContext,
   filter: Record<string, unknown>,
@@ -71,11 +63,6 @@ export async function searchWaitStatesByFilter(
   return result.body as WaitStateSearchResponse;
 }
 
-/**
- * Waits until `wait-states/search` reports at least one row for the given
- * process instance — absorbs exporter/indexing lag between instance
- * creation and the wait-state row becoming searchable.
- */
 export async function waitForWaitState(
   request: APIRequestContext,
   processInstanceKey: string,
@@ -92,7 +79,6 @@ export async function waitForWaitState(
   return result.item as WaitStateItem;
 }
 
-/** JOB wait state: a service task whose type is never claimed by a worker. */
 export async function createProcessInstanceWaitingOnJob(): Promise<{
   processInstanceKey: string;
 }> {
@@ -100,7 +86,6 @@ export async function createProcessInstanceWaitingOnJob(): Promise<{
   return createSingleInstance('simpleServiceTaskProcess', 1);
 }
 
-/** MESSAGE wait state: a receive task with a literal correlation key. */
 export async function createProcessInstanceWaitingOnMessage(): Promise<{
   processInstanceKey: string;
 }> {
@@ -108,7 +93,6 @@ export async function createProcessInstanceWaitingOnMessage(): Promise<{
   return createSingleInstance('messageCatchEvent1', 1);
 }
 
-/** SIGNAL wait state: an intermediate catch event subscribed to Signal_220k2ur. */
 export async function createProcessInstanceWaitingOnSignal(): Promise<{
   processInstanceKey: string;
 }> {
@@ -118,7 +102,6 @@ export async function createProcessInstanceWaitingOnSignal(): Promise<{
   });
 }
 
-/** USER_TASK wait state. */
 export async function createProcessInstanceWaitingOnUserTask(): Promise<{
   processInstanceKey: string;
 }> {
@@ -126,11 +109,6 @@ export async function createProcessInstanceWaitingOnUserTask(): Promise<{
   return createSingleInstance('user_task_api_test_process', 1);
 }
 
-/**
- * TIMER wait state. `duration` is an ISO-8601 duration (e.g. `PT2S` for a
- * short-lived timer that resolves on its own, `PT1H` for one that stays
- * waiting for the duration of a test).
- */
 export async function createProcessInstanceWaitingOnTimer(
   duration: string,
 ): Promise<{processInstanceKey: string}> {
@@ -140,11 +118,8 @@ export async function createProcessInstanceWaitingOnTimer(
   });
 }
 
-/**
- * CONDITIONAL wait state. Starts with `x=1` (condition `x > 10` unmet).
- * Resolve by calling `setVariables(processInstanceKey, {x: 42})` — the same
- * mechanism dev's own WaitStateConditionalIT uses to re-trigger evaluation.
- */
+// Starts with x=1 (condition `x > 10` unmet); resolve via
+// setVariables(processInstanceKey, {x: 42}).
 export async function createProcessInstanceWaitingOnCondition(): Promise<{
   processInstanceKey: string;
 }> {
@@ -154,11 +129,6 @@ export async function createProcessInstanceWaitingOnCondition(): Promise<{
   });
 }
 
-/**
- * High-cardinality multi-instance JOB wait state, all on the same
- * elementId, for cap-behavior testing. Never claimed by a worker — the
- * `highCardinalityWaitTask` job type is dedicated to this resource.
- */
 export async function createProcessInstanceWithManyWaitingTokens(
   tokenCount: number,
 ): Promise<{processInstanceKey: string}> {


### PR DESCRIPTION
## Summary

QA epic [product-hub#3652](https://github.com/camunda/product-hub/issues/3652) for **First-Class Waiting States** (eng epic camunda/camunda#45040) listed regression automation as "Not Started". Dev already covers per-type add/update/remove lifecycle and negative cases extensively at the acceptance-test layer (`qa/acceptance-tests/.../it/waitstate/*IT.java`), but two gaps were uncovered: the real (unmocked) Operate UI rendering path, and full-stack behavior of the `waitStatesEnabled` flag.

This PR automates 5 of the 6 P1 cases identified:

- **Details tab renders per wait-state type without crashing**, asserting the exact reason text (e.g. "Waiting for message: Message_143t419") not just that something rendered (regression for #54983) — `tests/operate/processInstanceWaitStates.spec.ts`
- **Full waiting lifecycle** (indicator appears → resolve → clears) for JOB/MESSAGE/SIGNAL/USER_TASK/TIMER/CONDITIONAL, plus cancel-while-waiting — same file
- **`waitStatesEnabled=false` disables the UI + suppresses queries** — `tests/operate/processInstanceWaitStatesFlagOff.spec.ts`
- **`waitStatesEnabled=false` disables indexing full-stack** — `tests/api/v2/wait-state/wait-state-flag-isolated/wait-state-flag-off.spec.ts`
- **Large single-element cardinality**, on both `wait-states/search` and `statistics/wait-states` — `tests/api/v2/wait-state/wait-state-search-cap-api.spec.ts`
- **Request validation** (unknown filter, non-matching filter, unauthenticated) — `tests/api/v2/wait-state/wait-state-search-validation-api.spec.ts`

**Deferred (not in this PR):** cross-tenant isolation (P1-API-1). The default stack runs with `CAMUNDA_SECURITY_MULTITENANCY_CHECKSENABLED=false` — every process instance gets `tenantId: '<default>'` regardless of any tenant entity created, so true cross-tenant isolation can't be tested here. `c8-cross-component-e2e-tests`' `SM-8.10/mt-enabled-user-flows.spec.ts` is the only place with a real multi-tenant deployment (`IS_MT=true`, live SM+Keycloak) — a separate repo/environment, follow-up tracked separately.

## New shared infrastructure

- `utils/requestHelpers/wait-state-requestHelpers.ts` — search + per-type instance-creation helpers
- `resources/timerIntermediateCatchEvent.bpmn`, `conditionalIntermediateCatchEvent.bpmn`, `highCardinalityMultiInstance.bpmn` — no existing resource covered a non-start conditional catch event, a standalone timer catch, or a >100-token single-element multi-instance
- `OperateProcessInstancePage.waitingStatus` / `OperateDiagramPage.getWaitingOverlay()` — dedicated locators for the `waiting-status` / `waiting-state-overlay` testids (separate components from the existing `state-overlay-{state}` family)
- `config/docker-compose.waitstates-isolated.yml` + `utils/dockerComposeControl.ts` — single flag-off isolated stack, modeled on the existing analytics-exporter isolated-stack pattern, needed because the shared stack always boots with the flag on

## Test plan

- [x] `npm run lint` (tsc + eslint) — clean on all changed files
- [x] Full suite run against a live cluster (default stack + a fresh isolated flag-off stack): 25/25 passing (17 UI, 8 API)
- [x] Run the on-demand workflow (`c8-orchestration-cluster-e2e-tests-on-demand.yml`) against this branch before requesting review, per suite convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)


