### PR TITLE
fix: remove leaked `PROCESS_INSTANCE_CORRELATION_KEYS` row on cross-partition message-start

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleaseReleasedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleaseReleasedV1Applier.java
@@ -20,13 +20,19 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
  * a cross-partition message-start holder instance has completed. For each holder carried by the
  * event it drops the underlying correlation-key lock ({@link
  * MutableMessageState#removeActiveProcessInstance}) so the next buffered message for that key can
- * be picked up, and removes the holder-instance discriminator that the pull-based release loop
- * polls on ({@link MutableMessageState#removeCrossPartitionStartLock}).
+ * be picked up, removes the holder-instance discriminator that the pull-based release loop polls on
+ * ({@link MutableMessageState#removeCrossPartitionStartLock}), and removes the process-instance ->
+ * correlation-key row ({@link MutableMessageState#removeProcessInstanceCorrelationKey}) that {@code
+ * P_K} wrote for the remote holder when it created it via the handshake — otherwise that row leaks
+ * once per cross-partition start, since the completing element lives on {@code P_B} and never
+ * reaches {@code P_K}'s local cleanup path.
  *
  * <p>The release decision — including the idempotency guard that ensures the lock is still held by
  * the exact instance the reply names — lives in the {@code RELEASE} processor; the event is only
- * written for holders that actually have a matching live lock, so this applier removes
- * unconditionally.
+ * written for holders that actually have a matching live lock, so the lock removal is
+ * unconditional. The correlation-key row removal is guarded (the underlying delete throws on a
+ * missing key), which also tolerates holders that never had one (empty correlation key) and replays
+ * of a {@code RELEASE} whose row was already removed.
  */
 final class MessageStartCorrelationKeyLockReleaseReleasedV1Applier
     implements TypedEventApplier<
@@ -45,6 +51,11 @@ final class MessageStartCorrelationKeyLockReleaseReleasedV1Applier
       final var correlationKey = BufferUtil.wrapString(holder.getCorrelationKey());
       messageState.removeActiveProcessInstance(bpmnProcessId, correlationKey);
       messageState.removeCrossPartitionStartLock(bpmnProcessId, correlationKey);
+
+      final var holderProcessInstanceKey = holder.getProcessInstanceKey();
+      if (messageState.getProcessInstanceCorrelationKey(holderProcessInstanceKey) != null) {
+        messageState.removeProcessInstanceCorrelationKey(holderProcessInstanceKey);
+      }
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleaseReleasedV1ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MessageStartCorrelationKeyLockReleaseReleasedV1ApplierTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartCorrelationKeyLockReleaseRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class MessageStartCorrelationKeyLockReleaseReleasedV1ApplierTest {
+  private static final long HOLDER_PROCESS_INSTANCE_KEY = 4503599627370497L;
+  private static final String BPMN_PROCESS_ID = "process";
+  private static final String CORRELATION_KEY = "ck-1";
+  private static final String TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableMessageState messageState;
+  private MessageStartCorrelationKeyLockReleaseReleasedV1Applier applier;
+
+  @BeforeEach
+  public void setUp() {
+    messageState = processingState.getMessageState();
+    applier = new MessageStartCorrelationKeyLockReleaseReleasedV1Applier(messageState);
+  }
+
+  @Test
+  public void shouldReleaseLockOnRelease() {
+    // given a cross-partition lock held by a remote instance
+    seedLock();
+
+    // when the holder completion is released
+    applier.applyState(1L, releaseRecord());
+
+    // then the underlying correlation-key lock is released
+    assertThat(
+            messageState.getCrossPartitionStartLockHolder(
+                wrapString(BPMN_PROCESS_ID), wrapString(CORRELATION_KEY)))
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldRemoveProcessInstanceCorrelationKeyOnRelease() {
+    // given a cross-partition lock held by a remote instance, plus the process-instance ->
+    // correlation-key row that P_K wrote when it created the holder via the handshake
+    seedLock();
+    messageState.putProcessInstanceCorrelationKey(
+        HOLDER_PROCESS_INSTANCE_KEY, wrapString(CORRELATION_KEY));
+
+    // when the holder completion is released
+    applier.applyState(1L, releaseRecord());
+
+    // then the correlation-key row is removed rather than leaked
+    assertThat(messageState.getProcessInstanceCorrelationKey(HOLDER_PROCESS_INSTANCE_KEY)).isNull();
+  }
+
+  @Test
+  public void shouldNotFailWhenProcessInstanceCorrelationKeyAbsent() {
+    // given a cross-partition lock with no process-instance -> correlation-key row (e.g. a holder
+    // with an empty correlation key, or a RELEASE replayed after the row was already removed)
+    seedLock();
+
+    // when the holder completion is released
+    // then the removal is guarded and does not throw
+    assertThatCode(() -> applier.applyState(1L, releaseRecord())).doesNotThrowAnyException();
+  }
+
+  private void seedLock() {
+    messageState.putActiveProcessInstance(wrapString(BPMN_PROCESS_ID), wrapString(CORRELATION_KEY));
+    messageState.putCrossPartitionStartLock(
+        wrapString(BPMN_PROCESS_ID),
+        wrapString(CORRELATION_KEY),
+        HOLDER_PROCESS_INSTANCE_KEY,
+        TENANT);
+  }
+
+  private MessageStartCorrelationKeyLockReleaseRecord releaseRecord() {
+    final var record = new MessageStartCorrelationKeyLockReleaseRecord();
+    record
+        .addHolder()
+        .setProcessInstanceKey(HOLDER_PROCESS_INSTANCE_KEY)
+        .setBpmnProcessId(BPMN_PROCESS_ID)
+        .setCorrelationKey(CORRELATION_KEY)
+        .setTenantId(TENANT);
+    return record;
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartCorrelationKeyLockRelease_RELEASED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/MessageStartCorrelationKeyLockRelease_RELEASED_v1.golden
@@ -20,13 +20,19 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
  * a cross-partition message-start holder instance has completed. For each holder carried by the
  * event it drops the underlying correlation-key lock ({@link
  * MutableMessageState#removeActiveProcessInstance}) so the next buffered message for that key can
- * be picked up, and removes the holder-instance discriminator that the pull-based release loop
- * polls on ({@link MutableMessageState#removeCrossPartitionStartLock}).
+ * be picked up, removes the holder-instance discriminator that the pull-based release loop polls on
+ * ({@link MutableMessageState#removeCrossPartitionStartLock}), and removes the process-instance ->
+ * correlation-key row ({@link MutableMessageState#removeProcessInstanceCorrelationKey}) that {@code
+ * P_K} wrote for the remote holder when it created it via the handshake — otherwise that row leaks
+ * once per cross-partition start, since the completing element lives on {@code P_B} and never
+ * reaches {@code P_K}'s local cleanup path.
  *
  * <p>The release decision — including the idempotency guard that ensures the lock is still held by
  * the exact instance the reply names — lives in the {@code RELEASE} processor; the event is only
- * written for holders that actually have a matching live lock, so this applier removes
- * unconditionally.
+ * written for holders that actually have a matching live lock, so the lock removal is
+ * unconditional. The correlation-key row removal is guarded (the underlying delete throws on a
+ * missing key), which also tolerates holders that never had one (empty correlation key) and replays
+ * of a {@code RELEASE} whose row was already removed.
  */
 final class MessageStartCorrelationKeyLockReleaseReleasedV1Applier
     implements TypedEventApplier<
@@ -45,6 +51,11 @@ final class MessageStartCorrelationKeyLockReleaseReleasedV1Applier
       final var correlationKey = BufferUtil.wrapString(holder.getCorrelationKey());
       messageState.removeActiveProcessInstance(bpmnProcessId, correlationKey);
       messageState.removeCrossPartitionStartLock(bpmnProcessId, correlationKey);
+
+      final var holderProcessInstanceKey = holder.getProcessInstanceKey();
+      if (messageState.getProcessInstanceCorrelationKey(holderProcessInstanceKey) != null) {
+        messageState.removeProcessInstanceCorrelationKey(holderProcessInstanceKey);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

On `P_K`, the `START`-reply processor writes `CORRELATED` with the **remote holder's process-instance key**, so the `CORRELATED` applier inserts a `processInstanceCorrelationKey[remoteHolderPiKey]` row. For a cross-partition message-start, the only local remover (PROCESS-element completion/termination) runs on `P_B` — where the row was never written — and the `RELEASED` applier previously removed the lock and active-instance marker but **not** this row. The result was one permanently leaked `PROCESS_INSTANCE_CORRELATION_KEYS` row on `P_K` per cross-partition message-start.

This PR fixes the leak by removing the `processInstanceCorrelationKey` row in `MessageStartCorrelationKeyLockReleaseReleasedV1Applier` when the holder completion is released.

### Changes

- **`MessageStartCorrelationKeyLockReleaseReleasedV1Applier`**: for each released holder, also removes the `processInstance -> correlationKey` row via `removeProcessInstanceCorrelationKey`. The removal is **guarded** (`getProcessInstanceCorrelationKey(...) != null`) because the underlying delete throws on a missing key — this also tolerates holders that never had a row (empty correlation key) and replays of a `RELEASE` whose row was already removed.
- Updated the applier's Javadoc (and the corresponding `.golden` resource) to document the new cleanup responsibility and why it is guarded.
- **New test** `MessageStartCorrelationKeyLockReleaseReleasedV1ApplierTest` covering:
  - lock release on `RELEASE`,
  - removal of the `processInstanceCorrelationKey` row rather than leaking it,
  - no failure when the row is absent (guarded removal).

## Related issues

closes #58560