### PR TITLE
feat: bridge legacy Optimize security config to camunda.security.* for CSL

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -8,7 +8,9 @@
 package io.camunda.optimize.rest.security.csl;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -69,6 +71,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     bridgeIdentityOidc(env, derived);
     bridgeAuth0Cloud(env, derived);
     bridgePublicApiJwt(env, derived);
+    bridgeAudiences(env, derived);
     bridgeResponseHeaders(env, derived);
     warnObsoleteKeys(env);
 
@@ -107,7 +110,7 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE", OIDC_PREFIX + "audiences");
+    // The identity audience is collected in bridgeAudiences (all audience sources share one key).
   }
 
   // OIDC / Auth0 (CCSaaS cloud), from the CAMUNDA_OPTIMIZE_AUTH0_* / CAMUNDA_OPTIMIZE_CLIENT_* env
@@ -170,7 +173,8 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     warnDeprecated("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_AUTH0_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", OIDC_PREFIX + "audiences");
+    // The Auth0 client audience is collected in bridgeAudiences (all audience sources share one
+    // key).
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION", OIDC_PREFIX + "organization-id");
     // Pass the cloud Accounts API audience as Auth0's `audience` authorize param, so the login
@@ -213,7 +217,39 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         derived,
         "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI",
         OIDC_PREFIX + "jwk-set-uri");
-    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_API_AUDIENCE", OIDC_PREFIX + "audiences");
+    // The public-API audience is collected in bridgeAudiences (all audience sources share one key).
+  }
+
+  // CSL exposes one Set-valued audiences property, but Optimize has three legacy audience keys that
+  // feed it: the login audience (CCSM identity or, in cloud, the Auth0 client audience - the two
+  // are
+  // mutually exclusive) and the public-API audience. The login audience and the public-API audience
+  // can both be configured, and both must survive: dropping either breaks the corresponding token
+  // validation (interactive login vs public API). Emitting each through putIfAbsent let only the
+  // first writer win. Collect every present source into one comma-joined value instead; Spring
+  // binds
+  // a comma-delimited string to the Set<String>.
+  private void bridgeAudiences(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    final Set<String> audiences = new LinkedHashSet<>();
+    final String loginAudienceKey =
+        isAuth0Configured(env)
+            ? "CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE"
+            : "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE";
+    addAudience(env, audiences, loginAudienceKey);
+    addAudience(env, audiences, "CAMUNDA_OPTIMIZE_API_AUDIENCE");
+    if (!audiences.isEmpty()) {
+      derived.putIfAbsent(OIDC_PREFIX + "audiences", String.join(",", audiences));
+    }
+  }
+
+  private void addAudience(
+      final ConfigurableEnvironment env, final Set<String> audiences, final String legacyKey) {
+    final String value = env.getProperty(legacyKey);
+    if (value != null && !value.isBlank()) {
+      audiences.add(value.trim());
+      warnDeprecated(legacyKey, OIDC_PREFIX + "audiences");
+    }
   }
 
   // HSTS max-age: negative disables the header in CSL.

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * Backward-compatibility bridge for operators adopting CSL (ADR-0038).
+ *
+ * <p>Reads Optimize's existing auth/security configuration and emits the equivalent {@code
+ * camunda.security.*} properties, so operators are not forced to migrate their configuration when
+ * Optimize adopts CSL. Mirrors OC's {@code PersistentWebSessionPropertiesPostProcessor}.
+ *
+ * <p>The derived property source is added at the <b>end</b> of the source list (lowest precedence),
+ * so any explicit {@code camunda.security.*} value an operator sets still wins.
+ *
+ * <p>Only active when {@code optimize.security.csl.enabled=true}. Keys with no meaning under CSL
+ * (server-side sessions, no self-signed tokens) are logged as deprecated and otherwise ignored.
+ *
+ * <p>Bridges the CCSM (Identity) and CCSaaS (Auth0) OIDC registrations from their {@code
+ * CAMUNDA_OPTIMIZE_IDENTITY_*} / {@code CAMUNDA_OPTIMIZE_AUTH0_*} / {@code
+ * CAMUNDA_OPTIMIZE_CLIENT_*} env-var interface (the {@code ${...}} placeholders in {@code
+ * service-config.yaml}).
+ *
+ * <p>Every recognised legacy key logs a deprecation warning naming its {@code camunda.security.*}
+ * replacement (or, for obsolete keys, stating that it no longer has any effect). Legacy keys stay
+ * supported until 8.11 and are removed afterwards.
+ */
+public final class OptimizeSecurityConfigCompatibilityPostProcessor
+    implements EnvironmentPostProcessor, Ordered {
+
+  static final String CSL_ENABLED_PROPERTY = "optimize.security.csl.enabled";
+  static final String COMPATIBILITY_PROPERTY_SOURCE_NAME = "optimizeCslCompatibility";
+
+  private static final String OIDC_PREFIX = "camunda.security.authentication.oidc.";
+  private static final String LEGACY_KEY_REMOVAL_VERSION = "8.11";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OptimizeSecurityConfigCompatibilityPostProcessor.class);
+
+  @Override
+  public int getOrder() {
+    // After Spring's config-data processing; lowest precedence for our derived source.
+    return Ordered.LOWEST_PRECEDENCE;
+  }
+
+  @Override
+  public void postProcessEnvironment(
+      final ConfigurableEnvironment env, final SpringApplication application) {
+    if (!Boolean.parseBoolean(env.getProperty(CSL_ENABLED_PROPERTY, "false"))) {
+      return;
+    }
+
+    final Map<String, Object> derived = new HashMap<>();
+    applyAlwaysOnDefaults(derived);
+    bridgeIdentityOidc(env, derived);
+    bridgeAuth0Cloud(env, derived);
+    bridgePublicApiJwt(env, derived);
+    bridgeResponseHeaders(env, derived);
+    warnObsoleteKeys(env);
+
+    if (!derived.isEmpty()) {
+      // Add last so explicit camunda.security.* values keep precedence over the bridged defaults.
+      env.getPropertySources()
+          .addLast(new MapPropertySource(COMPATIBILITY_PROPERTY_SOURCE_NAME, derived));
+      LOG.info(
+          "Optimize CSL compatibility bridge applied {} camunda.security.* properties"
+              + " (always-on defaults plus values derived from legacy Optimize config).",
+          derived.size());
+    }
+  }
+
+  // Always applied when CSL is enabled, independent of any legacy key.
+  private void applyAlwaysOnDefaults(final Map<String, Object> derived) {
+    derived.put("camunda.security.authentication.method", "oidc");
+    // Optimize's webapp chain is /**, so the CSL deny chain must be suppressed.
+    derived.put("camunda.security.authentication.catch-all-unhandled-paths-enabled", "false");
+    // Session persistence is intentionally not set here: it is owned by the dedicated session-store
+    // configuration (task 1.3, #58471), not by this legacy-config bridge.
+    // CSL needs a redirect-uri for authorization-code login and derives its listener path from it
+    // (ADR-0038). CCSM reuses Optimize's existing /api/authentication/callback (no Identity-client
+    // change); bridgeAuth0Cloud overrides it for Auth0. putIfAbsent so an explicit value wins.
+    derived.putIfAbsent(OIDC_PREFIX + "redirect-uri", "{baseUrl}/api/authentication/callback");
+  }
+
+  // OIDC / Identity (CCSM), from the CAMUNDA_OPTIMIZE_IDENTITY_* env vars. Skipped when Auth0 is
+  // configured (the two modes are mutually exclusive, cloud wins) to avoid a mixed registration.
+  private void bridgeIdentityOidc(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    if (isAuth0Configured(env)) {
+      return;
+    }
+    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", OIDC_PREFIX + "issuer-uri");
+    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
+    mapIfPresent(
+        env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
+    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE", OIDC_PREFIX + "audiences");
+  }
+
+  // OIDC / Auth0 (CCSaaS cloud), from the CAMUNDA_OPTIMIZE_AUTH0_* / CAMUNDA_OPTIMIZE_CLIENT_* env
+  // vars (service-config.yaml, security.auth.cloud).
+  private void bridgeAuth0Cloud(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    if (!isAuth0Configured(env)) {
+      return;
+    }
+    final String auth0ClientId = env.getProperty("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID");
+    final String clusterId = env.getProperty("CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID");
+    bridgeAuth0RedirectAndContextPath(env, derived, clusterId);
+    bridgeAuth0Credentials(env, derived, auth0ClientId);
+    bridgeAuth0SaasOrgAndCluster(env, derived, clusterId);
+  }
+
+  private static boolean isAuth0Configured(final ConfigurableEnvironment env) {
+    final String auth0ClientId = env.getProperty("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID");
+    return auth0ClientId != null && !auth0ClientId.isBlank();
+  }
+
+  // Reproduces Optimize's legacy Auth0 callback so no re-registration is needed: root host (no
+  // context path) + ?uuid=<clusterId>, which the cloud ingress rewrites to
+  // /<clusterId>/sso-callback (Auth0 cannot wildcard callback paths). {baseScheme}://{baseHost}
+  // {basePort} excludes the context path (unlike {baseUrl}); put() overrides the CCSM default.
+  // The app runs under /<clusterId>, but contextPath is derived only when the operator set neither
+  // the Spring "contextPath" key nor CAMUNDA_OPTIMIZE_CONTEXT_PATH (getContextPath reads the former
+  // first), to stay non-breaking.
+  private void bridgeAuth0RedirectAndContextPath(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String clusterId) {
+    final boolean hasClusterId = clusterId != null && !clusterId.isBlank();
+    final String uuidParam = hasClusterId ? "?uuid=" + clusterId : "";
+    derived.put(
+        OIDC_PREFIX + "redirect-uri",
+        "{baseScheme}://{baseHost}{basePort}/sso-callback" + uuidParam);
+    if (hasClusterId) {
+      if (!hasExplicitContextPath(env)) {
+        derived.put("contextPath", "/" + clusterId);
+      }
+      warnDeprecated(
+          "CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID",
+          "camunda.security.saas.cluster-id (also derives the redirect-uri and contextPath)");
+    }
+  }
+
+  // True when the operator set a context path via either the Spring "contextPath" property or the
+  // legacy CAMUNDA_OPTIMIZE_CONTEXT_PATH env var.
+  private static boolean hasExplicitContextPath(final ConfigurableEnvironment env) {
+    return env.getProperty("contextPath") != null
+        || env.getProperty("CAMUNDA_OPTIMIZE_CONTEXT_PATH") != null;
+  }
+
+  private void bridgeAuth0Credentials(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String auth0ClientId) {
+    derived.putIfAbsent(OIDC_PREFIX + "client-id", auth0ClientId);
+    warnDeprecated("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", OIDC_PREFIX + "client-id");
+    mapIfPresent(
+        env, derived, "CAMUNDA_OPTIMIZE_AUTH0_CLIENTSECRET", OIDC_PREFIX + "client-secret");
+    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", OIDC_PREFIX + "audiences");
+    mapIfPresent(
+        env, derived, "CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION", OIDC_PREFIX + "organization-id");
+    // Pass the cloud Accounts API audience as Auth0's `audience` authorize param, so the login
+    // token is accepted by the Accounts API (CCSaaSUserCache). Legacy baked it into the authorize
+    // URL; CSL reads it from authorize-request.additional-parameters.
+    mapIfPresent(
+        env,
+        derived,
+        "CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_AUTH0_AUDIENCE",
+        OIDC_PREFIX + "authorize-request.additional-parameters.audience");
+
+    // Auth0 issuer is https://<customDomain>/; CSL discovers token/jwks/userinfo from it.
+    final String auth0Domain = env.getProperty("CAMUNDA_OPTIMIZE_AUTH0_DOMAIN");
+    if (auth0Domain != null && !auth0Domain.isBlank()) {
+      derived.putIfAbsent(OIDC_PREFIX + "issuer-uri", toAuth0IssuerUri(auth0Domain));
+      warnDeprecated("CAMUNDA_OPTIMIZE_AUTH0_DOMAIN", OIDC_PREFIX + "issuer-uri");
+    }
+  }
+
+  // CSL SaaS config requires BOTH organization-id and cluster-id; set them together only when both
+  // are present so a partial config never trips SaasConfiguration#isConfigured().
+  private void bridgeAuth0SaasOrgAndCluster(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String clusterId) {
+    final String organizationId = env.getProperty("CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION");
+    final boolean hasOrganizationId = organizationId != null && !organizationId.isBlank();
+    final boolean hasClusterId = clusterId != null && !clusterId.isBlank();
+    if (hasOrganizationId && hasClusterId) {
+      derived.putIfAbsent("camunda.security.saas.organization-id", organizationId);
+      derived.putIfAbsent("camunda.security.saas.cluster-id", clusterId);
+    }
+  }
+
+  // Public API JWT (api.jwtSetUri / api.audience).
+  private void bridgePublicApiJwt(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    mapIfPresent(
+        env,
+        derived,
+        "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI",
+        OIDC_PREFIX + "jwk-set-uri");
+    mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_API_AUDIENCE", OIDC_PREFIX + "audiences");
+  }
+
+  // HSTS max-age: negative disables the header in CSL.
+  private void bridgeResponseHeaders(
+      final ConfigurableEnvironment env, final Map<String, Object> derived) {
+    final String hstsMaxAge =
+        env.getProperty("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE");
+    if (hstsMaxAge == null || hstsMaxAge.isBlank()) {
+      return;
+    }
+    final long maxAgeSeconds;
+    try {
+      maxAgeSeconds = Long.parseLong(hstsMaxAge.trim());
+    } catch (final NumberFormatException e) {
+      // A compatibility bridge must never fail startup on a malformed legacy value; skip it and
+      // let CSL apply its own HSTS default. Value is not logged (may be operator-sensitive).
+      LOG.warn(
+          "Ignoring 'CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE': not a valid number;"
+              + " leaving 'camunda.security.http-headers.hsts.*' at its CSL default.");
+      return;
+    }
+    final String replacement;
+    if (maxAgeSeconds < 0) {
+      // A negative legacy max-age means "disable HSTS", which maps to hsts.disabled, not max-age.
+      derived.put("camunda.security.http-headers.hsts.disabled", "true");
+      replacement = "camunda.security.http-headers.hsts.disabled";
+    } else {
+      derived.put("camunda.security.http-headers.hsts.max-age-in-seconds", hstsMaxAge.trim());
+      replacement = "camunda.security.http-headers.hsts.max-age-in-seconds";
+    }
+    warnDeprecated("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", replacement);
+  }
+
+  // Legacy keys that have no meaning under CSL (server-side sessions, no self-signed tokens, no
+  // deprecated response headers). Their presence never fails startup; it only logs a warning.
+  private void warnObsoleteKeys(final ConfigurableEnvironment env) {
+    warnObsolete(
+        env,
+        "CAMUNDA_OPTIMIZE_SECURITY_AUTH_TOKEN_SECRET",
+        "self-signed session tokens are not minted under CSL's server-side sessions");
+    warnObsolete(
+        env,
+        "CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_MAX_SIZE",
+        "cookie splitting is gone; the session-id cookie is small");
+    warnObsolete(
+        env,
+        "CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED",
+        "CSL sets the SameSite attribute on its session cookie automatically");
+    warnObsolete(
+        env,
+        "OPTIMIZE_API_ACCESS_TOKEN",
+        "a static shared API token is not supported by the CSL bearer chain");
+    warnObsolete(
+        env,
+        "security.responseHeaders.X-XSS-Protection",
+        "CSL does not emit this deprecated header");
+  }
+
+  private void mapIfPresent(
+      final ConfigurableEnvironment env,
+      final Map<String, Object> derived,
+      final String legacyKey,
+      final String cslKey) {
+    final String value = env.getProperty(legacyKey);
+    if (value != null && !value.isBlank()) {
+      derived.putIfAbsent(cslKey, value);
+      warnDeprecated(legacyKey, cslKey);
+    }
+  }
+
+  // Auth0 issuer URI is https://<domain>/ (trailing slash required for OIDC discovery). Accepts a
+  // bare domain or a full URL.
+  private static String toAuth0IssuerUri(final String domain) {
+    final String base =
+        domain.startsWith("http://") || domain.startsWith("https://")
+            ? domain
+            : "https://" + domain;
+    return base.endsWith("/") ? base : base + "/";
+  }
+
+  // Deprecation warning for a legacy key that still maps to a CSL property. Never logs the value,
+  // only the key names, so secrets (client secrets, tokens) never reach the log.
+  private void warnDeprecated(final String legacyKey, final String replacement) {
+    LOG.warn(
+        "Optimize config '{}' is deprecated; migrate to '{}'. Support for the legacy key will be"
+            + " removed in {}.",
+        legacyKey,
+        replacement,
+        LEGACY_KEY_REMOVAL_VERSION);
+  }
+
+  // Deprecation warning for a legacy key that no longer has any effect under CSL.
+  private void warnObsolete(
+      final ConfigurableEnvironment env, final String legacyKey, final String why) {
+    if (env.getProperty(legacyKey) != null) {
+      LOG.warn(
+          "Optimize config '{}' is deprecated and has no effect under CSL ({}). It will be removed"
+              + " in {}.",
+          legacyKey,
+          why,
+          LEGACY_KEY_REMOVAL_VERSION);
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -216,20 +216,25 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         OIDC_PREFIX + "jwk-set-uri");
   }
 
-  // CSL has one Set-valued audiences property. Optimize feeds it from a login audience (CCSM
-  // identity, or the Auth0 client audience in cloud - mutually exclusive) and the public-API
-  // audience, which can both be set. Both must survive, so collect every present source into one
-  // comma-joined value that Spring binds to the Set; the old per-key putIfAbsent kept only the
-  // first.
+  // CSL has one Set-valued audiences property, so we collect every legacy audience source that
+  // applies to the active mode into one comma-joined value that Spring binds to the Set; the old
+  // per-key putIfAbsent kept only the first and silently dropped the rest.
+  //
+  // CCSM validated two distinct audiences on two paths: the identity audience on the login/session
+  // token and the public-API audience on the bearer path. Both must survive here.
+  //
+  // CCSaaS/Auth0 only ever validated the client audience (on the public-API path; the login
+  // id_token was not audience-checked). The public-API audience is a CCSM-only key, so we do not
+  // feed it in Auth0 mode - doing so would accept an audience legacy cloud never honoured.
   private void bridgeAudiences(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     final Set<String> audiences = new LinkedHashSet<>();
-    final String loginAudienceKey =
-        isAuth0Configured(env)
-            ? "CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE"
-            : "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE";
-    addAudience(env, audiences, loginAudienceKey);
-    addAudience(env, audiences, "CAMUNDA_OPTIMIZE_API_AUDIENCE");
+    if (isAuth0Configured(env)) {
+      addAudience(env, audiences, "CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE");
+    } else {
+      addAudience(env, audiences, "CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE");
+      addAudience(env, audiences, "CAMUNDA_OPTIMIZE_API_AUDIENCE");
+    }
     if (!audiences.isEmpty()) {
       derived.putIfAbsent(OIDC_PREFIX + "audiences", String.join(",", audiences));
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessor.java
@@ -110,7 +110,6 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     mapIfPresent(env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    // The identity audience is collected in bridgeAudiences (all audience sources share one key).
   }
 
   // OIDC / Auth0 (CCSaaS cloud), from the CAMUNDA_OPTIMIZE_AUTH0_* / CAMUNDA_OPTIMIZE_CLIENT_* env
@@ -173,8 +172,6 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
     warnDeprecated("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", OIDC_PREFIX + "client-id");
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_AUTH0_CLIENTSECRET", OIDC_PREFIX + "client-secret");
-    // The Auth0 client audience is collected in bridgeAudiences (all audience sources share one
-    // key).
     mapIfPresent(
         env, derived, "CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION", OIDC_PREFIX + "organization-id");
     // Pass the cloud Accounts API audience as Auth0's `audience` authorize param, so the login
@@ -217,18 +214,13 @@ public final class OptimizeSecurityConfigCompatibilityPostProcessor
         derived,
         "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI",
         OIDC_PREFIX + "jwk-set-uri");
-    // The public-API audience is collected in bridgeAudiences (all audience sources share one key).
   }
 
-  // CSL exposes one Set-valued audiences property, but Optimize has three legacy audience keys that
-  // feed it: the login audience (CCSM identity or, in cloud, the Auth0 client audience - the two
-  // are
-  // mutually exclusive) and the public-API audience. The login audience and the public-API audience
-  // can both be configured, and both must survive: dropping either breaks the corresponding token
-  // validation (interactive login vs public API). Emitting each through putIfAbsent let only the
-  // first writer win. Collect every present source into one comma-joined value instead; Spring
-  // binds
-  // a comma-delimited string to the Set<String>.
+  // CSL has one Set-valued audiences property. Optimize feeds it from a login audience (CCSM
+  // identity, or the Auth0 client audience in cloud - mutually exclusive) and the public-API
+  // audience, which can both be set. Both must survive, so collect every present source into one
+  // comma-joined value that Spring binds to the Set; the old per-key putIfAbsent kept only the
+  // first.
   private void bridgeAudiences(
       final ConfigurableEnvironment env, final Map<String, Object> derived) {
     final Set<String> audiences = new LinkedHashSet<>();

--- a/optimize/backend/src/main/resources/META-INF/spring.factories
+++ b/optimize/backend/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 # Environment Post Processor
 org.springframework.boot.env.EnvironmentPostProcessor=\
-io.camunda.optimize.SpringPropertiesPostProcessor
+io.camunda.optimize.SpringPropertiesPostProcessor,\
+io.camunda.optimize.rest.security.csl.OptimizeSecurityConfigCompatibilityPostProcessor

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -179,6 +179,34 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
+  void shouldMergeCcsmLoginAndPublicApiAudiences() {
+    // A distinct login audience and public-API audience must both survive: dropping either breaks
+    // the corresponding token validation. They map to CSL's single Set-valued audiences property.
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://localhost:18080/realm");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE", "optimize-login");
+    legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-login,optimize-public-api");
+  }
+
+  @Test
+  void shouldMergeAuth0LoginAndPublicApiAudiences() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", "optimize");
+    legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize,optimize-public-api");
+  }
+
+  @Test
   void shouldBridgeHstsMaxAge() {
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", "31536000");

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.security.csl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.netmikey.logunit.api.LogCapturer;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.event.Level;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+class OptimizeSecurityConfigCompatibilityPostProcessorTest {
+
+  private static final String OIDC = "camunda.security.authentication.oidc.";
+
+  @RegisterExtension
+  final LogCapturer logs =
+      LogCapturer.create()
+          .captureForType(OptimizeSecurityConfigCompatibilityPostProcessor.class, Level.WARN);
+
+  private final OptimizeSecurityConfigCompatibilityPostProcessor processor =
+      new OptimizeSecurityConfigCompatibilityPostProcessor();
+
+  private static StandardEnvironment environmentWith(final Map<String, Object> legacy) {
+    final StandardEnvironment env = new StandardEnvironment();
+    env.getPropertySources().addFirst(new MapPropertySource("test-legacy", legacy));
+    return env;
+  }
+
+  private static Map<String, Object> cslEnabledConfig() {
+    final Map<String, Object> legacy = new HashMap<>();
+    legacy.put("optimize.security.csl.enabled", "true");
+    return legacy;
+  }
+
+  @Test
+  void shouldDoNothingWhenCslDisabled() {
+    final Map<String, Object> legacy = new HashMap<>();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isNull();
+    assertThat(env.getProperty(OIDC + "client-id")).isNull();
+    logs.assertDoesNotContain(
+        entry -> entry.getLevel() == Level.WARN, "expected no logging when CSL is disabled");
+  }
+
+  @Test
+  void shouldBridgeCcsmIdentityConfigAndLogDeprecation() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://localhost:18080/realm");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", "optimize");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET", "identity-secret");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE", "optimize-api");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
+    assertThat(env.getProperty("camunda.security.authentication.catch-all-unhandled-paths-enabled"))
+        .isEqualTo("false");
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("http://localhost:18080/realm");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("identity-secret");
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-api");
+    assertThat(env.getProperty(OIDC + "redirect-uri"))
+        .isEqualTo("{baseUrl}/api/authentication/callback");
+    assertThat(env.getProperty("camunda.security.saas.organization-id")).isNull();
+    assertThat(env.getProperty("camunda.security.saas.cluster-id")).isNull();
+    assertThat(env.getProperty("contextPath")).isNull();
+
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL")
+                && entry.getMessage().contains(OIDC + "issuer-uri"),
+        "expected deprecation warning naming the legacy key and its replacement");
+    // the secret value itself must never be logged
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("identity-secret"),
+        "client secret value must never be logged");
+  }
+
+  @Test
+  void shouldLetExplicitCamundaSecurityValueTakePrecedenceOverBridgedDefault() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://localhost:18080/realm");
+    legacy.put(OIDC + "issuer-uri", "https://operator-configured.example.com/realm");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "issuer-uri"))
+        .isEqualTo("https://operator-configured.example.com/realm");
+  }
+
+  @Test
+  void shouldBridgeAuth0CloudConfig() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTSECRET", "cloud-secret");
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_DOMAIN", "weblogin.example.com");
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION", "org-42");
+    legacy.put("CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID", "cluster-7");
+    legacy.put("CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", "optimize");
+    legacy.put("CAMUNDA_OPTIMIZE_M2M_ACCOUNTS_AUTH0_AUDIENCE", "cloud.accounts");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.authentication.method")).isEqualTo("oidc");
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
+    assertThat(env.getProperty(OIDC + "client-secret")).isEqualTo("cloud-secret");
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("https://weblogin.example.com/");
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize");
+    assertThat(env.getProperty(OIDC + "organization-id")).isEqualTo("org-42");
+    assertThat(env.getProperty(OIDC + "redirect-uri"))
+        .isEqualTo("{baseScheme}://{baseHost}{basePort}/sso-callback?uuid=cluster-7");
+    assertThat(env.getProperty("camunda.security.saas.organization-id")).isEqualTo("org-42");
+    assertThat(env.getProperty("camunda.security.saas.cluster-id")).isEqualTo("cluster-7");
+    // context path derived from the clusterId so CAMUNDA_OPTIMIZE_CONTEXT_PATH is not needed
+    assertThat(env.getProperty("contextPath")).isEqualTo("/cluster-7");
+    // Auth0 `audience` authorization param so the login token is valid for the cloud Accounts API
+    assertThat(env.getProperty(OIDC + "authorize-request.additional-parameters.audience"))
+        .isEqualTo("cloud.accounts");
+
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("cloud-secret"),
+        "client secret value must never be logged");
+  }
+
+  @Test
+  void shouldNotSetSaasPropertiesWhenOnlyOrganizationIdIsPresent() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_ORGANIZATION", "org-42");
+    // no clusterId set
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.saas.organization-id")).isNull();
+    assertThat(env.getProperty("camunda.security.saas.cluster-id")).isNull();
+    assertThat(env.getProperty("contextPath")).isNull();
+    // redirect-uri still bridges to the Auth0 callback shape, but with no uuid query param
+    assertThat(env.getProperty(OIDC + "redirect-uri"))
+        .isEqualTo("{baseScheme}://{baseHost}{basePort}/sso-callback");
+  }
+
+  @Test
+  void shouldBridgePublicApiJwtConfig() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put(
+        "SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI",
+        "https://idp.example.com/.well-known/jwks.json");
+    legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty(OIDC + "jwk-set-uri"))
+        .isEqualTo("https://idp.example.com/.well-known/jwks.json");
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize-public-api");
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI")
+                && entry.getMessage().contains(OIDC + "jwk-set-uri"),
+        "expected deprecation warning for the public-API JWK set uri");
+  }
+
+  @Test
+  void shouldBridgeHstsMaxAge() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", "31536000");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.http-headers.hsts.max-age-in-seconds"))
+        .isEqualTo("31536000");
+    assertThat(env.getProperty("camunda.security.http-headers.hsts.disabled")).isNull();
+  }
+
+  @Test
+  void shouldDisableHeaderWhenHstsMaxAgeIsNegative() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", "-1");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.http-headers.hsts.disabled")).isEqualTo("true");
+    assertThat(env.getProperty("camunda.security.http-headers.hsts.max-age-in-seconds")).isNull();
+    // the migration hint must point at hsts.disabled for the disable case, not max-age-in-seconds
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("camunda.security.http-headers.hsts.disabled")
+                && !entry.getMessage().contains("max-age-in-seconds"),
+        "expected the deprecation warning to name hsts.disabled for a negative max-age");
+  }
+
+  @Test
+  void shouldIgnoreObsoleteKeysWithDeprecationWarningAndNotFailStartup() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_SECURITY_AUTH_TOKEN_SECRET", "some-secret-value");
+    legacy.put("CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_MAX_SIZE", "3968");
+    legacy.put("CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED", "false");
+    legacy.put("OPTIMIZE_API_ACCESS_TOKEN", "static-token-value");
+    legacy.put("security.responseHeaders.X-XSS-Protection", "0");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    logs.assertContains(
+        entry -> entry.getMessage().contains("CAMUNDA_OPTIMIZE_SECURITY_AUTH_TOKEN_SECRET"),
+        "expected obsolete-key warning for the token secret");
+    logs.assertContains(
+        entry -> entry.getMessage().contains("CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_MAX_SIZE"),
+        "expected obsolete-key warning for the cookie max size");
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED"),
+        "expected obsolete-key warning for the same-site cookie flag");
+    logs.assertContains(
+        entry -> entry.getMessage().contains("OPTIMIZE_API_ACCESS_TOKEN"),
+        "expected obsolete-key warning for the static API access token");
+    logs.assertContains(
+        entry -> entry.getMessage().contains("security.responseHeaders.X-XSS-Protection"),
+        "expected obsolete-key warning for X-XSS-Protection");
+
+    // secret/token values must never be logged, only the key names
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("some-secret-value"),
+        "token secret value must never be logged");
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("static-token-value"),
+        "API access token value must never be logged");
+  }
+
+  @Test
+  void shouldIgnoreMalformedHstsMaxAgeAndNotFailStartup() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE", "not-a-number");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    // must not throw during environment post-processing
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("camunda.security.http-headers.hsts.max-age-in-seconds")).isNull();
+    assertThat(env.getProperty("camunda.security.http-headers.hsts.disabled")).isNull();
+    logs.assertContains(
+        entry ->
+            entry.getMessage().contains("CAMUNDA_OPTIMIZE_SECURITY_RESPONSE_HEADERS_HSTS_MAX_AGE"),
+        "expected a warning naming the malformed HSTS key");
+    // the (potentially sensitive) malformed value must not be logged
+    logs.assertDoesNotContain(
+        entry -> entry.getMessage().contains("not-a-number"),
+        "the malformed value must not be logged");
+  }
+
+  @Test
+  void shouldNotBridgeCcsmIdentityWhenAuth0IsConfigured() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    // both sets present: cloud wins, CCSM identity keys must be ignored
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_DOMAIN", "weblogin.example.com");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL", "http://localhost:18080/realm");
+    legacy.put("CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID", "ccsm-client");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    // Auth0 values win, no mix with the CCSM identity values
+    assertThat(env.getProperty(OIDC + "client-id")).isEqualTo("cloud-client");
+    assertThat(env.getProperty(OIDC + "issuer-uri")).isEqualTo("https://weblogin.example.com/");
+  }
+
+  @Test
+  void shouldNotDeriveContextPathWhenLegacyContextPathIsAlreadySet() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID", "cluster-7");
+    // operator still configures the context path the legacy way
+    legacy.put("CAMUNDA_OPTIMIZE_CONTEXT_PATH", "/legacy-path");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    // the clusterId-derived default must not shadow the operator's existing setting
+    assertThat(env.getProperty("contextPath")).isNull();
+  }
+
+  @Test
+  void shouldNotDeriveContextPathWhenExplicitSpringContextPathIsSet() {
+    final Map<String, Object> legacy = cslEnabledConfig();
+    legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
+    legacy.put("CAMUNDA_OPTIMIZE_CLIENT_CLUSTERID", "cluster-7");
+    legacy.put("contextPath", "/explicit");
+
+    final StandardEnvironment env = environmentWith(legacy);
+    processor.postProcessEnvironment(env, null);
+
+    assertThat(env.getProperty("contextPath")).isEqualTo("/explicit");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/security/csl/OptimizeSecurityConfigCompatibilityPostProcessorTest.java
@@ -194,16 +194,18 @@ class OptimizeSecurityConfigCompatibilityPostProcessorTest {
   }
 
   @Test
-  void shouldMergeAuth0LoginAndPublicApiAudiences() {
+  void shouldBridgeOnlyClientAudienceInAuth0ModeIgnoringPublicApiAudience() {
     final Map<String, Object> legacy = cslEnabledConfig();
     legacy.put("CAMUNDA_OPTIMIZE_AUTH0_CLIENTID", "cloud-client");
     legacy.put("CAMUNDA_OPTIMIZE_CLIENT_AUDIENCE", "optimize");
+    // The public-API audience is a CCSM-only key; legacy cloud never validated it, so it must not
+    // leak into the audience set in Auth0 mode.
     legacy.put("CAMUNDA_OPTIMIZE_API_AUDIENCE", "optimize-public-api");
 
     final StandardEnvironment env = environmentWith(legacy);
     processor.postProcessEnvironment(env, null);
 
-    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize,optimize-public-api");
+    assertThat(env.getProperty(OIDC + "audiences")).isEqualTo("optimize");
   }
 
   @Test


### PR DESCRIPTION
Closes #58470

## What

Adds `OptimizeSecurityConfigCompatibilityPostProcessor`, a Spring `EnvironmentPostProcessor` that lets operators keep their existing Optimize security configuration when Optimize adopts CSL. It reads the legacy keys and emits the equivalent `camunda.security.*` properties at the lowest precedence, so any explicit new value an operator sets still wins. It mirrors OC's `PersistentWebSessionPropertiesPostProcessor`.

Only active when `optimize.security.csl.enabled=true`. Every recognised legacy key logs a deprecation WARN naming its `camunda.security.*` replacement. Secret values (client secrets, token secrets) are never logged, only key names. Legacy keys stay supported until 8.11.

## Key groups

- **Mapped** — CCSM Identity and CCSaaS Auth0 OIDC registration (issuer, client id/secret, audiences), Auth0 issuer derived from the domain, public-API JWK set uri and audience, HSTS max-age to `camunda.security.http-headers.hsts.*` (negative disables the header).
- **CCSaaS/Auth0** — client id/secret, issuer from Auth0 domain, organization id + cluster id (set together only when both are present, so a partial config never trips `SaasConfiguration#isConfigured()`), public-API audience, Accounts API audience passed as the Auth0 `audience` authorize param, and the servlet context path derived from the clusterId.
- **Obsolete by design** — `token.secret`, `cookie.maxSize`, `cookie.same-site`, `api.accessToken`, `X-XSS-Protection`. Ignored with a WARN naming why they no longer apply; their presence never fails startup.

The mapping is documented inline in the post-processor (one bridge helper per group, each with a comment stating the legacy source and the CSL target).

The legacy audience keys feed CSL's single `Set`-valued `camunda.security.authentication.oidc.audiences`, matching how each mode validated audiences before:

- **CCSM** validated two distinct audiences on two paths (identity audience on the login/session token, public-API audience on the bearer path). The bridge collects both into one comma-joined value so both survive; the old per-key `putIfAbsent` kept only the first and silently dropped the public-API audience.
- **CCSaaS/Auth0** only ever validated the client audience (public-API path; the login id_token was not audience-checked). The public-API audience is a CCSM-only key, so it is not bridged in Auth0 mode.

## Acceptance criteria

- [x] Each mapped legacy key produces the documented `camunda.security.*` value at a precedence below explicit user config (the derived source is added with `addLast`).
- [x] Obsolete keys are ignored with a WARN naming the replacement; their presence does not fail startup.
- [x] CCSaaS/Auth0 keys bridge correctly (verified against a SaaS config fixture), including the Accounts audience authorize param and the clusterId-derived context path.
- [x] Unit test covers the mapped, obsolete, and CCSaaS groups plus the mode-scoped audience bridging (CCSM merges identity + public-API; Auth0 bridges only the client audience) (`OptimizeSecurityConfigCompatibilityPostProcessorTest`, 15 tests, green).

## Notes for reviewers

- `security.responseHeaders.X-XSS-Protection` has no `${ENV_VAR:default}` indirection in `service-config.yaml`, and `ConfigurationService` parses that YAML itself via Jackson, independent of Spring's `Environment`. So this post-processor can only detect an override of that key when it reaches Spring's `Environment` directly (system property, command-line arg, or the relaxed-binding env var). This is a structural limit of the `EnvironmentPostProcessor` layer, not a bug. The key is obsolete anyway, so this only affects whether the deprecation WARN fires.

## Docs

This is a user-visible config change: operators keep their old keys but see deprecation warnings pointing at the new `camunda.security.*` names. When CSL adoption is enabled by default, the Optimize configuration reference in [camunda/camunda-docs](https://github.com/camunda/camunda-docs) should gain a "deprecated, maps to `camunda.security.*`" note per key. Tracking this at the epic level (#58403) rather than in this PR, since the keys are still fully functional and the flag defaults to off.

## Decision record

ADR-0038: https://github.com/camunda/camunda-security-library/blob/main/docs/adr/0038-optimize-reuses-stateful-oidc-webapp-chain.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

