### PR TITLE
Ensure agent instance is migrated with process instance migration

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentInstanceWriter.java
@@ -52,7 +52,12 @@ public class AgentInstanceWriter extends ProcessInstanceDependant implements Rdb
         mergeToQueue(
             agentInstance.agentInstanceKey(),
             b -> {
-              b.status(agentInstance.status())
+              b.processDefinitionId(agentInstance.processDefinitionId())
+                  .processDefinitionKey(agentInstance.processDefinitionKey())
+                  .processDefinitionVersion(agentInstance.processDefinitionVersion())
+                  .versionTag(agentInstance.versionTag())
+                  .elementId(agentInstance.elementId())
+                  .status(agentInstance.status())
                   .inputTokens(agentInstance.inputTokens())
                   .outputTokens(agentInstance.outputTokens())
                   .modelCalls(agentInstance.modelCalls())

--- a/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentInstanceMapper.xml
@@ -71,18 +71,28 @@
     )
   </insert>
 
-  <!-- partial update: only mutable fields; immutable fields (definition, limits, identity) are left unchanged -->
+  <!--
+  Partial update: mutable fields plus the process-definition fields (only ever changed by a MIGRATED event)
+  Limits and identity columns are the only ones left genuinely write-once.
+  -->
   <update id="update" parameterType="io.camunda.db.rdbms.write.domain.AgentInstanceDbModel">
     UPDATE ${prefix}AGENT_INSTANCE
     SET
-      STATUS              = #{status},
-      INPUT_TOKENS        = #{inputTokens},
-      OUTPUT_TOKENS       = #{outputTokens},
-      MODEL_CALLS         = #{modelCalls},
-      TOOL_CALLS          = #{toolCalls},
-      TOOLS               = #{tools, jdbcType=CLOB},
-      LAST_UPDATED_DATE   = #{lastUpdatedDate, jdbcType=TIMESTAMP}
-      <if test="completionDate != null">, COMPLETION_DATE = #{completionDate, jdbcType=TIMESTAMP}</if>
+      PROCESS_DEFINITION_ID      = #{processDefinitionId},
+      PROCESS_DEFINITION_KEY     = #{processDefinitionKey},
+      PROCESS_DEFINITION_VERSION = #{processDefinitionVersion},
+      VERSION_TAG                = #{versionTag},
+      ELEMENT_ID                 = #{elementId},
+      STATUS                     = #{status},
+      INPUT_TOKENS               = #{inputTokens},
+      OUTPUT_TOKENS              = #{outputTokens},
+      MODEL_CALLS                = #{modelCalls},
+      TOOL_CALLS                 = #{toolCalls},
+      TOOLS                      = #{tools, jdbcType=CLOB},
+      LAST_UPDATED_DATE          = #{lastUpdatedDate, jdbcType=TIMESTAMP}
+      <if test="completionDate != null">
+        , COMPLETION_DATE = #{completionDate, jdbcType=TIMESTAMP}
+      </if>
     WHERE AGENT_INSTANCE_KEY = #{agentInstanceKey}
   </update>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/AgentInstanceMigrationIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration;
+
+import static io.camunda.it.util.TestHelper.activateAndCompleteJobs;
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.response.Process;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Acceptance tests for process instance migration of agent instances, covering both element types
+ * {@code AgentInstanceCreateProcessor} supports as an agent instance's owning element: {@code
+ * SERVICE_TASK} and {@code AD_HOC_SUB_PROCESS}.
+ */
+@MultiDbTest
+public class AgentInstanceMigrationIT {
+
+  private static CamundaClient client;
+
+  @Test
+  void shouldMigrateOrphanedButActiveAgentInstanceOfServiceTask() {
+    // given — the agentic job completes (and the process moves on to "nextTask") before
+    // migration, while the agent instance itself stays active
+    final String sourceElementId = "agentTask";
+    final String targetElementId = "agentTask2";
+    final String sourceNextElementId = "nextTask";
+    final String targetNextElementId = "nextTask2";
+    final String agentJobType = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+    final var sourceProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-service-task_v1")
+                .startEvent()
+                .serviceTask(sourceElementId, t -> t.zeebeJobType(agentJobType))
+                .userTask(sourceNextElementId)
+                .endEvent()
+                .done(),
+            "migration-agent-service-task_v1.bpmn");
+    final var targetProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-service-task_v2")
+                .startEvent()
+                .serviceTask(targetElementId, t -> t.zeebeJobType(agentJobType))
+                .userTask(targetNextElementId)
+                .endEvent()
+                .done(),
+            "migration-agent-service-task_v2.bpmn");
+
+    final var processInstanceKey =
+        startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(processInstanceKey, sourceElementId);
+
+    activateAndCompleteJobs(client, agentJobType, "test-worker", 1);
+    waitForElementInstances(
+        client, f -> f.elementId(sourceNextElementId).processInstanceKey(processInstanceKey), 1);
+
+    // when — "agentTask" is mapped even though it no longer has an active element instance
+    client
+        .newMigrateProcessInstanceCommand(processInstanceKey)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(targetProcess.getProcessDefinitionKey())
+                .addMappingInstruction(sourceElementId, targetElementId)
+                .addMappingInstruction(sourceNextElementId, targetNextElementId)
+                .build())
+        .execute();
+
+    // then — the agent instance is migrated even though its owning element instance already
+    // completed and is not part of the migrated element tree
+    assertAgentInstanceMigratedTo(agentInstanceKey, targetProcess, targetElementId);
+  }
+
+  @Test
+  void shouldMigrateAgentInstanceOfAdHocSubProcess() {
+    // given
+    final String sourceElementId = "agentAhsp";
+    final String targetElementId = "agentAhsp2";
+
+    final var sourceProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-ahsp_v1")
+                .startEvent()
+                .adHocSubProcess(sourceElementId, p -> p.task("agentTask"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .endEvent()
+                .done(),
+            "migration-agent-ahsp_v1.bpmn");
+    final var targetProcess =
+        deployProcessAndWaitForIt(
+            client,
+            Bpmn.createExecutableProcess("migration-agent-ahsp_v2")
+                .startEvent()
+                .adHocSubProcess(targetElementId, p -> p.task("agentTask2"))
+                .zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+                .endEvent()
+                .done(),
+            "migration-agent-ahsp_v2.bpmn");
+
+    final var processInstanceKey =
+        startProcessInstance(client, sourceProcess.getBpmnProcessId()).getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(processInstanceKey, sourceElementId);
+
+    // when
+    client
+        .newMigrateProcessInstanceCommand(processInstanceKey)
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(targetProcess.getProcessDefinitionKey())
+                .addMappingInstruction(sourceElementId, targetElementId)
+                .build())
+        .execute();
+
+    // then
+    assertAgentInstanceMigratedTo(agentInstanceKey, targetProcess, targetElementId);
+  }
+
+  private long createAgentInstance(final long processInstanceKey, final String elementId) {
+    waitForElementInstances(
+        client, f -> f.elementId(elementId).processInstanceKey(processInstanceKey), 1);
+    final var elementInstanceKey =
+        client
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(elementId).processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    final var agentInstanceKey =
+        client
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .execute()
+            .getAgentInstanceKey();
+    waitForAgentInstanceToBeIndexed(client, agentInstanceKey);
+    return agentInstanceKey;
+  }
+
+  private void assertAgentInstanceMigratedTo(
+      final long agentInstanceKey, final Process targetProcess, final String targetElementId) {
+    await("agent instance reflects the target process definition after migration")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response = client.newAgentInstanceGetRequest(agentInstanceKey).execute();
+              assertSoftly(
+                  softly -> {
+                    softly
+                        .assertThat(response.getProcessDefinitionKey())
+                        .as("processDefinitionKey")
+                        .isEqualTo(targetProcess.getProcessDefinitionKey());
+                    softly
+                        .assertThat(response.getProcessDefinitionId())
+                        .as("processDefinitionId")
+                        .isEqualTo(targetProcess.getBpmnProcessId());
+                    softly
+                        .assertThat(response.getProcessDefinitionVersion())
+                        .as("processDefinitionVersion")
+                        .isEqualTo(targetProcess.getVersion());
+                    softly
+                        .assertThat(response.getElementId())
+                        .as("elementId")
+                        .isEqualTo(targetElementId);
+                  });
+            });
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agentinstance/AgentInstanceIT.java
@@ -12,6 +12,7 @@ import static io.camunda.it.rdbms.db.fixtures.AgentInstanceFixtures.createAndSav
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.AgentInstanceDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
@@ -44,6 +45,37 @@ public class AgentInstanceIT {
     assertThat(entity).isNotNull();
     assertThat(entity.agentInstanceKey()).isEqualTo(model.agentInstanceKey());
     assertFieldsMatch(model, entity);
+  }
+
+  @TestTemplate
+  public void shouldUpdateDefinitionFieldsOnMigration(
+      final CamundaRdbmsTestApplication testApplication) {
+    final AgentInstanceDbModel model = createAndSaveRandomAgentInstance(testApplication, b -> b);
+
+    final AgentInstanceDbModel migrated =
+        model.copy(
+            b ->
+                ((AgentInstanceDbModel.Builder) b)
+                    .processDefinitionId("migrated-" + nextStringId())
+                    .processDefinitionKey(model.processDefinitionKey() + 1)
+                    .processDefinitionVersion(model.processDefinitionVersion() + 1)
+                    .versionTag("v2")
+                    .elementId("migrated-element"));
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    rdbmsWriters.getAgentInstanceWriter().update(migrated);
+    rdbmsWriters.flush();
+
+    final var entity =
+        testApplication
+            .getRdbmsService()
+            .getAgentInstanceDbReader()
+            .getByKey(model.agentInstanceKey(), ResourceAccessChecks.disabled());
+
+    assertThat(entity.processDefinitionId()).isEqualTo(migrated.processDefinitionId());
+    assertThat(entity.processDefinitionKey()).isEqualTo(migrated.processDefinitionKey());
+    assertThat(entity.processDefinitionVersion()).isEqualTo(migrated.processDefinitionVersion());
+    assertThat(entity.versionTag()).isEqualTo("v2");
+    assertThat(entity.elementId()).isEqualTo("migrated-element");
   }
 
   @TestTemplate

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationAgentInstanceBehavior.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.AgentInstanceState;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+
+public class ProcessInstanceMigrationAgentInstanceBehavior {
+
+  private final StateWriter stateWriter;
+  private final AgentInstanceState agentInstanceState;
+
+  public ProcessInstanceMigrationAgentInstanceBehavior(
+      final StateWriter stateWriter, final AgentInstanceState agentInstanceState) {
+    this.stateWriter = stateWriter;
+    this.agentInstanceState = agentInstanceState;
+  }
+
+  /**
+   * Re-points every agent instance of the given process instance at the target process definition.
+   *
+   * @param mappedElementIds the source-to-target element id mapping resolved for this migration; an
+   *     agent instance whose {@code elementId} has no entry keeps its current id
+   */
+  public void migrateAgentInstances(
+      final long processInstanceKey,
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> mappedElementIds) {
+    agentInstanceState
+        .getAgentInstanceKeysByProcessInstanceKey(processInstanceKey)
+        .forEach(
+            agentInstanceKey ->
+                migrateAgentInstance(
+                    agentInstanceKey,
+                    processInstanceKey,
+                    targetProcessDefinition,
+                    mappedElementIds));
+  }
+
+  private void migrateAgentInstance(
+      final long agentInstanceKey,
+      final long processInstanceKey,
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> mappedElementIds) {
+    final var record = agentInstanceState.getRecord(agentInstanceKey);
+    if (record == null) {
+      throw new SafetyCheckFailedException(
+          String.format(
+              """
+              Expected to migrate an agent instance for process instance with key '%d', \
+              but could not find agent instance with key '%d'. \
+              Please report this as a bug""",
+              processInstanceKey, agentInstanceKey));
+    }
+    final var targetElementId =
+        mappedElementIds.getOrDefault(record.getElementId(), record.getElementId());
+
+    stateWriter.appendFollowUpEvent(
+        agentInstanceKey,
+        AgentInstanceIntent.MIGRATED,
+        record
+            .setProcessDefinitionKey(targetProcessDefinition.getKey())
+            .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
+            .setBpmnProcessId(BufferUtil.bufferAsString(targetProcessDefinition.getBpmnProcessId()))
+            .setVersionTag(targetProcessDefinition.getVersionTag())
+            .setElementId(targetElementId));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -84,6 +84,7 @@ public class ProcessInstanceMigrationMigrateProcessor
   private final ProcessInstanceMigrationJobBehavior migrationJobBehaviour;
   private final ProcessInstanceMigrationSequenceFlowBehavior migrationSequenceFlowBehaviour;
   private final ProcessInstanceMigrationUserTaskBehavior migrationUserTaskBehaviour;
+  private final ProcessInstanceMigrationAgentInstanceBehavior migrationAgentInstanceBehaviour;
 
   public ProcessInstanceMigrationMigrateProcessor(
       final Writers writers,
@@ -130,6 +131,9 @@ public class ProcessInstanceMigrationMigrateProcessor
     migrationSequenceFlowBehaviour =
         new ProcessInstanceMigrationSequenceFlowBehavior(
             keyGenerator, stateWriter, elementInstanceState);
+    migrationAgentInstanceBehaviour =
+        new ProcessInstanceMigrationAgentInstanceBehavior(
+            stateWriter, processingState.getAgentInstanceState());
   }
 
   @Override
@@ -367,6 +371,21 @@ public class ProcessInstanceMigrationMigrateProcessor
 
     migrateCalledSubProcessElements(
         elementInstance.getCalledChildInstanceKey(), updatedElementInstanceRecord);
+
+    migrateAgentInstances(
+        elementInstanceRecord, targetProcessDefinition, sourceElementIdToTargetElementId);
+  }
+
+  private void migrateAgentInstances(
+      final ProcessInstanceRecord elementInstanceRecord,
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> sourceElementIdToTargetElementId) {
+    if (elementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrationAgentInstanceBehaviour.migrateAgentInstances(
+          elementInstanceRecord.getProcessInstanceKey(),
+          targetProcessDefinition,
+          sourceElementIdToTargetElementId);
+    }
   }
 
   private void migrateCatchEvents(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceMigratedApplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+
+/**
+ * Applies the {@link AgentInstanceIntent#MIGRATED} event by re-pointing the agent instance at the
+ * target process definition. Only the primary record is updated: process instance migration never
+ * changes the {@code processInstanceKey} or {@code elementInstanceKey}, so neither the
+ * process-instance secondary index nor the element-instance back-link needs maintenance.
+ */
+public final class AgentInstanceMigratedApplier
+    implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
+
+  private final MutableAgentInstanceState agentInstanceState;
+
+  public AgentInstanceMigratedApplier(final MutableAgentInstanceState agentInstanceState) {
+    this.agentInstanceState = agentInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final AgentInstanceRecord value) {
+    agentInstanceState.update(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -206,6 +206,9 @@ public final class EventAppliers implements EventApplier {
     register(
         AgentInstanceIntent.COMPLETED,
         new AgentInstanceCompletedApplier(state.getAgentInstanceState()));
+    register(
+        AgentInstanceIntent.MIGRATED,
+        new AgentInstanceMigratedApplier(state.getAgentInstanceState()));
   }
 
   private void registerJobMetricsBatchEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateAgentInstanceTest {
+
+  private static final String AGENT_JOB_TYPE = "agent-job";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateOrphanedButActiveAgentInstanceOfServiceTask() {
+    // given — an agent instance created on a service task whose job completes (and the process
+    // moves on to "B") before migration, while the agent instance itself stays active; "A" is
+    // explicitly mapped to "A2" even though it no longer has an active element instance
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .versionTag("v1")
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .versionTag("v2")
+                    .startEvent()
+                    .serviceTask("A2", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .userTask("B2")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(agentTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
+    engine.jobs().withType(AGENT_JOB_TYPE).activate();
+    engine.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("A")
+                .exists())
+        .describedAs("The owning service task has completed before migration")
+        .isTrue();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .addMappingInstruction("B", "B2")
+        .migrate();
+
+    // then — the agent instance is migrated even though its owning element instance "A" already
+    // completed and is not part of the migrated element tree
+    Assertions.assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withRecordKey(agentInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("The agent instance keeps belonging to the same process instance")
+        .hasProcessInstanceKey(processInstanceKey)
+        .describedAs("Definition fields are updated to the target process definition")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasVersionTag("v2")
+        .describedAs("elementId is remapped despite \"A\" having no active element instance")
+        .hasElementId("A2");
+  }
+
+  @Test
+  public void shouldMigrateMultipleAgentInstancesOfServiceTasksInSameProcessInstance() {
+    // given — two service tasks in parallel, each with its own agent instance, both still active
+    // (neither job completes) at migration time; "A" is remapped to "A2" while "B" keeps its id
+    // unchanged across the migration, requiring an explicit self-mapping since it stays active
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String otherJobType = "other-agent-job";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .parallelGateway("join")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .serviceTask("B", t -> t.zeebeJobType(otherJobType))
+                    .connectTo("join")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork2")
+                    .serviceTask("A2", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                    .parallelGateway("join2")
+                    .endEvent()
+                    .moveToNode("fork2")
+                    .serviceTask("B", t -> t.zeebeJobType(otherJobType))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var firstTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    final var secondTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("B")
+            .getFirst();
+    final long firstAgentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(firstTaskInstance.getKey())
+            .create()
+            .getKey();
+    final long secondAgentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(secondTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A2")
+        .addMappingInstruction("B", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            AgentInstanceRecordValue::getAgentInstanceKey,
+            AgentInstanceRecordValue::getProcessDefinitionKey,
+            AgentInstanceRecordValue::getElementId)
+        .describedAs(
+            "Both agent instances move to the target process definition; \"A\"'s agent instance "
+                + "is remapped to \"A2\" while \"B\"'s keeps its unchanged id")
+        .containsExactlyInAnyOrder(
+            tuple(firstAgentInstanceKey, targetProcessDefinitionKey, "A2"),
+            tuple(secondAgentInstanceKey, targetProcessDefinitionKey, "B"));
+  }
+
+  @Test
+  public void shouldMigrateAgentInstanceOfAdHocSubProcess() {
+    // given — an agent instance attached to an ad-hoc sub-process itself, the other element type
+    // AgentInstanceCreateProcessor supports besides SERVICE_TASK
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .adHocSubProcess(
+                        "ahsp",
+                        ahsp -> {
+                          ahsp.task("tool");
+                          ahsp.zeebeJobType(AGENT_JOB_TYPE);
+                        })
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .adHocSubProcess(
+                        "ahsp2",
+                        ahsp -> {
+                          ahsp.task("tool2");
+                          ahsp.zeebeJobType(AGENT_JOB_TYPE);
+                        })
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final long adHocSubProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("ahsp")
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .getFirst()
+            .getKey();
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(adHocSubProcessInstanceKey)
+            .create()
+            .getKey();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("ahsp", "ahsp2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withRecordKey(agentInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "The agent instance attached to the ad-hoc sub-process container migrates like any "
+                + "other agent instance, remapping to the target definition and element id")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("ahsp2");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -123,6 +123,101 @@ public class MigrateAgentInstanceTest {
   }
 
   @Test
+  public void shouldKeepStaleElementIdWhenOwningElementIsRemovedFromTargetProcessDefinition() {
+    // given — service task "A" completes before a new version (v2) of the *same* process
+    // definition is deployed, dropping "A" entirely (a common case: requirements changed while
+    // instances were already running past it); since "A" has no active element instance at
+    // migration time, no mapping instruction is required or provided for it, and the target
+    // version does not define an element with this id either. This documents the current
+    // fallback behavior: the agent instance keeps its stale, no-longer-existing elementId
+    final String processId = helper.getBpmnProcessId();
+
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .versionTag("v1")
+                .startEvent()
+                .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
+                .userTask("B")
+                .endEvent()
+                .done())
+        .deploy();
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final var agentTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+    final long agentInstanceKey =
+        engine
+            .agentInstances()
+            .withElementInstanceKey(agentTaskInstance.getKey())
+            .create()
+            .getKey();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED).withType(AGENT_JOB_TYPE).await();
+    engine.jobs().withType(AGENT_JOB_TYPE).activate();
+    engine.job().ofInstance(processInstanceKey).withType(AGENT_JOB_TYPE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("A")
+                .exists())
+        .describedAs("The owning service task has completed before migration")
+        .isTrue();
+
+    // deploy v2 of the same process definition only now, after "A" has already completed, to
+    // mirror the realistic sequence: the process model is corrected/simplified while instances
+    // are already running past the removed element
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .versionTag("v2")
+                    .startEvent()
+                    .userTask("B2")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId);
+
+    // when — no mapping instruction is provided for "A" since it has no active element instance;
+    // v2 of the process definition does not define an element with id "A" either
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B", "B2")
+        .migrate();
+
+    // then — the agent instance still migrates to version 2 of the process definition, but its
+    // elementId is left unchanged and now refers to an element that no longer exists in v2
+    Assertions.assertThat(
+            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+                .withRecordKey(agentInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Definition fields are updated to point at version 2 of the (same) process "
+                + "definition")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(processId)
+        .hasProcessDefinitionVersion(2)
+        .hasVersionTag("v2")
+        .describedAs(
+            "elementId keeps its stale value \"A\" since no mapping instruction was provided and "
+                + "v2 of the process definition no longer contains an element with this id")
+        .hasElementId("A");
+  }
+
+  @Test
   public void shouldMigrateMultipleAgentInstancesOfServiceTasksInSameProcessInstance() {
     // given — two service tasks in parallel, each with its own agent instance, both still active
     // (neither job completes) at migration time; "A" is remapped to "A2" while "B" keeps its id

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateAgentInstanceTest.java
@@ -9,10 +9,10 @@ package io.camunda.zeebe.engine.processing.processinstance.migration;
 
 import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceDefinition;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
@@ -23,6 +23,8 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -128,12 +130,15 @@ public class MigrateAgentInstanceTest {
     final String processId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "2";
     final String otherJobType = "other-agent-job";
+    final String firstSystemPrompt = "Summarize the incoming request for review.";
+    final String secondSystemPrompt = "Draft a polite acknowledgement email.";
 
     final var deployment =
         engine
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
+                    .versionTag("v1")
                     .startEvent()
                     .parallelGateway("fork")
                     .serviceTask("A", t -> t.zeebeJobType(AGENT_JOB_TYPE))
@@ -145,6 +150,7 @@ public class MigrateAgentInstanceTest {
                     .done())
             .withXmlResource(
                 Bpmn.createExecutableProcess(targetProcessId)
+                    .versionTag("v2")
                     .startEvent()
                     .parallelGateway("fork2")
                     .serviceTask("A2", t -> t.zeebeJobType(AGENT_JOB_TYPE))
@@ -174,12 +180,14 @@ public class MigrateAgentInstanceTest {
         engine
             .agentInstances()
             .withElementInstanceKey(firstTaskInstance.getKey())
+            .withDefinition("gpt-4o", "openai", firstSystemPrompt)
             .create()
             .getKey();
     final long secondAgentInstanceKey =
         engine
             .agentInstances()
             .withElementInstanceKey(secondTaskInstance.getKey())
+            .withDefinition("claude-sonnet-4-5", "anthropic", secondSystemPrompt)
             .create()
             .getKey();
 
@@ -194,21 +202,53 @@ public class MigrateAgentInstanceTest {
         .migrate();
 
     // then
-    assertThat(
-            RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(2))
-        .extracting(Record::getValue)
-        .extracting(
-            AgentInstanceRecordValue::getAgentInstanceKey,
-            AgentInstanceRecordValue::getProcessDefinitionKey,
-            AgentInstanceRecordValue::getElementId)
+    final var migratedValuesByAgentInstanceKey =
+        RecordingExporter.agentInstanceRecords(AgentInstanceIntent.MIGRATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(2)
+            .map(Record::getValue)
+            .collect(
+                Collectors.toMap(
+                    AgentInstanceRecordValue::getAgentInstanceKey, Function.identity()));
+
+    assertThat(migratedValuesByAgentInstanceKey)
+        .describedAs("Both agent instances are migrated to the target process definition")
+        .containsOnlyKeys(firstAgentInstanceKey, secondAgentInstanceKey);
+
+    Assertions.assertThat(migratedValuesByAgentInstanceKey.get(firstAgentInstanceKey))
         .describedAs(
-            "Both agent instances move to the target process definition; \"A\"'s agent instance "
-                + "is remapped to \"A2\" while \"B\"'s keeps its unchanged id")
-        .containsExactlyInAnyOrder(
-            tuple(firstAgentInstanceKey, targetProcessDefinitionKey, "A2"),
-            tuple(secondAgentInstanceKey, targetProcessDefinitionKey, "B"));
+            "\"A\"'s agent instance moves to the target process definition and is remapped to \"A2\"")
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasProcessDefinitionVersion(1)
+        .hasVersionTag("v2")
+        .hasElementId("A2")
+        .describedAs(
+            "Properties migration must not touch stay exactly as they were before migration")
+        .hasDefinition(
+            new AgentInstanceDefinition()
+                .setModel("gpt-4o")
+                .setProvider("openai")
+                .setSystemPrompt(firstSystemPrompt));
+
+    Assertions.assertThat(migratedValuesByAgentInstanceKey.get(secondAgentInstanceKey))
+        .describedAs(
+            "\"B\"'s agent instance moves to the target process definition but keeps its "
+                + "unchanged id")
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasProcessDefinitionVersion(1)
+        .hasVersionTag("v2")
+        .hasElementId("B")
+        .describedAs(
+            "Properties migration must not touch stay exactly as they were before migration")
+        .hasDefinition(
+            new AgentInstanceDefinition()
+                .setModel("claude-sonnet-4-5")
+                .setProvider("anthropic")
+                .setSystemPrompt(secondSystemPrompt));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceMigratedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AgentInstanceMigratedApplierTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.value.AgentInstanceStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class AgentInstanceMigratedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableAgentInstanceState agentInstanceState;
+  private AgentInstanceCreatedApplier createdApplier;
+  private AgentInstanceMigratedApplier migratedApplier;
+
+  @BeforeEach
+  public void setup() {
+    agentInstanceState = processingState.getAgentInstanceState();
+    final MutableElementInstanceState elementInstanceState =
+        processingState.getElementInstanceState();
+    createdApplier = new AgentInstanceCreatedApplier(agentInstanceState, elementInstanceState);
+    migratedApplier = new AgentInstanceMigratedApplier(agentInstanceState);
+  }
+
+  @Test
+  void shouldUpdateProcessDefinitionFields() {
+    // given — an agent instance created against the source process definition.
+    final long agentInstanceKey = 7L;
+    createdApplier.applyState(agentInstanceKey, sourceRecord(agentInstanceKey));
+
+    // when — a MIGRATED event re-points it at the target process definition.
+    migratedApplier.applyState(agentInstanceKey, targetRecord(agentInstanceKey));
+
+    // then — the stored record reflects the target process definition and remapped element id.
+    final var stored = agentInstanceState.getRecord(agentInstanceKey);
+    assertThat(stored).isNotNull();
+    assertThat(stored.getProcessDefinitionKey()).isEqualTo(200L);
+    assertThat(stored.getProcessDefinitionVersion()).isEqualTo(2);
+    assertThat(stored.getBpmnProcessId()).isEqualTo("target-process");
+    assertThat(stored.getVersionTag()).isEqualTo("v2.0");
+    assertThat(stored.getElementId()).isEqualTo("agent2");
+  }
+
+  @Test
+  void shouldKeepAgentInstanceRetrievableByProcessInstanceKey() {
+    // given — an agent instance created against the source process definition.
+    final long agentInstanceKey = 11L;
+    createdApplier.applyState(agentInstanceKey, sourceRecord(agentInstanceKey));
+
+    // when — a MIGRATED event is applied (the process instance key is unchanged by migration).
+    migratedApplier.applyState(agentInstanceKey, targetRecord(agentInstanceKey));
+
+    // then — the process-instance secondary index still resolves the agent instance.
+    assertThat(agentInstanceState.getAgentInstanceKeysByProcessInstanceKey(3L))
+        .containsExactly(agentInstanceKey);
+  }
+
+  private AgentInstanceRecord sourceRecord(final long agentInstanceKey) {
+    return new AgentInstanceRecord()
+        .setAgentInstanceKey(agentInstanceKey)
+        .setProcessInstanceKey(3L)
+        .setProcessDefinitionKey(100L)
+        .setProcessDefinitionVersion(1)
+        .setBpmnProcessId("source-process")
+        .setVersionTag("v1.0")
+        .setElementId("agent")
+        .setStatus(AgentInstanceStatus.INITIALIZING);
+  }
+
+  private AgentInstanceRecord targetRecord(final long agentInstanceKey) {
+    return new AgentInstanceRecord()
+        .setAgentInstanceKey(agentInstanceKey)
+        .setProcessInstanceKey(3L)
+        .setProcessDefinitionKey(200L)
+        .setProcessDefinitionVersion(2)
+        .setBpmnProcessId("target-process")
+        .setVersionTag("v2.0")
+        .setElementId("agent2")
+        .setStatus(AgentInstanceStatus.INITIALIZING);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_MIGRATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentInstance_MIGRATED_v1.golden
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAgentInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentInstanceIntent;
+
+/**
+ * Applies the {@link AgentInstanceIntent#MIGRATED} event by re-pointing the agent instance at the
+ * target process definition. Only the primary record is updated: process instance migration never
+ * changes the {@code processInstanceKey} or {@code elementInstanceKey}, so neither the
+ * process-instance secondary index nor the element-instance back-link needs maintenance.
+ */
+public final class AgentInstanceMigratedApplier
+    implements TypedEventApplier<AgentInstanceIntent, AgentInstanceRecord> {
+
+  private final MutableAgentInstanceState agentInstanceState;
+
+  public AgentInstanceMigratedApplier(final MutableAgentInstanceState agentInstanceState) {
+    this.agentInstanceState = agentInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final AgentInstanceRecord value) {
+    agentInstanceState.update(key, value);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentInstanceHandler.java
@@ -7,15 +7,20 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_INSTANCE_KEYS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.INPUT_TOKENS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.MODEL_CALLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.OUTPUT_TOKENS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
@@ -43,7 +48,10 @@ public class AgentInstanceHandler
 
   private static final Set<AgentInstanceIntent> HANDLED_INTENTS =
       Set.of(
-          AgentInstanceIntent.CREATED, AgentInstanceIntent.UPDATED, AgentInstanceIntent.COMPLETED);
+          AgentInstanceIntent.CREATED,
+          AgentInstanceIntent.UPDATED,
+          AgentInstanceIntent.COMPLETED,
+          AgentInstanceIntent.MIGRATED);
 
   private final String indexName;
 
@@ -126,6 +134,15 @@ public class AgentInstanceHandler
     // intent. Including it here would overwrite the existing index value with null on
     // every UPDATED / COMPLETED event.
     final Map<String, Object> updateFields = new HashMap<>();
+    // Identity fields: only MIGRATED changes these, but flush() can't see the intent, so
+    // always included.
+    updateFields.put(BPMN_PROCESS_ID, entity.getBpmnProcessId());
+    updateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
+    updateFields.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
+    updateFields.put(VERSION_TAG, entity.getVersionTag());
+    updateFields.put(ELEMENT_ID, entity.getElementId());
+
+    // Runtime fields
     updateFields.put(STATUS, entity.getStatus());
     updateFields.put(INPUT_TOKENS, entity.getInputTokens());
     updateFields.put(OUTPUT_TOKENS, entity.getOutputTokens());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentInstanceHandlerTest.java
@@ -7,15 +7,20 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.COMPLETION_DATE;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.ELEMENT_INSTANCE_KEYS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.INPUT_TOKENS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.LAST_UPDATED_DATE;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.MODEL_CALLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.OUTPUT_TOKENS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.PROCESS_DEFINITION_VERSION;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.STATUS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOLS;
 import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.TOOL_CALLS;
+import static io.camunda.webapps.schema.descriptors.template.AgentInstanceTemplate.VERSION_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -62,7 +67,7 @@ final class AgentInstanceHandlerTest {
   @ParameterizedTest(name = "[{index}] Should handle \''{0}\'' record")
   @EnumSource(
       value = AgentInstanceIntent.class,
-      names = {"CREATED", "UPDATED", "COMPLETED"},
+      names = {"CREATED", "UPDATED", "COMPLETED", "MIGRATED"},
       mode = Mode.INCLUDE)
   void shouldHandleRecord(final AgentInstanceIntent intent) {
     assertThat(underTest.handlesRecord(generateRecord(intent))).isTrue();
@@ -71,7 +76,7 @@ final class AgentInstanceHandlerTest {
   @ParameterizedTest(name = "[{index}] Should not handle \''{0}\'' record")
   @EnumSource(
       value = AgentInstanceIntent.class,
-      names = {"CREATED", "UPDATED", "COMPLETED"},
+      names = {"CREATED", "UPDATED", "COMPLETED", "MIGRATED"},
       mode = Mode.EXCLUDE)
   void shouldNotHandleRecord(final AgentInstanceIntent intent) {
     assertThat(underTest.handlesRecord(generateRecord(intent))).isFalse();
@@ -371,6 +376,13 @@ final class AgentInstanceHandlerTest {
     // completionDate is null on UPDATED intent but still written so the upsert script
     // payload is identical across intents (no-op when null overwrites null in the index).
     expectedUpdateFields.put(COMPLETION_DATE, null);
+    // The definition fields are only ever changed by MIGRATED, but are re-asserted on every
+    // intent since flush() has no access to the record intent (see AgentInstanceHandler#flush).
+    expectedUpdateFields.put(BPMN_PROCESS_ID, entity.getBpmnProcessId());
+    expectedUpdateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
+    expectedUpdateFields.put(PROCESS_DEFINITION_VERSION, entity.getProcessDefinitionVersion());
+    expectedUpdateFields.put(VERSION_TAG, entity.getVersionTag());
+    expectedUpdateFields.put(ELEMENT_ID, entity.getElementId());
 
     verify(mockRequest, times(1)).upsert(indexName, entity.getId(), entity, expectedUpdateFields);
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandler.java
@@ -30,7 +30,10 @@ public class AgentInstanceExportHandler implements RdbmsExportHandler<AgentInsta
 
   private static final Set<AgentInstanceIntent> EXPORTABLE_INTENTS =
       Set.of(
-          AgentInstanceIntent.CREATED, AgentInstanceIntent.UPDATED, AgentInstanceIntent.COMPLETED);
+          AgentInstanceIntent.CREATED,
+          AgentInstanceIntent.UPDATED,
+          AgentInstanceIntent.COMPLETED,
+          AgentInstanceIntent.MIGRATED);
 
   private final AgentInstanceWriter writer;
 

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentInstanceExportHandlerTest.java
@@ -46,7 +46,10 @@ class AgentInstanceExportHandlerTest {
 
   private static final Set<AgentInstanceIntent> EXPORTABLE_INTENTS =
       EnumSet.of(
-          AgentInstanceIntent.CREATED, AgentInstanceIntent.UPDATED, AgentInstanceIntent.COMPLETED);
+          AgentInstanceIntent.CREATED,
+          AgentInstanceIntent.UPDATED,
+          AgentInstanceIntent.COMPLETED,
+          AgentInstanceIntent.MIGRATED);
 
   private final ProtocolFactory factory = new ProtocolFactory();
 
@@ -167,6 +170,42 @@ class AgentInstanceExportHandlerTest {
     assertThat(model.completionDate()).isNull();
     // creationDate is only set on CREATED intent
     assertThat(model.creationDate()).isNull();
+  }
+
+  @Test
+  void shouldCallUpdateOnMigratedIntentWithTargetDefinition() {
+    // given
+    final long agentKey = 46L;
+    final var recordValue =
+        ImmutableAgentInstanceRecordValue.builder()
+            .from(buildRecordValue(agentKey))
+            .withBpmnProcessId("targetProcess")
+            .withProcessDefinitionKey(999L)
+            .withProcessDefinitionVersion(4)
+            .withVersionTag("v2.0")
+            .withElementId("targetElement")
+            .build();
+    final Record<AgentInstanceRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_INSTANCE,
+            r ->
+                r.withIntent(AgentInstanceIntent.MIGRATED)
+                    .withKey(agentKey)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then — MIGRATED is dispatched and the target definition carried by the record is mapped onto
+    // the model unconditionally
+    verify(writer).update(modelCaptor.capture());
+    final AgentInstanceDbModel model = modelCaptor.getValue();
+    assertThat(model.processDefinitionId()).isEqualTo("targetProcess");
+    assertThat(model.processDefinitionKey()).isEqualTo(999L);
+    assertThat(model.processDefinitionVersion()).isEqualTo(4);
+    assertThat(model.versionTag()).isEqualTo("v2.0");
+    assertThat(model.elementId()).isEqualTo("targetElement");
+    assertThat(model.completionDate()).isNull();
   }
 
   @ParameterizedTest(name = "[{index}] Should map protocol status ''{0}'' to entity status")

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentInstanceIntent.java
@@ -21,7 +21,8 @@ public enum AgentInstanceIntent implements Intent {
   UPDATE((short) 2, false),
   UPDATED((short) 3, true),
   COMPLETE((short) 4, false),
-  COMPLETED((short) 5, true);
+  COMPLETED((short) 5, true),
+  MIGRATED((short) 6, true);
 
   private final short value;
   private final boolean isEvent;
@@ -55,6 +56,8 @@ public enum AgentInstanceIntent implements Intent {
         return COMPLETE;
       case 5:
         return COMPLETED;
+      case 6:
+        return MIGRATED;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

Process instance migration re-points a running process instance at a target process definition,
but agent instances kept their original `processDefinitionKey`, `processDefinitionVersion`,
`bpmnProcessId`, `versionTag` and `elementId` after migration. This is stale in a user-visible way
in agent instance search, and `bpmnProcessId` specifically is an authorization-correctness problem,
since it's the resource id checked against authorized resource ids.

Agent instances can't be migrated the way jobs or user tasks are: an agent instance outlives the
element instance that created it (it's only completed when the whole process instance ends), so
there's no reliable active element instance to hang migration off of. This PR adds a dedicated
`MIGRATED` event for agent instances, migrated once per process instance regardless of whether the
owning element instance is still active, and threads the target process definition through to both
secondary storage backends.

**What's included:**
- A new `AgentInstanceIntent.MIGRATED` event, applied via a dedicated event applier.
- A process-instance-scoped migration step that looks up every agent instance belonging to the
  process instance and re-points it at the target definition, invoked once per process instance
  during migration rather than gated on any specific element instance.
- camunda-exporter (Elasticsearch/OpenSearch) and rdbms-exporter support so the migrated definition
  fields are reflected in agent instance search on both backends.

**Test coverage:**
- Engine-level tests validate that agent instances are migrated correctly even when their owning
  element instance has already completed and is no longer part of the migrated element tree — the
  core scenario this feature exists to handle — for both supported owning element types, including
  element id remapping and multiple agent instances on one process instance.
- Exporter-level tests (both camunda-exporter and rdbms-exporter) verify the `MIGRATED` intent is
  handled and that the target definition fields are written through to the respective index/table,
  including verification against real databases across all supported RDBMS vendors.
- An end-to-end integration test exercises the full path — client migrate command, engine event,
  both exporters, and the agent instance search API — confirming the definition fields observed
  after migration are actually the target's, not just what an isolated unit test claims.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #53292