### PR TITLE
feat: add endpoints POST /cluster/zones and DELETE /cluster/zones

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.shared.management;
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
@@ -498,6 +500,44 @@ public class ClusterEndpoint {
       final var migrationRequest = new ClusterZoneMigrationRequest(request.getZone(), dryRun);
       return ClusterApiUtils.mapOperationResponse(
           requestSender.migrateToZones(migrationRequest).join());
+    } catch (final Exception exception) {
+      return ClusterApiUtils.mapError(exception);
+    }
+  }
+
+  @DeleteMapping(path = "/zones/{zoneId}")
+  public ResponseEntity<?> forceRemoveZone(
+      @PathVariable final String zoneId,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+    try {
+      final var forceRemoveRequest = new ForceZoneRemoveRequest(zoneId, dryRun);
+      return ClusterApiUtils.mapOperationResponse(
+          requestSender.forceRemoveZone(forceRemoveRequest).join());
+    } catch (final Exception exception) {
+      return ClusterApiUtils.mapError(exception);
+    }
+  }
+
+  @PostMapping(path = "/zones/{zoneId}", consumes = "application/json")
+  public ResponseEntity<?> addZone(
+      @PathVariable final String zoneId,
+      @RequestBody final io.camunda.zeebe.management.cluster.AddZoneRequest request,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+    try {
+      final var brokerIds = request.getBrokers().stream().map(BrokerId::toString).toList();
+      return withValidMembers(
+          brokerIds,
+          members -> {
+            final var addZoneRequest =
+                new AddZoneRequest(
+                    zoneId,
+                    request.getNumberOfReplicas(),
+                    request.getPriority(),
+                    Set.copyOf(members),
+                    dryRun);
+            return ClusterApiUtils.mapOperationResponse(
+                requestSender.addZone(addZoneRequest).join());
+          });
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -219,6 +219,64 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /zones/{zoneId}:
+    delete:
+      summary: Force-remove a zone
+      description: Force-evicts the given zone's brokers from the cluster and drops the zone from
+        the persisted partition distribution configuration, in one atomic change. Use this when a
+        zone is down and its brokers are unreachable.
+      parameters:
+        - $ref: '#/components/parameters/ZoneId'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+    post:
+      summary: Add back a previously force-removed zone
+      description: Re-adds the operator-supplied brokers and re-includes the given zone in the
+        persisted partition distribution configuration, with the supplied replica count and
+        priority, in one atomic change.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "components.yaml#/schemas/AddZoneRequest"
+      parameters:
+        - $ref: '#/components/parameters/ZoneId'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
   /zones:
     put:
       summary:
@@ -263,6 +321,13 @@ components:
       description: Id of the broker
       schema:
         $ref: 'components.yaml#/schemas/BrokerId'
+    ZoneId:
+      name: zoneId
+      required: true
+      in: path
+      description: Name of the zone
+      schema:
+        type: string
     DryRunParameter:
       name: dryRun
       description: If true, requested changes are only simulated and not actually applied.

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -196,6 +196,31 @@ schemas:
         description: Preferred-leader ranking; higher value wins
         example: 1000
 
+  AddZoneRequest:
+    description: Request body for adding back a previously force-removed zone. The zone name is
+      given in the path.
+    type: object
+    required:
+      - numberOfReplicas
+      - priority
+      - brokers
+    properties:
+      numberOfReplicas:
+        type: integer
+        format: int32
+        description: Number of partition replicas placed in the zone
+        example: 2
+      priority:
+        type: integer
+        format: int32
+        description: Preferred-leader ranking; higher value wins
+        example: 1000
+      brokers:
+        type: array
+        description: The brokers to re-add to the zone
+        items:
+          $ref: "components.yaml#/schemas/BrokerId"
+
   ClusterZoneMigrationRequest:
     description: >
       Request to migrate one zone from a bare or partially zoned cluster. The complete zone order,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
@@ -8,12 +8,13 @@
 package io.camunda.zeebe.it.cluster.clustering.zoneaware;
 
 import static io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers.*;
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.configuration.Zone;
 import io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers.AddZoneScenario;
-import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
-import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
+import io.camunda.zeebe.management.cluster.AddZoneRequest;
+import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -62,35 +63,26 @@ final class AddZoneToClusterIT {
 
       // when - start a broker in the new zone, add it to the topology, then add the zone to the
       // partition distribution
-      closeables.manage(
-          addBrokerInZone(
-              cluster,
-              actuator,
-              scenario.clusterName(),
-              scenario.newZone(),
-              0,
-              3,
-              scenario.targetZones()));
+      final var broker =
+          closeables.manage(
+              startBrokerInZone(cluster, scenario.newZone(), 0, 3, scenario.targetZones()));
 
-      final var config =
-          new PartitionDistributionConfig()
-              .type(TypeEnum.ZONE_AWARE)
-              .zones(
-                  scenario.targetZones().stream()
-                      .map(
-                          z ->
-                              new ZoneSpec()
-                                  .name(z.name())
-                                  .numberOfReplicas(z.numberOfReplicas())
-                                  .priority(z.priority()))
-                      .toList());
-      final var response = actuator.patchPartitionDistribution(config, false);
+      final var priority = 1;
+      final var response =
+          actuator.addZone(
+              scenario.newZone(),
+              new AddZoneRequest()
+                  .brokers(List.of(BrokerId.of(broker.nodeId())))
+                  .numberOfReplicas(1)
+                  .priority(priority),
+              false);
 
       // then - the new distribution is applied and the new zone hosts partitions
       Awaitility.await()
           .untilAsserted(
               () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
-      assertThat(actuator.getTopology().getPartitionDistribution()).isEqualTo(config);
+      assertThat(actuator.getTopology().getPartitionDistribution().getZones())
+          .contains(new ZoneSpec(scenario.newZone(), 1, priority));
       assertZoneHostsPartitions(actuator, scenario.newZone(), 0);
     }
   }
@@ -100,17 +92,17 @@ final class AddZoneToClusterIT {
         Arguments.of(
             new AddZoneScenario(
                 "add-zone-single",
-                List.of(new Zone("zoneA", 2, 2, 100)),
-                List.of(new Zone("zoneA", 2, 2, 100), new Zone("zoneB", 1, 1, 10)),
-                "zoneB")),
+                List.of(new Zone(ZONE_A, 2, 2, 100)),
+                List.of(new Zone(ZONE_A, 2, 2, 100), new Zone(ZONE_B, 1, 1, 10)),
+                ZONE_B)),
         Arguments.of(
             new AddZoneScenario(
                 "add-zone-two",
-                List.of(new Zone("zoneA", 1, 1, 100), new Zone("zoneB", 1, 1, 10)),
+                List.of(new Zone(ZONE_A, 1, 1, 100), new Zone(ZONE_B, 1, 1, 10)),
                 List.of(
-                    new Zone("zoneA", 1, 1, 100),
-                    new Zone("zoneB", 1, 1, 10),
-                    new Zone("zoneC", 1, 1, 5)),
-                "zoneC")));
+                    new Zone(ZONE_A, 1, 1, 100),
+                    new Zone(ZONE_B, 1, 1, 10),
+                    new Zone(ZONE_C, 1, 1, 5)),
+                ZONE_C)));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -19,9 +19,7 @@ import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
-import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import java.util.List;
-import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 
 public class ZoneHelpers {
@@ -43,19 +41,16 @@ public class ZoneHelpers {
   }
 
   /**
-   * Starts a standalone broker in {@code zone} (static node id, joining the running cluster), adds
-   * it to the persisted topology, and waits for the change to be applied. The broker's blocking
-   * {@link TestStandaloneBroker#start()} runs on a virtual thread because it only returns once the
-   * broker has joined the topology (i.e. after {@code addBroker}).
+   * Starts a broker with id in a zone without adding it to the topology. The {@link
+   * TestStandaloneBroker#start} is run in a virtual thread as it returns only after it is able to
+   * join the topology
    */
-  public static TestStandaloneBroker addBrokerInZone(
+  public static TestStandaloneBroker startBrokerInZone(
       final TestCluster cluster,
-      final ClusterActuator actuator,
-      final String clusterName,
       final String zone,
       final int nodeId,
-      final int newTotalSize,
-      final List<Zone> targetZones) {
+      final int clusterSize,
+      final List<Zone> newZones) {
     final var contactPoint =
         cluster.brokers().values().iterator().next().address(TestZeebePort.CLUSTER);
     final var broker =
@@ -64,26 +59,17 @@ public class ZoneHelpers {
             .withUnifiedConfig(
                 cfg -> {
                   final var clusterCfg = cfg.getCluster();
-                  clusterCfg.setName(clusterName);
+                  clusterCfg.setName(cluster.name());
                   clusterCfg.setInitialContactPoints(List.of(contactPoint));
                   clusterCfg.setZone(zone);
+                  clusterCfg.setSize(clusterSize);
                   clusterCfg.setNodeId(nodeId);
-                  clusterCfg.setSize(newTotalSize);
                   clusterCfg.getPartitioning().setScheme(Scheme.ZONE_AWARE);
-                  clusterCfg.getPartitioning().setZoneAware(new ZoneAware(targetZones));
+                  clusterCfg.getPartitioning().setZoneAware(new ZoneAware(newZones));
                   cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
                 });
 
-    final var startThread =
-        Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
-
-    final var added = actuator.addBroker(MemberId.from(zone, nodeId).toString());
-    try {
-      Awaitility.await()
-          .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(added));
-    } catch (final Exception e) {
-      CloseHelper.close(broker);
-    }
+    Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
 
     return broker;
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -12,9 +12,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import feign.FeignException;
 import io.atomix.cluster.MemberId;
-import io.camunda.configuration.Partitioning.Scheme;
 import io.camunda.configuration.Zone;
-import io.camunda.configuration.ZoneAware;
+import io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers;
 import io.camunda.zeebe.management.cluster.AddZoneRequest;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
@@ -26,10 +25,7 @@ import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
-import java.util.Arrays;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
@@ -292,10 +288,6 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
     }
   }
 
-  private static List<MemberId> brokersInZone(final String zone, final int... ids) {
-    return Arrays.stream(ids).mapToObj(id -> MemberId.from(zone, id)).toList();
-  }
-
   @Test
   void shouldRecoverZoneAwareClusterAfterForceRemoveZone() {
     try (final var cluster = createCluster(minReplicationFactor())) {
@@ -318,7 +310,8 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       ClusterActuatorAssert.assertThat(actuator).doesNotHaveBroker(brokerId(2));
 
       // when - start a fresh broker in zoneA and add the zone back with it
-      final var newZoneABroker = startBrokerInZone(cluster, ZONES[0], 0);
+      final var newZoneABroker =
+          ZoneHelpers.startBrokerInZone(cluster, ZONES[0], 0, 3, cluster.getMultiZoneConfig());
       try {
         final var addZoneRequest =
             new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of(brokerId(0)));
@@ -424,36 +417,5 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("less than the requested number of replicas");
     }
-  }
-
-  /**
-   * Starts a standalone broker in {@code zone} (static node id, joining the running cluster) and
-   * waits until it is part of the cluster's raft membership. The broker's blocking {@link
-   * TestStandaloneBroker#start()} runs on a virtual thread because it only returns once the broker
-   * has joined the topology (i.e. after {@code addZone} adds it as a member).
-   */
-  private TestStandaloneBroker startBrokerInZone(
-      final TestCluster cluster, final String zone, final int nodeId) {
-    final var contactPoint =
-        cluster.brokers().values().iterator().next().address(TestZeebePort.CLUSTER);
-    final var targetZones = List.of(new Zone(ZONES[0], 2, 1, 100), new Zone(ZONES[1], 1, 1, 10));
-    final var broker =
-        new TestStandaloneBroker()
-            .withUnauthenticatedAccess()
-            .withUnifiedConfig(
-                cfg -> {
-                  final var clusterCfg = cfg.getCluster();
-                  clusterCfg.setName("zeebe-cluster");
-                  clusterCfg.setInitialContactPoints(List.of(contactPoint));
-                  clusterCfg.setZone(zone);
-                  clusterCfg.setNodeId(nodeId);
-                  clusterCfg.setSize(brokerCount());
-                  clusterCfg.getPartitioning().setScheme(Scheme.ZONE_AWARE);
-                  clusterCfg.getPartitioning().setZoneAware(new ZoneAware(targetZones));
-                  cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
-                });
-
-    Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
-    return broker;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
-import static io.camunda.zeebe.it.cluster.clustering.zoneaware.ZoneHelpers.addBrokerInZone;
-import static io.camunda.zeebe.qa.util.cluster.TestClusterBuilder.DEFAULT_CLUSTER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import feign.FeignException;
 import io.atomix.cluster.MemberId;
+import io.camunda.configuration.Partitioning.Scheme;
 import io.camunda.configuration.Zone;
+import io.camunda.configuration.ZoneAware;
+import io.camunda.zeebe.management.cluster.AddZoneRequest;
 import io.camunda.zeebe.management.cluster.BrokerId;
-import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.Operation;
@@ -27,13 +27,12 @@ import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
@@ -271,98 +270,6 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
   }
 
   @Test
-  @Timeout(2 * 60)
-  @SuppressWarnings("resource")
-  void shouldRecoverZoneAwareClusterAfterZoneFailover() {
-    // given -- zoneA x2, zoneB x2, RF=4 (2 replicas/zone), 2 partitions
-    try (final var cluster = createCluster(4, 2, 4)) {
-      cluster.awaitCompleteTopology();
-      // Pin the actuator to a surviving zoneB broker -- availableGateway() may resolve to a
-      // zoneA broker, which is closed below and would take the actuator connection down with it.
-      final var actuator = ClusterActuator.of(cluster.brokers().get(MemberId.from(ZONES[1], 0)));
-
-      // when
-      // 1. stop both zoneA brokers (incl. coordinator zoneA_0)
-      final var brokersToRemove = List.of(MemberId.from("zoneA", 0), MemberId.from("zoneA", 1));
-      brokersToRemove.forEach(b -> cluster.brokers().get(b).close());
-
-      // 2. force-remove both zoneA brokers; remaining member set = zoneB only
-      final var removed =
-          actuator.patchCluster(
-              new ClusterConfigPatchRequest()
-                  .brokers(
-                      new ClusterConfigPatchRequestBrokers()
-                          .remove(brokersToRemove.stream().map(BrokerId::of).toList())),
-              false,
-              true);
-
-      assertChangeDone(actuator, removed);
-
-      final var zoneBOnlyResponse =
-          actuator.patchPartitionDistribution(
-              new PartitionDistributionConfig()
-                  .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
-                  .zones(List.of(new ZoneSpec().name(ZONES[1]).numberOfReplicas(2).priority(10))),
-              false);
-      assertChangeDone(actuator, zoneBOnlyResponse);
-
-      // 3. add 2 new brokers to zoneB (zoneB_2, zoneB_3)
-      final var targetZones = List.of(new Zone(ZONES[1], 4, 4, 10));
-      final var brokersToAdd = brokersInZone(ZONES[1], 2, 3);
-      final var zoneBBrokers = new HashMap<MemberId, TestStandaloneBroker>();
-      cluster.brokers().entrySet().stream()
-          .filter(e -> e.getKey().isInZone(ZONES[1]))
-          .forEach(e -> zoneBBrokers.put(e.getKey(), e.getValue()));
-      brokersToAdd.forEach(
-          id -> {
-            final var broker =
-                closeables.manage(
-                    addBrokerInZone(
-                        cluster,
-                        actuator,
-                        DEFAULT_CLUSTER_NAME,
-                        id.zone(),
-                        id.nodeIdx(),
-                        4,
-                        targetZones));
-            zoneBBrokers.put(id, broker);
-          });
-
-      // 4. reconfigure partition distribution: RF=4 all in zoneB, no zoneA
-      final var config =
-          new PartitionDistributionConfig()
-              .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
-              .zones(List.of(new ZoneSpec().name(ZONES[1]).numberOfReplicas(4).priority(10)));
-      final var response = actuator.patchPartitionDistribution(config, false);
-
-      // then -- recovery applied; RF=4 all in zoneB
-      assertChangeDone(actuator, response);
-
-      final var finalTopology = actuator.getTopology();
-      assertThat(finalTopology.getPartitionDistribution()).isEqualTo(config);
-
-      final var expectedMemberIds = brokersInZone(ZONES[1], 0, 1, 2, 3);
-
-      // all zoneB brokers present in the final topology, each hosting both partitions (RF=4)
-      assertThat(finalTopology.getBrokers())
-          .describedAs("all zoneB brokers present in final topology")
-          .extracting(BrokerState::getId)
-          .containsExactlyInAnyOrder(
-              expectedMemberIds.stream().map(BrokerId::of).toList().toArray(new BrokerId[0]));
-      assertThat(finalTopology.getBrokers())
-          .allSatisfy(
-              broker ->
-                  assertThat(broker.getPartitions())
-                      .describedAs("broker %s has all partitions", broker.getId())
-                      .hasSize(2));
-      for (final var id : expectedMemberIds) {
-        Awaitility.await()
-            .untilAsserted(() -> TestCluster.assertHealthyTopology(zoneBBrokers.get(id)));
-      }
-    }
-  }
-
-  @Test
   void shouldRejectClusterPatchWithBareIntegers() {
     try (final var cluster = createCluster(brokerCount())) {
       // given
@@ -383,5 +290,169 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
   private static List<MemberId> brokersInZone(final String zone, final int... ids) {
     return Arrays.stream(ids).mapToObj(id -> MemberId.from(zone, id)).toList();
+  }
+
+  @Test
+  void shouldRecoverZoneAwareClusterAfterForceRemoveZone() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given - zoneA (brokers 0 and 2) is down; use the zoneB broker as the actuator, since it is
+      // the only one that stays alive throughout the test
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.brokers().get(memberIdForBroker(1)));
+      cluster.brokers().get(memberIdForBroker(0)).close();
+      cluster.brokers().get(memberIdForBroker(2)).close();
+
+      // when - force-remove zoneA: force-evict its brokers and drop it from the distribution config
+      final var forceRemoveResponse = actuator.forceRemoveZone(ZONES[0], false);
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(actuator)
+                      .hasAppliedChanges(forceRemoveResponse));
+      ClusterActuatorAssert.assertThat(actuator).doesNotHaveBroker(brokerId(0));
+      ClusterActuatorAssert.assertThat(actuator).doesNotHaveBroker(brokerId(2));
+
+      // when - start a fresh broker in zoneA and add the zone back with it
+      final var newZoneABroker = startBrokerInZone(cluster, ZONES[0], 0);
+      try {
+        final var addZoneRequest =
+            new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of(brokerId(0)));
+        final var addZoneResponse = actuator.addZone(ZONES[0], addZoneRequest, false);
+
+        // then - the cluster recovers: zoneA is back in the distribution and hosts partitions
+        Awaitility.await()
+            .untilAsserted(
+                () ->
+                    ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(addZoneResponse));
+        ClusterActuatorAssert.assertThat(actuator).hasActiveBroker(brokerId(0).toString());
+        final var expectedDistribution =
+            new PartitionDistributionConfig()
+                .type(TypeEnum.ZONE_AWARE)
+                .zones(
+                    List.of(
+                        new ZoneSpec().name(ZONES[1]).numberOfReplicas(1).priority(10),
+                        new ZoneSpec().name(ZONES[0]).numberOfReplicas(1).priority(100)));
+        assertThat(actuator.getTopology().getPartitionDistribution())
+            .isEqualTo(expectedDistribution);
+      } finally {
+        newZoneABroker.close();
+      }
+    }
+  }
+
+  @Test
+  void shouldRejectForceRemoveOfUnknownZone() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - then
+      assertThatCode(() -> actuator.forceRemoveZone("zoneUnknown", false))
+          .isInstanceOf(FeignException.BadRequest.class)
+          .hasMessageContaining("unknown zone");
+    }
+  }
+
+  @Test
+  void shouldRejectForceRemoveOfLastRemainingZone() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given - force-remove zoneA first, leaving zoneB as the only zone. Use the zoneB broker as
+      // the actuator, since it is the only one that stays alive throughout the test
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.brokers().get(memberIdForBroker(1)));
+      cluster.brokers().get(memberIdForBroker(0)).close();
+      cluster.brokers().get(memberIdForBroker(2)).close();
+      final var forceRemoveResponse = actuator.forceRemoveZone(ZONES[0], false);
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(actuator)
+                      .hasAppliedChanges(forceRemoveResponse));
+
+      // when - then - force-removing the last remaining zone is rejected
+      assertThatCode(() -> actuator.forceRemoveZone(ZONES[1], false))
+          .isInstanceOf(FeignException.BadRequest.class)
+          .hasMessageContaining("last remaining zone");
+    }
+  }
+
+  @Test
+  void shouldRejectAddZoneOfExistingZone() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given - zoneA is still present in the distribution config
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - then
+      final var addZoneRequest =
+          new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of(brokerId(0)));
+      assertThatCode(() -> actuator.addZone(ZONES[0], addZoneRequest, false))
+          .isInstanceOf(FeignException.BadRequest.class)
+          .hasMessageContaining("already present");
+    }
+  }
+
+  @Test
+  void shouldRejectAddZoneWithMismatchedBrokers() {
+    try (final var cluster = createCluster(minReplicationFactor())) {
+      // given - zoneA is down and force-removed. Use the zoneB broker as the actuator, since it is
+      // the only one that stays alive throughout the test
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.brokers().get(memberIdForBroker(1)));
+      cluster.brokers().get(memberIdForBroker(0)).close();
+      cluster.brokers().get(memberIdForBroker(2)).close();
+      final var forceRemoveResponse = actuator.forceRemoveZone(ZONES[0], false);
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(actuator)
+                      .hasAppliedChanges(forceRemoveResponse));
+
+      // when - then - empty brokers[] is rejected
+      final var emptyBrokersRequest =
+          new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of());
+      assertThatCode(() -> actuator.addZone(ZONES[0], emptyBrokersRequest, false))
+          .isInstanceOf(FeignException.BadRequest.class)
+          .hasMessageContaining("at least one broker");
+
+      // when - then - fewer brokers than numberOfReplicas is rejected
+      final var tooFewBrokersRequest =
+          new AddZoneRequest().numberOfReplicas(2).priority(100).brokers(List.of(brokerId(0)));
+      assertThatCode(() -> actuator.addZone(ZONES[0], tooFewBrokersRequest, false))
+          .isInstanceOf(FeignException.BadRequest.class)
+          .hasMessageContaining("less than the requested number of replicas");
+    }
+  }
+
+  /**
+   * Starts a standalone broker in {@code zone} (static node id, joining the running cluster) and
+   * waits until it is part of the cluster's raft membership. The broker's blocking {@link
+   * TestStandaloneBroker#start()} runs on a virtual thread because it only returns once the broker
+   * has joined the topology (i.e. after {@code addZone} adds it as a member).
+   */
+  private TestStandaloneBroker startBrokerInZone(
+      final TestCluster cluster, final String zone, final int nodeId) {
+    final var contactPoint =
+        cluster.brokers().values().iterator().next().address(TestZeebePort.CLUSTER);
+    final var targetZones = List.of(new Zone(ZONES[0], 2, 1, 100), new Zone(ZONES[1], 1, 1, 10));
+    final var broker =
+        new TestStandaloneBroker()
+            .withUnauthenticatedAccess()
+            .withUnifiedConfig(
+                cfg -> {
+                  final var clusterCfg = cfg.getCluster();
+                  clusterCfg.setName("zeebe-cluster");
+                  clusterCfg.setInitialContactPoints(List.of(contactPoint));
+                  clusterCfg.setZone(zone);
+                  clusterCfg.setNodeId(nodeId);
+                  clusterCfg.setSize(brokerCount());
+                  clusterCfg.getPartitioning().setScheme(Scheme.ZONE_AWARE);
+                  clusterCfg.getPartitioning().setZoneAware(new ZoneAware(targetZones));
+                  cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
+                });
+
+    Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
+    return broker;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -32,7 +32,11 @@ import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import java.util.Arrays;
 import java.util.List;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
@@ -298,6 +302,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // given - zoneA (brokers 0 and 2) is down; use the zoneB broker as the actuator, since it is
       // the only one that stays alive throughout the test
       cluster.awaitCompleteTopology();
+      // odd id means zoneB
       final var actuator = ClusterActuator.of(cluster.brokers().get(memberIdForBroker(1)));
       cluster.brokers().get(memberIdForBroker(0)).close();
       cluster.brokers().get(memberIdForBroker(2)).close();
@@ -340,49 +345,58 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
     }
   }
 
-  @Test
-  void shouldRejectForceRemoveOfUnknownZone() {
-    try (final var cluster = createCluster(minReplicationFactor())) {
-      // given
+  @Nested
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+  final class ZoneManagementRejections {
+    @AutoClose private final TestCluster cluster = createCluster(minReplicationFactor());
+
+    @AutoClose
+    private final TestCluster clusterAfterZoneRemoval = createCluster(minReplicationFactor());
+
+    private ClusterActuator actuator;
+    private ClusterActuator actuatorAfterZoneRemoval;
+
+    @BeforeAll
+    void awaitCompleteTopology() {
       cluster.awaitCompleteTopology();
-      final var actuator = ClusterActuator.of(cluster.availableGateway());
+      actuator = ClusterActuator.of(cluster.availableGateway());
+
+      clusterAfterZoneRemoval.awaitCompleteTopology();
+      actuatorAfterZoneRemoval =
+          ClusterActuator.of(clusterAfterZoneRemoval.brokers().get(memberIdForBroker(1)));
+      clusterAfterZoneRemoval.brokers().get(memberIdForBroker(0)).close();
+      clusterAfterZoneRemoval.brokers().get(memberIdForBroker(2)).close();
+      final var forceRemoveResponse = actuatorAfterZoneRemoval.forceRemoveZone(ZONES[0], false);
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  ClusterActuatorAssert.assertThat(actuatorAfterZoneRemoval)
+                      .hasAppliedChanges(forceRemoveResponse));
+    }
+
+    @Test
+    void shouldRejectForceRemoveOfUnknownZone() {
+      // given - the shared cluster is running with both zones present
 
       // when - then
       assertThatCode(() -> actuator.forceRemoveZone("zoneUnknown", false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("unknown zone");
     }
-  }
 
-  @Test
-  void shouldRejectForceRemoveOfLastRemainingZone() {
-    try (final var cluster = createCluster(minReplicationFactor())) {
-      // given - force-remove zoneA first, leaving zoneB as the only zone. Use the zoneB broker as
-      // the actuator, since it is the only one that stays alive throughout the test
-      cluster.awaitCompleteTopology();
-      final var actuator = ClusterActuator.of(cluster.brokers().get(memberIdForBroker(1)));
-      cluster.brokers().get(memberIdForBroker(0)).close();
-      cluster.brokers().get(memberIdForBroker(2)).close();
-      final var forceRemoveResponse = actuator.forceRemoveZone(ZONES[0], false);
-      Awaitility.await()
-          .untilAsserted(
-              () ->
-                  ClusterActuatorAssert.assertThat(actuator)
-                      .hasAppliedChanges(forceRemoveResponse));
+    @Test
+    void shouldRejectForceRemoveOfLastRemainingZone() {
+      // given - zoneA has already been force-removed from the shared cluster
 
       // when - then - force-removing the last remaining zone is rejected
-      assertThatCode(() -> actuator.forceRemoveZone(ZONES[1], false))
+      assertThatCode(() -> actuatorAfterZoneRemoval.forceRemoveZone(ZONES[1], false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("last remaining zone");
     }
-  }
 
-  @Test
-  void shouldRejectAddZoneOfExistingZone() {
-    try (final var cluster = createCluster(minReplicationFactor())) {
-      // given - zoneA is still present in the distribution config
-      cluster.awaitCompleteTopology();
-      final var actuator = ClusterActuator.of(cluster.availableGateway());
+    @Test
+    void shouldRejectAddZoneOfExistingZone() {
+      // given - zoneA is still present in the shared cluster's distribution config
 
       // when - then
       final var addZoneRequest =
@@ -391,35 +405,22 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("already present");
     }
-  }
 
-  @Test
-  void shouldRejectAddZoneWithMismatchedBrokers() {
-    try (final var cluster = createCluster(minReplicationFactor())) {
-      // given - zoneA is down and force-removed. Use the zoneB broker as the actuator, since it is
-      // the only one that stays alive throughout the test
-      cluster.awaitCompleteTopology();
-      final var actuator = ClusterActuator.of(cluster.brokers().get(memberIdForBroker(1)));
-      cluster.brokers().get(memberIdForBroker(0)).close();
-      cluster.brokers().get(memberIdForBroker(2)).close();
-      final var forceRemoveResponse = actuator.forceRemoveZone(ZONES[0], false);
-      Awaitility.await()
-          .untilAsserted(
-              () ->
-                  ClusterActuatorAssert.assertThat(actuator)
-                      .hasAppliedChanges(forceRemoveResponse));
+    @Test
+    void shouldRejectAddZoneWithMismatchedBrokers() {
+      // given - zoneA has already been force-removed from the shared cluster
 
       // when - then - empty brokers[] is rejected
       final var emptyBrokersRequest =
           new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of());
-      assertThatCode(() -> actuator.addZone(ZONES[0], emptyBrokersRequest, false))
+      assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONES[0], emptyBrokersRequest, false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("at least one broker");
 
       // when - then - fewer brokers than numberOfReplicas is rejected
       final var tooFewBrokersRequest =
           new AddZoneRequest().numberOfReplicas(2).priority(100).brokers(List.of(brokerId(0)));
-      assertThatCode(() -> actuator.addZone(ZONES[0], tooFewBrokersRequest, false))
+      assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONES[0], tooFewBrokersRequest, false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("less than the requested number of replicas");
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.ZONE_A;
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.ZONE_B;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -36,7 +38,7 @@ import org.junit.jupiter.api.TestInstance;
 
 final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
-  private static final String[] ZONES = {"zoneA", "zoneB"};
+  private static final String[] ZONES = {ZONE_A, ZONE_B};
 
   @Override
   protected int brokerCount() {
@@ -69,7 +71,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
   @Override
   protected String zone() {
-    return ZONES[0];
+    return ZONE_A;
   }
 
   @Override
@@ -109,8 +111,8 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
     final var brokersZoneB = brokerCount / ZONES.length;
     final var brokersZoneA = brokerCount - brokersZoneB;
     return List.of(
-        new Zone(ZONES[0], brokersZoneA, replicasZoneA, 100),
-        new Zone(ZONES[1], brokersZoneB, replicasZoneB, 10));
+        new Zone(ZONE_A, brokersZoneA, replicasZoneA, 100),
+        new Zone(ZONE_B, brokersZoneB, replicasZoneB, 10));
   }
 
   @Test
@@ -182,8 +184,8 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
               .type(PartitionDistributionConfig.TypeEnum.ZONE_AWARE)
               .zones(
                   List.of(
-                      new ZoneSpec().name(ZONES[0]).numberOfReplicas(2).priority(100),
-                      new ZoneSpec().name(ZONES[1]).numberOfReplicas(1).priority(10)));
+                      new ZoneSpec().name(ZONE_A).numberOfReplicas(2).priority(100),
+                      new ZoneSpec().name(ZONE_B).numberOfReplicas(1).priority(10)));
       final var response = actuator.patchPartitionDistribution(config, false);
 
       // then - exact planned operations.
@@ -300,7 +302,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       cluster.brokers().get(memberIdForBroker(2)).close();
 
       // when - force-remove zoneA: force-evict its brokers and drop it from the distribution config
-      final var forceRemoveResponse = actuator.forceRemoveZone(ZONES[0], false);
+      final var forceRemoveResponse = actuator.forceRemoveZone(ZONE_A, false);
       Awaitility.await()
           .untilAsserted(
               () ->
@@ -311,11 +313,11 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
 
       // when - start a fresh broker in zoneA and add the zone back with it
       final var newZoneABroker =
-          ZoneHelpers.startBrokerInZone(cluster, ZONES[0], 0, 3, cluster.getMultiZoneConfig());
+          ZoneHelpers.startBrokerInZone(cluster, ZONE_A, 0, 3, cluster.getMultiZoneConfig());
       try {
         final var addZoneRequest =
             new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of(brokerId(0)));
-        final var addZoneResponse = actuator.addZone(ZONES[0], addZoneRequest, false);
+        final var addZoneResponse = actuator.addZone(ZONE_A, addZoneRequest, false);
 
         // then - the cluster recovers: zoneA is back in the distribution and hosts partitions
         Awaitility.await()
@@ -328,8 +330,8 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
                 .type(TypeEnum.ZONE_AWARE)
                 .zones(
                     List.of(
-                        new ZoneSpec().name(ZONES[1]).numberOfReplicas(1).priority(10),
-                        new ZoneSpec().name(ZONES[0]).numberOfReplicas(1).priority(100)));
+                        new ZoneSpec().name(ZONE_B).numberOfReplicas(1).priority(10),
+                        new ZoneSpec().name(ZONE_A).numberOfReplicas(1).priority(100)));
         assertThat(actuator.getTopology().getPartitionDistribution())
             .isEqualTo(expectedDistribution);
       } finally {
@@ -359,7 +361,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
           ClusterActuator.of(clusterAfterZoneRemoval.brokers().get(memberIdForBroker(1)));
       clusterAfterZoneRemoval.brokers().get(memberIdForBroker(0)).close();
       clusterAfterZoneRemoval.brokers().get(memberIdForBroker(2)).close();
-      final var forceRemoveResponse = actuatorAfterZoneRemoval.forceRemoveZone(ZONES[0], false);
+      final var forceRemoveResponse = actuatorAfterZoneRemoval.forceRemoveZone(ZONE_A, false);
       Awaitility.await()
           .untilAsserted(
               () ->
@@ -382,7 +384,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // given - zoneA has already been force-removed from the shared cluster
 
       // when - then - force-removing the last remaining zone is rejected
-      assertThatCode(() -> actuatorAfterZoneRemoval.forceRemoveZone(ZONES[1], false))
+      assertThatCode(() -> actuatorAfterZoneRemoval.forceRemoveZone(ZONE_B, false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("last remaining zone");
     }
@@ -394,7 +396,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then
       final var addZoneRequest =
           new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of(brokerId(0)));
-      assertThatCode(() -> actuator.addZone(ZONES[0], addZoneRequest, false))
+      assertThatCode(() -> actuator.addZone(ZONE_A, addZoneRequest, false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("already present");
     }
@@ -406,14 +408,14 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then - empty brokers[] is rejected
       final var emptyBrokersRequest =
           new AddZoneRequest().numberOfReplicas(1).priority(100).brokers(List.of());
-      assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONES[0], emptyBrokersRequest, false))
+      assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONE_A, emptyBrokersRequest, false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("at least one broker");
 
       // when - then - fewer brokers than numberOfReplicas is rejected
       final var tooFewBrokersRequest =
           new AddZoneRequest().numberOfReplicas(2).priority(100).brokers(List.of(brokerId(0)));
-      assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONES[0], tooFewBrokersRequest, false))
+      assertThatCode(() -> actuatorAfterZoneRemoval.addZone(ZONE_A, tooFewBrokersRequest, false))
           .isInstanceOf(FeignException.BadRequest.class)
           .hasMessageContaining("less than the requested number of replicas");
     }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -20,6 +20,7 @@ import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.container.cluster.BrokerNode;
+import io.camunda.zeebe.management.cluster.AddZoneRequest;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.ClusterZoneMigrationRequest;
@@ -364,6 +365,27 @@ public interface ClusterActuator {
   @Headers({"Content-Type: application/json", "accept: application/json"})
   PlannedOperationsResponse migrateZone(
       @RequestBody final ClusterZoneMigrationRequest request, @Param boolean dryRun);
+
+  /**
+   * Force-removes the given zone: force-evicts the zone's brokers and drops the zone from the
+   * partition distribution config.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("DELETE /zones/{zoneId}?dryRun={dryRun}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse forceRemoveZone(@Param final String zoneId, @Param boolean dryRun);
+
+  /**
+   * Adds back the given zone: re-adds the given brokers and re-includes the zone in the partition
+   * distribution config.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /zones/{zoneId}?dryRun={dryRun}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse addZone(
+      @Param final String zoneId, @RequestBody final AddZoneRequest request, @Param boolean dryRun);
 
   /**
    * Requests a cluster mode change.

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -14,11 +14,13 @@ import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.configuration.Zone;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
@@ -84,6 +86,7 @@ public final class TestCluster implements CloseableSilently {
 
   private final String name;
   private final Map<MemberId, TestStandaloneGateway> gateways;
+  private final List<Zone> multiZoneConfig;
   private final Map<MemberId, TestStandaloneBroker> brokers;
   private final int replicationFactor;
   private final int partitionsCount;
@@ -102,12 +105,14 @@ public final class TestCluster implements CloseableSilently {
       final int replicationFactor,
       final int partitionsCount,
       final Map<MemberId, TestStandaloneBroker> brokers,
-      final Map<MemberId, TestStandaloneGateway> gateways) {
+      final Map<MemberId, TestStandaloneGateway> gateways,
+      final List<Zone> multiZoneConfig) {
     this.name = name;
     this.replicationFactor = replicationFactor;
     this.partitionsCount = partitionsCount;
     this.brokers = Collections.unmodifiableMap(brokers);
     this.gateways = Collections.unmodifiableMap(gateways);
+    this.multiZoneConfig = multiZoneConfig;
   }
 
   /** Returns a new cluster builder */
@@ -446,5 +451,9 @@ public final class TestCluster implements CloseableSilently {
         .filter(TestApplication::isGateway)
         .filter(TestGateway.class::isInstance)
         .map(node -> (TestGateway<?>) node);
+  }
+
+  public List<Zone> getMultiZoneConfig() {
+    return multiZoneConfig;
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -290,7 +290,12 @@ public final class TestClusterBuilder {
     createGateways();
 
     return new TestCluster(
-        name, replicationFactor, partitionsCount, new HashMap<>(brokers), new HashMap<>(gateways));
+        name,
+        replicationFactor,
+        partitionsCount,
+        new HashMap<>(brokers),
+        new HashMap<>(gateways),
+        multiZoneConfigs);
   }
 
   private void applyConfigFunctions(final MemberId id, final TestApplication<?> zeebe) {


### PR DESCRIPTION
## Description

Adds two REST actuator APIs:
-  POST /cluster/zones/{zoneId}
  - adds a zone to the cluster (failback) 
-  DELETE /cluster/zones/{zoneId} 
  - force removes a zone from a cluster (failover) even if coordinator is in the zone that was removed
 

I think I can put all the other tests in `ClusterEndpointIT` and subclasses in Nested classes when they are just testing rejections to speed up the tests in a followup. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51593 
