### PR TITLE
feat: detect missing secret references on job activation and emit RESOLUTION_REQUESTED

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.CslAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.DroppedJob;
@@ -32,9 +33,11 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
@@ -45,12 +48,20 @@ import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
 import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
 @ExcludeAuthorizationCheck
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
+
+  /**
+   * Slack added to a RESOLUTION_REQUESTED event's value length when checking batch capacity, to
+   * cover the log entry's key, source index, and metadata framing (see {@code
+   * LogAppendEntry#getLength}), so a guarded append never overflows the record batch.
+   */
+  private static final int RESOLUTION_EVENT_FRAMING_SLACK = 512;
 
   /** Scratch copy of the batch that carries the injected secret values to the response only. */
   private final JobBatchRecord responseValue = new JobBatchRecord();
@@ -199,7 +210,41 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
                 raiseIncidentJobTooLargeForMessageSize(
                     largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
 
+    // capture before activateJobBatch: building the response injects the secret values, which
+    // resets the injector and clears the jobs registered for resolution
+    final var jobsWithNonCachedSecrets =
+        new LinkedHashMap<>(jobSecretInjector.jobsWithNonCachedSecrets());
+
     activateJobBatch(record, value, jobBatchKey);
+
+    requestSecretResolution(jobsWithNonCachedSecrets);
+  }
+
+  /**
+   * Requests the background resolution of the secret references that kept the collector from
+   * activating some jobs. Appends one {@code RESOLUTION_REQUESTED} event per reference with the
+   * keys of the jobs waiting on it; its applier records the pending reference and parks the jobs so
+   * a long poll does not collect them again until the secret is resolved.
+   *
+   * <p>Stops appending once the record batch is full instead of letting the append overflow and
+   * roll back the whole activation. The references left out keep their jobs activatable, so the
+   * next activation registers and parks them with a fresh batch budget.
+   */
+  private void requestSecretResolution(
+      final Map<SecretReference, List<Long>> jobsWithNonCachedSecrets) {
+    for (final var waiting : jobsWithNonCachedSecrets.entrySet()) {
+      final var reference = waiting.getKey();
+      final var event =
+          new SecretReferenceRecord()
+              .setStoreId(reference.storeId())
+              .setSecretReference(reference.name());
+      waiting.getValue().forEach(event::addJobKey);
+      if (!stateWriter.canWriteEventOfLength(event.getLength() + RESOLUTION_EVENT_FRAMING_SLACK)) {
+        return;
+      }
+      stateWriter.appendFollowUpEvent(
+          keyGenerator.nextKey(), SecretReferenceIntent.RESOLUTION_REQUESTED, event);
+    }
   }
 
   private void rejectCommand(final TypedRecord<JobBatchRecord> record, final Rejection rejection) {
@@ -246,8 +291,9 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   /** Raises the incident matching the reason the injection dropped the job from the activation. */
   private void raiseIncidentForDroppedJob(final DroppedJob droppedJob) {
     switch (droppedJob) {
-      case OversizedJob oversized -> raiseIncidentJobSecretValuesTooLargeForMessageSize(oversized);
-      case FailedInjectionJob failed -> raiseIncidentJobSecretInjectionFailed(failed);
+      case final OversizedJob oversized ->
+          raiseIncidentJobSecretValuesTooLargeForMessageSize(oversized);
+      case final FailedInjectionJob failed -> raiseIncidentJobSecretInjectionFailed(failed);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.secretstore.SecretStoreRegistry;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
@@ -48,20 +49,12 @@ import io.camunda.zeebe.util.ByteValue;
 import io.camunda.zeebe.util.Either;
 import java.time.InstantSource;
 import java.util.EnumMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
 @ExcludeAuthorizationCheck
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
-
-  /**
-   * Slack added to a RESOLUTION_REQUESTED event's value length when checking batch capacity, to
-   * cover the log entry's key, source index, and metadata framing (see {@code
-   * LogAppendEntry#getLength}), so a guarded append never overflows the record batch.
-   */
-  private static final int RESOLUTION_EVENT_FRAMING_SLACK = 512;
 
   /** Scratch copy of the batch that carries the injected secret values to the response only. */
   private final JobBatchRecord responseValue = new JobBatchRecord();
@@ -210,10 +203,9 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
                 raiseIncidentJobTooLargeForMessageSize(
                     largeJob.key(), largeJob.jobRecord(), largeJob.expectedEventLength()));
 
-    // capture before activateJobBatch: building the response injects the secret values, which
+    // snapshot before activateJobBatch: building the response injects the secret values, which
     // resets the injector and clears the jobs registered for resolution
-    final var jobsWithNonCachedSecrets =
-        new LinkedHashMap<>(jobSecretInjector.jobsWithNonCachedSecrets());
+    final var jobsWithNonCachedSecrets = jobSecretInjector.jobsWithNonCachedSecrets();
 
     activateJobBatch(record, value, jobBatchKey);
 
@@ -239,7 +231,13 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
               .setStoreId(reference.storeId())
               .setSecretReference(reference.name());
       waiting.getValue().forEach(event::addJobKey);
-      if (!stateWriter.canWriteEventOfLength(event.getLength() + RESOLUTION_EVENT_FRAMING_SLACK)) {
+      // the capacity check needs the length of the whole log entry, whose metadata is only
+      // decorated with the command's authorization, agent and request source info once the entry is
+      // appended. The batch calculation buffer covers that framing on top of the value, the same
+      // way the collector sizes the job records it appends; over-estimating only defers a reference
+      // to the next activation, which keeps its jobs activatable.
+      if (!stateWriter.canWriteEventOfLength(
+          event.getLength() + EngineConfiguration.BATCH_SIZE_CALCULATION_BUFFER)) {
         return;
       }
       stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -125,11 +125,19 @@ final class JobBatchCollector {
           final var secretCheckResult = jobSecretInjector.checkSecrets(jobRecord);
           if (!secretCheckResult.nonCachedSecrets().isEmpty()) {
             // Skip jobs with an uncached secret reference without consuming a batch slot, so the
-            // jobs behind them can still be activated
+            // jobs behind them can still be activated, and register them so the processor can
+            // request the background resolution of their non-cached references and park them
+            jobSecretInjector.registerForResolution(secretCheckResult, key);
             jobMetrics.countJobEvent(JobAction.SKIPPED, jobRecord.getJobKind(), value.getType());
             skippedUncachedSecretJobs.increment();
-            return skippedUncachedSecretJobs.value
-                < EngineConfiguration.MAX_UNCACHED_SECRET_JOBS_SKIPPED_PER_ACTIVATION;
+            if (skippedUncachedSecretJobs.value
+                >= EngineConfiguration.MAX_UNCACHED_SECRET_JOBS_SKIPPED_PER_ACTIVATION) {
+              // stop at the skip cap and mark the batch truncated, so the client re-polls right
+              // away for the jobs behind the cap instead of parking until the poll times out
+              value.setTruncated(true);
+              return false;
+            }
+            return true;
           }
 
           // fill in the job record properties first in order to accurately estimate its size before

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -23,10 +23,14 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobSecretReference;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.agrona.io.DirectBufferInputStream;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
@@ -79,6 +83,10 @@ public final class JobSecretInjector {
   private final Map<SecretReference, String> values = new HashMap<>();
   private final List<JobWithCachedSecrets> jobsWithCachedSecrets = new ArrayList<>();
 
+  // jobs skipped for a non-cached secret reference, grouped by reference so the processor can emit
+  // one RESOLUTION_REQUESTED event per reference; insertion-ordered for a deterministic emission
+  private final Map<SecretReference, List<Long>> jobsWithNonCachedSecrets = new LinkedHashMap<>();
+
   public JobSecretInjector(final SecretStoreRegistry secretStoreRegistry) {
     caches = secretStoreRegistry.getCaches();
   }
@@ -87,6 +95,7 @@ public final class JobSecretInjector {
   public void reset() {
     values.clear();
     jobsWithCachedSecrets.clear();
+    jobsWithNonCachedSecrets.clear();
   }
 
   /**
@@ -95,9 +104,9 @@ public final class JobSecretInjector {
    * even after the first miss, so the caller sees all non-cached references of the job. A cache
    * lookup failure propagates to the caller and fails the activation command.
    *
-   * <p>TODO(https://github.com/camunda/camunda/issues/57846): the skipped jobs stay activatable,
-   * which can make a long poll collect them again right away. Instead, mark them as waiting for
-   * secret resolution and request the background resolution of their non-cached references.
+   * <p>The collector skips a job with any non-cached reference and registers it via {@link
+   * #registerForResolution}, so the processor can request the background resolution of the
+   * non-cached references and park the job until it is resolved.
    */
   public SecretCheckResult checkSecrets(final JobRecord job) {
     if (!job.hasSecretReferences()) {
@@ -129,9 +138,35 @@ public final class JobSecretInjector {
     }
   }
 
+  /**
+   * Registers a job skipped by the collector because some of its secret references have no cached
+   * value, grouping the job's key under each of its non-cached references. The processor emits one
+   * {@code RESOLUTION_REQUESTED} event per reference with the keys of the jobs waiting on it. A
+   * reference that occurs more than once for the same job (e.g. at two paths) records the job once.
+   */
+  public void registerForResolution(final SecretCheckResult check, final long jobKey) {
+    final Set<SecretReference> seen = new HashSet<>();
+    for (final Secret secret : check.nonCachedSecrets()) {
+      if (seen.add(secret.reference())) {
+        jobsWithNonCachedSecrets
+            .computeIfAbsent(secret.reference(), reference -> new ArrayList<>())
+            .add(jobKey);
+      }
+    }
+  }
+
   /** Returns whether any job registered since the last reset has cached secret values to inject. */
   public boolean hasSecretsToInject() {
     return !jobsWithCachedSecrets.isEmpty();
+  }
+
+  /**
+   * Returns the keys of the jobs waiting on each non-cached secret reference, grouped by reference
+   * in registration order. The processor consumes this before {@link #injectSecretValues} resets
+   * the injector.
+   */
+  public Map<SecretReference, List<Long>> jobsWithNonCachedSecrets() {
+    return Collections.unmodifiableMap(jobsWithNonCachedSecrets);
   }
 
   /**
@@ -350,8 +385,6 @@ public final class JobSecretInjector {
     return secrets;
   }
 
-  record Secret(SecretReference reference, String path, String placeholder) {}
-
   /**
    * The result of {@link #checkSecrets} for one job: the job's secrets with a cached value and
    * those without one, each materialized once (both empty for a job without secret references). A
@@ -359,16 +392,6 @@ public final class JobSecretInjector {
    */
   public record SecretCheckResult(List<Secret> cachedSecrets, List<Secret> nonCachedSecrets) {
     static final SecretCheckResult NO_SECRETS = new SecretCheckResult(List.of(), List.of());
-  }
-
-  /** A registered job: its index in the batch, the job, and its cached secrets. */
-  record JobWithCachedSecrets(int index, JobRecord job, List<Secret> cachedSecrets) {}
-
-  /** A job dropped from the activation batch that the processor must raise an incident for. */
-  public sealed interface DroppedJob permits OversizedJob, FailedInjectionJob {
-    long jobKey();
-
-    JobRecord job();
   }
 
   /**
@@ -380,6 +403,18 @@ public final class JobSecretInjector {
   /** A job dropped from the batch because injecting its secret values failed. */
   public record FailedInjectionJob(long jobKey, JobRecord job) implements DroppedJob {}
 
+  record Secret(SecretReference reference, String path, String placeholder) {}
+
+  /** A registered job: its index in the batch, the job, and its cached secrets. */
+  record JobWithCachedSecrets(int index, JobRecord job, List<Secret> cachedSecrets) {}
+
   /** The first job removed by {@link #dropJobsFromIndex}, i.e. the one at the given index. */
   private record RemovedJob(long jobKey, JobRecord job) {}
+
+  /** A job dropped from the activation batch that the processor must raise an incident for. */
+  public sealed interface DroppedJob permits OversizedJob, FailedInjectionJob {
+    long jobKey();
+
+    JobRecord job();
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobSecretInjector.java
@@ -162,11 +162,15 @@ public final class JobSecretInjector {
 
   /**
    * Returns the keys of the jobs waiting on each non-cached secret reference, grouped by reference
-   * in registration order. The processor consumes this before {@link #injectSecretValues} resets
-   * the injector.
+   * in registration order. The processor takes this snapshot before {@link #injectSecretValues}
+   * resets the injector; the snapshot is immutable and detached from the reset, so the caller keeps
+   * the keys registered at the time of the call.
    */
   public Map<SecretReference, List<Long>> jobsWithNonCachedSecrets() {
-    return Collections.unmodifiableMap(jobsWithNonCachedSecrets);
+    final Map<SecretReference, List<Long>> snapshot = new LinkedHashMap<>();
+    jobsWithNonCachedSecrets.forEach(
+        (reference, jobKeys) -> snapshot.put(reference, List.copyOf(jobKeys)));
+    return Collections.unmodifiableMap(snapshot);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -179,7 +179,8 @@ public final class EventAppliers implements EventApplier {
   private void registerSecretReferenceEventAppliers(final MutableProcessingState state) {
     register(
         SecretReferenceIntent.RESOLUTION_REQUESTED,
-        new SecretReferenceResolutionRequestedApplier(state.getSecretReferenceState()));
+        new SecretReferenceResolutionRequestedApplier(
+            state.getSecretReferenceState(), state.getJobState()));
     register(
         SecretReferenceIntent.RESOLUTION_COMPLETED,
         new SecretReferenceResolutionCompletedApplier(state.getSecretReferenceState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 
@@ -16,10 +18,12 @@ public final class SecretReferenceResolutionRequestedApplier
     implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
 
   private final MutableSecretReferenceState secretReferenceState;
+  private final MutableJobState jobState;
 
   public SecretReferenceResolutionRequestedApplier(
-      final MutableSecretReferenceState secretReferenceState) {
+      final MutableSecretReferenceState secretReferenceState, final MutableJobState jobState) {
     this.secretReferenceState = secretReferenceState;
+    this.jobState = jobState;
   }
 
   @Override
@@ -31,6 +35,19 @@ public final class SecretReferenceResolutionRequestedApplier
 
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+      parkJob(jobKey);
+    }
+  }
+
+  /**
+   * Removes the job from the activatable index so a long poll does not collect it again while it
+   * waits for secret resolution. The job keeps its {@code ACTIVATABLE} state and is reactivated
+   * once the secret is resolved. A missing job record is skipped as a defensive guard.
+   */
+  private void parkJob(final long jobKey) {
+    final JobRecord job = jobState.getJob(jobKey);
+    if (job != null) {
+      jobState.makeJobNotActivatable(jobKey, job);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplier.java
@@ -34,20 +34,23 @@ public final class SecretReferenceResolutionRequestedApplier
     secretReferenceState.addPendingSecretReference(storeId, secretReference);
 
     for (final long jobKey : value.getJobKeys()) {
-      secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
-      parkJob(jobKey);
+      parkWaitingJob(storeId, secretReference, jobKey);
     }
   }
 
   /**
-   * Removes the job from the activatable index so a long poll does not collect it again while it
-   * waits for secret resolution. The job keeps its {@code ACTIVATABLE} state and is reactivated
-   * once the secret is resolved. A missing job record is skipped as a defensive guard.
+   * Records the job as waiting for the secret reference and removes it from the activatable index,
+   * so a long poll does not collect it again while it waits for the resolution. The job keeps its
+   * {@code ACTIVATABLE} state and is reactivated once the secret is resolved. A job that no longer
+   * exists is skipped entirely, leaving no waiting entry behind for it.
    */
-  private void parkJob(final long jobKey) {
+  private void parkWaitingJob(
+      final String storeId, final String secretReference, final long jobKey) {
     final JobRecord job = jobState.getJob(jobKey);
-    if (job != null) {
-      jobState.makeJobNotActivatable(jobKey, job);
+    if (job == null) {
+      return;
     }
+    secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+    jobState.makeJobNotActivatable(jobKey, job);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -188,12 +188,12 @@ final class JobBatchCollectorTest {
     final Either<TooLargeJob, Map<JobKind, Integer>> result =
         collector.collectJobs(record, List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
-    // then - collection stops at the skip limit, keeping the jobs collected before it; the plain
-    // job behind the skipped ones is not reached
+    // then - collection stops at the skip limit, keeping the jobs collected before it; the batch is
+    // marked truncated so the client re-polls right away for the jobs behind the cap
     EitherAssert.assertThat(result).right().isEqualTo(Map.of(JobKind.BPMN_ELEMENT, 1));
     JobBatchRecordValueAssert.assertThat(record.getValue())
         .hasOnlyJobKeys(firstPlainJob.key)
-        .isNotTruncated();
+        .isTruncated();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretActivationInjectionTest.java
@@ -23,12 +23,15 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.SecretReferenceRecordValue;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -102,10 +105,11 @@ public final class JobSecretActivationInjectionTest {
   }
 
   @Test
-  public void shouldNotActivateJobWhenSecretIsNotCached() {
+  public void shouldParkJobAndRequestResolutionWhenSecretIsNotCached() {
     // given - the secret has no cached value (empty cache)
     deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
-    createInstanceAndAwaitJob();
+    final long processInstanceKey = createInstanceAndAwaitJob();
+    final long jobKey = jobKeyOf(processInstanceKey);
 
     // when
     final Record<JobBatchRecordValue> activated =
@@ -119,21 +123,85 @@ public final class JobSecretActivationInjectionTest {
         .untilAsserted(() -> assertThat(activationResponse).isNotNull());
     assertThat(activationResponse.getJobs()).isEmpty();
 
-    // and - the job stays activatable: once the secret value is cached, a later activation hands
-    // it out with the resolved value on the response
+    // and - a RESOLUTION_REQUESTED event is written for the missing reference with the job key
+    final Record<SecretReferenceRecordValue> requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(requested.getValue().getStoreId()).isEmpty();
+    assertThat(requested.getValue().getJobKeys()).containsExactly(jobKey);
+
+    // and - the job is parked: a later activation does not hand it out again, even once the value
+    // is cached (it is reactivated only after the background resolution completes, see #57852)
     cachedSecrets.put("token", "resolved-secret");
     final Record<JobBatchRecordValue> secondAttempt =
         engine.jobs().withType(JOB_TYPE).withRequestStreamId(2).withRequestId(2L).activate();
-    assertThat(secondAttempt.getValue().getJobs()).hasSize(1);
-    Awaitility.await("until the second activation response is written")
-        .atMost(Duration.ofSeconds(5))
-        .untilAsserted(() -> assertThat(activationResponse.getJobs()).hasSize(1));
-    assertThat(activationResponse.getJobs().get(0).getVariables())
-        .containsEntry("authorization", "Bearer resolved-secret");
+    assertThat(secondAttempt.getValue().getJobs()).isEmpty();
 
     // and - no exported record (state, log) leaks the resolved secret value
     assertThat(RecordingExporter.getRecords())
         .noneMatch(record -> record.toString().contains("resolved-secret"));
+  }
+
+  @Test
+  public void shouldRequestResolutionOncePerReferenceForMultipleWaitingJobs() {
+    // given - two jobs of the same type waiting on the same uncached secret reference
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    final long firstJobKey = jobKeyOf(createInstanceAndAwaitJob());
+    final long secondJobKey = jobKeyOf(createInstanceAndAwaitJob());
+
+    // when
+    engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - a single RESOLUTION_REQUESTED event carries both waiting job keys
+    final Record<SecretReferenceRecordValue> requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .withSecretReference("token")
+            .getFirst();
+    assertThat(requested.getValue().getJobKeys())
+        .containsExactlyInAnyOrder(firstJobKey, secondJobKey);
+  }
+
+  @Test
+  public void shouldRequestResolutionForEachMissingReferenceOfAJob() {
+    // given - a job with two uncached secret references
+    deploy(
+        t ->
+            t.zeebeInputExpression("camunda.secrets.token", "a")
+                .zeebeInputExpression("camunda.secrets.apiKey", "b"));
+    final long jobKey = jobKeyOf(createInstanceAndAwaitJob());
+
+    // when
+    engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+
+    // then - one RESOLUTION_REQUESTED event per reference, each carrying the job key
+    final var requested =
+        RecordingExporter.secretReferenceRecords(SecretReferenceIntent.RESOLUTION_REQUESTED)
+            .limit(2)
+            .asList();
+    assertThat(requested)
+        .extracting(record -> record.getValue().getSecretReference())
+        .containsExactlyInAnyOrder("token", "apiKey");
+    assertThat(requested)
+        .allSatisfy(record -> assertThat(record.getValue().getJobKeys()).containsExactly(jobKey));
+  }
+
+  @Test
+  public void shouldNotRequestResolutionWhenSecretIsCached() {
+    // given
+    cachedSecrets.put("token", "resolved-secret");
+    deploy(t -> t.zeebeInputExpression("\"Bearer \" + camunda.secrets.token", "authorization"));
+    final long processInstanceKey = createInstanceAndAwaitJob();
+
+    // when - the job is activated normally
+    final Record<JobBatchRecordValue> activated =
+        engine.jobs().withType(JOB_TYPE).withRequestStreamId(1).withRequestId(1L).activate();
+    assertThat(activated.getValue().getJobs()).hasSize(1);
+
+    // then - completing the job runs the process to the end without any RESOLUTION_REQUESTED event
+    engine.job().withKey(activated.getValue().getJobKeys().get(0)).complete();
+    assertThat(RecordingExporter.records().limitToProcessInstance(processInstanceKey))
+        .noneMatch(record -> record.getValueType() == ValueType.SECRET_REFERENCE);
   }
 
   @Test
@@ -307,6 +375,13 @@ public final class JobSecretActivationInjectionTest {
         .withProcessInstanceKey(processInstanceKey)
         .getFirst();
     return processInstanceKey;
+  }
+
+  private long jobKeyOf(final long processInstanceKey) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getKey();
   }
 
   private void deploy(final Consumer<ServiceTaskBuilder> modifier) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.secretstore.InMemorySecretCache;
 import io.camunda.secretstore.NoopSecretStore;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,8 +59,8 @@ final class JobSecretInjectorTest {
 
   /**
    * Mirrors the collector: checks each job, appends only the activatable ones to the batch (keys
-   * starting at 100, in the given order), and registers the appended jobs with secret references
-   * for the injection.
+   * starting at 100, in the given order), registers the appended jobs with secret references for
+   * the injection, and registers the skipped jobs with a non-cached reference for the resolution.
    */
   private static JobBatchRecord collect(final JobSecretInjector injector, final JobRecord... jobs) {
     final var batch = new JobBatchRecord().setType("task-type");
@@ -71,10 +73,21 @@ final class JobSecretInjectorTest {
         final JobRecord appendedJob = batch.jobs().add();
         appendedJob.copyFrom(job);
         injector.registerForInjection(check, batch.jobs().size() - 1, appendedJob);
+      } else {
+        injector.registerForResolution(check, key);
       }
       key++;
     }
     return batch;
+  }
+
+  private static Map<String, List<Long>> resolutionsByReferenceName(
+      final JobSecretInjector injector) {
+    final Map<String, List<Long>> byName = new LinkedHashMap<>();
+    injector
+        .jobsWithNonCachedSecrets()
+        .forEach((reference, keys) -> byName.put(reference.name(), keys));
+    return byName;
   }
 
   private static JobBatchRecord copyOf(final JobBatchRecord batch) {
@@ -344,6 +357,90 @@ final class JobSecretInjectorTest {
       // then
       assertThat(jobKeysOf(batch)).containsExactly(100L, 101L);
       assertThat(injector.hasSecretsToInject()).isFalse();
+    }
+  }
+
+  @Nested
+  final class RegisterForResolution {
+
+    @Test
+    void shouldGroupWaitingJobsByNonCachedReference() {
+      // given - two jobs waiting on the same uncached reference, a third on another
+      final var injector = injector(Map.of());
+
+      // when
+      collect(
+          injector,
+          job(Map.of("a", "camunda.secrets.token"), ref("token", "/a")),
+          job(Map.of("b", "camunda.secrets.token"), ref("token", "/b")),
+          job(Map.of("c", "camunda.secrets.other"), ref("other", "/c")));
+
+      // then - one entry per reference, with the keys of the jobs waiting on it in order
+      assertThat(resolutionsByReferenceName(injector))
+          .containsOnly(entry("token", List.of(100L, 101L)), entry("other", List.of(102L)));
+    }
+
+    @Test
+    void shouldRecordJobOncePerReferenceWhenReferenceRepeats() {
+      // given - one job referencing the same uncached secret at two paths
+      final var injector = injector(Map.of());
+
+      // when
+      collect(
+          injector,
+          job(
+              Map.of("a", "camunda.secrets.token", "b", "camunda.secrets.token"),
+              ref("token", "/a"),
+              ref("token", "/b")));
+
+      // then - the job is recorded once for the reference
+      assertThat(resolutionsByReferenceName(injector)).containsOnly(entry("token", List.of(100L)));
+    }
+
+    @Test
+    void shouldRegisterOnlyNonCachedReferencesOfASkippedJob() {
+      // given - a job with one cached and one non-cached reference
+      final var injector = injector(Map.of("token", "resolved"));
+
+      // when
+      collect(
+          injector,
+          job(
+              Map.of("a", "camunda.secrets.token", "b", "camunda.secrets.other"),
+              ref("token", "/a"),
+              ref("other", "/b")));
+
+      // then - only the non-cached reference is registered for resolution
+      assertThat(resolutionsByReferenceName(injector)).containsOnly(entry("other", List.of(100L)));
+    }
+
+    @Test
+    void shouldRegisterNothingWhenAllJobsAreActivatable() {
+      // given - a fully cached secret job and a job without references
+      final var injector = injector(Map.of("token", "resolved"));
+
+      // when
+      collect(
+          injector,
+          job(Map.of("a", "camunda.secrets.token"), ref("token", "/a")),
+          job(Map.of("foo", "bar")));
+
+      // then
+      assertThat(injector.jobsWithNonCachedSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldClearRegisteredResolutionsOnReset() {
+      // given
+      final var injector = injector(Map.of());
+      collect(injector, job(Map.of("a", "camunda.secrets.token"), ref("token", "/a")));
+      assertThat(injector.jobsWithNonCachedSecrets()).isNotEmpty();
+
+      // when
+      injector.reset();
+
+      // then
+      assertThat(injector.jobsWithNonCachedSecrets()).isEmpty();
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobSecretInjectorTest.java
@@ -16,6 +16,7 @@ import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretCache;
 import io.camunda.secretstore.SecretStoreRegistry;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.DroppedJob;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.FailedInjectionJob;
 import io.camunda.zeebe.engine.processing.job.JobSecretInjector.OversizedJob;
@@ -83,10 +84,13 @@ final class JobSecretInjectorTest {
 
   private static Map<String, List<Long>> resolutionsByReferenceName(
       final JobSecretInjector injector) {
+    return byReferenceName(injector.jobsWithNonCachedSecrets());
+  }
+
+  private static Map<String, List<Long>> byReferenceName(
+      final Map<SecretReference, List<Long>> jobsByReference) {
     final Map<String, List<Long>> byName = new LinkedHashMap<>();
-    injector
-        .jobsWithNonCachedSecrets()
-        .forEach((reference, keys) -> byName.put(reference.name(), keys));
+    jobsByReference.forEach((reference, keys) -> byName.put(reference.name(), keys));
     return byName;
   }
 
@@ -441,6 +445,26 @@ final class JobSecretInjectorTest {
 
       // then
       assertThat(injector.jobsWithNonCachedSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnRegisteredResolutionsAsImmutableSnapshot() {
+      // given
+      final var injector = injector(Map.of());
+      collect(
+          injector,
+          job(Map.of("a", "camunda.secrets.token"), ref("token", "/a")),
+          job(Map.of("b", "camunda.secrets.token"), ref("token", "/b")));
+      final var snapshot = injector.jobsWithNonCachedSecrets();
+
+      // when - the caller tries to change the snapshot, and the next command resets the injector
+      assertThatThrownBy(() -> snapshot.values().iterator().next().add(999L))
+          .isInstanceOf(UnsupportedOperationException.class);
+      assertThatThrownBy(snapshot::clear).isInstanceOf(UnsupportedOperationException.class);
+      injector.reset();
+
+      // then - the snapshot still holds the job keys registered when it was taken
+      assertThat(byReferenceName(snapshot)).containsOnly(entry("token", List.of(100L, 101L)));
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -7,15 +7,21 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
+import org.agrona.DirectBuffer;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,14 +30,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ProcessingStateExtension.class)
 final class SecretReferenceResolutionRequestedApplierTest {
 
+  private static final String TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+
   private MutableProcessingState processingState;
   private MutableSecretReferenceState state;
+  private MutableJobState jobState;
   private SecretReferenceResolutionRequestedApplier applier;
 
   @BeforeEach
   void setUp() {
     state = processingState.getSecretReferenceState();
-    applier = new SecretReferenceResolutionRequestedApplier(state);
+    jobState = processingState.getJobState();
+    applier = new SecretReferenceResolutionRequestedApplier(state, jobState);
   }
 
   @Test
@@ -206,5 +216,85 @@ final class SecretReferenceResolutionRequestedApplierTest {
         });
     assertThat(pairs)
         .containsExactlyInAnyOrder(tuple("store-1", "secret-a"), tuple("store-1", "secret-b"));
+  }
+
+  @Test
+  void shouldParkWaitingJobSoItIsNoLongerActivatable() {
+    // given - an activatable job waiting for an uncached secret
+    final DirectBuffer type = wrapString("type-a");
+    createActivatableJob(1L, type);
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then - the job keeps its ACTIVATABLE state but is removed from the activatable index, so a
+    // long poll does not collect it again until it is reactivated
+    assertThat(jobState.isInState(1L, State.ACTIVATABLE)).isTrue();
+    assertThat(activatableKeys(type)).isEmpty();
+  }
+
+  @Test
+  void shouldParkOnlyTheWaitingJobs() {
+    // given - two activatable jobs, only one waiting for the uncached secret
+    final DirectBuffer type = wrapString("type-a");
+    createActivatableJob(1L, type);
+    createActivatableJob(2L, type);
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then - only the waiting job is parked; the other stays activatable
+    assertThat(activatableKeys(type)).containsExactly(2L);
+  }
+
+  @Test
+  void shouldNotFailWhenWaitingJobDoesNotExist() {
+    // given - a job key with no job in state (e.g. already completed or canceled)
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(404L);
+
+    // when / then - the apply does not fail and still records the waiting reference
+    applier.applyState(100L, record);
+    assertThat(state.isPending("store-1", "secret-a")).isTrue();
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(waitingJobs).containsExactly(404L);
+  }
+
+  private void createActivatableJob(final long key, final DirectBuffer type) {
+    final JobRecord record = new JobRecord().setType(type).setTenantId(TENANT).setRetries(1);
+    jobState.insertJobRecordActivatable(key, record);
+    jobState.makeJobActivatableByPriority(type, key, TENANT, record.getPriority());
+  }
+
+  private List<Long> activatableKeys(final DirectBuffer type) {
+    final List<Long> keys = new ArrayList<>();
+    jobState.forEachActivatableJobs(
+        type,
+        List.of(TENANT),
+        (key, job) -> {
+          keys.add(key);
+          return true;
+        });
+    return keys;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/SecretReferenceResolutionRequestedApplierTest.java
@@ -63,6 +63,8 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldAddAllJobsWaitingForSecretReference() {
     // given
+    createActivatableJob(1L, wrapString("type-a"));
+    createActivatableJob(2L, wrapString("type-a"));
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -89,6 +91,8 @@ final class SecretReferenceResolutionRequestedApplierTest {
   void shouldAccumulateJobsAcrossSeparateResolutionRequestedEvents() {
     // given — two separate RESOLUTION_REQUESTED events for the same secret, each adding a different
     // job
+    createActivatableJob(1L, wrapString("type-a"));
+    createActivatableJob(2L, wrapString("type-a"));
     final var record1 =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -120,6 +124,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldIndexSecretReferenceByJob() {
     // given
+    createActivatableJob(1L, wrapString("type-a"));
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -143,6 +148,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldNotDuplicateJobOnRepeatedResolutionRequest() {
     // given
+    createActivatableJob(1L, wrapString("type-a"));
     final var record =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -191,6 +197,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   @Test
   void shouldIndexMultipleSecretReferencesByJob() {
     // given — the same job key waiting on two different secret references
+    createActivatableJob(1L, wrapString("type-a"));
     final var record1 =
         new SecretReferenceRecord()
             .setStoreId("store-1")
@@ -258,7 +265,7 @@ final class SecretReferenceResolutionRequestedApplierTest {
   }
 
   @Test
-  void shouldNotFailWhenWaitingJobDoesNotExist() {
+  void shouldNotRecordWaitingJobWhenJobDoesNotExist() {
     // given - a job key with no job in state (e.g. already completed or canceled)
     final var record =
         new SecretReferenceRecord()
@@ -266,8 +273,10 @@ final class SecretReferenceResolutionRequestedApplierTest {
             .setSecretReference("secret-a")
             .addJobKey(404L);
 
-    // when / then - the apply does not fail and still records the waiting reference
+    // when
     applier.applyState(100L, record);
+
+    // then - the reference is pending, but no waiting entry is left behind for a job that is gone
     assertThat(state.isPending("store-1", "secret-a")).isTrue();
     final List<Long> waitingJobs = new ArrayList<>();
     state.visitJobsBySecretReference(
@@ -277,7 +286,41 @@ final class SecretReferenceResolutionRequestedApplierTest {
           waitingJobs.add(jobKey);
           return true;
         });
-    assertThat(waitingJobs).containsExactly(404L);
+    assertThat(waitingJobs).isEmpty();
+    final List<Tuple> pairs = new ArrayList<>();
+    state.visitSecretReferencesByJob(
+        404L,
+        (storeId, secretReference) -> {
+          pairs.add(tuple(storeId, secretReference));
+          return true;
+        });
+    assertThat(pairs).isEmpty();
+  }
+
+  @Test
+  void shouldRecordOnlyTheJobsThatStillExist() {
+    // given - one existing job and one gone, both waiting on the same reference
+    createActivatableJob(1L, wrapString("type-a"));
+    final var record =
+        new SecretReferenceRecord()
+            .setStoreId("store-1")
+            .setSecretReference("secret-a")
+            .addJobKey(1L)
+            .addJobKey(404L);
+
+    // when
+    applier.applyState(100L, record);
+
+    // then
+    final List<Long> waitingJobs = new ArrayList<>();
+    state.visitJobsBySecretReference(
+        "store-1",
+        "secret-a",
+        jobKey -> {
+          waitingJobs.add(jobKey);
+          return true;
+        });
+    assertThat(waitingJobs).containsExactly(1L);
   }
 
   private void createActivatableJob(final long key, final DirectBuffer type) {

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableSecretReferenceState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.secretreference.SecretReferenceRecord;
 import io.camunda.zeebe.protocol.record.intent.SecretReferenceIntent;
 
@@ -16,10 +18,12 @@ public final class SecretReferenceResolutionRequestedApplier
     implements TypedEventApplier<SecretReferenceIntent, SecretReferenceRecord> {
 
   private final MutableSecretReferenceState secretReferenceState;
+  private final MutableJobState jobState;
 
   public SecretReferenceResolutionRequestedApplier(
-      final MutableSecretReferenceState secretReferenceState) {
+      final MutableSecretReferenceState secretReferenceState, final MutableJobState jobState) {
     this.secretReferenceState = secretReferenceState;
+    this.jobState = jobState;
   }
 
   @Override
@@ -31,6 +35,19 @@ public final class SecretReferenceResolutionRequestedApplier
 
     for (final long jobKey : value.getJobKeys()) {
       secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+      parkJob(jobKey);
+    }
+  }
+
+  /**
+   * Removes the job from the activatable index so a long poll does not collect it again while it
+   * waits for secret resolution. The job keeps its {@code ACTIVATABLE} state and is reactivated
+   * once the secret is resolved. A missing job record is skipped as a defensive guard.
+   */
+  private void parkJob(final long jobKey) {
+    final JobRecord job = jobState.getJob(jobKey);
+    if (job != null) {
+      jobState.makeJobNotActivatable(jobKey, job);
     }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/SecretReference_RESOLUTION_REQUESTED_v1.golden
@@ -34,20 +34,23 @@ public final class SecretReferenceResolutionRequestedApplier
     secretReferenceState.addPendingSecretReference(storeId, secretReference);
 
     for (final long jobKey : value.getJobKeys()) {
-      secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
-      parkJob(jobKey);
+      parkWaitingJob(storeId, secretReference, jobKey);
     }
   }
 
   /**
-   * Removes the job from the activatable index so a long poll does not collect it again while it
-   * waits for secret resolution. The job keeps its {@code ACTIVATABLE} state and is reactivated
-   * once the secret is resolved. A missing job record is skipped as a defensive guard.
+   * Records the job as waiting for the secret reference and removes it from the activatable index,
+   * so a long poll does not collect it again while it waits for the resolution. The job keeps its
+   * {@code ACTIVATABLE} state and is reactivated once the secret is resolved. A job that no longer
+   * exists is skipped entirely, leaving no waiting entry behind for it.
    */
-  private void parkJob(final long jobKey) {
+  private void parkWaitingJob(
+      final String storeId, final String secretReference, final long jobKey) {
     final JobRecord job = jobState.getJob(jobKey);
-    if (job != null) {
-      jobState.makeJobNotActivatable(jobKey, job);
+    if (job == null) {
+      return;
     }
+    secretReferenceState.addWaitingJob(storeId, secretReference, jobKey);
+    jobState.makeJobNotActivatable(jobKey, job);
   }
 }


### PR DESCRIPTION
## Description

On the long-poll job activation path, when a job has secret references that are not yet in the per-store cache, the job is kept out of the activation batch and a `SecretReference.RESOLUTION_REQUESTED` event is emitted per missing reference, carrying the keys of the jobs waiting on it. Its applier records the pending reference in `SecretReferenceState` and parks the waiting jobs (removed from the activatable index; the job keeps its `ACTIVATABLE` state), so a long poll does not hand them out again until the background resolution completes and reactivates them (#57852).

Jobs whose references are all cached are activated normally. Resolved secret values are never written to state, records, or logs.

Three commits:

1. Park jobs waiting for secret resolution (applier removes each waiting job from the activatable index).
2. Collect uncached secret references during job batch collection (group the waiting jobs per reference; on hitting the per-activation skip cap the batch is marked truncated so the client re-polls right away).
3. Emit `SecretReference.RESOLUTION_REQUESTED` for the excluded jobs, after the `ACTIVATED` event, guarding each append against the record-batch capacity so a near-full batch cannot overflow and roll back the whole activation.

## Related

Part of the Secret Resolution epic #56563.

Stacked on #57850 (`bcan/57850-inject-secrets-on-activation`); the base will be retargeted to `main` once #57850 merges.

Closes #57846