### PR TITLE
fix: prevent C3 sidebar timer leaking past Operate AppHeader test teardown

### DIFF
--- a/operate/client/src/App/Layout/AppHeader/tests/infoBar.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/infoBar.test.tsx
@@ -23,6 +23,15 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
 };
 
 describe('Info bar', () => {
+  beforeEach(() => {
+    // C3 sidebar schedules a real timer on open; fake timers ensure it is
+    // discarded on teardown instead of leaking past the test environment.
+    vi.useFakeTimers({shouldAdvanceTime: true});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render with correct links', async () => {
     mockMe().withSuccess(createUser({authorizedComponents: ['operate']}));
     const mockOpenFn = vi.fn();

--- a/operate/client/src/App/Layout/AppHeader/tests/infoBar.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/infoBar.test.tsx
@@ -29,6 +29,7 @@ describe('Info bar', () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
   });
   afterEach(() => {
+    vi.clearAllTimers();
     vi.useRealTimers();
   });
 

--- a/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
@@ -43,6 +43,7 @@ describe('User info', () => {
     vi.useFakeTimers({shouldAdvanceTime: true});
   });
   afterEach(() => {
+    vi.clearAllTimers();
     vi.useRealTimers();
   });
 

--- a/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/userInfo.test.tsx
@@ -37,6 +37,15 @@ const mockSsoUser = createUser({
 });
 
 describe('User info', () => {
+  beforeEach(() => {
+    // C3 sidebar schedules a real timer on open; fake timers ensure it is
+    // discarded on teardown instead of leaking past the test environment.
+    vi.useFakeTimers({shouldAdvanceTime: true});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should render user display name', async () => {
     mockMe().withSuccess(mockUser);
 


### PR DESCRIPTION
## Problem

The Operate front-end unit job failed on `stable/8.8` ([run 30050788287](https://github.com/camunda/camunda/actions/runs/30050788287/job/89353530589)) even though all 1244 tests passed:

```
Uncaught Exception: ReferenceError: window is not defined
 ❯ handleResize   c3-navigation-sidebar.js:54
 ❯ Timeout._onTimeout c3-navigation-sidebar.js:64   (setTimeout 120ms)
This error was caught after test environment was torn down.
```

The C3 navigation sidebar (`@camunda/camunda-composite-components`) schedules a real 120ms `setTimeout` whenever a panel opens (`isOpen === true`). Under CI load that timer could fire after jsdom tore the environment down, so react-dom's `dispatchSetState` read a gone `window` and threw — failing the whole run.

The timer only schedules while a panel is open, so it was contained to the two AppHeader tests that click to open one: `userInfo.test.tsx` and `infoBar.test.tsx`.

## Fix

Use the repo's existing fake-timer pattern (`vi.useFakeTimers({shouldAdvanceTime: true})` / `vi.useRealTimers()`) in those two files. `shouldAdvanceTime: true` keeps `userEvent`/MSW/`waitFor` working; the C3 timer now lives on the fake clock and is discarded at teardown instead of leaking past the environment.

## Verification

- `userInfo` + `infoBar`: 10/10 pass
- Full `AppHeader/` dir: 24/24 pass, no unhandled errors
- Confirmed the sidebar's pending timers sit on the fake clock and are discarded by `vi.useRealTimers()`

## Notes

On `main` this leak is currently masked by `dangerouslyIgnoreUnhandledErrors: true` in `vite.config.ts`; that flag was never backported to `stable/8.8`, which is why the job fails there. This addresses the root cause. Backport to `stable/8.8` requested via label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)