### PR TITLE
feat: allow setting metadata on Java client cluster variable commands

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableCreationCommandStep1.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateClusterVariableResponse;
 import io.camunda.client.api.search.enums.ClusterVariableKind;
+import java.util.Map;
 
 /**
  * Represents a request to create a globally-scoped cluster variable.
@@ -59,4 +60,12 @@ public interface GloballyScopedClusterVariableCreationCommandStep1
    * @return this builder for method chaining
    */
   GloballyScopedClusterVariableCreationCommandStep1 kind(ClusterVariableKind kind);
+
+  /**
+   * Sets the metadata bag of the cluster variable (optional). Values must be strings or numbers.
+   *
+   * @param metadata a map of metadata key to value
+   * @return this builder for method chaining
+   */
+  GloballyScopedClusterVariableCreationCommandStep1 metadata(Map<String, Object> metadata);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableUpdateCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/GloballyScopedClusterVariableUpdateCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UpdateClusterVariableResponse;
+import java.util.Map;
 
 /**
  * Represents a request to update a globally-scoped cluster variable.
@@ -50,4 +51,12 @@ public interface GloballyScopedClusterVariableUpdateCommandStep1
    * @return this builder for method chaining
    */
   GloballyScopedClusterVariableUpdateCommandStep1 update(String name, Object value);
+
+  /**
+   * Sets the metadata bag of the cluster variable (optional). Values must be strings or numbers.
+   *
+   * @param metadata a map of metadata key to value
+   * @return this builder for method chaining
+   */
+  GloballyScopedClusterVariableUpdateCommandStep1 metadata(Map<String, Object> metadata);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableCreationCommandStep1.java
@@ -17,6 +17,7 @@ package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.CreateClusterVariableResponse;
 import io.camunda.client.api.search.enums.ClusterVariableKind;
+import java.util.Map;
 
 /**
  * Represents a request to create a tenant-scoped cluster variable.
@@ -59,4 +60,12 @@ public interface TenantScopedClusterVariableCreationCommandStep1
    * @return this builder for method chaining
    */
   TenantScopedClusterVariableCreationCommandStep1 kind(ClusterVariableKind kind);
+
+  /**
+   * Sets the metadata bag of the cluster variable (optional). Values must be strings or numbers.
+   *
+   * @param metadata a map of metadata key to value
+   * @return this builder for method chaining
+   */
+  TenantScopedClusterVariableCreationCommandStep1 metadata(Map<String, Object> metadata);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableUpdateCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/TenantScopedClusterVariableUpdateCommandStep1.java
@@ -16,6 +16,7 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.UpdateClusterVariableResponse;
+import java.util.Map;
 
 /**
  * Represents a request to update a tenant-scoped cluster variable.
@@ -50,4 +51,12 @@ public interface TenantScopedClusterVariableUpdateCommandStep1
    * @return this builder for method chaining
    */
   TenantScopedClusterVariableUpdateCommandStep1 update(String name, Object value);
+
+  /**
+   * Sets the metadata bag of the cluster variable (optional). Values must be strings or numbers.
+   *
+   * @param metadata a map of metadata key to value
+   * @return this builder for method chaining
+   */
+  TenantScopedClusterVariableUpdateCommandStep1 metadata(Map<String, Object> metadata);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedCreateClusterVariableImpl.java
@@ -28,6 +28,7 @@ import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.CreateClusterVariableRequest;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
@@ -60,6 +61,13 @@ public class GloballyScopedCreateClusterVariableImpl
   public GloballyScopedClusterVariableCreationCommandStep1 kind(final ClusterVariableKind kind) {
     ArgumentUtil.ensureNotNull("kind", kind);
     createVariableRequest.setKind(EnumUtil.convert(kind, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public GloballyScopedClusterVariableCreationCommandStep1 metadata(
+      final Map<String, Object> metadata) {
+    createVariableRequest.metadata(metadata);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedUpdateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/GloballyScopedUpdateClusterVariableImpl.java
@@ -25,6 +25,7 @@ import io.camunda.client.impl.response.UpdateClusterVariableResponseImpl;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.UpdateClusterVariableRequest;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
@@ -52,6 +53,13 @@ public class GloballyScopedUpdateClusterVariableImpl
     ArgumentUtil.ensureNotNull("value", value);
     this.name = name;
     updateVariableRequest.value(value);
+    return this;
+  }
+
+  @Override
+  public GloballyScopedClusterVariableUpdateCommandStep1 metadata(
+      final Map<String, Object> metadata) {
+    updateVariableRequest.metadata(metadata);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedCreateClusterVariableImpl.java
@@ -28,6 +28,7 @@ import io.camunda.client.protocol.rest.ClusterVariableKindEnum;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.CreateClusterVariableRequest;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
@@ -63,6 +64,13 @@ public class TenantScopedCreateClusterVariableImpl
   public TenantScopedClusterVariableCreationCommandStep1 kind(final ClusterVariableKind kind) {
     ArgumentUtil.ensureNotNull("kind", kind);
     createVariableRequest.setKind(EnumUtil.convert(kind, ClusterVariableKindEnum.class));
+    return this;
+  }
+
+  @Override
+  public TenantScopedClusterVariableCreationCommandStep1 metadata(
+      final Map<String, Object> metadata) {
+    createVariableRequest.metadata(metadata);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedUpdateClusterVariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/TenantScopedUpdateClusterVariableImpl.java
@@ -25,6 +25,7 @@ import io.camunda.client.impl.response.UpdateClusterVariableResponseImpl;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.UpdateClusterVariableRequest;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
@@ -55,6 +56,13 @@ public class TenantScopedUpdateClusterVariableImpl
     ArgumentUtil.ensureNotNull("value", value);
     this.name = name;
     updateVariableRequest.value(value);
+    return this;
+  }
+
+  @Override
+  public TenantScopedClusterVariableUpdateCommandStep1 metadata(
+      final Map<String, Object> metadata) {
+    updateVariableRequest.metadata(metadata);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/CreateClusterVariableTest.java
@@ -31,6 +31,8 @@ import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
+import java.util.HashMap;
+import java.util.Map;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -166,6 +168,53 @@ public class CreateClusterVariableTest extends ClientRestTest {
     final CreateClusterVariableRequest sentRequest =
         gatewayService.getLastRequest(CreateClusterVariableRequest.class);
     assertThat(sentRequest.getKind()).isEqualTo(ClusterVariableKindEnum.SECRET_REFERENCE);
+  }
+
+  @Test
+  void shouldCreateGlobalClusterVariableWithMetadata() {
+    // given
+    final Map<String, Object> metadata = new HashMap<>();
+    metadata.put("kind", "CREDENTIAL");
+    metadata.put("schemaVersion", 2);
+    gatewayService.onCreateGlobalClusterVariableRequest(
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
+
+    // when
+    client
+        .newGloballyScopedClusterVariableCreateRequest()
+        .create(VARIABLE_NAME, VARIABLE_VALUE)
+        .metadata(metadata)
+        .send()
+        .join();
+
+    // then
+    final CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(CreateClusterVariableRequest.class);
+    assertThat(sentRequest.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldCreateTenantClusterVariableWithMetadata() {
+    // given
+    final Map<String, Object> metadata = new HashMap<>();
+    metadata.put("kind", "CREDENTIAL");
+    metadata.put("schemaVersion", 2);
+    gatewayService.onCreateTenantClusterVariableRequest(
+        TENANT_ID,
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
+
+    // when
+    client
+        .newTenantScopedClusterVariableCreateRequest(TENANT_ID)
+        .create(VARIABLE_NAME, VARIABLE_VALUE)
+        .metadata(metadata)
+        .send()
+        .join();
+
+    // then
+    final CreateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(CreateClusterVariableRequest.class);
+    assertThat(sentRequest.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/clustervariable/UpdateClusterVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/clustervariable/UpdateClusterVariableTest.java
@@ -24,9 +24,12 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ClusterVariableResult;
 import io.camunda.client.protocol.rest.ClusterVariableScopeEnum;
 import io.camunda.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.UpdateClusterVariableRequest;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
 import io.camunda.client.util.RestGatewayService;
+import java.util.HashMap;
+import java.util.Map;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 
@@ -77,6 +80,55 @@ public class UpdateClusterVariableTest extends ClientRestTest {
     assertThat(request.getUrl())
         .isEqualTo(RestGatewayPaths.getClusterVariablesUpdateTenantUrl(TENANT_ID, VARIABLE_NAME));
     assertThat(request.getMethod()).isEqualTo(RequestMethod.PUT);
+  }
+
+  @Test
+  void shouldUpdateGlobalClusterVariableWithMetadata() {
+    // given
+    final Map<String, Object> metadata = new HashMap<>();
+    metadata.put("kind", "CREDENTIAL");
+    metadata.put("schemaVersion", 3);
+    gatewayService.onUpdateGlobalClusterVariableRequest(
+        VARIABLE_NAME,
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.GLOBAL));
+
+    // when
+    client
+        .newGloballyScopedClusterVariableUpdateRequest()
+        .update(VARIABLE_NAME, VARIABLE_VALUE)
+        .metadata(metadata)
+        .send()
+        .join();
+
+    // then
+    final UpdateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(UpdateClusterVariableRequest.class);
+    assertThat(sentRequest.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
+  }
+
+  @Test
+  void shouldUpdateTenantClusterVariableWithMetadata() {
+    // given
+    final Map<String, Object> metadata = new HashMap<>();
+    metadata.put("kind", "CREDENTIAL");
+    metadata.put("schemaVersion", 3);
+    gatewayService.onUpdateTenantClusterVariableRequest(
+        TENANT_ID,
+        VARIABLE_NAME,
+        Instancio.create(ClusterVariableResult.class).scope(ClusterVariableScopeEnum.TENANT));
+
+    // when
+    client
+        .newTenantScopedClusterVariableUpdateRequest(TENANT_ID)
+        .update(VARIABLE_NAME, VARIABLE_VALUE)
+        .metadata(metadata)
+        .send()
+        .join();
+
+    // then
+    final UpdateClusterVariableRequest sentRequest =
+        gatewayService.getLastRequest(UpdateClusterVariableRequest.class);
+    assertThat(sentRequest.getMetadata()).containsExactlyInAnyOrderEntriesOf(metadata);
   }
 
   @Test


### PR DESCRIPTION
The Java client read path already exposed cluster variable metadata (search filter and response), but the create/update commands had no way to set it, even though the underlying REST request DTO supports it. This prevented clients (and acceptance tests) from writing a metadata bag.

Add a metadata(Map<String, Object>) setter to the create and update command steps (global and tenant scoped) and wire it to the request DTO.

Validation is done through the request validator and is not duplicated here.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #55092 