### PR TITLE
fix: scope /v2/status to the default physical tenant

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -37,13 +37,22 @@ paths:
       # via SecurityPathAdapter. `security: []` overrides the conditional
       # enforcement on the global schemes for this operation.
       security: []
-      summary: Get cluster status
-      description: Checks the health status of the cluster by verifying if there's at least one partition with a healthy leader.
+      summary: Get physical tenant status
+      description: >-
+        Checks the health status of the default physical tenant by verifying if there's at least one
+        partition of its group with a healthy leader. This endpoint is scoped to the default physical
+        tenant only: it is available unprefixed and at `/physical-tenants/default/v2/status`, but not
+        for any other physical tenant id (`/physical-tenants/{id}/v2/status` returns 404 for every
+        other id, whether or not a physical tenant with that id exists). If the cluster has only a
+        single physical tenant (the default), this endpoint is equivalent to `/cluster/v2/status`.
+        Use `/cluster/v2/status` for the aggregated status of the whole cluster, or
+        `/physical-tenants/{id}/v2/topology` for the health of a specific physical tenant's
+        partitions.
       responses:
         "204":
-          description: The cluster is UP and has at least one partition with a healthy leader.
+          description: The default physical tenant is UP and has at least one partition with a healthy leader.
         "503":
-          description: The cluster is DOWN and does not have any partition with a healthy leader.
+          description: The default physical tenant is DOWN and does not have any partition with a healthy leader.
       x-added-in-version: "8.8"
 
   /mode:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/ApiFiltersConfiguration.java
@@ -17,6 +17,7 @@ import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.controller.EndpointAccessErrorFilter;
 import io.camunda.zeebe.gateway.rest.controller.PhysicalTenantFilter;
+import io.camunda.zeebe.gateway.rest.controller.PhysicalTenantStatusScopeFilter;
 import io.camunda.zeebe.gateway.rest.controller.PhysicalTenantSwaggerFilter;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Arrays;
@@ -74,6 +75,21 @@ public class ApiFiltersConfiguration {
   public FilterRegistrationBean<PhysicalTenantFilter> physicalTenantFilter() {
     final FilterRegistrationBean<PhysicalTenantFilter> registration =
         new FilterRegistrationBean<>(new PhysicalTenantFilter());
+    registration.addUrlPatterns(PHYSICAL_TENANTS_PATH_SEGMENT + "*");
+    registration.setOrder(PHYSICAL_TENANT_FILTER_ORDER);
+    return registration;
+  }
+
+  /**
+   * Scopes {@code /v2/status} to the default physical tenant (ADR 001 D3): rejects every {@code
+   * /physical-tenants/{id}/v2/status} request for a non-default id with a uniform 404, before
+   * Spring Security selects a per-tenant chain, so a configured non-default tenant and an unknown
+   * one are indistinguishable to unauthenticated callers.
+   */
+  @Bean
+  public FilterRegistrationBean<PhysicalTenantStatusScopeFilter> physicalTenantStatusScopeFilter() {
+    final FilterRegistrationBean<PhysicalTenantStatusScopeFilter> registration =
+        new FilterRegistrationBean<>(new PhysicalTenantStatusScopeFilter());
     registration.addUrlPatterns(PHYSICAL_TENANTS_PATH_SEGMENT + "*");
     registration.setOrder(PHYSICAL_TENANT_FILTER_ORDER);
     return registration;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantStatusScopeFilter.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantStatusScopeFilter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Scopes {@code GET /v2/status} to the default physical tenant, per ADR 001 D3 (see {@code
+ * docs/adr/management/001-physical-tenant-health-status-topology.md}).
+ *
+ * <p>{@code /v2/status} and {@code /physical-tenants/default/v2/status} are the only forms this
+ * endpoint is exposed under; both are handled normally by {@code StatusController} and reach it
+ * unaffected by this filter. Every {@code /physical-tenants/{id}/v2/status} request for any other
+ * id — whether that id belongs to a configured physical tenant or not — gets rejected here with the
+ * exact same 404, so unauthenticated callers cannot use response differences (e.g. 401 vs. 404) to
+ * enumerate physical tenant ids.
+ *
+ * <p>The rejection writes a fixed, path-independent body directly rather than calling {@link
+ * HttpServletResponse#sendError}: {@code sendError} triggers the servlet container's error-page
+ * dispatch to {@code GlobalErrorController}, whose {@code ProblemDetail} embeds the request path in
+ * its {@code instance} field — that would make the response for an existing non-default tenant
+ * distinguishable from an unknown one, exactly what this filter must prevent.
+ *
+ * <p>{@code ApiFiltersConfiguration} registers this to run before Spring Security's {@code
+ * FilterChainProxy}, alongside {@link PhysicalTenantFilter}: the rejection must happen before
+ * per-physical-tenant security chain selection, so a configured non-default tenant and an unknown
+ * one are indistinguishable to unauthenticated callers. See ADR-0003 for why pre-security filters
+ * are the established mechanism for physical-tenant-aware routing decisions.
+ */
+public final class PhysicalTenantStatusScopeFilter extends HttpFilter {
+
+  private static final String STATUS_SUFFIX = "/v2/status";
+
+  // Fixed, path-independent body: identical for every rejected request, so an existing
+  // non-default tenant and an unknown one are indistinguishable. Deliberately does not use
+  // CamundaProblemDetail / GlobalErrorController (see class javadoc) — those embed the request
+  // path.
+  private static final String NOT_FOUND_BODY =
+      """
+      {"type":"about:blank","status":404,"title":"Not Found"}""";
+  private static final byte[] NOT_FOUND_BODY_BYTES =
+      NOT_FOUND_BODY.getBytes(StandardCharsets.UTF_8);
+
+  @Override
+  protected void doFilter(
+      final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
+      throws IOException, ServletException {
+    if (isNonDefaultTenantStatusRequest(request)) {
+      writeNotFound(response);
+      return;
+    }
+    chain.doFilter(request, response);
+  }
+
+  private static void writeNotFound(final HttpServletResponse response) throws IOException {
+    response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+    response.setContentType("application/problem+json");
+    response.setContentLength(NOT_FOUND_BODY_BYTES.length);
+    response.getOutputStream().write(NOT_FOUND_BODY_BYTES);
+  }
+
+  private boolean isNonDefaultTenantStatusRequest(final HttpServletRequest request) {
+    final String path = contextRelativePath(request);
+    if (path == null || !path.startsWith(PHYSICAL_TENANTS_PATH_SEGMENT)) {
+      return false;
+    }
+
+    final int start = PHYSICAL_TENANTS_PATH_SEGMENT.length();
+    final int slash = path.indexOf('/', start);
+    if (slash <= start) {
+      // no id segment, or an empty one, follows the prefix
+      return false;
+    }
+
+    final String tenantId = path.substring(start, slash);
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId)) {
+      return false;
+    }
+
+    final String remainder = path.substring(slash);
+    return STATUS_SUFFIX.equals(remainder) || (STATUS_SUFFIX + "/").equals(remainder);
+  }
+
+  private static String contextRelativePath(final HttpServletRequest request) {
+    final String uri = request.getRequestURI();
+    if (uri == null) {
+      return null;
+    }
+    final String contextPath = request.getContextPath();
+    if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+      return uri.substring(contextPath.length());
+    }
+    return uri;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/StatusController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/StatusController.java
@@ -17,6 +17,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+/**
+ * {@code GET /v2/status} is scoped to the default physical tenant only (ADR 001 D3): it is exposed
+ * unprefixed and at {@code /physical-tenants/default/v2/status}, both reaching this controller.
+ * {@code /physical-tenants/{id}/v2/status} for any other id gets a uniform 404 from {@link
+ * PhysicalTenantStatusScopeFilter}, before this controller — or Spring Security — is ever reached,
+ * so unauthenticated callers cannot enumerate physical tenant ids.
+ */
 @CamundaRestController
 @RequestMapping("/v2")
 public class StatusController {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantStatusScopeFilterTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantStatusScopeFilterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/** Unit tests for {@link PhysicalTenantStatusScopeFilter}. */
+@ExtendWith(MockitoExtension.class)
+class PhysicalTenantStatusScopeFilterTest {
+
+  @Mock private FilterChain chain;
+
+  private final PhysicalTenantStatusScopeFilter filter = new PhysicalTenantStatusScopeFilter();
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/physical-tenants/tenanta/v2/status",
+        "/physical-tenants/tenantb/v2/status",
+        "/physical-tenants/unknown/v2/status",
+      })
+  void shouldRejectNonDefaultTenantStatusRequestWithUniform404(final String uri) throws Exception {
+    final var request = new MockHttpServletRequest("GET", uri);
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+    // the body must be fixed and path-independent — sendError()/error-page dispatch would embed
+    // the request path in the ProblemDetail instance, breaking the uniform-404 contract
+    assertThat(response.getContentAsString())
+        .isEqualTo("{\"type\":\"about:blank\",\"status\":404,\"title\":\"Not Found\"}");
+    assertThat(response.getContentType()).isEqualTo("application/problem+json");
+    verify(chain, never()).doFilter(request, response);
+  }
+
+  @Test
+  void shouldRejectExistingNonDefaultTenantIdenticallyToUnknownTenant() throws Exception {
+    // both an existing non-default tenant and an unknown one must be indistinguishable — status,
+    // body, and headers must all match, not just the status code
+    final var existingTenantRequest =
+        new MockHttpServletRequest("GET", "/physical-tenants/tenanta/v2/status");
+    final var existingTenantResponse = new MockHttpServletResponse();
+    final var unknownTenantRequest =
+        new MockHttpServletRequest("GET", "/physical-tenants/unknown/v2/status");
+    final var unknownTenantResponse = new MockHttpServletResponse();
+
+    filter.doFilter(existingTenantRequest, existingTenantResponse, chain);
+    filter.doFilter(unknownTenantRequest, unknownTenantResponse, chain);
+
+    assertThat(existingTenantResponse.getStatus()).isEqualTo(unknownTenantResponse.getStatus());
+    assertThat(existingTenantResponse.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+    assertThat(existingTenantResponse.getContentAsString())
+        .isEqualTo(unknownTenantResponse.getContentAsString());
+    assertThat(existingTenantResponse.getContentType())
+        .isEqualTo(unknownTenantResponse.getContentType());
+    assertThat(existingTenantResponse.getHeaderNames())
+        .containsExactlyInAnyOrderElementsOf(unknownTenantResponse.getHeaderNames());
+  }
+
+  @Test
+  void shouldAllowDefaultTenantStatusRequest() throws Exception {
+    final var request = new MockHttpServletRequest("GET", "/physical-tenants/default/v2/status");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldAllowUnprefixedStatusRequest() throws Exception {
+    final var request = new MockHttpServletRequest("GET", "/v2/status");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldAllowOtherTenantPrefixedEndpoints() throws Exception {
+    // this filter is scoped to /v2/status only; other tenant-prefixed endpoints are unaffected
+    final var request = new MockHttpServletRequest("GET", "/physical-tenants/tenanta/v2/topology");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldAllowNonPrefixedPath() throws Exception {
+    final var request = new MockHttpServletRequest("GET", "/actuator/health");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldRejectRegardlessOfContextPath() throws Exception {
+    final var request =
+        new MockHttpServletRequest("GET", "/zeebe/physical-tenants/tenanta/v2/status");
+    request.setContextPath("/zeebe");
+    final var response = new MockHttpServletResponse();
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+    verify(chain, never()).doFilter(request, response);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantStatusScopeIT.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/PhysicalTenantStatusScopeIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.TopologyServices;
+import io.camunda.service.TopologyServices.ClusterStatus;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.config.ApiFiltersConfiguration;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+/**
+ * Integration test proving {@code /v2/status} is scoped to the default physical tenant end-to-end,
+ * through the real filter registration/order in {@link ApiFiltersConfiguration} — not just the
+ * {@link PhysicalTenantStatusScopeFilter} class in isolation (covered by {@link
+ * PhysicalTenantStatusScopeFilterTest}).
+ *
+ * <p>Guards against a regression where the filter is registered at the wrong order (or not at all)
+ * and a non-default {@code /physical-tenants/{id}/v2/status} request reaches {@link
+ * StatusController} instead of getting rejected upfront. This {@code @WebMvcTest} slice does not
+ * load Spring Security, so it cannot itself prove the filter runs ahead of a per-tenant security
+ * chain; instead {@link #shouldRegisterStatusScopeFilterBeforeSpringSecuritysFilterChainProxy}
+ * asserts the {@link FilterRegistrationBean} order directly against {@code
+ * SecurityProperties.DEFAULT_FILTER_ORDER} ({@code -100}), so a future order regression is caught
+ * even without a security context. See ADR 001 D3.
+ */
+@WebMvcTest(StatusController.class)
+@Import(ApiFiltersConfiguration.class)
+class PhysicalTenantStatusScopeIT extends RestControllerTest {
+
+  // Spring Security's FilterChainProxy registers at SecurityProperties.DEFAULT_FILTER_ORDER
+  // (-100); mirrors the constant inlined in ApiFiltersConfiguration for the same reason (avoids a
+  // spring-boot-security dependency for one constant).
+  private static final int SPRING_SECURITY_DEFAULT_FILTER_ORDER = -100;
+
+  @MockitoBean TopologyServices topologyServices;
+  @MockitoBean ServiceRegistry serviceRegistry;
+
+  @Autowired
+  FilterRegistrationBean<PhysicalTenantStatusScopeFilter> physicalTenantStatusScopeFilter;
+
+  @BeforeEach
+  void setup() {
+    when(serviceRegistry.topologyServices(any())).thenReturn(topologyServices);
+    when(topologyServices.getStatus())
+        .thenReturn(CompletableFuture.completedFuture(ClusterStatus.HEALTHY));
+  }
+
+  @Test
+  void shouldRegisterStatusScopeFilterBeforeSpringSecuritysFilterChainProxy() {
+    // the rejection must happen before Spring Security selects a per-tenant chain (ADR 001 D3);
+    // a lower order runs earlier in the chain
+    assertThat(physicalTenantStatusScopeFilter.getOrder())
+        .as(
+            "PhysicalTenantStatusScopeFilter must run before Spring Security's FilterChainProxy"
+                + " (order %d) so per-tenant chain selection never sees a rejected request",
+            SPRING_SECURITY_DEFAULT_FILTER_ORDER)
+        .isLessThan(SPRING_SECURITY_DEFAULT_FILTER_ORDER);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/physical-tenants/tenanta/v2/status",
+        "/physical-tenants/unknown/v2/status",
+      })
+  void shouldReturnUniform404ForNonDefaultTenantStatusBeforeReachingController(final String uri) {
+    // when / then
+    webClient
+        .get()
+        .uri(uri)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .json(
+            "{\"type\":\"about:blank\",\"status\":404,\"title\":\"Not Found\"}",
+            JsonCompareMode.STRICT);
+
+    // the request must never reach the controller — or a per-tenant security chain — at all
+    verify(topologyServices, never()).getStatus();
+  }
+
+  @Test
+  void shouldReturnIdenticalBodyAndContentTypeForExistingAndUnknownTenant() {
+    // an existing non-default tenant and an unknown one must be indistinguishable: same status,
+    // same body, same content type — guards against error-page dispatch embedding the request path
+    final var existingTenant =
+        webClient.get().uri("/physical-tenants/tenanta/v2/status").exchange();
+    final var unknownTenant = webClient.get().uri("/physical-tenants/unknown/v2/status").exchange();
+
+    final var existingBody = existingTenant.expectBody(String.class).returnResult();
+    final var unknownBody = unknownTenant.expectBody(String.class).returnResult();
+
+    assertThat(existingBody.getStatus()).isEqualTo(unknownBody.getStatus());
+    assertThat(existingBody.getResponseBody()).isEqualTo(unknownBody.getResponseBody());
+    assertThat(existingBody.getResponseHeaders().getContentType())
+        .isEqualTo(unknownBody.getResponseHeaders().getContentType());
+  }
+
+  @Test
+  void shouldReachControllerForDefaultTenantPrefixedPath() {
+    // when / then
+    webClient
+        .get()
+        .uri("/physical-tenants/default/v2/status")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(topologyServices).getStatus();
+  }
+
+  @Test
+  void shouldReachControllerForUnprefixedPath() {
+    // when / then
+    webClient
+        .get()
+        .uri("/v2/status")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(topologyServices).getStatus();
+  }
+}


### PR DESCRIPTION
## Description

/physical-tenants/{id}/v2/status now returns an identical 404 for every non-default id, whether or not a physical tenant with that id exists, preventing unauthenticated enumeration of physical tenant ids. The check runs in a new pre-security filter, before per-tenant security chain selection. /v2/status and /physical-tenants/default/v2/status are unaffected.

Also updates the OpenAPI description for GET /status to document the default-tenant scoping.

## Related issues

related to #57375 
