### PR TITLE
test: harden decision-instance navigation and diagram-load waits (nightly 8.7)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -275,11 +275,14 @@ test.describe('Decision Navigation', () => {
           // filters (no name/version) — this resets both the URL params and the
           // client-side React filter state deterministically. Then
           // give the importer time to make the instance queryable before
-          // re-applying the name filter from scratch.
+          // re-applying the name filter from scratch. Bumped from 3s: nightly
+          // run 30057312392 still exhausted all 8 retries with the same
+          // decisionPanel-not-visible failure, so the importer occasionally
+          // needs longer than 3s per cycle to catch up under nightly load.
           await operateDecisionsPage.gotoDecisionsPage({
             searchParams: {evaluated: 'true', failed: 'true'},
           });
-          await sleep(3000);
+          await sleep(6000);
           await operateDecisionsPage.selectDecisionName(
             'Assign Approver Group Navigation',
           );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -856,7 +856,19 @@ test.describe.serial('Process Instance Migration', () => {
       });
 
       await operateProcessesPage.clickProcessInstanceLink();
-      await operateDiagramPage.resetDiagramZoomButton.click();
+      // The diagram can take longer than the suite's 10s actionTimeout to
+      // render after navigating in, which fails the very next action
+      // (clicking "Reset diagram zoom") with a locator timeout rather than
+      // a content assertion. Same recovery already used for the "Business
+      // rule task incident" flake above: reload and retry the click.
+      await waitForAssertion({
+        assertion: async () => {
+          await operateDiagramPage.resetDiagramZoomButton.click();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
     });
 
     await test.step('Verify signal intermediate catch event migration', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceMigration.spec.ts
@@ -863,7 +863,7 @@ test.describe.serial('Process Instance Migration', () => {
       // rule task incident" flake above: reload and retry the click.
       await waitForAssertion({
         assertion: async () => {
-          await operateDiagramPage.resetDiagramZoomButton.click();
+          await operateDiagramPage.resetDiagramZoomButton.click({timeout: 30_000});
         },
         onFailure: async () => {
           await page.reload();


### PR DESCRIPTION
## Failing run
https://github.com/camunda/camunda/actions/runs/30057312392 — C8 Orchestration Cluster Nightly 8.7 - E2E Tests, `nightly-e2e-tests-v1 / E2E Tests (stable/8.7 - Tasklist v1 mode)` job.

Two unrelated failures:
- `should navigate through DRD to another decision instance` (`tests/operate/decisionNavigation.spec.ts`)
- `Migrated signal elements` (`tests/operate/processInstanceMigration.spec.ts`)

## Root cause 1 — decisionNavigation.spec.ts

Timed out on `decisionPanel` visibility after exhausting all 8 retries of the existing "open decision instance" recovery loop. This exact failure mode — Operate redirecting back to the decisions list because the decision instance isn't queryable yet — is already documented in this file's own comments and specifically hardened for (list-reset + refilter recovery). Nightly history shows this same test failing on 2026-07-20 (run 29710168849) and 2026-07-21 (run 29791554514) in addition to today, so this is the known flake needing more headroom, not a new regression.

Checked Gate B: compared the last clean nightly (29667740022, 2026-07-19) against today's commit range via `gh api compare` — the only paths anywhere near "decision" are RDBMS DB reader changes (`db/rdbms/.../DecisionInstanceDbReader.java` etc.), irrelevant to this Elasticsearch-backed nightly. No pinnable product change.

**Fix**: bumped the recovery loop's settle sleep from 3s to 6s. The code's own comment already states this sleep's purpose is to "give the importer time to make the instance queryable" — this just gives it more real catch-up time per retry cycle, without materially changing the step's total worst-case time budget (kept `maxRetries: 8` unchanged rather than increasing retry count, to avoid pushing the step's worst case further into the suite's 12-minute test timeout).

## Root cause 2 — processInstanceMigration.spec.ts

Timed out (10s `actionTimeout`, per `playwright.config.ts`) clicking "Reset diagram zoom" immediately after navigating to the process instance — the diagram occasionally takes longer than 10s to render. The identical bare `.click()` (no wait) exists in five other places in this same file; only this one flaked this run, consistent with a load-timing race rather than a structural gap unique to this test.

**Fix**: wrapped the click in the same `waitForAssertion` + `page.reload()` retry this file already uses for the "Business rule task incident" step, which documents fixing the exact same class of flake ("backend contention ... outlasting the retry budget").

## Verification

- `npx prettier --check` and `npx eslint` on both changed files — clean. The 3 existing `playwright/no-wait-for-timeout` / `no-conditional-in-test` warnings in `processInstanceMigration.spec.ts` are pre-existing at unrelated lines (confirmed via `git stash` diff against the unmodified file).
- `npx tsc --noEmit` for the whole suite — clean, no errors.
- `npx playwright test --list` could not run in this environment (pre-existing Node ESM resolution mismatch for `@camunda8/sdk`'s `dist/zeebe/types` import, unrelated to this change) — flagging this as the residual verification gap. Per this suite's own contribution guideline, please trigger the on-demand workflow against this branch before review/merge.