### PR TITLE
test: await default-tenant and per-user authentication readiness in multi-db tests

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -16,6 +16,7 @@ import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.TestUser;
 import io.camunda.qa.util.multidb.TestEntityCollector.TestEntityCollection;
 import io.camunda.qa.util.multidb.TestEntityConfigurer.ConfigurationTestEntities;
 import io.camunda.security.api.model.config.AuthenticationMethod;
@@ -628,6 +629,19 @@ public class CamundaMultiDBExtension
     }
   }
 
+  private void awaitTestUserClientsAuthenticated(final TestEntityCollection testEntities) {
+    for (final TestUser user : testEntities.users()) {
+      final CamundaClient client = authenticatedClientFactory.getCamundaClient(user.username());
+      if (client == null) {
+        continue;
+      }
+      Awaitility.await("until user '%s' can authenticate".formatted(user.username()))
+          .timeout(Duration.ofSeconds(60))
+          .ignoreExceptions()
+          .untilAsserted(() -> client.newTopologyRequest().send().join());
+    }
+  }
+
   private void injectStaticMultiPtClientsField(
       final Class<?> testClass, final MultiPhysicalTenantClients ptClients) {
     for (final Field field : testClass.getDeclaredFields()) {
@@ -930,6 +944,8 @@ public class CamundaMultiDBExtension
 
     createClientsForTestEntities(shouldSetupKeycloak, testEntities);
 
+    awaitTestUserClientsAuthenticated(testEntities);
+
     // we support only static fields for now - to make sure test setups are build in a way
     // such they are reusable and tests methods are not relying on order, etc.
     // We want to run tests in an efficient manner, and reduce setup time
@@ -1059,6 +1075,21 @@ public class CamundaMultiDBExtension
         .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)
         .pollInterval(Duration.ofMillis(500))
         .until(() -> setupHelper.validateSchemaCreation(testPrefix));
+
+    if ((physicalTenantId != null || multiPhysicalTenantIds != null)
+        && application
+            .clientAuthenticationMethod()
+            .map(AuthenticationMethod.BASIC::equals)
+            .orElse(false)) {
+      try (final var defaultScopeClient = application.newClientBuilder().build()) {
+        application.awaitCompleteTopology(
+            clusterCfg.getSize(),
+            clusterCfg.getPartitionCount(),
+            clusterCfg.getReplicationFactor(),
+            Duration.ofSeconds(30),
+            defaultScopeClient);
+      }
+    }
   }
 
   private ElasticsearchContainer setupElasticsearch() {


### PR DESCRIPTION
## Description

Since #57286 enabled the physical-tenant ES CI legs, `ActivateJobIT` (~140x/day, `UNAUTHENTICATED`) and `SecretAuthorizationIT` (~110x/day, `ACCESS_DENIED`) top the flaky-test dashboard. `CamundaMultiDBExtension`'s readiness barriers all run through the PT-scoped admin client, so they never prove:

1. that the **default tenant's** user store can authenticate — tests building [unscoped clients](https://github.com/camunda/camunda/blob/1aa8b0a123d0fd00f12953e5b717c734100702f3/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java#L71) race the root-side seeding/export;
2. that each `@UserDefinition` user can actually log in — `EntityManager.await` only checks search visibility.

This adds two barriers in the extension: a topology await with an unscoped client in PT mode, and an authenticated probe per test user. Both are no-ops once the system is ready.

Validated locally: both test classes pass under `-Pphysical-tenant` (rdbms_h2).

## Related issues

Flakiness introduced by the CI legs added in #57286 (see the 2026-07-24 medic thread).
