### PR TITLE
build: release camunda-api-zod-schemas 0.0.83 and bump internal consumers

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.83",
+		"@camunda/camunda-api-zod-schemas": "0.0.84",
 		"@camunda/camunda-composite-components": "0.25.4",
 		"@carbon/grid": "11.58.0",
 		"@carbon/layout": "11.55.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.83",
+				"@camunda/camunda-api-zod-schemas": "0.0.84",
 				"@camunda/camunda-composite-components": "0.25.4",
 				"@carbon/grid": "11.58.0",
 				"@carbon/layout": "11.55.0",
@@ -11704,7 +11704,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.83",
+				"@camunda/camunda-api-zod-schemas": "0.0.84",
 				"typescript": "7.0.2"
 			}
 		},
@@ -11745,7 +11745,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.83",
+			"version": "0.0.84",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.1.1",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.83",
+		"@camunda/camunda-api-zod-schemas": "0.0.84",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.84
+
+### 🚀 Enhancements
+
+- Add `SECRET` authorization resource type and `REVEAL` permission ([#58391](https://github.com/camunda/camunda/pull/58391))
+
+### ❤️ Contributors
+
+- [@HeleneW-dot](https://github.com/HeleneW-dot)
+
 ## v0.0.83
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.83",
+	"version": "0.0.84",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
related to #56570

## Description

Releases `@camunda/camunda-api-zod-schemas` v0.0.83 and bumps the internal workspace consumers to match.

v0.0.83 contains the `SECRET` authorization resource type and `REVEAL` permission added in #58391. Publishing it is required so consumers (notably Identity/Admin) can pick up the new resource type.

- Bump package version `0.0.82` → `0.0.83` + CHANGELOG entry
- Bump workspace consumers (`orchestration-cluster-webapp`, `c8-mocks`) + lockfile

TODO after merge:
Publish (manual `workflow_dispatch` on `publish-zod-schemas.yml`) to be run after merge.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #56570
