### PR TITLE
feat: physical-tenant-aware node-level actuators (banning, partitions, jobstreams)

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
@@ -60,4 +60,16 @@ final class BrokerJobStreamService implements JobStreamEndpoint.Service {
         .map(ActorFuture::join)
         .orElse(Collections.emptyList());
   }
+
+  @Override
+  public Collection<ClientStream<JobActivationProperties>> clientJobStreams(
+      final Optional<String> physicalTenantId) {
+    if (physicalTenantId.isEmpty()) {
+      return clientJobStreams();
+    }
+    final var tenantId = physicalTenantId.get();
+    return clientJobStreams().stream()
+        .filter(stream -> tenantId.equals(stream.physicalTenantId()))
+        .toList();
+  }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +37,18 @@ final class BrokerJobStreamService implements JobStreamEndpoint.Service {
                 services.stream()
                     .flatMap(svc -> svc.remoteStreamService().streams().stream())
                     .toList())
+        .orElse(Collections.emptyList());
+  }
+
+  @Override
+  public Collection<RemoteStreamInfo<JobActivationProperties>> remoteJobStreams(
+      final Optional<String> physicalTenantId) {
+    if (physicalTenantId.isEmpty()) {
+      return remoteJobStreams();
+    }
+    return bridge
+        .getJobStreamService(physicalTenantId.get())
+        .map(svc -> svc.remoteStreamService().streams())
         .orElse(Collections.emptyList());
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceEndpoint.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.gateway.Loggers;
 import java.util.concurrent.CompletionException;
 import org.slf4j.Logger;
@@ -16,6 +18,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Selector.Match;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,12 +32,26 @@ public final class BanInstanceEndpoint {
     this.banInstanceService = banInstanceService;
   }
 
+  /**
+   * Bans the process instance whose key is given. Without a {@code physicalTenant} query parameter,
+   * the request targets the default physical tenant: the given key encodes a bare partition id
+   * which aliases across partition groups. With the parameter, the request targets the given
+   * physical tenant's partition group instead.
+   */
   @WriteOperation
   public WebEndpointResponse<?> post(
-      @Selector(match = Match.SINGLE) final long processInstanceKey) {
+      @Selector(match = Match.SINGLE) final long processInstanceKey,
+      @Nullable final String physicalTenant) {
+    final var physicalTenantId =
+        physicalTenant != null && !physicalTenant.isBlank()
+            ? physicalTenant
+            : DEFAULT_PHYSICAL_TENANT_ID;
     try {
-      LOG.info("Send AdminRequest to ban instance with key {}", processInstanceKey);
-      banInstanceService.banInstance(processInstanceKey);
+      LOG.info(
+          "Send AdminRequest to ban instance with key {} on physical tenant {}",
+          processInstanceKey,
+          physicalTenantId);
+      banInstanceService.banInstance(processInstanceKey, physicalTenantId);
       return new WebEndpointResponse<>(WebEndpointResponse.STATUS_NO_CONTENT);
     } catch (final CompletionException e) {
       return new WebEndpointResponse<>(

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BanInstanceService.java
@@ -25,4 +25,10 @@ public final class BanInstanceService {
   public void banInstance(final long key) {
     client.sendRequest(new BrokerAdminRequest().banInstance(key));
   }
+
+  public void banInstance(final long key, final String physicalTenantId) {
+    final var request = new BrokerAdminRequest().banInstance(key);
+    request.setPartitionGroup(physicalTenantId);
+    client.sendRequest(request);
+  }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
 
@@ -52,13 +54,18 @@ public final class JobStreamEndpoint {
    * Returns the complete list of remote and client job streams as an object with two keys: {@code
    * remote} and {@code client}. Both are collections of the job streams of the appropriate type.
    *
+   * <p>Without the {@code physicalTenant} query parameter, streams from every physical tenant are
+   * included (today's whole-cluster meaning). With the parameter, only streams belonging to that
+   * physical tenant are returned.
+   *
    * <p>This view is mostly used for human debugging to quickly correlate the state of a stream on
    * the gateway and brokers.
    */
   @ReadOperation
-  public WebEndpointResponse<JobStreams> list() {
+  public WebEndpointResponse<JobStreams> list(@Nullable final String physicalTenant) {
+    final var tenant = Optional.ofNullable(physicalTenant).filter(t -> !t.isBlank());
     return new WebEndpointResponse<>(
-        new JobStreams(getRemoteStreams(), getClientStreams()),
+        new JobStreams(getRemoteStreams(tenant), getClientStreams(tenant)),
         200,
         MimeTypeUtils.APPLICATION_JSON);
   }
@@ -68,10 +75,14 @@ public final class JobStreamEndpoint {
    * {@code type}. If the type is unknown, returns a 400 with a singleton map containing an error
    * field with an appropriate message.
    *
+   * <p>Without the {@code physicalTenant} query parameter, streams from every physical tenant are
+   * included. With the parameter, only streams belonging to that physical tenant are returned.
+   *
    * @param type the type of streams to return
    */
   @ReadOperation
-  public WebEndpointResponse<?> list(final @Selector String type) {
+  public WebEndpointResponse<?> list(
+      final @Selector String type, @Nullable final String physicalTenant) {
     if (!TYPES.contains(type)) {
       return new WebEndpointResponse<>(
           Map.of("error", "No known stream type '%s'; should be one of %s".formatted(type, TYPES)),
@@ -79,16 +90,18 @@ public final class JobStreamEndpoint {
           MimeTypeUtils.APPLICATION_JSON);
     }
 
-    final Collection<?> streams = "client".equals(type) ? getClientStreams() : getRemoteStreams();
+    final var tenant = Optional.ofNullable(physicalTenant).filter(t -> !t.isBlank());
+    final Collection<?> streams =
+        "client".equals(type) ? getClientStreams(tenant) : getRemoteStreams(tenant);
     return new WebEndpointResponse<>(streams, 200, MimeTypeUtils.APPLICATION_JSON);
   }
 
-  private Collection<RemoteJobStream> getRemoteStreams() {
-    return transformRemote(service.remoteJobStreams());
+  private Collection<RemoteJobStream> getRemoteStreams(final Optional<String> physicalTenantId) {
+    return transformRemote(service.remoteJobStreams(physicalTenantId));
   }
 
-  private Collection<ClientJobStream> getClientStreams() {
-    return transformClient(service.clientJobStreams());
+  private Collection<ClientJobStream> getClientStreams(final Optional<String> physicalTenantId) {
+    return transformClient(service.clientJobStreams(physicalTenantId));
   }
 
   private Collection<RemoteJobStream> transformRemote(
@@ -167,6 +180,25 @@ public final class JobStreamEndpoint {
 
     /** Returns the list of registered client/gateway job streams. */
     Collection<ClientStream<JobActivationProperties>> clientJobStreams();
+
+    /**
+     * Returns the list of registered remote/broker job streams, optionally filtered to a single
+     * physical tenant. The default implementation ignores the filter and returns every stream;
+     * tenant-aware implementations should override this to narrow the result.
+     */
+    default Collection<RemoteStreamInfo<JobActivationProperties>> remoteJobStreams(
+        final Optional<String> physicalTenantId) {
+      return remoteJobStreams();
+    }
+
+    /**
+     * Returns the list of registered client/gateway job streams, optionally filtered to a single
+     * physical tenant. The default implementation ignores the filter and returns every stream.
+     */
+    default Collection<ClientStream<JobActivationProperties>> clientJobStreams(
+        final Optional<String> physicalTenantId) {
+      return clientJobStreams();
+    }
   }
 
   public interface JobStream {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -68,7 +68,7 @@ public class SpringBrokerBridge {
   /** Returns the {@link BrokerAdminService} for the given physical tenant, if any. */
   public Optional<BrokerAdminService> getAdminService(final String physicalTenantId) {
     return Optional.ofNullable(adminServiceByTenantLookup)
-        .map(lookup -> lookup.apply(physicalTenantId));
+        .flatMap(lookup -> Optional.ofNullable(lookup.apply(physicalTenantId)));
   }
 
   public void registerJobStreamClientSupplier(
@@ -98,7 +98,7 @@ public class SpringBrokerBridge {
   /** Returns the {@link JobStreamService} for the given physical tenant, if any. */
   public Optional<JobStreamService> getJobStreamService(final String physicalTenantId) {
     return Optional.ofNullable(jobStreamServiceByTenantLookup)
-        .map(lookup -> lookup.apply(physicalTenantId));
+        .flatMap(lookup -> Optional.ofNullable(lookup.apply(physicalTenantId)));
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ public class SpringBrokerBridge {
 
   private Supplier<BrokerHealthCheckService> healthCheckServiceSupplier;
   private Supplier<BrokerAdminService> adminServiceSupplier;
+  private Function<String, BrokerAdminService> adminServiceByTenantLookup;
   private Supplier<Collection<JobStreamService>> jobStreamServicesSupplier;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
 
@@ -51,6 +53,21 @@ public class SpringBrokerBridge {
 
   public Optional<BrokerAdminService> getAdminService() {
     return Optional.ofNullable(adminServiceSupplier).map(Supplier::get);
+  }
+
+  /**
+   * Registers a lookup function resolving the {@link BrokerAdminService} responsible for a given
+   * physical tenant's partitions.
+   */
+  public void registerBrokerAdminServiceByTenantLookup(
+      final Function<String, BrokerAdminService> adminServiceByTenantLookup) {
+    this.adminServiceByTenantLookup = adminServiceByTenantLookup;
+  }
+
+  /** Returns the {@link BrokerAdminService} for the given physical tenant, if any. */
+  public Optional<BrokerAdminService> getAdminService(final String physicalTenantId) {
+    return Optional.ofNullable(adminServiceByTenantLookup)
+        .map(lookup -> lookup.apply(physicalTenantId));
   }
 
   public void registerJobStreamClientSupplier(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -33,6 +33,7 @@ public class SpringBrokerBridge {
   private Supplier<BrokerAdminService> adminServiceSupplier;
   private Function<String, BrokerAdminService> adminServiceByTenantLookup;
   private Supplier<Collection<JobStreamService>> jobStreamServicesSupplier;
+  private Function<String, JobStreamService> jobStreamServiceByTenantLookup;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
 
   private BiConsumer<Integer, String> shutdownHelper;
@@ -86,6 +87,18 @@ public class SpringBrokerBridge {
 
   public Optional<Collection<JobStreamService>> getJobStreamServices() {
     return Optional.ofNullable(jobStreamServicesSupplier).map(Supplier::get);
+  }
+
+  /** Registers a lookup function resolving the {@link JobStreamService} for a given tenant. */
+  public void registerJobStreamServiceByTenantLookup(
+      final Function<String, JobStreamService> jobStreamServiceByTenantLookup) {
+    this.jobStreamServiceByTenantLookup = jobStreamServiceByTenantLookup;
+  }
+
+  /** Returns the {@link JobStreamService} for the given physical tenant, if any. */
+  public Optional<JobStreamService> getJobStreamService(final String physicalTenantId) {
+    return Optional.ofNullable(jobStreamServiceByTenantLookup)
+        .map(lookup -> lookup.apply(physicalTenantId));
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -32,6 +33,7 @@ public class SpringBrokerBridge {
   private Supplier<BrokerHealthCheckService> healthCheckServiceSupplier;
   private Supplier<BrokerAdminService> adminServiceSupplier;
   private Function<String, BrokerAdminService> adminServiceByTenantLookup;
+  private Supplier<Set<String>> adminServiceTenantIdsSupplier;
   private Supplier<Collection<JobStreamService>> jobStreamServicesSupplier;
   private Function<String, JobStreamService> jobStreamServiceByTenantLookup;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
@@ -69,6 +71,21 @@ public class SpringBrokerBridge {
   public Optional<BrokerAdminService> getAdminService(final String physicalTenantId) {
     return Optional.ofNullable(adminServiceByTenantLookup)
         .flatMap(lookup -> Optional.ofNullable(lookup.apply(physicalTenantId)));
+  }
+
+  /**
+   * Registers a supplier of every physical tenant ID that has a {@link BrokerAdminService}
+   * registered, so that node-level operations without an explicit {@code physicalTenant} can be
+   * applied across the whole node (all physical tenants) rather than defaulting to a single one.
+   */
+  public void registerBrokerAdminServiceTenantIdsSupplier(
+      final Supplier<Set<String>> adminServiceTenantIdsSupplier) {
+    this.adminServiceTenantIdsSupplier = adminServiceTenantIdsSupplier;
+  }
+
+  /** Returns every physical tenant ID that has a {@link BrokerAdminService} registered. */
+  public Set<String> getBrokerAdminServiceTenantIds() {
+    return Optional.ofNullable(adminServiceTenantIdsSupplier).map(Supplier::get).orElse(Set.of());
   }
 
   public void registerJobStreamClientSupplier(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerAdminServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerAdminServiceStep.java
@@ -66,6 +66,9 @@ final class BrokerAdminServiceStep extends AbstractBrokerStartupStep {
                     .getSpringBrokerBridge()
                     .registerBrokerAdminServiceByTenantLookup(
                         brokerStartupContext::getBrokerAdminService);
+                brokerStartupContext
+                    .getSpringBrokerBridge()
+                    .registerBrokerAdminServiceTenantIdsSupplier(() -> tenantIds);
 
                 startupFuture.complete(brokerStartupContext);
               },

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerAdminServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerAdminServiceStep.java
@@ -7,11 +7,20 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 
+/**
+ * Sets up one {@link BrokerAdminServiceImpl} per physical tenant and registers each in the broker
+ * startup context, so that node-level admin operations (partition status, pause/resume
+ * processing/exporting, snapshots) can be scoped to a single physical tenant's partitions via the
+ * {@code partitions} actuator's {@code physicalTenant} parameter.
+ */
 final class BrokerAdminServiceStep extends AbstractBrokerStartupStep {
 
   @Override
@@ -25,20 +34,24 @@ final class BrokerAdminServiceStep extends AbstractBrokerStartupStep {
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
 
-    final var adminService =
-        new BrokerAdminServiceImpl(
-            brokerStartupContext
-                .getPartitionManagers()
-                .get(PartitionManagerImpl.DEFAULT_GROUP_NAME));
+    final var tenantIds = brokerStartupContext.getPhysicalTenantIds().known();
 
-    final var submitActorFuture =
-        brokerStartupContext.getActorSchedulingService().submitActor(adminService);
+    final var futures =
+        tenantIds.stream()
+            .map(tenantId -> startTenantService(brokerStartupContext, tenantId, concurrencyControl))
+            .collect(new ActorFutureCollector<>(concurrencyControl));
 
     concurrencyControl.runOnCompletion(
-        submitActorFuture,
-        (ok, error) -> {
+        futures,
+        (services, error) -> {
           if (error != null) {
-            startupFuture.complete(brokerStartupContext);
+            final var cleanupFutures =
+                tenantIds.stream()
+                    .map(id -> shutdownTenantService(brokerStartupContext, id, concurrencyControl))
+                    .collect(new ActorFutureCollector<>(concurrencyControl));
+            concurrencyControl.runOnCompletion(
+                cleanupFutures,
+                (ignored, cleanupError) -> startupFuture.completeExceptionally(error));
             return;
           }
 
@@ -46,13 +59,71 @@ final class BrokerAdminServiceStep extends AbstractBrokerStartupStep {
               () -> {
                 brokerStartupContext
                     .getSpringBrokerBridge()
-                    .registerBrokerAdminServiceSupplier(() -> adminService);
+                    .registerBrokerAdminServiceSupplier(
+                        () ->
+                            brokerStartupContext.getBrokerAdminService(DEFAULT_PHYSICAL_TENANT_ID));
+                brokerStartupContext
+                    .getSpringBrokerBridge()
+                    .registerBrokerAdminServiceByTenantLookup(
+                        brokerStartupContext::getBrokerAdminService);
 
-                brokerStartupContext.setBrokerAdminService(adminService);
                 startupFuture.complete(brokerStartupContext);
               },
               startupFuture);
         });
+  }
+
+  private ActorFuture<BrokerAdminServiceImpl> startTenantService(
+      final BrokerStartupContext brokerStartupContext,
+      final String physicalTenantId,
+      final ConcurrencyControl concurrencyControl) {
+
+    final var adminService =
+        new BrokerAdminServiceImpl(
+            brokerStartupContext.getPartitionManagers().get(physicalTenantId));
+
+    final var result = concurrencyControl.<BrokerAdminServiceImpl>createFuture();
+    final var submitActorFuture =
+        brokerStartupContext.getActorSchedulingService().submitActor(adminService);
+
+    concurrencyControl.runOnCompletion(
+        submitActorFuture,
+        (ok, error) -> {
+          if (error != null) {
+            result.completeExceptionally(error);
+            return;
+          }
+
+          brokerStartupContext.addBrokerAdminService(physicalTenantId, adminService);
+          result.complete(adminService);
+        });
+
+    return result;
+  }
+
+  private ActorFuture<Void> shutdownTenantService(
+      final BrokerStartupContext ctx,
+      final String physicalTenantId,
+      final ConcurrencyControl concurrencyControl) {
+
+    final var adminService = ctx.getBrokerAdminService(physicalTenantId);
+    if (adminService == null) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    ctx.removeBrokerAdminService(physicalTenantId);
+
+    final var result = concurrencyControl.<Void>createFuture();
+    concurrencyControl.runOnCompletion(
+        adminService.closeAsync(),
+        (ok, error) -> {
+          if (error != null) {
+            result.completeExceptionally(error);
+          } else {
+            result.complete(null);
+          }
+        });
+    return result;
   }
 
   @Override
@@ -61,29 +132,23 @@ final class BrokerAdminServiceStep extends AbstractBrokerStartupStep {
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> shutdownFuture) {
 
-    final var adminService = brokerShutdownContext.getBrokerAdminService();
+    final var tenantIds = brokerShutdownContext.getPhysicalTenantIds().known();
 
-    if (adminService == null) {
-      shutdownFuture.complete(brokerShutdownContext);
-      return;
-    }
-    final var closeFuture = adminService.closeAsync();
+    final var futures =
+        tenantIds.stream()
+            .map(
+                tenantId ->
+                    shutdownTenantService(brokerShutdownContext, tenantId, concurrencyControl))
+            .collect(new ActorFutureCollector<>(concurrencyControl));
 
     concurrencyControl.runOnCompletion(
-        closeFuture,
+        futures,
         (ok, error) -> {
           if (error != null) {
             shutdownFuture.completeExceptionally(error);
-            return;
+          } else {
+            shutdownFuture.complete(brokerShutdownContext);
           }
-
-          forwardExceptions(
-              () -> {
-                brokerShutdownContext.setBrokerAdminService(null);
-
-                shutdownFuture.complete(brokerShutdownContext);
-              },
-              shutdownFuture);
         });
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -134,9 +134,11 @@ public interface BrokerStartupContext {
 
   void setRocksDbResources(RocksDbResources sharedRocksDbResources);
 
-  BrokerAdminServiceImpl getBrokerAdminService();
+  BrokerAdminServiceImpl getBrokerAdminService(String physicalTenantId);
 
-  void setBrokerAdminService(final BrokerAdminServiceImpl brokerAdminService);
+  void addBrokerAdminService(String physicalTenantId, BrokerAdminServiceImpl brokerAdminService);
+
+  void removeBrokerAdminService(String physicalTenantId);
 
   ClusterConfigurationService getClusterConfigurationService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -86,8 +86,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private EmbeddedGatewayService embeddedGatewayService;
   private final Map<String, JobStreamService> jobStreamServices = new LinkedHashMap<>();
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
+  private final Map<String, BrokerAdminServiceImpl> brokerAdminServices = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
-  private BrokerAdminServiceImpl brokerAdminService;
   private ClusterConfigurationService clusterConfigurationService;
   private SnapshotApiRequestHandler snapshotApiRequestHandler;
   private CheckpointSchedulingService checkpointSchedulingService;
@@ -310,13 +310,19 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public BrokerAdminServiceImpl getBrokerAdminService() {
-    return brokerAdminService;
+  public BrokerAdminServiceImpl getBrokerAdminService(final String physicalTenantId) {
+    return brokerAdminServices.get(physicalTenantId);
   }
 
   @Override
-  public void setBrokerAdminService(final BrokerAdminServiceImpl brokerAdminService) {
-    this.brokerAdminService = brokerAdminService;
+  public void addBrokerAdminService(
+      final String physicalTenantId, final BrokerAdminServiceImpl brokerAdminService) {
+    brokerAdminServices.put(physicalTenantId, brokerAdminService);
+  }
+
+  @Override
+  public void removeBrokerAdminService(final String physicalTenantId) {
+    brokerAdminServices.remove(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -118,7 +118,7 @@ public final class BrokerStartupProcess {
         bsc.getClusterServices(),
         bsc.getEmbeddedGatewayService(),
         bsc.getPartitionManagers().get(PartitionManagerImpl.DEFAULT_GROUP_NAME),
-        bsc.getBrokerAdminService(),
+        bsc.getBrokerAdminService(PartitionManagerImpl.DEFAULT_GROUP_NAME),
         bsc.getApiMessagingService());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -76,6 +76,9 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                           .map(brokerStartupContext::getJobStreamService)
                           .filter(Objects::nonNull)
                           .toList());
+          brokerStartupContext
+              .getSpringBrokerBridge()
+              .registerJobStreamServiceByTenantLookup(brokerStartupContext::getJobStreamService);
           startupFuture.complete(brokerStartupContext);
         });
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
@@ -11,8 +11,10 @@ import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
@@ -40,41 +42,108 @@ public class BrokerAdminServiceEndpoint {
   }
 
   /**
-   * Triggers the given admin operation. Without the {@code physicalTenant} query parameter, this
-   * broker-local operation applies to the default physical tenant's partitions, matching today's
-   * behavior. With the parameter, it applies to the given physical tenant's partitions instead.
+   * Triggers the given admin operation. With the {@code physicalTenant} query parameter, this
+   * broker-local operation applies only to the given physical tenant's partitions. Without it, it
+   * applies to every physical tenant known on this node (Node scope, per ADR 003 D3); the response
+   * is keyed by physical tenant ID unless there is at most one known physical tenant, in which case
+   * it keeps today's flat, single-tenant shape.
    */
   @WriteOperation
-  public Map<Integer, PartitionStatus> trigger(
-      @Selector final String operation, @Nullable final String physicalTenant) {
+  public Object trigger(@Selector final String operation, @Nullable final String physicalTenant) {
     final var consumer = operations.get(operation);
     if (consumer == null) {
       // Not a valid operation
       return null;
     }
-    final var adminService = resolveAdminService(physicalTenant);
-    adminService.ifPresent(consumer);
-    return partitionStatus(physicalTenant);
+    final var tenant = normalize(physicalTenant);
+    if (tenant.isPresent()) {
+      springBrokerBridge.getAdminService(tenant.get()).ifPresent(consumer);
+      return partitionStatusForTenant(tenant.get());
+    }
+    final var tenantIds = tenantIds();
+    tenantIds.forEach(id -> springBrokerBridge.getAdminService(id).ifPresent(consumer));
+    return aggregatedPartitionStatus(tenantIds);
   }
 
+  /**
+   * Returns the partition status. With the {@code physicalTenant} query parameter, scoped to that
+   * physical tenant's partitions only (flat, keyed by partition ID, matching today's shape).
+   * Without it, returns every physical tenant known on this node (Node scope), keyed by physical
+   * tenant ID unless there is at most one known physical tenant, in which case it keeps today's
+   * flat, single-tenant shape.
+   */
   @ReadOperation
-  public Map<Integer, PartitionStatus> partitionStatus(@Nullable final String physicalTenant) {
-    return resolveAdminService(physicalTenant)
+  public Object partitionStatus(@Nullable final String physicalTenant) {
+    final var tenant = normalize(physicalTenant);
+    if (tenant.isPresent()) {
+      return partitionStatusForTenant(tenant.get());
+    }
+    return aggregatedPartitionStatus(tenantIds());
+  }
+
+  /**
+   * Returns the status of a single partition. With the {@code physicalTenant} query parameter,
+   * resolves the partition within that physical tenant's group. Without it, and if more than one
+   * physical tenant is known on this node, the partition ID alone is ambiguous (it aliases across
+   * physical tenant groups), so the result is keyed by physical tenant ID instead of returning a
+   * single status.
+   */
+  @ReadOperation
+  public Object singlePartition(
+      @Selector final Integer partitionId, @Nullable final String physicalTenant) {
+    final var tenant = normalize(physicalTenant);
+    if (tenant.isPresent()) {
+      return Optional.ofNullable(partitionStatusForTenant(tenant.get()).get(partitionId));
+    }
+    final var tenantIds = tenantIds();
+    if (tenantIds.size() <= 1) {
+      final var tenantId = tenantIds.stream().findFirst().orElse(DEFAULT_PHYSICAL_TENANT_ID);
+      return Optional.ofNullable(partitionStatusForTenant(tenantId).get(partitionId));
+    }
+    final Map<String, PartitionStatus> byTenant = new LinkedHashMap<>();
+    for (final var id : tenantIds) {
+      final var status = partitionStatusForTenant(id).get(partitionId);
+      if (status != null) {
+        byTenant.put(id, status);
+      }
+    }
+    return byTenant;
+  }
+
+  /**
+   * Returns the flat, per-partition status map for a single physical tenant, matching today's
+   * shape.
+   */
+  private Map<Integer, PartitionStatus> partitionStatusForTenant(final String physicalTenantId) {
+    return springBrokerBridge
+        .getAdminService(physicalTenantId)
         .map(BrokerAdminService::getPartitionStatus)
         .orElse(Map.of());
   }
 
-  @ReadOperation
-  public Optional<PartitionStatus> singlePartition(
-      @Selector final Integer partitionId, @Nullable final String physicalTenant) {
-    return Optional.ofNullable(partitionStatus(physicalTenant).get(partitionId));
+  /**
+   * Aggregates the partition status across every given physical tenant. If there is at most one
+   * known physical tenant, returns the flat, single-tenant shape for full backward compatibility;
+   * otherwise, keys the result by physical tenant ID since partition IDs alias across physical
+   * tenant groups.
+   */
+  private Object aggregatedPartitionStatus(final Set<String> tenantIds) {
+    if (tenantIds.size() <= 1) {
+      final var tenantId = tenantIds.stream().findFirst().orElse(DEFAULT_PHYSICAL_TENANT_ID);
+      return partitionStatusForTenant(tenantId);
+    }
+    final Map<String, Map<Integer, PartitionStatus>> byTenant = new LinkedHashMap<>();
+    for (final var id : tenantIds) {
+      byTenant.put(id, partitionStatusForTenant(id));
+    }
+    return byTenant;
   }
 
-  private Optional<BrokerAdminService> resolveAdminService(@Nullable final String physicalTenant) {
-    final var physicalTenantId =
-        physicalTenant != null && !physicalTenant.isBlank()
-            ? physicalTenant
-            : DEFAULT_PHYSICAL_TENANT_ID;
-    return springBrokerBridge.getAdminService(physicalTenantId);
+  private Set<String> tenantIds() {
+    return springBrokerBridge.getBrokerAdminServiceTenantIds();
+  }
+
+  private Optional<String> normalize(@Nullable final String physicalTenant) {
+    return Optional.ofNullable(physicalTenant).filter(t -> !t.isBlank());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.system.management;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +18,7 @@ import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -24,68 +27,54 @@ public class BrokerAdminServiceEndpoint {
 
   @Autowired private SpringBrokerBridge springBrokerBridge;
 
-  private final Map<String, Runnable> operations = new HashMap<>();
+  private final Map<String, java.util.function.Consumer<BrokerAdminService>> operations =
+      new HashMap<>();
 
   public BrokerAdminServiceEndpoint() {
-    operations.put("pauseProcessing", this::pauseProcessing);
-    operations.put("resumeProcessing", this::resumeProcessing);
-    operations.put("takeSnapshot", this::takeSnapshot);
-    operations.put("pauseExporting", this::pauseExporting);
-    operations.put("softPauseExporting", this::softPauseExporting);
-    operations.put("resumeExporting", this::resumeExporting);
+    operations.put("pauseProcessing", BrokerAdminService::pauseStreamProcessing);
+    operations.put("resumeProcessing", BrokerAdminService::resumeStreamProcessing);
+    operations.put("takeSnapshot", BrokerAdminService::takeSnapshot);
+    operations.put("pauseExporting", BrokerAdminService::pauseExporting);
+    operations.put("softPauseExporting", BrokerAdminService::softPauseExporting);
+    operations.put("resumeExporting", BrokerAdminService::resumeExporting);
   }
 
+  /**
+   * Triggers the given admin operation. Without the {@code physicalTenant} query parameter, this
+   * broker-local operation applies to the default physical tenant's partitions, matching today's
+   * behavior. With the parameter, it applies to the given physical tenant's partitions instead.
+   */
   @WriteOperation
-  public Map<Integer, PartitionStatus> trigger(@Selector final String operation) {
-    final var runnable = operations.get(operation);
-    if (runnable != null) {
-      runnable.run();
-      return partitionStatus();
+  public Map<Integer, PartitionStatus> trigger(
+      @Selector final String operation, @Nullable final String physicalTenant) {
+    final var consumer = operations.get(operation);
+    if (consumer == null) {
+      // Not a valid operation
+      return null;
     }
-    // Not a valid operation
-    return null;
-  }
-
-  private Map<Integer, PartitionStatus> pauseProcessing() {
-    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::pauseStreamProcessing);
-    return partitionStatus();
-  }
-
-  private Map<Integer, PartitionStatus> resumeProcessing() {
-    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::resumeStreamProcessing);
-    return partitionStatus();
-  }
-
-  private Map<Integer, PartitionStatus> pauseExporting() {
-    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::pauseExporting);
-    return partitionStatus();
-  }
-
-  private Map<Integer, PartitionStatus> softPauseExporting() {
-    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::softPauseExporting);
-    return partitionStatus();
-  }
-
-  private Map<Integer, PartitionStatus> resumeExporting() {
-    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::resumeExporting);
-    return partitionStatus();
-  }
-
-  private Map<Integer, PartitionStatus> takeSnapshot() {
-    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::takeSnapshot);
-    return partitionStatus();
+    final var adminService = resolveAdminService(physicalTenant);
+    adminService.ifPresent(consumer);
+    return partitionStatus(physicalTenant);
   }
 
   @ReadOperation
-  public Map<Integer, PartitionStatus> partitionStatus() {
-    return springBrokerBridge
-        .getAdminService()
+  public Map<Integer, PartitionStatus> partitionStatus(@Nullable final String physicalTenant) {
+    return resolveAdminService(physicalTenant)
         .map(BrokerAdminService::getPartitionStatus)
         .orElse(Map.of());
   }
 
   @ReadOperation
-  public Optional<PartitionStatus> singlePartition(@Selector final Integer partitionId) {
-    return Optional.ofNullable(partitionStatus().get(partitionId));
+  public Optional<PartitionStatus> singlePartition(
+      @Selector final Integer partitionId, @Nullable final String physicalTenant) {
+    return Optional.ofNullable(partitionStatus(physicalTenant).get(partitionId));
+  }
+
+  private Optional<BrokerAdminService> resolveAdminService(@Nullable final String physicalTenant) {
+    final var physicalTenantId =
+        physicalTenant != null && !physicalTenant.isBlank()
+            ? physicalTenant
+            : DEFAULT_PHYSICAL_TENANT_ID;
+    return springBrokerBridge.getAdminService(physicalTenantId);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerAdminServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerAdminServiceStepTest.java
@@ -7,71 +7,73 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.time.Duration;
-import java.util.function.Supplier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 final class BrokerAdminServiceStepTest {
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
 
-  private BrokerStartupContext mockBrokerStartupContext;
-  private ActorSchedulingService mockActorSchedulingService;
-  private SpringBrokerBridge mockSpringBrokerBridge;
-  private BrokerAdminServiceImpl mockBrokerAdminService;
-
+  private final List<CompletableActorFuture<Void>> scheduledActorFutures = new ArrayList<>();
+  private MockBrokerStartupContext ctx;
   private ActorFuture<BrokerStartupContext> future;
 
   private final BrokerAdminServiceStep sut = new BrokerAdminServiceStep();
 
   @BeforeEach
   void setUp() {
-    mockActorSchedulingService = mock(ActorSchedulingService.class);
+    scheduledActorFutures.clear();
+    ctx = new MockBrokerStartupContext();
+    ctx.setConcurrencyControl(CONCURRENCY_CONTROL);
+    ctx.addPartitionManager(DEFAULT_PHYSICAL_TENANT_ID, mock(PartitionManager.class));
 
-    when(mockActorSchedulingService.submitActor(any()))
-        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
-
-    mockSpringBrokerBridge = mock(SpringBrokerBridge.class);
-
-    mockBrokerAdminService = mock(BrokerAdminServiceImpl.class);
-    when(mockBrokerAdminService.closeAsync()).thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
-
-    mockBrokerStartupContext = mock(BrokerStartupContext.class);
-
-    when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
-    when(mockBrokerStartupContext.getBrokerInfo()).thenReturn(mock(BrokerInfo.class));
-    when(mockBrokerStartupContext.getActorSchedulingService())
-        .thenReturn(mockActorSchedulingService);
-    when(mockBrokerStartupContext.getSpringBrokerBridge()).thenReturn(mockSpringBrokerBridge);
-    when(mockBrokerStartupContext.getBrokerAdminService()).thenReturn(mockBrokerAdminService);
-
-    when(mockBrokerStartupContext.getClusterServices())
-        .thenReturn(mock(ClusterServicesImpl.class, Mockito.RETURNS_DEEP_STUBS));
+    final var mockScheduler = mock(ActorSchedulingService.class);
+    when(mockScheduler.submitActor(any()))
+        .thenAnswer(
+            inv -> {
+              final var f = new CompletableActorFuture<Void>();
+              scheduledActorFutures.add(f);
+              return f;
+            });
+    ctx.setActorSchedulingService(mockScheduler);
+    ctx.setClusterServices(mock(ClusterServicesImpl.class, Mockito.RETURNS_DEEP_STUBS));
 
     future = CONCURRENCY_CONTROL.createFuture();
+  }
+
+  private void completeAllScheduledActors() {
+    for (int i = 0; i < scheduledActorFutures.size(); i++) {
+      final var f = scheduledActorFutures.get(i);
+      if (!f.isDone()) {
+        f.complete(null);
+      }
+    }
   }
 
   @Test
   void shouldCompleteFutureOnStartup() {
     // when
-    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    sut.startupInternal(ctx, CONCURRENCY_CONTROL, future);
+    completeAllScheduledActors();
 
     // then
     assertThat(future).succeedsWithin(TIME_OUT);
@@ -79,39 +81,52 @@ final class BrokerAdminServiceStepTest {
   }
 
   @Test
-  void shouldScheduleBrokerAdminServiceOnStartup() {
+  void shouldRegisterBrokerAdminServiceForDefaultTenantOnStartup() {
     // when
-    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
-    await().until(future::isDone);
+    sut.startupInternal(ctx, CONCURRENCY_CONTROL, future);
+    completeAllScheduledActors();
 
     // then
-    final var argumentCaptor = ArgumentCaptor.forClass(BrokerAdminServiceImpl.class);
-    verify(mockActorSchedulingService).submitActor(argumentCaptor.capture());
-
-    verify(mockBrokerStartupContext).setBrokerAdminService(argumentCaptor.getValue());
+    assertThat(future).succeedsWithin(TIME_OUT);
+    assertThat(ctx.getBrokerAdminService(DEFAULT_PHYSICAL_TENANT_ID)).isNotNull();
   }
 
   @Test
-  void shouldRegisterBrokerAdminServiceInSpringBrokerBridgeOnStartup() {
+  void shouldCreateDistinctServicesForEachPhysicalTenant() {
+    // given
+    final var secondTenantId = "second";
+    ctx.setPhysicalTenantIds(() -> Set.of(DEFAULT_PHYSICAL_TENANT_ID, secondTenantId));
+    ctx.addPartitionManager(secondTenantId, mock(PartitionManager.class));
+
     // when
-    sut.startupInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
-    await().until(future::isDone);
+    sut.startupInternal(ctx, CONCURRENCY_CONTROL, future);
+    completeAllScheduledActors();
 
     // then
-    final var adminServiceCaptor = ArgumentCaptor.forClass(BrokerAdminServiceImpl.class);
-    verify(mockBrokerStartupContext).setBrokerAdminService(adminServiceCaptor.capture());
+    assertThat(future).succeedsWithin(TIME_OUT);
+    final var defaultService = ctx.getBrokerAdminService(DEFAULT_PHYSICAL_TENANT_ID);
+    final var secondService = ctx.getBrokerAdminService(secondTenantId);
+    assertThat(defaultService).isNotNull();
+    assertThat(secondService).isNotNull();
+    assertThat(defaultService).isNotSameAs(secondService);
+  }
 
-    final var adminServiceSupplierCaptor = ArgumentCaptor.forClass(Supplier.class);
-    verify(mockSpringBrokerBridge)
-        .registerBrokerAdminServiceSupplier(adminServiceSupplierCaptor.capture());
+  @Test
+  void shouldRegisterAdminServiceSupplierAndByTenantLookupWithSpringBrokerBridge() {
+    // when
+    sut.startupInternal(ctx, CONCURRENCY_CONTROL, future);
+    completeAllScheduledActors();
 
-    assertThat(adminServiceSupplierCaptor.getValue().get()).isSameAs(adminServiceCaptor.getValue());
+    // then
+    assertThat(future).succeedsWithin(TIME_OUT);
+    verify(ctx.getSpringBrokerBridge()).registerBrokerAdminServiceSupplier(notNull());
+    verify(ctx.getSpringBrokerBridge()).registerBrokerAdminServiceByTenantLookup(notNull());
   }
 
   @Test
   void shouldCompleteFutureOnShutdown() {
     // when
-    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
+    sut.shutdownInternal(ctx, CONCURRENCY_CONTROL, future);
 
     // then
     assertThat(future).succeedsWithin(TIME_OUT);
@@ -120,12 +135,17 @@ final class BrokerAdminServiceStepTest {
 
   @Test
   void shouldStopBrokerAdminServiceOnShutdown() {
+    // given
+    sut.startupInternal(ctx, CONCURRENCY_CONTROL, future);
+    completeAllScheduledActors();
+    assertThat(future).succeedsWithin(TIME_OUT);
+
     // when
-    sut.shutdownInternal(mockBrokerStartupContext, CONCURRENCY_CONTROL, future);
-    await().until(future::isDone);
+    final var shutdownFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
+    sut.shutdownInternal(ctx, CONCURRENCY_CONTROL, shutdownFuture);
 
     // then
-    verify(mockBrokerAdminService).closeAsync();
-    verify(mockBrokerStartupContext).setBrokerAdminService(null);
+    assertThat(shutdownFuture).succeedsWithin(TIME_OUT);
+    assertThat(ctx.getBrokerAdminService(DEFAULT_PHYSICAL_TENANT_ID)).isNull();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -79,7 +79,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private final Map<String, JobStreamService> jobStreamServices = new LinkedHashMap<>();
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
-  private BrokerAdminServiceImpl brokerAdminService = mock(BrokerAdminServiceImpl.class);
+  private final Map<String, BrokerAdminServiceImpl> brokerAdminServices = new LinkedHashMap<>();
   private ClusterConfigurationService clusterConfigurationService =
       mock(ClusterConfigurationService.class);
   private BrokerClient brokerClient = mock(BrokerClient.class);
@@ -291,13 +291,19 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public BrokerAdminServiceImpl getBrokerAdminService() {
-    return brokerAdminService;
+  public BrokerAdminServiceImpl getBrokerAdminService(final String physicalTenantId) {
+    return brokerAdminServices.get(physicalTenantId);
   }
 
   @Override
-  public void setBrokerAdminService(final BrokerAdminServiceImpl brokerAdminService) {
-    this.brokerAdminService = brokerAdminService;
+  public void addBrokerAdminService(
+      final String physicalTenantId, final BrokerAdminServiceImpl brokerAdminService) {
+    brokerAdminServices.put(physicalTenantId, brokerAdminService);
+  }
+
+  @Override
+  public void removeBrokerAdminService(final String physicalTenantId) {
+    brokerAdminServices.remove(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -97,7 +97,7 @@ class PartitionManagerStepTest {
       testBrokerStartupContext.setShutdownTimeout(TEST_SHUTDOWN_TIMEOUT);
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
-      testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
+      testBrokerStartupContext.addBrokerAdminService(PHYSICAL_TENANT_ID, mock(BrokerAdminServiceImpl.class));
       testBrokerStartupContext.addJobStreamService(
           PHYSICAL_TENANT_ID, mock(JobStreamService.class));
       final ClusterConfigurationService clusterConfigurationService =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -97,7 +97,8 @@ class PartitionManagerStepTest {
       testBrokerStartupContext.setShutdownTimeout(TEST_SHUTDOWN_TIMEOUT);
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
-      testBrokerStartupContext.addBrokerAdminService(PHYSICAL_TENANT_ID, mock(BrokerAdminServiceImpl.class));
+      testBrokerStartupContext.addBrokerAdminService(
+          PHYSICAL_TENANT_ID, mock(BrokerAdminServiceImpl.class));
       testBrokerStartupContext.addJobStreamService(
           PHYSICAL_TENANT_ID, mock(JobStreamService.class));
       final ClusterConfigurationService clusterConfigurationService =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBanningActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantBanningActuatorIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.qa.util.actuator.BanningActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the {@code banning} actuator's {@code physicalTenant} query parameter routes a ban
+ * to the given physical tenant's partition group, leaving other physical tenants' instances
+ * unaffected, while omitting the parameter still targets the default physical tenant (today's
+ * behavior).
+ */
+@ZeebeIntegration
+final class PhysicalTenantBanningActuatorIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String PROCESS_ID = "banning-process";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker().withUnauthenticatedAccess().withRecordingExporter(true));
+
+  @AutoClose private CamundaClient defaultClient;
+  @AutoClose private CamundaClient tenantAClient;
+
+  private BanningActuator actuator;
+
+  @BeforeEach
+  void beforeEach() {
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    actuator = BanningActuator.of(broker);
+  }
+
+  @Test
+  void shouldBanInstanceOnTargetedPhysicalTenantOnly() {
+    // given - a process instance in tenant A and one in the default tenant
+    final var process = Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+
+    // tenant A's partition group may need a moment to elect a leader after startup; retry the
+    // first command until it lands (its topology is not observable via the default topology RPC)
+    await("deployment to tenant A succeeds")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        tenantAClient
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, PROCESS_ID + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+    defaultClient
+        .newDeployResourceCommand()
+        .addProcessModel(process, PROCESS_ID + ".bpmn")
+        .send()
+        .join();
+
+    final long tenantAInstanceKey =
+        tenantAClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+    final long defaultInstanceKey =
+        defaultClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    // when - banning tenant A's instance via the physicalTenant parameter
+    actuator.ban(tenantAInstanceKey, TENANT_A);
+
+    // then - tenant A's instance is banned...
+    await("tenant A instance is banned")
+        .untilAsserted(() -> assertThat(hasErrorEventFor(tenantAInstanceKey)).isTrue());
+    // and - the default tenant's instance is unaffected by that call
+    assertThat(noErrorEventFor(defaultInstanceKey)).isTrue();
+
+    // when - banning the default tenant's instance without specifying a physicalTenant, matching
+    // today's default behavior
+    actuator.ban(defaultInstanceKey);
+
+    // then - the default tenant's instance is banned too
+    await("default tenant instance is banned")
+        .untilAsserted(() -> assertThat(hasErrorEventFor(defaultInstanceKey)).isTrue());
+  }
+
+  private static boolean hasErrorEventFor(final long key) {
+    return RecordingExporter.records()
+        .filter(record -> record.getRecordType() == RecordType.EVENT)
+        .filter(record -> record.getValueType() == ValueType.ERROR)
+        .filter(record -> record.getKey() == key)
+        .exists();
+  }
+
+  private static boolean noErrorEventFor(final long key) {
+    return RecordingExporter.expectNoMatchingRecords(
+        records ->
+            !records
+                .filter(record -> record.getRecordType() == RecordType.EVENT)
+                .filter(record -> record.getValueType() == ValueType.ERROR)
+                .filter(record -> record.getKey() == key)
+                .exists());
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobStreamActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobStreamActuatorIT.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.qa.util.actuator.JobStreamActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the {@code jobstreams} actuator's {@code physicalTenant} query parameter filters
+ * remote job streams to the given physical tenant, while omitting the parameter still returns
+ * streams across every physical tenant (today's whole-cluster behavior).
+ */
+@ZeebeIntegration
+final class PhysicalTenantJobStreamActuatorIT {
+
+  private static final String TENANT_A = "tenanta";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  @AutoClose private CamundaClient tenantAClient;
+
+  private JobStreamActuator actuator;
+
+  @BeforeEach
+  void beforeEach() {
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    actuator = JobStreamActuator.of(broker);
+  }
+
+  @Test
+  void shouldListRemoteStreamsForTargetedPhysicalTenantOnly() {
+    // given - a job stream registered only on tenant A
+    final var jobType = Strings.newRandomValidBpmnId();
+    tenantAClient
+        .newStreamJobsCommand()
+        .jobType(jobType)
+        .consumer(ignored -> {})
+        .workerName("worker")
+        .timeout(Duration.ofSeconds(1))
+        .send();
+
+    // when + then - the stream is visible when scoped to tenant A...
+    await("tenant A's remote stream is registered")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var streams = actuator.listRemote(TENANT_A);
+              assertThat(streams).hasSize(1);
+              assertThat(streams.get(0).jobType()).isEqualTo(jobType);
+            });
+
+    // and - it is not visible when scoped to the default physical tenant
+    assertThat(actuator.listRemote(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)).isEmpty();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobStreamActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantJobStreamActuatorIT.java
@@ -78,4 +78,31 @@ final class PhysicalTenantJobStreamActuatorIT {
     // and - it is not visible when scoped to the default physical tenant
     assertThat(actuator.listRemote(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)).isEmpty();
   }
+
+  @Test
+  void shouldListClientStreamsForTargetedPhysicalTenantOnly() {
+    // given - a job stream registered only on tenant A, from the gateway's (client-side) point of
+    // view
+    final var jobType = Strings.newRandomValidBpmnId();
+    tenantAClient
+        .newStreamJobsCommand()
+        .jobType(jobType)
+        .consumer(ignored -> {})
+        .workerName("worker")
+        .timeout(Duration.ofSeconds(1))
+        .send();
+
+    // when + then - the stream is visible when scoped to tenant A...
+    await("tenant A's client stream is registered")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var streams = actuator.listClient(TENANT_A);
+              assertThat(streams).hasSize(1);
+              assertThat(streams.get(0).jobType()).isEqualTo(jobType);
+            });
+
+    // and - it is not visible when scoped to the default physical tenant
+    assertThat(actuator.listClient(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)).isEmpty();
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionsActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionsActuatorIT.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the broker-local {@code partitions} actuator's {@code physicalTenant} query
+ * parameter scopes both read and write operations to the given physical tenant's partitions,
+ * leaving other physical tenants unaffected, while omitting the parameter still targets the default
+ * physical tenant (today's behavior).
+ */
+@ZeebeIntegration
+final class PhysicalTenantPartitionsActuatorIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final int PARTITION_ID = 1;
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private final PartitionsActuator actuator = PartitionsActuator.of(broker);
+
+  @Test
+  void shouldPauseProcessingOnTargetedPhysicalTenantOnly() {
+    // given - both physical tenants' partitions are processing before any operation
+    await("both physical tenants report a processing partition")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              assertThat(
+                      actuator
+                          .query(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+                          .get(PARTITION_ID)
+                          .streamProcessorPhase())
+                  .isEqualTo("PROCESSING");
+              assertThat(actuator.query(TENANT_A).get(PARTITION_ID).streamProcessorPhase())
+                  .isEqualTo("PROCESSING");
+            });
+
+    // when - pausing processing on the default physical tenant only
+    actuator.pauseProcessing(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+
+    // then - the default tenant's partition is paused...
+    await("default tenant partition is paused")
+        .untilAsserted(
+            () ->
+                assertThat(
+                        actuator
+                            .query(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+                            .get(PARTITION_ID)
+                            .streamProcessorPhase())
+                    .isEqualTo("PAUSED"));
+    // and - tenant A's partition is unaffected
+    assertThat(actuator.query(TENANT_A).get(PARTITION_ID).streamProcessorPhase())
+        .isEqualTo("PROCESSING");
+
+    // cleanup - resume the default tenant's processing
+    actuator.resumeProcessing(PhysicalTenantsITHelper.DEFAULT_TENANT_ID);
+    await("default tenant partition resumes processing")
+        .untilAsserted(
+            () ->
+                assertThat(
+                        actuator
+                            .query(PhysicalTenantsITHelper.DEFAULT_TENANT_ID)
+                            .get(PARTITION_ID)
+                            .streamProcessorPhase())
+                    .isEqualTo("PROCESSING"));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionsActuatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantPartitionsActuatorIT.java
@@ -89,4 +89,23 @@ final class PhysicalTenantPartitionsActuatorIT {
                             .streamProcessorPhase())
                     .isEqualTo("PROCESSING"));
   }
+
+  @Test
+  void shouldReturnNodeScopedStatusForEveryPhysicalTenantWithoutParameter() {
+    // when - querying without a physicalTenant parameter on a node with more than one physical
+    // tenant, per ADR 003 D3 this is Node-scoped: every known physical tenant's status is
+    // returned, keyed by physical tenant ID (partition IDs alias across physical tenant groups, so
+    // a flat map could not represent all of them)
+    await("both physical tenants are reported without a physicalTenant parameter")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var statusByTenant = actuator.queryByTenant();
+              assertThat(statusByTenant)
+                  .containsOnlyKeys(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, TENANT_A);
+              assertThat(statusByTenant.get(PhysicalTenantsITHelper.DEFAULT_TENANT_ID))
+                  .containsKey(PARTITION_ID);
+              assertThat(statusByTenant.get(TENANT_A)).containsKey(PARTITION_ID);
+            });
+  }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BanningActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BanningActuator.java
@@ -44,4 +44,13 @@ public interface BanningActuator {
   @RequestLine("POST /{id}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void ban(@Param final long id);
+
+  /**
+   * Bans the given process instance key on the given physical tenant's partition group.
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /{id}?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void ban(@Param final long id, @Param final String physicalTenant);
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/JobStreamActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/JobStreamActuator.java
@@ -84,6 +84,10 @@ public interface JobStreamActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   List<ClientJobStream> listClient();
 
+  @RequestLine("GET /client?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  List<ClientJobStream> listClient(@feign.Param final String physicalTenant);
+
   @RequestLine("GET /remote")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   List<RemoteJobStream> listRemote();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/JobStreamActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/JobStreamActuator.java
@@ -76,6 +76,10 @@ public interface JobStreamActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   JobStreams list();
 
+  @RequestLine("GET ?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  JobStreams list(@feign.Param final String physicalTenant);
+
   @RequestLine("GET /client")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   List<ClientJobStream> listClient();
@@ -83,4 +87,8 @@ public interface JobStreamActuator {
   @RequestLine("GET /remote")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   List<RemoteJobStream> listRemote();
+
+  @RequestLine("GET /remote?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  List<RemoteJobStream> listRemote(@feign.Param final String physicalTenant);
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -88,6 +88,15 @@ public interface PartitionsActuator {
   @Headers("Accept: application/json")
   Map<Integer, PartitionStatus> query();
 
+  /**
+   * Same as {@link #query()}, but decodes the response as the Node-scoped (all physical tenants)
+   * shape returned when there is more than one known physical tenant on the node: a map keyed by
+   * physical tenant ID, whose values are the usual per-partition status map.
+   */
+  @RequestLine("GET")
+  @Headers("Accept: application/json")
+  Map<String, Map<Integer, PartitionStatus>> queryByTenant();
+
   @RequestLine("GET ?physicalTenant={physicalTenant}")
   @Headers("Accept: application/json")
   Map<Integer, PartitionStatus> query(@feign.Param final String physicalTenant);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -108,9 +108,17 @@ public interface PartitionsActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> pauseProcessing();
 
+  @RequestLine("POST /pauseProcessing?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<Integer, PartitionStatus> pauseProcessing(@feign.Param final String physicalTenant);
+
   @RequestLine("POST /resumeProcessing")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> resumeProcessing();
+
+  @RequestLine("POST /resumeProcessing?physicalTenant={physicalTenant}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<Integer, PartitionStatus> resumeProcessing(@feign.Param final String physicalTenant);
 
   @RequestLine("POST /takeSnapshot")
   @Headers({"Content-Type: application/json", "Accept: application/json"})

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -88,6 +88,10 @@ public interface PartitionsActuator {
   @Headers("Accept: application/json")
   Map<Integer, PartitionStatus> query();
 
+  @RequestLine("GET ?physicalTenant={physicalTenant}")
+  @Headers("Accept: application/json")
+  Map<Integer, PartitionStatus> query(@feign.Param final String physicalTenant);
+
   @RequestLine("POST /pauseExporting")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> pauseExporting();


### PR DESCRIPTION
## Description

Makes the node-level diagnostic actuators physical-tenant-aware per ADR 003 D3 (camunda/camunda#56795): `banning`, the broker-local `partitions` endpoint, and `jobstreams` now accept an optional `?physicalTenant={id}` query parameter.

- **`banning`**: without a parameter, targets the default physical tenant (the process instance key encodes a bare partition id, which aliases across partition groups); with the parameter, targets the specified tenant's partition group.
- **`partitions`** (broker-local admin endpoint): broker admin services (partition status, pause/resume processing/exporting, snapshots) are now created per physical tenant instead of only for the default group; the endpoint is scoped to the specified tenant's partitions when the parameter is given.
- **`jobstreams`**: read operations can now be filtered to a single physical tenant's remote/client job streams.

Without the `physicalTenant` parameter, all three endpoints keep their current whole-cluster / default-tenant behavior, so this is backward compatible.

## Related issues

closes #57378
