### PR TITLE
deps: bump netty to 4.1.136.Final to resolve CVE-2026-55831

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -61,7 +61,7 @@
     <quartz.version>2.3.2</quartz.version>
     <kotlin-stdlib.version>2.1.0</kotlin-stdlib.version>
     <jakarta.rs-api.version>4.0.0</jakarta.rs-api.version>
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <log4j2.version>2.25.4</log4j2.version>
     <lombok.version>1.18.34</lombok.version>
     <logback.version>1.5.37</logback.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
     <version.mockito>5.13.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.8</version.msgpack>
-    <version.netty>4.1.135.Final</version.netty>
+    <version.netty>4.1.136.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
     <version.opentelemetry>1.62.0</version.opentelemetry>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1009,6 +1009,18 @@
         <scope>import</scope>
       </dependency>
 
+      <!--
+        Override Spring Boot's netty version to resolve CVE-2026-55831.
+        Must be declared before spring-boot-dependencies so this version wins.
+      -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
@@ -1286,14 +1298,6 @@
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
         <version>${version.protobuf-common}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${version.netty}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

Bump netty to 4.1.136.Final to resolve CVE-2026-55831

## Related issues

closes https://github.com/camunda/camunda/issues/58616
