### PR TITLE
Fix/request validation nightly eslint

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
+++ b/.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml
@@ -1,4 +1,4 @@
-# description: Runs Request Validation tests on the C8 Orchestration Cluster REST API for 8.8+ versions nightly
+# description: Runs Request Validation tests on the C8 Orchestration Cluster REST API nightly
 # test location: /qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/request-validation
 # type: CI
 # owner: @camunda/core-features
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [stable/8.8, main]
+        branch: [main]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/emit/qaEmitter.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/v2-stateless-tests/request-validation-test-generator/src/emit/qaEmitter.ts
@@ -100,7 +100,14 @@ function buildFile(
   meta.push(' */');
   lines.push(meta.join('\n'));
   lines.push("import {test, expect} from '@playwright/test'");
-  lines.push(`import {jsonHeaders, buildUrl} from '${httpImport}'`);
+  const needsJsonHeaders = scenarios.some(
+    (s) => s.headersAuth && s.bodyEncoding !== 'multipart',
+  );
+  lines.push(
+    needsJsonHeaders
+      ? `import {jsonHeaders, buildUrl} from '${httpImport}'`
+      : `import {buildUrl} from '${httpImport}'`,
+  );
   lines.push('');
   lines.push(`test.describe('${describeTitle}', () => {`);
   // Pre-compute base titles and detect duplicates for uniqueness


### PR DESCRIPTION
## Description

- fix `jsonHeaders` in `qaEmitter.ts` as it does later in line 157
- remove `stable/8.8` since this CI hasn't been backported ([ref](https://camunda.slack.com/archives/C0BKD2Y3L8M/p1784880253874389))

`npm run generate:full` is clean and passing now

## Related issues

[#inc-6647-unsuccessful-job-c8-orchestration-cluster-v2-stateless-tests-night](https://camunda.slack.com/archives/C0BKD2Y3L8M)
