### PR TITLE
feat: source current-user and IdP tokens from the CSL session in Optimize

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -119,6 +119,10 @@
     <!-- Camunda Security Library -->
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-library-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-core</artifactId>
     </dependency>
     <dependency>

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/AccountsUserAccessTokenProvider.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/cloud/AccountsUserAccessTokenProvider.java
@@ -9,11 +9,16 @@ package io.camunda.optimize.rest.cloud;
 
 import io.camunda.optimize.service.security.AuthCookieService;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -26,34 +31,60 @@ public class AccountsUserAccessTokenProvider {
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(AccountsUserAccessTokenProvider.class);
 
-  public AccountsUserAccessTokenProvider() {}
+  // Present only under CSL; absent in the legacy CCSaaS setup, which reads the token from the
+  // cookie.
+  private final ObjectProvider<OAuth2AuthorizedClientRepository> authorizedClientRepositoryProvider;
+
+  public AccountsUserAccessTokenProvider(
+      final ObjectProvider<OAuth2AuthorizedClientRepository> authorizedClientRepositoryProvider) {
+    this.authorizedClientRepositoryProvider = authorizedClientRepositoryProvider;
+  }
 
   private Optional<String> retrieveServiceTokenFromFramework() {
     final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication instanceof final JwtAuthenticationToken jwt) {
+      return Optional.ofNullable(jwt.getToken().getTokenValue());
+    }
+    // Under CSL the token lives in the OIDC session's authorized client, not a bearer token.
+    if (authentication instanceof final OAuth2AuthenticationToken oauthToken) {
+      return cslSessionAccessToken(oauthToken);
+    }
     if (authentication != null) {
-      if (authentication instanceof JwtAuthenticationToken) {
-        return Optional.ofNullable(
-            ((JwtAuthenticationToken) authentication).getToken().getTokenValue());
-      } else {
-        LOG.info(
-            "Could not retrieve Jwt Token. Provided token has type "
-                + authentication.getClass().getTypeName());
-        return Optional.empty();
-      }
+      LOG.info(
+          "Could not retrieve access token. Unsupported authentication type {}",
+          authentication.getClass().getTypeName());
     }
     return Optional.empty();
   }
 
+  private Optional<String> cslSessionAccessToken(final OAuth2AuthenticationToken oauthToken) {
+    final OAuth2AuthorizedClientRepository repository =
+        authorizedClientRepositoryProvider == null
+            ? null
+            : authorizedClientRepositoryProvider.getIfAvailable();
+    if (repository == null) {
+      return Optional.empty();
+    }
+    return currentRequest()
+        .map(
+            request ->
+                repository.<OAuth2AuthorizedClient>loadAuthorizedClient(
+                    oauthToken.getAuthorizedClientRegistrationId(), oauthToken, request))
+        .map(OAuth2AuthorizedClient::getAccessToken)
+        .map(token -> token.getTokenValue());
+  }
+
+  private static Optional<HttpServletRequest> currentRequest() {
+    return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+        .filter(ServletRequestAttributes.class::isInstance)
+        .map(ServletRequestAttributes.class::cast)
+        .map(ServletRequestAttributes::getRequest);
+  }
+
   public Optional<String> getCurrentUsersAccessToken() {
     Optional<String> accessToken =
-        Optional.ofNullable(RequestContextHolder.getRequestAttributes())
-            .filter(ServletRequestAttributes.class::isInstance)
-            .map(ServletRequestAttributes.class::cast)
-            .map(ServletRequestAttributes::getRequest)
-            .flatMap(AuthCookieService::getServiceAccessToken);
-    // In case we don't have a cookie to extract the service token from, we try to retrieve it
-    // directly from the
-    // framework
+        currentRequest().flatMap(AuthCookieService::getServiceAccessToken);
+    // No service-token cookie (e.g. under CSL): fall back to the SecurityContext.
     if (accessToken.isEmpty()) {
       accessToken = retrieveServiceTokenFromFramework();
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
@@ -31,7 +31,10 @@ import io.camunda.optimize.dto.optimize.UserDto;
 import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.CCSMCondition;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,7 +44,12 @@ import java.util.Locale;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -73,14 +81,22 @@ public class CCSMTokenService {
   private final AuthCookieService authCookieService;
   private final ConfigurationService configurationService;
   private final Identity identity;
+  // Both present only under CSL; absent in the legacy CCSM setup, which falls back to the auth
+  // cookie and the token's sub claim.
+  private final ObjectProvider<OAuth2AuthorizedClientRepository> authorizedClientRepositoryProvider;
+  private final ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderProvider;
 
   public CCSMTokenService(
       final AuthCookieService authCookieService,
       final ConfigurationService configurationService,
-      final Identity identity) {
+      final Identity identity,
+      final ObjectProvider<OAuth2AuthorizedClientRepository> authorizedClientRepositoryProvider,
+      final ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderProvider) {
     this.authCookieService = authCookieService;
     this.configurationService = configurationService;
     this.identity = identity;
+    this.authorizedClientRepositoryProvider = authorizedClientRepositoryProvider;
+    this.camundaAuthenticationProviderProvider = camundaAuthenticationProviderProvider;
   }
 
   public List<Cookie> createOptimizeAuthNewCookies(
@@ -292,6 +308,13 @@ public class CCSMTokenService {
   }
 
   public Optional<String> getCurrentUserIdFromAuthToken() {
+    // Under CSL the principal is resolved from the configured username-claim, which may not be the
+    // sub claim. Prefer it over re-decoding the access token (whose subject is always sub), so the
+    // resolved user id matches the CSL SecurityContext principal.
+    final Optional<String> cslUserId = cslAuthenticatedUsername();
+    if (cslUserId.isPresent()) {
+      return cslUserId;
+    }
     try {
       // The userID is the subject of the current JWT token
       return getCurrentUserAuthToken().map(token -> authentication().decodeJWT(token).getSubject());
@@ -300,12 +323,57 @@ public class CCSMTokenService {
     }
   }
 
+  private Optional<String> cslAuthenticatedUsername() {
+    final CamundaAuthenticationProvider provider =
+        camundaAuthenticationProviderProvider == null
+            ? null
+            : camundaAuthenticationProviderProvider.getIfAvailable();
+    if (provider == null) {
+      return Optional.empty();
+    }
+    if (!(SecurityContextHolder.getContext().getAuthentication()
+        instanceof OAuth2AuthenticationToken)) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(provider.getCamundaAuthentication())
+        .map(CamundaAuthentication::authenticatedUsername);
+  }
+
   public Optional<String> getCurrentUserAuthToken() {
+    final HttpServletRequest request = currentRequest().orElse(null);
+    if (request == null) {
+      return Optional.empty();
+    }
+    // Under CSL the token lives in the OIDC session's authorized client; fall back to the auth
+    // cookie for the legacy CCSM setup.
+    return cslSessionAccessToken(request).or(() -> AuthCookieService.getAuthCookieToken(request));
+  }
+
+  private Optional<HttpServletRequest> currentRequest() {
     return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
         .filter(ServletRequestAttributes.class::isInstance)
         .map(ServletRequestAttributes.class::cast)
-        .map(ServletRequestAttributes::getRequest)
-        .flatMap(AuthCookieService::getAuthCookieToken);
+        .map(ServletRequestAttributes::getRequest);
+  }
+
+  private Optional<String> cslSessionAccessToken(final HttpServletRequest request) {
+    final OAuth2AuthorizedClientRepository repository =
+        authorizedClientRepositoryProvider == null
+            ? null
+            : authorizedClientRepositoryProvider.getIfAvailable();
+    if (repository == null) {
+      return Optional.empty();
+    }
+    if (!(SecurityContextHolder.getContext().getAuthentication()
+        instanceof final OAuth2AuthenticationToken oauthToken)) {
+      return Optional.empty();
+    }
+    final OAuth2AuthorizedClient client =
+        repository.loadAuthorizedClient(
+            oauthToken.getAuthorizedClientRegistrationId(), oauthToken, request);
+    return Optional.ofNullable(client)
+        .map(OAuth2AuthorizedClient::getAccessToken)
+        .map(token -> token.getTokenValue());
   }
 
   public List<TenantDto> getAuthorizedTenantsFromToken(final String accessToken) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/rest/cloud/AccountsUserAccessTokenProviderTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/rest/cloud/AccountsUserAccessTokenProviderTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.rest.cloud;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@ExtendWith(MockitoExtension.class)
+class AccountsUserAccessTokenProviderTest {
+
+  @Mock private ObjectProvider<OAuth2AuthorizedClientRepository> authorizedClientRepositoryProvider;
+  @Mock private OAuth2AuthorizedClientRepository authorizedClientRepository;
+  @Mock private OAuth2AuthorizedClient authorizedClient;
+  @Mock private OAuth2AccessToken accessToken;
+  @Mock private HttpServletRequest request;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    RequestContextHolder.resetRequestAttributes();
+  }
+
+  private AccountsUserAccessTokenProvider provider() {
+    return new AccountsUserAccessTokenProvider(authorizedClientRepositoryProvider);
+  }
+
+  private void currentRequestWithoutServiceCookie() {
+    when(request.getCookies()).thenReturn(new Cookie[0]);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  private void authenticateWith(
+      final org.springframework.security.core.Authentication authentication) {
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  private OAuth2AuthenticationToken oauthToken() {
+    final OAuth2User user =
+        new DefaultOAuth2User(
+            List.of(new SimpleGrantedAuthority("ROLE_USER")),
+            java.util.Map.of("sub", "user"),
+            "sub");
+    return new OAuth2AuthenticationToken(user, user.getAuthorities(), "auth0");
+  }
+
+  @Test
+  void shouldResolveAccessTokenFromOidcSessionForOAuth2Authentication() {
+    currentRequestWithoutServiceCookie();
+    final OAuth2AuthenticationToken token = oauthToken();
+    authenticateWith(token);
+    when(authorizedClientRepositoryProvider.getIfAvailable())
+        .thenReturn(authorizedClientRepository);
+    when(authorizedClientRepository.loadAuthorizedClient(eq("auth0"), eq(token), eq(request)))
+        .thenReturn(authorizedClient);
+    when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+    when(accessToken.getTokenValue()).thenReturn("csl-access-token");
+
+    assertThat(provider().getCurrentUsersAccessToken()).contains("csl-access-token");
+  }
+
+  @Test
+  void shouldReturnEmptyForOAuth2AuthenticationWhenNoAuthorizedClientRepositoryIsPresent() {
+    currentRequestWithoutServiceCookie();
+    authenticateWith(oauthToken());
+    when(authorizedClientRepositoryProvider.getIfAvailable()).thenReturn(null);
+
+    assertThat(provider().getCurrentUsersAccessToken()).isEmpty();
+  }
+
+  @Test
+  void shouldStillResolveBearerTokenFromJwtAuthentication() {
+    currentRequestWithoutServiceCookie();
+    final Jwt jwt =
+        Jwt.withTokenValue("bearer-token").header("alg", "none").claim("sub", "user").build();
+    authenticateWith(new JwtAuthenticationToken(jwt));
+
+    assertThat(provider().getCurrentUsersAccessToken()).contains("bearer-token");
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -10,6 +10,7 @@ package io.camunda.optimize.service.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.auth0.jwt.interfaces.Claim;
@@ -25,12 +26,30 @@ import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.security.AuthConfiguration;
 import io.camunda.optimize.service.util.configuration.security.CCSMAuthConfiguration;
+import io.camunda.security.api.context.CamundaAuthenticationProvider;
+import io.camunda.security.api.model.CamundaAuthentication;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @ExtendWith(MockitoExtension.class)
 public class CCSMTokenServiceTest {
@@ -53,8 +72,23 @@ public class CCSMTokenServiceTest {
   @Mock private UserDetails userDetails;
   @Mock private DecodedJWT decodedJWT;
   @Mock private Claim verClaim;
+  @Mock private ObjectProvider<OAuth2AuthorizedClientRepository> authorizedClientRepositoryProvider;
+  @Mock private OAuth2AuthorizedClientRepository authorizedClientRepository;
+  @Mock private OAuth2AuthorizedClient authorizedClient;
+  @Mock private OAuth2AccessToken oauth2AccessToken;
+  @Mock private HttpServletRequest request;
+
+  @Mock private ObjectProvider<CamundaAuthenticationProvider> camundaAuthenticationProviderProvider;
+
+  @Mock private CamundaAuthenticationProvider camundaAuthenticationProvider;
 
   private CCSMTokenService ccsmTokenService;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+    RequestContextHolder.resetRequestAttributes();
+  }
 
   @BeforeEach
   void setUp() {
@@ -69,7 +103,13 @@ public class CCSMTokenServiceTest {
     lenient().when(authConfiguration.getCcsmAuthConfiguration()).thenReturn(ccsmAuthConfiguration);
     lenient().when(ccsmAuthConfiguration.isEntraTokenVersionCheckEnabled()).thenReturn(true);
 
-    ccsmTokenService = new CCSMTokenService(authCookieService, configurationService, identity);
+    ccsmTokenService =
+        new CCSMTokenService(
+            authCookieService,
+            configurationService,
+            identity,
+            authorizedClientRepositoryProvider,
+            camundaAuthenticationProviderProvider);
   }
 
   @Test
@@ -271,5 +311,96 @@ public class CCSMTokenServiceTest {
 
     // then — token accepted despite being v1.0
     assertThat(result).isSameAs(accessToken);
+  }
+
+  // --- getCurrentUserAuthToken: token source (CSL OIDC session vs legacy cookie) ---
+
+  @Test
+  void shouldResolveAuthTokenFromAuthorizedClientRepositoryUnderCsl() {
+    // given — CSL OIDC webapp session: authorized-client repository present, OAuth2 authentication
+    setCurrentRequest();
+    final OAuth2AuthenticationToken oauthToken = oauthToken();
+    SecurityContextHolder.getContext().setAuthentication(oauthToken);
+    when(authorizedClientRepositoryProvider.getIfAvailable())
+        .thenReturn(authorizedClientRepository);
+    when(authorizedClientRepository.loadAuthorizedClient(eq("auth0"), eq(oauthToken), eq(request)))
+        .thenReturn(authorizedClient);
+    when(authorizedClient.getAccessToken()).thenReturn(oauth2AccessToken);
+    when(oauth2AccessToken.getTokenValue()).thenReturn("csl-access-token");
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
+
+    // then
+    assertThat(result).contains("csl-access-token");
+  }
+
+  @Test
+  void shouldFallBackToAuthCookieWhenNoAuthorizedClientRepository() {
+    // given — legacy CCSM: no authorized-client repository, token lives in the auth cookie
+    setCurrentRequestWithAuthCookie("cookie-token");
+    when(authorizedClientRepositoryProvider.getIfAvailable()).thenReturn(null);
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserAuthToken();
+
+    // then
+    assertThat(result).contains("cookie-token");
+  }
+
+  // --- getCurrentUserIdFromAuthToken: principal source (CSL claim vs legacy sub) ---
+
+  @Test
+  void shouldResolveCurrentUserIdFromCslPrincipalRespectingUsernameClaim() {
+    // given — CSL resolves the principal from the configured username-claim, not sub
+    SecurityContextHolder.getContext().setAuthentication(oauthToken());
+    when(camundaAuthenticationProviderProvider.getIfAvailable())
+        .thenReturn(camundaAuthenticationProvider);
+    when(camundaAuthenticationProvider.getCamundaAuthentication())
+        .thenReturn(CamundaAuthentication.of(b -> b.user("preferred-username")));
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserIdFromAuthToken();
+
+    // then — id comes from the CSL principal, without decoding the token
+    assertThat(result).contains("preferred-username");
+  }
+
+  @Test
+  void shouldFallBackToSubClaimForCurrentUserIdWhenNotUnderCsl() {
+    // given — legacy CCSM: no CSL principal provider, id derived from the token's sub claim
+    setCurrentRequestWithAuthCookie(ACCESS_TOKEN_VALUE);
+    when(camundaAuthenticationProviderProvider.getIfAvailable()).thenReturn(null);
+    when(authorizedClientRepositoryProvider.getIfAvailable()).thenReturn(null);
+    when(decodedJWT.getSubject()).thenReturn("sub-user-id");
+
+    // when
+    final Optional<String> result = ccsmTokenService.getCurrentUserIdFromAuthToken();
+
+    // then
+    assertThat(result).contains("sub-user-id");
+  }
+
+  private void setCurrentRequest() {
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  private void setCurrentRequestWithAuthCookie(final String token) {
+    final Cookie cookie =
+        new Cookie(
+            AuthCookieService.getAuthorizationCookieNameWithSuffix(0),
+            AuthCookieService.createOptimizeAuthCookieValue(token));
+    when(request.getAttributeNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getCookies()).thenReturn(new Cookie[] {cookie});
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+  }
+
+  private OAuth2AuthenticationToken oauthToken() {
+    final OAuth2User user =
+        new DefaultOAuth2User(
+            List.of(new SimpleGrantedAuthority("ROLE_USER")),
+            java.util.Map.of("sub", "user"),
+            "sub");
+    return new OAuth2AuthenticationToken(user, user.getAuthorities(), "auth0");
   }
 }


### PR DESCRIPTION
## Description

Bridges "current user" resolution and IdP-access-token retrieval onto the CSL
authentication for Optimize (ADR-0038 consequences 2 and 3):

- **Current-user / CCSM token** (`CCSMTokenService`): reads the IdP access token
  from the OIDC session's `OAuth2AuthorizedClientRepository`, keyed off the
  `OAuth2AuthenticationToken` in the Spring `SecurityContext`. Falls back to the
  legacy Optimize auth cookie.
- **CCSaaS Accounts token** (`AccountsUserAccessTokenProvider`): reads the token
  from the same authorized-client repository, still supports the bearer
  `JwtAuthenticationToken`, and preserves the service-token cookie fallback.

The authorized-client repository is an optional `ObjectProvider`, so the bridges
are inert in the legacy stack (no such bean registered). Behaviour is gated by
the default-off CSL flag, so nothing changes at runtime until a later phase
flips it.

## Why

Removing the custom cookie stack means the host must source the principal and
the IdP token from CSL's session, otherwise Identity/Accounts integration breaks
in CSL mode.

## Tests

- New `AccountsUserAccessTokenProviderTest`: OIDC-session token, missing
  authorized-client repository, and JWT-bearer paths.
- `CCSMTokenServiceTest` updated for the new constructor dependency.
- 21 unit tests green; Spotless/Checkstyle/license checks pass on
  `optimize/backend`.

Closes #58473