### PR TITLE
test: make the per-user authentication probe assertion explicit

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.qa.util.multidb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Fail.fail;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
@@ -622,10 +624,7 @@ public class CamundaMultiDBExtension
           .timeout(Duration.ofSeconds(60))
           .ignoreExceptions()
           .untilAsserted(
-              () ->
-                  org.assertj.core.api.Assertions.assertThat(
-                          admin.newUsersSearchRequest().send().join().items())
-                      .isNotNull());
+              () -> assertThat(admin.newUsersSearchRequest().send().join().items()).isNotNull());
     }
   }
 
@@ -639,7 +638,7 @@ public class CamundaMultiDBExtension
           .timeout(Duration.ofSeconds(60))
           .untilAsserted(
               () ->
-                  org.assertj.core.api.Assertions.assertThatNoException()
+                  assertThatNoException()
                       .isThrownBy(() -> client.newTopologyRequest().send().join()));
     }
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -637,8 +637,10 @@ public class CamundaMultiDBExtension
       }
       Awaitility.await("until user '%s' can authenticate".formatted(user.username()))
           .timeout(Duration.ofSeconds(60))
-          .ignoreExceptions()
-          .untilAsserted(() -> client.newTopologyRequest().send().join());
+          .untilAsserted(
+              () ->
+                  org.assertj.core.api.Assertions.assertThatNoException()
+                      .isThrownBy(() -> client.newTopologyRequest().send().join()));
     }
   }
 


### PR DESCRIPTION
## Description

Follow-up to #58608: the per-user authentication barrier used `ignoreExceptions()` with a bare `untilAsserted(join)`, which read like a no-op in review. Rewrite it as `assertThatNoException().isThrownBy(join)` — the success criterion is now explicit and `ignoreExceptions()` is unnecessary since the wrapped `AssertionError` is retried by `untilAsserted` natively. Behavior is identical.

## Related issues

Review feedback on #58608.
