### PR TITLE
feat: add creationTime as sortable field to jobs search API

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/JobSearchColumn.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.sql.columns;
 import io.camunda.search.entities.JobEntity;
 
 public enum JobSearchColumn implements SearchColumn<JobEntity> {
+  CREATION_TIME("creationTime"),
   DEADLINE("deadline"),
   DENIED_REASON("deniedReason"),
   ELEMENT_ID("elementId"),

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -460,6 +460,7 @@ public class SearchQuerySortRequestMapper {
         case KIND -> builder.jobKind();
         case LISTENER_EVENT_TYPE -> builder.listenerEventType();
         case END_TIME -> builder.endTime();
+        case CREATION_TIME -> builder.creationTime();
         case TENANT_ID -> builder.tenantId();
         case RETRIES -> builder.retries();
         case PRIORITY -> builder.priority();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobSortIT.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.it.rdbms.db.job;
 
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.JobFixtures.createAndSaveJob;
 import static io.camunda.it.rdbms.db.fixtures.JobFixtures.createAndSaveRandomJobs;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -114,6 +116,49 @@ public class JobSortIT {
         testApplication.getRdbmsService(),
         b -> b.processInstanceKey().desc(),
         Comparator.comparing(JobEntity::processInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByCreationTimeAsc(final CamundaRdbmsTestApplication testApplication) {
+    testCreationTimeSorting(
+        testApplication.getRdbmsService(),
+        b -> b.creationTime().asc(),
+        Comparator.comparing(JobEntity::creationTime));
+  }
+
+  @TestTemplate
+  public void shouldSortByCreationTimeDesc(final CamundaRdbmsTestApplication testApplication) {
+    testCreationTimeSorting(
+        testApplication.getRdbmsService(),
+        b -> b.creationTime().desc(),
+        Comparator.comparing(JobEntity::creationTime).reversed());
+  }
+
+  private void testCreationTimeSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<JobSort>> sortBuilder,
+      final Comparator<JobEntity> comparator) {
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final JobDbReader reader = rdbmsService.getJobReader();
+
+    final var processDefinitionId = nextStringId();
+    for (int i = 0; i < 20; i++) {
+      final var creationTime = NOW.plusSeconds(i);
+      createAndSaveJob(
+          rdbmsWriters, b -> b.processDefinitionId(processDefinitionId).creationTime(creationTime));
+    }
+
+    final var searchResult =
+        reader
+            .search(
+                new JobQuery(
+                    new JobFilter.Builder().processDefinitionIds(processDefinitionId).build(),
+                    JobSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
   }
 
   private void testSorting(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/JobSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/JobSortTest.java
@@ -47,6 +47,22 @@ public class JobSortTest extends AbstractSortTransformerTest {
   }
 
   @Test
+  public void shouldSortByCreationTimeDesc() {
+    // given
+    final var request =
+        SearchQueryBuilders.jobSearchQuery(q -> q.sort(s -> s.creationTime().desc()));
+
+    // when
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2); // [creationTime sort, default key sort]
+    assertThat(sort.getFirst().field().field()).isEqualTo("creationTime");
+    assertThat(sort.getFirst().field().order()).isEqualTo(SortOrder.DESC);
+    assertThat(sort.getFirst().field().missing()).isEqualTo("_last");
+  }
+
+  @Test
   public void shouldSortByOtherFieldsWithDefaultMissingLast() {
     // given — retries is a comparable int field on jobs; it should keep the _last default
     final var request = SearchQueryBuilders.jobSearchQuery(q -> q.sort(s -> s.retries().asc()));

--- a/search/search-domain/src/main/java/io/camunda/search/sort/JobSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/JobSort.java
@@ -80,6 +80,11 @@ public record JobSort(List<FieldSorting> orderings) implements SortOption {
       return this;
     }
 
+    public JobSort.Builder creationTime() {
+      currentOrdering = new FieldSorting("creationTime", null);
+      return this;
+    }
+
     public JobSort.Builder tenantId() {
       currentOrdering = new FieldSorting("tenantId", null);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -671,6 +671,7 @@ components:
           description: The field to sort by.
           type: string
           enum:
+            - creationTime
             - deadline
             - deniedReason
             - elementId

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -374,6 +374,7 @@ public class JobQueryControllerTest extends RestControllerTest {
       { "field": "errorMessage", "order": "desc" },
       { "field": "deadline", "order": "asc" },
       { "field": "endTime", "order": "desc" },
+      { "field": "creationTime", "order": "asc" },
       { "field": "processDefinitionId", "order": "asc" },
       { "field": "processDefinitionKey", "order": "desc" },
       { "field": "processInstanceKey", "order": "asc" },
@@ -435,6 +436,8 @@ public class JobQueryControllerTest extends RestControllerTest {
                                 .asc()
                                 .endTime()
                                 .desc()
+                                .creationTime()
+                                .asc()
                                 .processDefinitionId()
                                 .asc()
                                 .processDefinitionKey()


### PR DESCRIPTION
## Description

Adds `creationTime` as a sortable field to the jobs search API (`POST /v2/jobs/search`).

Jobs — including execution/task listeners — could previously only be sorted by
`deadline`, `endTime` or `jobKey`. `creationTime` is the natural creation-order key
and is already stored and indexed on the job entity, so this only wires it through
the sort layers that were missing it.

Layers touched:
- **OpenAPI contract** — added `creationTime` to the `JobSearchQuerySortRequest.field` enum ([jobs.yaml](https://github.com/camunda/camunda/blob/5ccacfeafba5c9ecafbb174d9f13e0a84a1f6a83/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml)).
- **Domain sort builder** — `JobSort.Builder.creationTime()`.
- **REST → domain mapper** — new `CREATION_TIME` case in `SearchQuerySortRequestMapper`.
- **RDBMS** — added `CREATION_TIME` to `JobSearchColumn` (the `CREATION_TIME` DB column and `creationTime` result mapping already exist).
- The ES/OS `JobFieldSortingTransformer` already mapped `creationTime`, so no change was needed there (covered by a new unit test).

## Tests
- `JobSortTest#shouldSortByCreationTimeDesc` (ES/OS transformer)
- `JobQueryControllerTest#shouldSearchJobWithFullSorting` extended with `creationTime`
- `JobSortIT#shouldSortByCreationTime{Asc,Desc}` (RDBMS, all supported databases)

## Notes
Frontend follow-ups, split out per the
[zod-schema release process](https://github.com/camunda/camunda/blob/main/docs/monorepo-docs/frontend/camunda-api-zod-schemas.md#when-the-schema-update-is-part-of-a-new-feature):
1. #59134 — adds `creationTime` to the `8.10` jobs zod schema and releases `v0.0.85` (then published manually).
2. A later PR bumps `operate/client` to `v0.0.85` and changes the Operate Listeners tab UI (default `creationTime desc` sort + sortable columns).

## Checklist

- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #58500
