### PR TITLE
Secret services endpoint isolation

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantAuthorizationCheckerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantAuthorizationCheckerConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.security.impl.SearchAuthorizationScopeRepository;
+import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Builds one {@link AuthorizationChecker} per physical tenant, each backed by that tenant's own
+ * {@link io.camunda.search.clients.reader.AuthorizationReader}, mirroring the per-tenant {@code
+ * ResourceAccessController} construction in {@link
+ * io.camunda.application.commons.search.ResourceAccessControllerConfiguration}.
+ *
+ * <p>This exists so that services which query {@link AuthorizationChecker} directly (bypassing the
+ * {@code ResourceAccessController}/data-plane path), such as {@code DocumentServices} and {@code
+ * SecretServices}, can be handed the checker for their own physical tenant instead of the single
+ * default-tenant-pinned {@link AuthorizationChecker} bean.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnSecondaryStorageEnabled
+public class PhysicalTenantAuthorizationCheckerConfiguration {
+
+  @Bean
+  public PhysicalTenantAuthorizationCheckers physicalTenantAuthorizationCheckers(
+      final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders) {
+    final Map<String, AuthorizationChecker> checkers = new LinkedHashMap<>();
+    physicalTenantSearchClientReaders
+        .readersByPhysicalTenant()
+        .forEach(
+            (tenantId, searchClientReaders) ->
+                checkers.put(
+                    tenantId,
+                    new AuthorizationChecker(
+                        new SearchAuthorizationScopeRepository(
+                            searchClientReaders.authorizationReader()))));
+    return new PhysicalTenantAuthorizationCheckers(Map.copyOf(checkers));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantAuthorizationCheckers.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/PhysicalTenantAuthorizationCheckers.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import io.camunda.security.core.authz.AuthorizationChecker;
+import java.util.Map;
+
+/**
+ * Holds the {@link AuthorizationChecker} for every physical tenant, keyed by physical tenant id.
+ *
+ * <p>This wrapper record is not strictly required — a dedicated bean of type {@code Map<String,
+ * AuthorizationChecker>} would work just as well. It is used to keep the injection point explicit
+ * and unambiguous: it avoids any confusion with Spring's bean-collection autowiring, which for a
+ * bare {@code Map<String, AuthorizationChecker>} injection point keys the map by bean name rather
+ * than by physical tenant id.
+ */
+public record PhysicalTenantAuthorizationCheckers(
+    Map<String, AuthorizationChecker> checkersByPhysicalTenant) {}

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.service;
 
 import io.camunda.application.commons.condition.ConditionalOnAnyHttpGatewayEnabled;
 import io.camunda.application.commons.document.CamundaDocumentStoreConfigurationLoader;
+import io.camunda.application.commons.security.PhysicalTenantAuthorizationCheckers;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
@@ -65,6 +66,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -116,6 +118,7 @@ public class CamundaServicesConfiguration {
       final ActivateJobsHandler<JobActivationResult> activateJobsHandler,
       final SearchClientsProxy searchClients,
       final AuthorizationChecker authorizationChecker,
+      final Optional<PhysicalTenantAuthorizationCheckers> physicalTenantAuthorizationCheckers,
       final CamundaSecurityLibraryProperties cslProperties,
       final GatewayRestConfiguration gatewayRestConfiguration,
       final BrokerTopologyManager brokerTopologyManager,
@@ -136,6 +139,17 @@ public class CamundaServicesConfiguration {
         .forEach(
             (tenantId, tenantConfig) -> {
               final var search = searchClients.withPhysicalTenant(tenantId);
+
+              // Per-tenant AuthorizationChecker for services that query it directly (bypassing
+              // ResourceAccessController), e.g. DocumentServices/SecretServices. Falls back to the
+              // shared, default-tenant-pinned bean only when secondary storage is disabled
+              // (SecondaryStorageType.none) and no PhysicalTenantAuthorizationCheckers bean exists
+              // at all -- in that mode there is exactly one (Noop) authorization source
+              // cluster-wide, so sharing it is correct.
+              final var tenantAuthorizationChecker =
+                  physicalTenantAuthorizationCheckers
+                      .map(checkers -> checkers.checkersByPhysicalTenant().get(tenantId))
+                      .orElse(authorizationChecker);
 
               // -- per-tenant BrokerRequestAuthorizationConverter --
               final var tenantSecurity = tenantConfig.getSecurity();
@@ -313,7 +327,7 @@ public class CamundaServicesConfiguration {
                           securityContextProvider,
                           new SimpleDocumentStoreRegistry(
                               new CamundaDocumentStoreConfigurationLoader(tenantConfig)),
-                          authorizationChecker,
+                          tenantAuthorizationChecker,
                           cslProperties.getAuthorizations(),
                           executor,
                           converter))
@@ -409,7 +423,7 @@ public class CamundaServicesConfiguration {
                           tenantId,
                           brokerClient,
                           securityContextProvider,
-                          authorizationChecker,
+                          tenantAuthorizationChecker,
                           cslProperties.getAuthorizations(),
                           executor,
                           converter))

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -118,7 +118,8 @@ class CamundaServicesConfigurationTest {
   void shouldFallBackToSharedAuthorizationCheckerWhenNoPhysicalTenantCheckersBeanExists() {
     // given: SecondaryStorageType.none -- no PhysicalTenantSearchClientReaders bean exists, so no
     // PhysicalTenantAuthorizationCheckers bean can be built either. Falling back to the shared,
-    // default-tenant-pinned checker
+    // default-tenant-pinned checker is correct here, since there is exactly one authorization
+    // source cluster-wide in this mode.
     when(sharedAuthorizationChecker.collectPermissionTypes(any(), any(), any()))
         .thenReturn(Set.of(PermissionType.CREATE));
     final var registry = buildRegistry(twoTenants(), Optional.empty());
@@ -137,6 +138,41 @@ class CamundaServicesConfigurationTest {
                 .join())
         .isEmpty();
     verify(sharedAuthorizationChecker, times(2)).collectPermissionTypes(any(), any(), any());
+  }
+
+  @Test
+  void shouldFallBackToSharedAuthorizationCheckerForTenantMissingFromPhysicalTenantCheckersMap() {
+    // given: PhysicalTenantAuthorizationCheckers exists but only has an entry for tenantA --
+    // tenantB is missing, e.g. config drift between PhysicalTenantResolver and the checkers map.
+    final var checkerA = mock(AuthorizationChecker.class);
+    when(checkerA.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+    when(sharedAuthorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+    final var registry =
+        buildRegistry(
+            twoTenants(),
+            Optional.of(new PhysicalTenantAuthorizationCheckers(Map.of(TENANT_A, checkerA))));
+
+    // when / then: tenantA uses its own checker, present in the map.
+    assertThat(
+            registry
+                .documentServices(TENANT_A)
+                .createDocumentBatch(List.of(), authentication)
+                .join())
+        .isEmpty();
+    verify(checkerA).collectPermissionTypes(any(), any(), any());
+    verifyNoInteractions(sharedAuthorizationChecker);
+
+    // when / then: tenantB, missing from the map, falls back to the shared checker without
+    // NPE-ing, instead of failing the whole tenant.
+    assertThat(
+            registry
+                .documentServices(TENANT_B)
+                .createDocumentBatch(List.of(), authentication)
+                .join())
+        .isEmpty();
+    verify(sharedAuthorizationChecker).collectPermissionTypes(any(), any(), any());
   }
 
   private static Map<String, Camunda> twoTenants() {

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -21,11 +21,13 @@ import io.camunda.configuration.Camunda;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationScope;
 import io.camunda.security.api.model.authz.PermissionType;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.service.ApiServicesExecutorProvider;
 import io.camunda.service.ManagementServices;
+import io.camunda.service.SecretServices.SecretErrorCode;
 import io.camunda.service.license.CamundaLicense;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.service.security.SecurityContextProvider;
@@ -173,6 +175,52 @@ class CamundaServicesConfigurationTest {
                 .join())
         .isEmpty();
     verify(sharedAuthorizationChecker).collectPermissionTypes(any(), any(), any());
+  }
+
+  @Test
+  void shouldWireDistinctAuthorizationCheckerPerPhysicalTenantIntoSecretServices() {
+    // given
+    final var checkerA = mock(AuthorizationChecker.class);
+    final var checkerB = mock(AuthorizationChecker.class);
+    when(checkerA.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(List.of(AuthorizationScope.WILDCARD));
+    when(checkerB.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(Collections.emptyList());
+    final var registry =
+        buildRegistry(
+            twoTenants(),
+            Optional.of(
+                new PhysicalTenantAuthorizationCheckers(
+                    Map.of(TENANT_A, checkerA, TENANT_B, checkerB))));
+
+    // when / then: tenant A's checker grants a wildcard -- the reference resolves using only
+    // tenant A's checker.
+    final var resolutionA =
+        registry
+            .secretServices(TENANT_A)
+            .resolve(List.of("camunda.secrets.token"), authentication)
+            .join();
+    assertThat(resolutionA.resolved()).hasSize(1);
+    assertThat(resolutionA.errors()).isEmpty();
+    verify(checkerA).retrieveAuthorizedAuthorizationScopes(any(), any());
+    verifyNoInteractions(checkerB);
+
+    // when / then: tenant B's own checker grants nothing -- must be denied even though tenant A's
+    // checker (queried above) would have granted a wildcard. Unlike DocumentServices, a denial
+    // here is reported as an ACCESS_DENIED entry on a normally-completed future, not an
+    // exceptional one.
+    final var resolutionB =
+        registry
+            .secretServices(TENANT_B)
+            .resolve(List.of("camunda.secrets.token"), authentication)
+            .join();
+    assertThat(resolutionB.resolved()).isEmpty();
+    assertThat(resolutionB.errors()).hasSize(1);
+    assertThat(resolutionB.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    verify(checkerB).retrieveAuthorizedAuthorizationScopes(any(), any());
+    // re-verify checkerA's count is still exactly one -- catches a leak in the other direction,
+    // where querying tenant B would incorrectly also consult tenant A's checker.
+    verify(checkerA, times(1)).retrieveAuthorizedAuthorizationScopes(any(), any());
   }
 
   private static Map<String, Camunda> twoTenants() {

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.commons.security.PhysicalTenantAuthorizationCheckers;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.service.ApiServicesExecutorProvider;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.CamundaLicense;
+import io.camunda.service.registry.ServiceRegistry;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
+import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class CamundaServicesConfigurationTest {
+
+  private static final String TENANT_A = "tenantA";
+  private static final String TENANT_B = "tenantB";
+
+  private final CamundaServicesConfiguration configuration = new CamundaServicesConfiguration();
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+  private final AuthorizationChecker sharedAuthorizationChecker = mock(AuthorizationChecker.class);
+
+  @Test
+  void shouldWireDistinctAuthorizationCheckerPerPhysicalTenantIntoDocumentServices() {
+    // given
+    final var checkerA = mock(AuthorizationChecker.class);
+    final var checkerB = mock(AuthorizationChecker.class);
+    when(checkerA.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+    when(checkerB.collectPermissionTypes(any(), any(), any())).thenReturn(Collections.emptySet());
+    final var registry =
+        buildRegistry(
+            twoTenants(),
+            Optional.of(
+                new PhysicalTenantAuthorizationCheckers(
+                    Map.of(TENANT_A, checkerA, TENANT_B, checkerB))));
+
+    // when / then: tenant A's checker grants CREATE -- the batch (empty, so no document store is
+    // touched) completes normally, using only tenant A's checker.
+    assertThat(
+            registry
+                .documentServices(TENANT_A)
+                .createDocumentBatch(List.of(), authentication)
+                .join())
+        .isEmpty();
+    verify(checkerA).collectPermissionTypes(any(), any(), any());
+    verifyNoInteractions(checkerB);
+
+    // when / then: tenant B's own checker denies CREATE -- must fail even though tenant A's
+    // checker (queried above) would have granted it.
+    final var deniedFuture =
+        registry.documentServices(TENANT_B).createDocumentBatch(List.of(), authentication);
+    assertThat(deniedFuture.isCompletedExceptionally()).isTrue();
+    verify(checkerB).collectPermissionTypes(any(), any(), any());
+    // re-verify checkerA's count is still exactly one -- catches a leak in the other direction,
+    // where querying tenant B would incorrectly also consult tenant A's checker.
+    verify(checkerA, times(1)).collectPermissionTypes(any(), any(), any());
+  }
+
+  @Test
+  void shouldWireExactlyOneEntryWhenOnlyTheDefaultPhysicalTenantExists() {
+    // given: a single-PT/default-only deployment
+    final var defaultChecker = mock(AuthorizationChecker.class);
+    when(defaultChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+    final var registry =
+        buildRegistry(
+            Map.of("default", new Camunda()),
+            Optional.of(
+                new PhysicalTenantAuthorizationCheckers(Map.of("default", defaultChecker))));
+
+    // when
+    final var future =
+        registry.documentServices("default").createDocumentBatch(List.of(), authentication);
+
+    // then
+    assertThat(future.join()).isEmpty();
+    verify(defaultChecker).collectPermissionTypes(any(), any(), any());
+    assertThatThrownBy(() -> registry.documentServices("some-other-tenant"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldFallBackToSharedAuthorizationCheckerWhenNoPhysicalTenantCheckersBeanExists() {
+    // given: SecondaryStorageType.none -- no PhysicalTenantSearchClientReaders bean exists, so no
+    // PhysicalTenantAuthorizationCheckers bean can be built either. Falling back to the shared,
+    // default-tenant-pinned checker
+    when(sharedAuthorizationChecker.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+    final var registry = buildRegistry(twoTenants(), Optional.empty());
+
+    // when / then: must not NPE, and both tenants fall back to the same shared checker.
+    assertThat(
+            registry
+                .documentServices(TENANT_A)
+                .createDocumentBatch(List.of(), authentication)
+                .join())
+        .isEmpty();
+    assertThat(
+            registry
+                .documentServices(TENANT_B)
+                .createDocumentBatch(List.of(), authentication)
+                .join())
+        .isEmpty();
+    verify(sharedAuthorizationChecker, times(2)).collectPermissionTypes(any(), any(), any());
+  }
+
+  private static Map<String, Camunda> twoTenants() {
+    final var tenants = new LinkedHashMap<String, Camunda>();
+    tenants.put(TENANT_A, new Camunda());
+    tenants.put(TENANT_B, new Camunda());
+    return tenants;
+  }
+
+  private ServiceRegistry buildRegistry(
+      final Map<String, Camunda> tenants,
+      final Optional<PhysicalTenantAuthorizationCheckers> physicalTenantAuthorizationCheckers) {
+    final var physicalTenantResolver = mock(PhysicalTenantResolver.class);
+    when(physicalTenantResolver.getAll()).thenReturn(tenants);
+
+    final var cslProperties = new CamundaSecurityLibraryProperties();
+    cslProperties.getAuthorizations().setEnabled(true);
+
+    return configuration.serviceRegistry(
+        physicalTenantResolver,
+        mock(BrokerClient.class),
+        new SecurityContextProvider(),
+        mock(PasswordEncoder.class),
+        mock(ActivateJobsHandler.class),
+        SearchClientsProxy.noop(),
+        sharedAuthorizationChecker,
+        physicalTenantAuthorizationCheckers,
+        cslProperties,
+        new GatewayRestConfiguration(),
+        mock(BrokerTopologyManager.class),
+        new SimpleMeterRegistry(),
+        new MockEnvironment(),
+        new ManagementServices(new CamundaLicense(null)),
+        new ApiServicesExecutorProvider(Executors.newSingleThreadExecutor()));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MultiPhysicalTenantDocumentAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MultiPhysicalTenantDocumentAuthorizationIT.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.qa.util.multidb.MultiPhysicalTenantClients;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@MultiDbTest
+@MultiDbPhysicalTenants({"tenanta", "tenantb"})
+@EnabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
+final class MultiPhysicalTenantDocumentAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+
+  static MultiPhysicalTenantClients ptClients;
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String RESTRICTED_PASSWORD = "restricted";
+  private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  @Test
+  void shouldDenyDocumentDeleteWhenGrantExistsOnlyInAnotherPhysicalTenant() {
+    final CamundaClient tenantAAdmin = ptClients.admin(TENANT_A);
+    final String username = createUserWithForeignTenantGrant("doc-del", PermissionType.DELETE);
+
+    final var documentReference =
+        tenantAAdmin.newCreateDocumentCommand().content("tenant-a-only-content").send().join();
+
+    try (final CamundaClient restrictedInA = restrictedClient(TENANT_A, username)) {
+      awaitForbidden(
+          "tenantb's own DOCUMENT:DELETE grant for this identity must not authorize a delete via"
+              + " tenanta -- only tenanta's own authorization data may",
+          () -> restrictedInA.newDeleteDocumentCommand(documentReference).send().join());
+
+      // positive control -- granting DELETE in tenanta's own storage flips the same request to
+      // allowed, proving the prior denial wasn't vacuous.
+      grant(tenantAAdmin, username, PermissionType.DELETE);
+      Awaitility.await("granting DELETE in tenanta itself authorizes the delete")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> restrictedInA.newDeleteDocumentCommand(documentReference).send().join());
+    }
+
+    // then: the document is actually gone from tenanta once deleted through it.
+    final var exception =
+        (ProblemException)
+            assertThatThrownBy(
+                    () ->
+                        tenantAAdmin.newDocumentContentGetRequest(documentReference).send().join())
+                .isInstanceOf(ProblemException.class)
+                .actual();
+    assertThat(exception.details().getStatus()).isEqualTo(404);
+  }
+
+  @Test
+  void shouldDenyDocumentCreateWhenGrantExistsOnlyInAnotherPhysicalTenant() {
+    final CamundaClient tenantAAdmin = ptClients.admin(TENANT_A);
+    final String username = createUserWithForeignTenantGrant("doc-create", PermissionType.CREATE);
+
+    try (final CamundaClient restrictedInA = restrictedClient(TENANT_A, username)) {
+      awaitForbidden(
+          "tenantb's own DOCUMENT:CREATE grant for this identity must not authorize creating a"
+              + " document via tenanta -- only tenanta's own authorization data may",
+          () ->
+              restrictedInA
+                  .newCreateDocumentCommand()
+                  .content("should-not-be-creatable")
+                  .send()
+                  .join());
+
+      // positive control -- granting CREATE in tenanta's own storage flips the same request to
+      // allowed, proving the prior denial wasn't vacuous.
+      grant(tenantAAdmin, username, PermissionType.CREATE);
+      final var createdDocument = new AtomicReference<DocumentReferenceResponse>();
+      Awaitility.await("granting CREATE in tenanta itself authorizes document creation")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  createdDocument.set(
+                      restrictedInA
+                          .newCreateDocumentCommand()
+                          .content("created-once-granted-in-tenant-a")
+                          .send()
+                          .join()));
+
+      // then: the document genuinely exists in tenanta's own store.
+      assertReadableContent(
+          tenantAAdmin, createdDocument.get(), "created-once-granted-in-tenant-a");
+    }
+  }
+
+  @Test
+  void shouldDenyDocumentContentGetWhenGrantExistsOnlyInAnotherPhysicalTenant() {
+    final CamundaClient tenantAAdmin = ptClients.admin(TENANT_A);
+    final String username = createUserWithForeignTenantGrant("doc-read", PermissionType.READ);
+
+    final var documentReference =
+        tenantAAdmin.newCreateDocumentCommand().content("tenant-a-secret-content").send().join();
+
+    try (final CamundaClient restrictedInA = restrictedClient(TENANT_A, username)) {
+      awaitForbidden(
+          "tenantb's own DOCUMENT:READ grant for this identity must not authorize reading a"
+              + " tenanta document",
+          () -> restrictedInA.newDocumentContentGetRequest(documentReference).send().join());
+
+      // positive control -- granting READ in tenanta's own storage flips the same request to
+      // allowed, proving the prior denial wasn't vacuous.
+      grant(tenantAAdmin, username, PermissionType.READ);
+      Awaitility.await("granting READ in tenanta itself authorizes reading the document")
+          .atMost(PROPAGATION_TIMEOUT)
+          .ignoreExceptions()
+          .untilAsserted(
+              () ->
+                  assertReadableContent(
+                      restrictedInA, documentReference, "tenant-a-secret-content"));
+    }
+  }
+
+  private String createUserWithForeignTenantGrant(
+      final String usernamePrefix, final PermissionType permission) {
+    final CamundaClient tenantAAdmin = ptClients.admin(TENANT_A);
+    final CamundaClient tenantBAdmin = ptClients.admin(TENANT_B);
+    final String username = usernamePrefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+    createRestrictedUserNamed(tenantAAdmin, username);
+    createRestrictedUserNamed(tenantBAdmin, username);
+    grant(tenantBAdmin, username, permission);
+    return username;
+  }
+
+  private static void awaitForbidden(final String reason, final ThrowingCallable operation) {
+    Awaitility.await(reason)
+        .during(PROPAGATION_TIMEOUT.dividedBy(6))
+        .atMost(PROPAGATION_TIMEOUT)
+        .untilAsserted(
+            () ->
+                assertThatThrownBy(operation)
+                    .isInstanceOf(ProblemException.class)
+                    .hasMessageContaining("status: 403")
+                    .hasMessageContaining("FORBIDDEN"));
+  }
+
+  private static void assertReadableContent(
+      final CamundaClient client,
+      final DocumentReferenceResponse documentReference,
+      final String expectedContent) {
+    try (final var content = client.newDocumentContentGetRequest(documentReference).send().join()) {
+      assertThat(new String(content.readAllBytes())).isEqualTo(expectedContent);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private CamundaClient restrictedClient(final String tenantId, final String username) {
+    final String base = BROKER.restAddress().toString().replaceAll("/+$", "");
+    final java.net.URI restAddress = java.net.URI.create(base + "/physical-tenants/" + tenantId);
+    return BROKER
+        .newClientBuilder()
+        .physicalTenantId(tenantId)
+        .preferRestOverGrpc(true)
+        // the REST address already carries the /physical-tenants/<id> prefix, so opt out of the
+        // client's auto-prefixing to avoid a doubled path
+        .prefixPhysicalTenantPath(false)
+        .restAddress(restAddress)
+        .grpcAddress(BROKER.grpcAddress())
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(username)
+                .password(RESTRICTED_PASSWORD)
+                .build())
+        .build();
+  }
+
+  private static void createRestrictedUserNamed(final CamundaClient admin, final String username) {
+    admin
+        .newCreateUserCommand()
+        .username(username)
+        .password(RESTRICTED_PASSWORD)
+        .name(username)
+        .email(username + "@example.com")
+        .send()
+        .join();
+    Awaitility.await("restricted user '" + username + "' exists in its PT")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        admin
+                            .newUsersSearchRequest()
+                            .filter(f -> f.username(username))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+  }
+
+  private static void grant(
+      final CamundaClient admin, final String username, final PermissionType permission) {
+    admin
+        .newCreateAuthorizationCommand()
+        .ownerId(username)
+        .ownerType(OwnerType.USER)
+        .resourceId("*")
+        .resourceType(ResourceType.DOCUMENT)
+        .permissionTypes(permission)
+        .send()
+        .join();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/MultiPhysicalTenantSecretAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/MultiPhysicalTenantSecretAuthorizationIT.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.enums.OwnerType;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.qa.util.multidb.MultiPhysicalTenantClients;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Regression coverage for camunda#58640: {@code SecretServices} consulted a single,
+ * default-physical-tenant-pinned {@code AuthorizationChecker} for every physical tenant's
+ * secret-reveal requests, so a {@code SECRET:REVEAL} grant that existed only in *another* physical
+ * tenant's own authorization storage incorrectly authorized reveals via a tenant whose own
+ * authorization data held no such grant. Sibling of camunda#58441 ({@code DocumentServices}); see
+ * {@link io.camunda.it.client.MultiPhysicalTenantDocumentAuthorizationIT} for the equivalent
+ * documents-side coverage.
+ *
+ * <p>Unlike the document endpoints, {@code POST /v2/secrets/resolve} has no fluent {@code
+ * CamundaClient} command yet, and a denied reference is reported as an {@code ACCESS_DENIED} entry
+ * in the response body on HTTP 200 -- never a thrown exception -- so this issues raw HTTP calls
+ * (mirroring {@code io.camunda.it.auth.SecretAuthorizationIT}) and polls the parsed JSON body
+ * instead of an exception, unlike the document IT's {@code awaitForbidden}.
+ *
+ * <p>RDBMS only, matching the multi-physical-tenant QA harness's current capability (see {@link
+ * io.camunda.it.auth.MultiPhysicalTenantAuthorizationIT} for the same restriction).
+ */
+@MultiDbTest
+@MultiDbPhysicalTenants({"tenanta", "tenantb"})
+@EnabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
+final class MultiPhysicalTenantSecretAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+
+  static MultiPhysicalTenantClients ptClients;
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String RESTRICTED_PASSWORD = "restricted";
+  private static final Duration PROPAGATION_TIMEOUT = Duration.ofSeconds(30);
+
+  // Resolvable by the mock backend (see SecretServices#MOCK_RESOLVABLE_REFERENCES).
+  private static final String GRANTED_REFERENCE = "camunda.secrets.token";
+
+  private static final ObjectMapper JSON =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @Test
+  void shouldDenySecretRevealWhenGrantExistsOnlyInAnotherPhysicalTenant() {
+    final CamundaClient tenantAAdmin = ptClients.admin(TENANT_A);
+    final String username = createUserWithForeignTenantGrant("secret-reveal");
+
+    try (final CamundaClient restrictedInA = restrictedClient(TENANT_A, username)) {
+      awaitAccessDenied(
+          "tenantb's own SECRET:REVEAL grant for this identity must not authorize revealing a"
+              + " secret via tenanta -- only tenanta's own authorization data may",
+          GRANTED_REFERENCE,
+          () -> resolve(restrictedInA, username, List.of(GRANTED_REFERENCE)));
+
+      // positive control -- granting REVEAL in tenanta's own storage flips the same request to
+      // allowed, proving the prior denial wasn't vacuous.
+      grant(tenantAAdmin, username);
+      awaitResolved(
+          "granting REVEAL in tenanta itself authorizes the reveal",
+          GRANTED_REFERENCE,
+          "mock-value-for-token-in-tenant-" + TENANT_A,
+          () -> resolve(restrictedInA, username, List.of(GRANTED_REFERENCE)));
+    }
+  }
+
+  private static void awaitAccessDenied(
+      final String reason, final String expectedReference, final HttpCall operation) {
+    Awaitility.await(reason)
+        .during(PROPAGATION_TIMEOUT.dividedBy(6))
+        .atMost(PROPAGATION_TIMEOUT)
+        .untilAsserted(
+            () -> {
+              final var response = operation.call();
+              assertThat(response.statusCode()).isEqualTo(200);
+              final var body = JSON.readTree(response.body());
+              assertThat(body.get("resolved")).isEmpty();
+              assertThat(body.get("errors")).hasSize(1);
+              assertThat(body.get("errors").get(0).get("reference").asText())
+                  .isEqualTo(expectedReference);
+              assertThat(body.get("errors").get(0).get("code").asText()).isEqualTo("ACCESS_DENIED");
+            });
+  }
+
+  private static void awaitResolved(
+      final String reason,
+      final String expectedReference,
+      final String expectedValue,
+      final HttpCall operation) {
+    Awaitility.await(reason)
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var response = operation.call();
+              assertThat(response.statusCode()).isEqualTo(200);
+              final var body = JSON.readTree(response.body());
+              assertThat(body.get("errors")).isEmpty();
+              assertThat(body.get("resolved")).hasSize(1);
+              assertThat(body.get("resolved").get(0).get("reference").asText())
+                  .isEqualTo(expectedReference);
+              assertThat(body.get("resolved").get(0).get("value").asText())
+                  .isEqualTo(expectedValue);
+            });
+  }
+
+  @FunctionalInterface
+  private interface HttpCall {
+    HttpResponse<String> call() throws Exception;
+  }
+
+  /**
+   * Issues a raw HTTP call to {@code POST /v2/secrets/resolve} authenticated as the given user. The
+   * endpoint has no fluent Java client method yet (see {@code SecretAuthorizationIT}).
+   */
+  private static HttpResponse<String> resolve(
+      final CamundaClient client, final String username, final List<String> references)
+      throws Exception {
+    final var body = JSON.writeValueAsString(Map.of("references", references));
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(createUri(client, "v2/secrets/resolve"))
+            .header("Content-Type", "application/json")
+            .header("Authorization", basicAuthentication(username))
+            .POST(BodyPublishers.ofString(body))
+            .build();
+    return HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+  }
+
+  private static URI createUri(final CamundaClient client, final String path) {
+    final String base = client.getConfiguration().getRestAddress().toString();
+    final String separator = base.endsWith("/") ? "" : "/";
+    return URI.create(base + separator + path);
+  }
+
+  private static String basicAuthentication(final String username) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString(
+                (username + ":" + RESTRICTED_PASSWORD).getBytes(StandardCharsets.UTF_8));
+  }
+
+  // --- helpers -------------------------------------------------------------------------
+
+  private String createUserWithForeignTenantGrant(final String usernamePrefix) {
+    final CamundaClient tenantAAdmin = ptClients.admin(TENANT_A);
+    final CamundaClient tenantBAdmin = ptClients.admin(TENANT_B);
+    final String username = usernamePrefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+    createRestrictedUserNamed(tenantAAdmin, username);
+    createRestrictedUserNamed(tenantBAdmin, username);
+    grant(tenantBAdmin, username);
+    return username;
+  }
+
+  private CamundaClient restrictedClient(final String tenantId, final String username) {
+    final String base = BROKER.restAddress().toString().replaceAll("/+$", "");
+    final java.net.URI restAddress = java.net.URI.create(base + "/physical-tenants/" + tenantId);
+    return BROKER
+        .newClientBuilder()
+        .physicalTenantId(tenantId)
+        .preferRestOverGrpc(true)
+        // the REST address already carries the /physical-tenants/<id> prefix, so opt out of the
+        // client's auto-prefixing to avoid a doubled path
+        .prefixPhysicalTenantPath(false)
+        .restAddress(restAddress)
+        .grpcAddress(BROKER.grpcAddress())
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(username)
+                .password(RESTRICTED_PASSWORD)
+                .build())
+        .build();
+  }
+
+  private static void createRestrictedUserNamed(final CamundaClient admin, final String username) {
+    admin
+        .newCreateUserCommand()
+        .username(username)
+        .password(RESTRICTED_PASSWORD)
+        .name(username)
+        .email(username + "@example.com")
+        .send()
+        .join();
+    Awaitility.await("restricted user '" + username + "' exists in its PT")
+        .atMost(PROPAGATION_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        admin
+                            .newUsersSearchRequest()
+                            .filter(f -> f.username(username))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1));
+  }
+
+  private static void grant(final CamundaClient admin, final String username) {
+    admin
+        .newCreateAuthorizationCommand()
+        .ownerId(username)
+        .ownerType(OwnerType.USER)
+        .resourceId("*")
+        .resourceType(ResourceType.SECRET)
+        .permissionTypes(PermissionType.REVEAL)
+        .send()
+        .join();
+  }
+}

--- a/service/src/test/java/io/camunda/service/DocumentServicesAuthorizationCheckerDelegationTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesAuthorizationCheckerDelegationTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.document.api.DocumentContent;
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentMetadataModel;
+import io.camunda.document.api.DocumentReference;
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreRecord;
+import io.camunda.document.store.SimpleDocumentStoreRegistry;
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.DocumentServices.DocumentCreateRequest;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.util.Either;
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterizes {@link DocumentServices}'s own contract: every permission check is delegated to
+ * whichever {@link AuthorizationChecker} instance it was constructed with, with no shared or static
+ * state leaking a check to a sibling instance's checker.
+ */
+class DocumentServicesAuthorizationCheckerDelegationTest {
+
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+  private final AuthorizationChecker checkerA = mock(AuthorizationChecker.class);
+  private final AuthorizationChecker checkerB = mock(AuthorizationChecker.class);
+  private final SimpleDocumentStoreRegistry registryA = mock(SimpleDocumentStoreRegistry.class);
+  private final SimpleDocumentStoreRegistry registryB = mock(SimpleDocumentStoreRegistry.class);
+  private DocumentServices servicesA;
+  private DocumentServices servicesB;
+
+  @BeforeEach
+  void beforeEach() {
+    final var enabledConfig = new AuthorizationsConfiguration();
+    enabledConfig.setEnabled(true);
+    servicesA =
+        new DocumentServices(
+            "tenant-a",
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            registryA,
+            checkerA,
+            enabledConfig,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+    servicesB =
+        new DocumentServices(
+            "tenant-b",
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            registryB,
+            checkerB,
+            enabledConfig,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+  }
+
+  @Test
+  void shouldOnlyQueryOwnPhysicalTenantsCheckerOnCreate() {
+    // given
+    when(checkerA.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.CREATE));
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeRecord.storeId()).thenReturn("store-a");
+    when(registryA.getDefaultDocumentStore()).thenReturn(storeRecord);
+    final var file = createDocRequest("tenant a");
+    final var expected = createDocumentReference(file);
+    when(storeInstance.createDocument(
+            new DocumentCreationRequest(
+                file.documentId(), file.contentInputStream(), file.metadata())))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(expected)));
+
+    // when
+    final var future = servicesA.createDocument(file, authentication);
+
+    // then
+    assertThat(future.join()).isNotNull();
+    verify(checkerA).collectPermissionTypes(any(), any(), any());
+    verifyNoInteractions(checkerB);
+  }
+
+  @Test
+  void shouldOnlyQueryOwnPhysicalTenantsCheckerOnDelete() {
+    // given
+    when(checkerA.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.DELETE));
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var documentId = "tenant-a-document";
+    when(registryA.getDocumentStore("store-a")).thenReturn(storeRecord);
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeInstance.deleteDocument(documentId))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(null)));
+
+    // when
+    final var future = servicesA.deleteDocument(documentId, "store-a", authentication);
+
+    // then
+    assertThat(future.isCompletedExceptionally()).isFalse();
+    verify(checkerA).collectPermissionTypes(any(), any(), any());
+    verifyNoInteractions(checkerB);
+  }
+
+  @Test
+  void shouldReadDocumentContentUsingOwnPhysicalTenantsChecker() {
+    // given
+    when(checkerB.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.READ));
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var documentId = "tenant-b-document";
+    final var contentHash = "tenant-b-hash";
+    when(registryB.getDocumentStore("store-b")).thenReturn(storeRecord);
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeInstance.verifyContentHash(documentId, contentHash))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(null)));
+    final var content = "hello from tenant b";
+    final var documentContent =
+        new DocumentContent(new ByteArrayInputStream(content.getBytes()), "text/plain");
+    when(storeInstance.getDocument(documentId))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(documentContent)));
+
+    // when
+    final var response =
+        servicesB.getDocumentContent(documentId, "store-b", contentHash, authentication).join();
+
+    // then
+    assertThat(response).isNotNull();
+    verify(checkerB).collectPermissionTypes(any(), any(), any());
+    verifyNoInteractions(checkerA);
+  }
+
+  @Test
+  void shouldDenyDeleteFromWrongTenantGrant() {
+    // given: tenant A's checker would grant DELETE, but this request is scoped to tenant B, whose
+    // own checker grants nothing -- proves DocumentServices always defers to the checker it was
+    // constructed with, never a sibling instance's. 
+    when(checkerA.collectPermissionTypes(any(), any(), any()))
+        .thenReturn(Set.of(PermissionType.DELETE));
+    when(checkerB.collectPermissionTypes(any(), any(), any())).thenReturn(Collections.emptySet());
+
+    // when
+    final var future = servicesB.deleteDocument("tenant-a-document", "store-a", authentication);
+
+    // then
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    verify(checkerB).collectPermissionTypes(any(), any(), any());
+    verifyNoInteractions(checkerA);
+  }
+
+  private DocumentCreateRequest createDocRequest(final String content) {
+    return new DocumentCreateRequest(
+        null,
+        null,
+        new ByteArrayInputStream(content.getBytes()),
+        new DocumentMetadataModel(
+            "text/plain",
+            UUID.randomUUID() + ".txt",
+            null,
+            (long) content.length(),
+            null,
+            null,
+            Map.of()));
+  }
+
+  private DocumentReference createDocumentReference(final DocumentCreateRequest request) {
+    return new DocumentReference(
+        request.documentId() != null ? request.documentId() : UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        new DocumentMetadataModel(
+            request.metadata().contentType(),
+            request.metadata().fileName(),
+            null,
+            request.metadata().size(),
+            request.metadata().processDefinitionId(),
+            request.metadata().processInstanceKey(),
+            request.metadata().customProperties()));
+  }
+}

--- a/service/src/test/java/io/camunda/service/DocumentServicesAuthorizationCheckerDelegationTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesAuthorizationCheckerDelegationTest.java
@@ -160,7 +160,7 @@ class DocumentServicesAuthorizationCheckerDelegationTest {
   void shouldDenyDeleteFromWrongTenantGrant() {
     // given: tenant A's checker would grant DELETE, but this request is scoped to tenant B, whose
     // own checker grants nothing -- proves DocumentServices always defers to the checker it was
-    // constructed with, never a sibling instance's. 
+    // constructed with, never a sibling instance's.
     when(checkerA.collectPermissionTypes(any(), any(), any()))
         .thenReturn(Set.of(PermissionType.DELETE));
     when(checkerB.collectPermissionTypes(any(), any(), any())).thenReturn(Collections.emptySet());

--- a/service/src/test/java/io/camunda/service/SecretServicesAuthorizationCheckerDelegationTest.java
+++ b/service/src/test/java/io/camunda/service/SecretServicesAuthorizationCheckerDelegationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.api.model.authz.AuthorizationScope;
+import io.camunda.security.api.model.config.AuthorizationsConfiguration;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.service.SecretServices.SecretErrorCode;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterizes {@link SecretServices}'s own contract: every permission check is delegated to
+ * whichever {@link AuthorizationChecker} instance it was constructed with, with no shared or static
+ * state leaking a check to a sibling instance's checker.
+ *
+ * <p>{@code SecretServices} has the identical shared-checker wiring bug shape as {@code
+ * DocumentServices} (camunda#58441) -- see {@code
+ * DocumentServicesAuthorizationCheckerDelegationTest} for the equivalent documents-side coverage.
+ * That wiring bug lived in {@code CamundaServicesConfiguration}, not in this class, which was
+ * always correct -- see {@code CamundaServicesConfigurationTest} for the regression guard on the
+ * actual fix.
+ */
+class SecretServicesAuthorizationCheckerDelegationTest {
+
+  private final CamundaAuthentication authentication = mock(CamundaAuthentication.class);
+  private final AuthorizationChecker checkerA = mock(AuthorizationChecker.class);
+  private final AuthorizationChecker checkerB = mock(AuthorizationChecker.class);
+  private SecretServices servicesA;
+  private SecretServices servicesB;
+
+  @BeforeEach
+  void beforeEach() {
+    final var enabledConfig = new AuthorizationsConfiguration();
+    enabledConfig.setEnabled(true);
+    servicesA =
+        new SecretServices(
+            "tenant-a",
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            checkerA,
+            enabledConfig,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+    servicesB =
+        new SecretServices(
+            "tenant-b",
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            checkerB,
+            enabledConfig,
+            mock(ApiServicesExecutorProvider.class),
+            null);
+  }
+
+  @Test
+  void shouldOnlyQueryOwnPhysicalTenantsCheckerOnResolve() {
+    // given
+    when(checkerA.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(List.of(AuthorizationScope.WILDCARD));
+
+    // when
+    final var resolution =
+        servicesA.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then
+    assertThat(resolution.resolved()).hasSize(1);
+    assertThat(resolution.errors()).isEmpty();
+    verify(checkerA).retrieveAuthorizedAuthorizationScopes(any(), any());
+    verifyNoInteractions(checkerB);
+  }
+
+  @Test
+  void shouldDenyResolveFromWrongTenantGrant() {
+    // given: tenant A's checker would grant a wildcard, but this request is scoped to tenant B,
+    // whose own checker grants nothing -- proves SecretServices always defers to the checker it
+    // was constructed with, never a sibling instance's.
+    when(checkerA.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(List.of(AuthorizationScope.WILDCARD));
+    when(checkerB.retrieveAuthorizedAuthorizationScopes(any(), any()))
+        .thenReturn(Collections.emptyList());
+
+    // when
+    final var resolution =
+        servicesB.resolve(List.of("camunda.secrets.token"), authentication).join();
+
+    // then
+    assertThat(resolution.resolved()).isEmpty();
+    assertThat(resolution.errors()).hasSize(1);
+    assertThat(resolution.errors().get(0).code()).isEqualTo(SecretErrorCode.ACCESS_DENIED);
+    verify(checkerB).retrieveAuthorizedAuthorizationScopes(any(), any());
+    verifyNoInteractions(checkerA);
+  }
+}


### PR DESCRIPTION
## Description
---WIP---
---DO NOT MERGE---
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #58640
