### PR TITLE
fix: prevent cell text overlap in Operate Listeners tab

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/ListenersTab/styled.ts
@@ -35,6 +35,8 @@ const StructuredList = styled(BaseStructuredList)`
 
 const CellContainer = styled(BaseStack)`
   padding: var(--cds-spacing-03) var(--cds-spacing-01);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 `;
 
 const WarningFilled = styled(BaseWarningFilled)`


### PR DESCRIPTION
## What

Fixes **only** the cell text overlap visual defect (ask #3 of #58500) in the Process Instance → bottom panel → **Listeners** tab.

Long, unbreakable job values (e.g. long job `type` strings such as `io.camunda:zeebe:execution-listener-...` or numeric job keys) did not wrap inside the fixed-width columns of the condensed `StructuredList` (`table-layout: fixed`). Each cell wraps its content in a Carbon `Stack`, which renders as `display: grid`; grid items default to `min-width: auto` and therefore refuse to shrink below their longest word. As a result the content overflowed its column and visually collided with adjacent cells.

## Fix

Scoped, one-file CSS change in `ListenersTab/styled.ts` — add `overflow-wrap: anywhere` (with `word-break: break-word` as a fallback for older engines) to the `CellContainer`, so long content wraps within its column and rows size to their content. No shared component was modified.

`overflow-wrap: anywhere` alone is sufficient (it makes soft-wrap opportunities count toward the grid item's min-content size); `word-break: break-word` is included as a belt-and-suspenders fallback per the issue's stated approach.

## Out of scope (deferred to a follow-up PR)

The sort-ordering changes (default newest-first + user-selectable sortable columns, asks #1 and #2 of #58500) are **deliberately not** included here. They depend on the unmerged jobs `creationTime` sort field (PR #58639) and will be delivered separately. The existing `StructuredList`, columns (including the current `Time` = `endTime` column), the listener-type filter dropdown, and the FAILED warning icon are all unchanged.

## How it was verified

- Built a faithful standalone reproduction using the real compiled Carbon CSS and the exact DOM/class structure, rendered in headless Chromium (Playwright) at a narrow bottom-panel width with representative long values. Measured cell geometry: **11/24 cells overflowed their column before**, **0/24 after** the fix. Confirmed visually that content wraps cleanly with no cross-column overlap.
- `npm run ts-check` ✅
- `npm run lint` ✅ (0 errors)
- `npm test` for `ListenersTab/index.test.tsx` ✅ (10/10)

> ⚠️ Please **visually confirm** the overlap is resolved in a real environment (e.g. `…/listeners?elementId=<element>` with long job types). Playwright visual snapshots for the Listeners tab likely need regeneration — the `update-snapshots` label should be applied.

Part of #58500