### PR TITLE
fix: recreate missing index templates and ILM/ISM policies on startup

### DIFF
--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -21,6 +21,7 @@ import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.util.RetryOperation;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
 import io.camunda.operate.webapp.management.dto.TakeBackupResponseDto;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,7 @@ import org.elasticsearch.client.indices.GetComponentTemplatesRequest;
 import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.repositories.fs.FsRepository;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,8 +82,34 @@ public class BackupRestoreTest {
     testContext = new BackupRestoreTestContext().setZeebeIndexPrefix(ZEEBE_INDEX_PREFIX);
   }
 
+  @After
+  public void tearDown() {
+    // Each test method runs its own set of containers; stop them so the two scenarios don't run
+    // their (heavyweight) Elasticsearch/Zeebe/Operate containers side by side. Stopping is best
+    // effort: a failure here must not mask the actual test outcome.
+    stopQuietly("Operate", () -> stopOperate());
+    stopQuietly("Zeebe", () -> testContainerUtil.stopZeebe((File) null));
+    stopQuietly("Elasticsearch", () -> testContainerUtil.stopElasticsearch());
+  }
+
+  /**
+   * The global cluster state carries the index templates, the component template and the ILM
+   * policy. Restoring a snapshot <em>with</em> global state therefore brings them all back, whereas
+   * restoring <em>without</em> global state only brings back the indices, leaving the templates and
+   * ILM policy to be recreated by Operate on startup
+   * (https://github.com/camunda/camunda/issues/32806).
+   */
   @Test
-  public void testBackupRestore() throws Exception {
+  public void testBackupRestoreWithGlobalState() throws Exception {
+    backupRestore(true);
+  }
+
+  @Test
+  public void testBackupRestoreWithoutGlobalState() throws Exception {
+    backupRestore(false);
+  }
+
+  private void backupRestore(final boolean restoreGlobalState) throws Exception {
     startAllApps();
     dataGenerator.createData(testContext);
     dataGenerator.assertData();
@@ -92,28 +120,69 @@ public class BackupRestoreTest {
     deleteOperateIndices();
     deleteComponentTemplate();
     deleteIlmPolicy();
-    restoreBackup();
-    assertIndexTemplates();
-    assertComponentTemplateRestored();
-    assertIlmPolicyRestored();
+    restoreBackup(restoreGlobalState);
+
+    if (restoreGlobalState) {
+      // The global cluster state includes the index templates, the component template and the ILM
+      // policy, so restoring it brings them all back as part of the snapshot restore.
+      assertIndexTemplatesPresent();
+      assertComponentTemplatePresent();
+      assertIlmPolicyPresent();
+    } else {
+      // Index templates and ILM policies live in the global state, not in the index snapshots.
+      // When the global state is not restored they stay missing until Operate recreates them on
+      // startup (https://github.com/camunda/camunda/issues/32806).
+      assertIndexTemplatesAbsent();
+      assertComponentTemplateAbsent();
+      assertIlmPolicyAbsent();
+    }
+
     startOperate();
+
+    // In both cases the schema must be complete once Operate has started: either the templates and
+    // ILM policy were restored from the global state, or they were recreated on schema startup.
+    assertIndexTemplatesPresent();
+    assertComponentTemplatePresent();
+    assertIlmPolicyPresent();
+
     dataGenerator.assertData();
   }
 
-  private void assertIndexTemplates() throws IOException {
+  private void assertIndexTemplatesPresent() throws IOException {
     for (final TemplateDescriptor descriptor : indexTemplateDescriptors) {
       final String templateName = descriptor.getTemplateName();
-      final boolean exists =
-          !testContext
-              .getEsClient()
-              .indices()
-              .getIndexTemplate(
-                  new GetComposableIndexTemplateRequest(templateName), RequestOptions.DEFAULT)
-              .getIndexTemplates()
-              .isEmpty();
-      assertThat(exists).as("Index template '%s' should be restored", templateName).isTrue();
+      assertThat(indexTemplateExists(templateName))
+          .as("Index template '%s' should be present", templateName)
+          .isTrue();
     }
-    LOGGER.info("************ Index templates verified ************");
+    LOGGER.info("************ Index templates present ************");
+  }
+
+  private void assertIndexTemplatesAbsent() throws IOException {
+    for (final TemplateDescriptor descriptor : indexTemplateDescriptors) {
+      final String templateName = descriptor.getTemplateName();
+      assertThat(indexTemplateExists(templateName))
+          .as("Index template '%s' should be absent before Operate startup", templateName)
+          .isFalse();
+    }
+    LOGGER.info("************ Index templates absent ************");
+  }
+
+  private boolean indexTemplateExists(final String templateName) throws IOException {
+    try {
+      return !testContext
+          .getEsClient()
+          .indices()
+          .getIndexTemplate(
+              new GetComposableIndexTemplateRequest(templateName), RequestOptions.DEFAULT)
+          .getIndexTemplates()
+          .isEmpty();
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   private void deleteComponentTemplate() throws Exception {
@@ -124,39 +193,42 @@ public class BackupRestoreTest {
         .noOfRetry(10)
         .delayInterval(2000, TimeUnit.MILLISECONDS)
         .retryPredicate(result -> !(boolean) result)
-        .retryConsumer(
-            () -> {
-              try {
-                testContext
-                    .getEsClient()
-                    .cluster()
-                    .getComponentTemplate(
-                        new GetComponentTemplatesRequest(OPERATE_TEMPLATE), RequestOptions.DEFAULT);
-                return false;
-              } catch (final ElasticsearchStatusException e) {
-                if (e.status().getStatus() == 404) {
-                  return true;
-                }
-                throw e;
-              }
-            })
+        .retryConsumer(() -> !componentTemplateExists())
         .build()
         .retry();
     LOGGER.info("************ Component template deleted ************");
   }
 
-  private void assertComponentTemplateRestored() throws IOException {
-    final boolean exists =
-        testContext
-                .getEsClient()
-                .cluster()
-                .getComponentTemplate(
-                    new GetComponentTemplatesRequest(OPERATE_TEMPLATE), RequestOptions.DEFAULT)
-                .getComponentTemplates()
-                .get(OPERATE_TEMPLATE)
-            != null;
-    assertThat(exists).as("Component template '%s' should be restored", OPERATE_TEMPLATE).isTrue();
-    LOGGER.info("************ Component template verified ************");
+  private void assertComponentTemplatePresent() throws IOException {
+    assertThat(componentTemplateExists())
+        .as("Component template '%s' should be present", OPERATE_TEMPLATE)
+        .isTrue();
+    LOGGER.info("************ Component template present ************");
+  }
+
+  private void assertComponentTemplateAbsent() throws IOException {
+    assertThat(componentTemplateExists())
+        .as("Component template '%s' should be absent before Operate startup", OPERATE_TEMPLATE)
+        .isFalse();
+    LOGGER.info("************ Component template absent ************");
+  }
+
+  private boolean componentTemplateExists() throws IOException {
+    try {
+      return testContext
+              .getEsClient()
+              .cluster()
+              .getComponentTemplate(
+                  new GetComponentTemplatesRequest(OPERATE_TEMPLATE), RequestOptions.DEFAULT)
+              .getComponentTemplates()
+              .get(OPERATE_TEMPLATE)
+          != null;
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   private void deleteIlmPolicy() throws Exception {
@@ -170,43 +242,45 @@ public class BackupRestoreTest {
         .noOfRetry(10)
         .delayInterval(2000, TimeUnit.MILLISECONDS)
         .retryPredicate(result -> !(boolean) result)
-        .retryConsumer(
-            () -> {
-              try {
-                testContext
-                    .getEsClient()
-                    .indexLifecycle()
-                    .getLifecyclePolicy(
-                        new GetLifecyclePolicyRequest(OPERATE_DELETE_ARCHIVED_INDICES),
-                        RequestOptions.DEFAULT);
-                return false;
-              } catch (final ElasticsearchStatusException e) {
-                if (e.status().getStatus() == 404) {
-                  return true;
-                }
-                throw e;
-              }
-            })
+        .retryConsumer(() -> !ilmPolicyExists())
         .build()
         .retry();
     LOGGER.info("************ ILM policy deleted ************");
   }
 
-  private void assertIlmPolicyRestored() throws IOException {
-    final boolean exists =
-        testContext
-                .getEsClient()
-                .indexLifecycle()
-                .getLifecyclePolicy(
-                    new GetLifecyclePolicyRequest(OPERATE_DELETE_ARCHIVED_INDICES),
-                    RequestOptions.DEFAULT)
-                .getPolicies()
-                .get(OPERATE_DELETE_ARCHIVED_INDICES)
-            != null;
-    assertThat(exists)
-        .as("ILM policy '%s' should be restored", OPERATE_DELETE_ARCHIVED_INDICES)
+  private void assertIlmPolicyPresent() throws IOException {
+    assertThat(ilmPolicyExists())
+        .as("ILM policy '%s' should be present", OPERATE_DELETE_ARCHIVED_INDICES)
         .isTrue();
-    LOGGER.info("************ ILM policy verified ************");
+    LOGGER.info("************ ILM policy present ************");
+  }
+
+  private void assertIlmPolicyAbsent() throws IOException {
+    assertThat(ilmPolicyExists())
+        .as(
+            "ILM policy '%s' should be absent before Operate startup",
+            OPERATE_DELETE_ARCHIVED_INDICES)
+        .isFalse();
+    LOGGER.info("************ ILM policy absent ************");
+  }
+
+  private boolean ilmPolicyExists() throws IOException {
+    try {
+      return testContext
+              .getEsClient()
+              .indexLifecycle()
+              .getLifecyclePolicy(
+                  new GetLifecyclePolicyRequest(OPERATE_DELETE_ARCHIVED_INDICES),
+                  RequestOptions.DEFAULT)
+              .getPolicies()
+              .get(OPERATE_DELETE_ARCHIVED_INDICES)
+          != null;
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw e;
+    }
   }
 
   private void deleteOperateIndices() throws Exception {
@@ -328,7 +402,7 @@ public class BackupRestoreTest {
     LOGGER.info("************ Operate stopped  ************");
   }
 
-  private void restoreBackup() {
+  private void restoreBackup(final boolean restoreGlobalState) {
     snapshots.forEach(
         snapshot -> {
           try {
@@ -338,14 +412,14 @@ public class BackupRestoreTest {
                 .restore(
                     new RestoreSnapshotRequest(REPOSITORY_NAME, snapshot)
                         .waitForCompletion(true)
-                        .includeGlobalState(true),
+                        .includeGlobalState(restoreGlobalState),
                     RequestOptions.DEFAULT);
           } catch (final IOException e) {
             throw new OperateRuntimeException(
                 "Exception occurred while restoring the backup: " + e.getMessage(), e);
           }
         });
-    LOGGER.info("************ Backup restored ************");
+    LOGGER.info("************ Backup restored (globalState={}) ************", restoreGlobalState);
   }
 
   private void createSnapshotRepository(final BackupRestoreTestContext testContext)
@@ -358,6 +432,19 @@ public class BackupRestoreTest {
                 .type(FsRepository.TYPE)
                 .settings(asMap("location", REPOSITORY_NAME)),
             RequestOptions.DEFAULT);
+  }
+
+  private void stopQuietly(final String name, final ThrowingRunnable action) {
+    try {
+      action.run();
+    } catch (final Exception e) {
+      LOGGER.warn("Failed to stop {} during teardown: {}", name, e.getMessage());
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -101,6 +101,8 @@ public class SchemaStartupIT extends AbstractSchemaIT {
 
   @Autowired public TestSchemaStartup schemaStartup;
   @Autowired public TestIndex testIndex;
+  @Autowired public TestTemplate testTemplate;
+  @Autowired public IndexSchemaValidator schemaValidator;
 
   @Autowired private OperateProperties operateProperties;
 
@@ -147,6 +149,30 @@ public class SchemaStartupIT extends AbstractSchemaIT {
                             new IndexMappingProperty()
                                 .setName("propC")
                                 .setTypeDefinition(Map.of("type", "keyword"))))));
+  }
+
+  @Test
+  public void shouldCreateMissingIndexTemplateWhenSchemaAlreadyExists() throws MigrationException {
+    // given
+    // a fully created schema (indices, aliases and templates)
+    schemaStartup.initializeSchemaOnDemand();
+    assertThat(schemaHelper.getTemplateMappings(testTemplate)).isNotNull();
+
+    // and an index template that got lost, as happens after restoring a backup into an empty
+    // cluster: the indices are restored from the snapshot but index templates are not part of a
+    // backup (https://github.com/camunda/camunda/issues/32806)
+    final boolean deleted = schemaManager.deleteTemplatesFor(testTemplate.getTemplateName());
+    assertThat(deleted).isTrue();
+    // the schema is still considered to exist, because the (restored) indices and aliases are there
+    assertThat(schemaValidator.schemaExists()).isTrue();
+
+    // when
+    // the application is (re)started
+    schemaStartup.initializeSchemaOnDemand();
+
+    // then
+    // the missing index template has been recreated
+    assertThat(schemaHelper.getTemplateMappings(testTemplate)).isNotNull();
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -154,6 +154,11 @@ public class SchemaStartupIT extends AbstractSchemaIT {
   @Test
   public void shouldCreateMissingIndexTemplateWhenSchemaAlreadyExists() throws MigrationException {
     // given
+    // migration is disabled: this test invokes initializeSchemaOnDemand() twice (to simulate a
+    // restart) within a single Spring context, and the Migrator's ExecutorService is shut down
+    // after the first run, so a second migration would fail with a TaskRejectedException. Template
+    // recreation, which is what this test verifies, is independent of migration.
+    migrationProperties.setMigrationEnabled(false);
     // a fully created schema (indices, aliases and templates)
     schemaStartup.initializeSchemaOnDemand();
     assertThat(schemaHelper.getTemplateMappings(testTemplate)).isNotNull();

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -30,13 +30,17 @@ public interface SchemaManager {
 
   /**
    * Creates the ILM/ISM retention policies, the component template and the index templates that
-   * make up the schema, but not the data indices themselves.
+   * make up the schema. Creating an index template also bootstraps its initial backing index, so
+   * some indices are created as a side effect; this method does not, however, run the separate step
+   * that creates the remaining plain (non-template) indices.
    *
    * <p>Index templates and ILM/ISM policies are not included in Elasticsearch/OpenSearch snapshots.
    * After restoring a backup into an empty cluster the restored indices exist while the templates
    * and policies are missing; without them the archiver would later create indices with an
-   * incorrect structure. This method (re)creates any missing templates and policies. Templates are
-   * created idempotently: existing ones are left untouched (created with {@code overwrite=false}).
+   * incorrect structure. This method (re)creates any missing templates and policies. It is
+   * idempotent: existing templates are left untouched (created with {@code overwrite=false}) and a
+   * retention policy is created only when it does not already exist, so a restart never overwrites
+   * a pre-existing one.
    *
    * <p>This is only ever invoked when schema creation is enabled ({@code createSchema=true}), i.e.
    * when the application is permitted to manage the schema and its retention policies. Guarding on

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -28,6 +28,26 @@ public interface SchemaManager {
 
   void createSchema();
 
+  /**
+   * Creates the ILM/ISM retention policies, the component template and the index templates that
+   * make up the schema, but not the data indices themselves.
+   *
+   * <p>Index templates and ILM/ISM policies are not included in Elasticsearch/OpenSearch snapshots.
+   * After restoring a backup into an empty cluster the restored indices exist while the templates
+   * and policies are missing; without them the archiver would later create indices with an
+   * incorrect structure. This method (re)creates any missing templates and policies. Templates are
+   * created idempotently: existing ones are left untouched (created with {@code overwrite=false}).
+   *
+   * <p>This is only ever invoked when schema creation is enabled ({@code createSchema=true}), i.e.
+   * when the application is permitted to manage the schema and its retention policies. Guarding on
+   * that flag is what makes touching ILM/ISM safe here: it avoids altering (or failing to alter,
+   * for lack of permissions) a pre-existing retention configuration on restart (see <a
+   * href="https://github.com/camunda/camunda/issues/28571">#28571</a>).
+   *
+   * @see <a href="https://github.com/camunda/camunda/issues/32806">#32806</a>
+   */
+  void createSchemaTemplatesAndPolicies();
+
   void createDefaults();
 
   void createIndex(IndexDescriptor indexDescriptor, String indexClasspathResource);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -63,13 +63,27 @@ public class SchemaStartup {
           DatabaseInfo.isOpensearch()
               ? operateProperties.getOpensearch().isUpdateSchemaSettings()
               : operateProperties.getElasticsearch().isUpdateSchemaSettings();
-      if (createSchema && !schemaValidator.schemaExists()) {
-        LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
-        schemaManager.createSchema();
-        LOGGER.info("SchemaStartup: update index mappings.");
+      if (createSchema) {
+        if (!schemaValidator.schemaExists()) {
+          LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
+          schemaManager.createSchema();
+          LOGGER.info("SchemaStartup: update index mappings.");
+        } else {
+          // Index templates and ILM/ISM retention policies are not part of a backup. After
+          // restoring a backup into an empty cluster, the restored indices exist (so the schema is
+          // considered to already exist) but the templates and policies are missing. Without them,
+          // the archiver would later create indices with an incorrect structure. Recreate the
+          // missing templates and policies. This runs only when schema creation is enabled
+          // (createSchema=true), so the application is permitted to manage them
+          // (https://github.com/camunda/camunda/issues/28571). See
+          // https://github.com/camunda/camunda/issues/32806
+          LOGGER.info(
+              "SchemaStartup: schema already exists. Ensuring index templates and policies are present.");
+          schemaManager.createSchemaTemplatesAndPolicies();
+        }
       } else {
         LOGGER.info(
-            "SchemaStartup: schema won't be created, it either already exist, or schema creation is disabled in configuration.");
+            "SchemaStartup: schema won't be created, as schema creation is disabled in configuration.");
       }
 
       if (!newFields.isEmpty()) {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -35,8 +35,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.indexlifecycle.DeleteAction;
+import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
 import org.elasticsearch.client.indexlifecycle.LifecycleAction;
 import org.elasticsearch.client.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.client.indexlifecycle.Phase;
@@ -401,6 +404,14 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   }
 
   private void createIndexLifeCycles() {
+    // Only create the policy when it is missing, so a restart never overwrites a (possibly
+    // customized) existing policy and never needs manage_ilm permissions when the policy is already
+    // there. This keeps createSchemaTemplatesAndPolicies() safe to run on every startup (#32806).
+    if (ilmPolicyExists(OPERATE_DELETE_ARCHIVED_INDICES)) {
+      LOGGER.info(
+          "ILM policy {} already exists, skipping creation.", OPERATE_DELETE_ARCHIVED_INDICES);
+      return;
+    }
     final TimeValue timeValue =
         TimeValue.parseTimeValue(
             operateProperties.getArchiver().getIlmMinAgeForDeleteArchivedIndices(),
@@ -417,6 +428,26 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     final LifecyclePolicy policy = new LifecyclePolicy(OPERATE_DELETE_ARCHIVED_INDICES, phases);
     final PutLifecyclePolicyRequest request = new PutLifecyclePolicyRequest(policy);
     retryElasticsearchClient.putLifeCyclePolicy(request);
+  }
+
+  private boolean ilmPolicyExists(final String policyName) {
+    try {
+      return retryElasticsearchClient
+          .getEsClient()
+          .indexLifecycle()
+          .getLifecyclePolicy(new GetLifecyclePolicyRequest(policyName), RequestOptions.DEFAULT)
+          .getPolicies()
+          .containsKey(policyName);
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw new OperateRuntimeException(
+          "Failed to check whether ILM policy exists: " + policyName, e);
+    } catch (final IOException e) {
+      throw new OperateRuntimeException(
+          "Failed to check whether ILM policy exists: " + policyName, e);
+    }
   }
 
   private void createIndices() {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -84,12 +84,17 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   @Override
   public void createSchema() {
+    createSchemaTemplatesAndPolicies();
+    createIndices();
+  }
+
+  @Override
+  public void createSchemaTemplatesAndPolicies() {
     if (operateProperties.getArchiver().isIlmEnabled()) {
       createIndexLifeCycles();
     }
     createDefaults();
     createTemplates();
-    createIndices();
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -101,12 +101,17 @@ public class OpensearchSchemaManager implements SchemaManager {
 
   @Override
   public void createSchema() {
+    createSchemaTemplatesAndPolicies();
+    createIndices();
+  }
+
+  @Override
+  public void createSchemaTemplatesAndPolicies() {
     if (operateProperties.getArchiver().isIlmEnabled()) {
       createIsmPolicy();
     }
     createDefaults();
     createTemplates();
-    createIndices();
   }
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -53,13 +53,27 @@ public class SchemaStartup {
           TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
               ? tasklistProperties.getOpenSearch().isUpdateSchemaSettings()
               : tasklistProperties.getElasticsearch().isUpdateSchemaSettings();
-      if (createSchema && !schemaValidator.schemaExists()) {
-        LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
-        schemaManager.createSchema();
-        LOGGER.info("SchemaStartup: update index mappings.");
+      if (createSchema) {
+        if (!schemaValidator.schemaExists()) {
+          LOGGER.info("SchemaStartup: schema is empty or not complete. Indices will be created.");
+          schemaManager.createSchema();
+          LOGGER.info("SchemaStartup: update index mappings.");
+        } else {
+          // Index templates and ILM/ISM retention policies are not part of a backup. After
+          // restoring a backup into an empty cluster, the restored indices exist (so the schema is
+          // considered to already exist) but the templates and policies are missing. Without them,
+          // the archiver would later create indices with an incorrect structure. Recreate the
+          // missing templates and policies. This runs only when schema creation is enabled
+          // (createSchema=true), so the application is permitted to manage them
+          // (https://github.com/camunda/camunda/issues/28571). See
+          // https://github.com/camunda/camunda/issues/32806
+          LOGGER.info(
+              "SchemaStartup: schema already exists. Ensuring index templates and policies are present.");
+          schemaManager.createSchemaTemplatesAndPolicies();
+        }
       } else {
         LOGGER.info(
-            "SchemaStartup: schema won't be created, it either already exist, or schema creation is disabled in configuration.");
+            "SchemaStartup: schema won't be created, as schema creation is disabled in configuration.");
       }
 
       if (!newFields.isEmpty()) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -94,12 +94,17 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   @Override
   public void createSchema() {
+    createSchemaTemplatesAndPolicies();
+    createIndices();
+  }
+
+  @Override
+  public void createSchemaTemplatesAndPolicies() {
     if (tasklistProperties.getArchiver().isIlmEnabled()) {
       createIndexLifeCycles();
     }
     createDefaults();
     createTemplates();
-    createIndices();
   }
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.client.indexlifecycle.DeleteAction;
+import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
 import org.elasticsearch.client.indexlifecycle.LifecycleAction;
 import org.elasticsearch.client.indexlifecycle.LifecyclePolicy;
 import org.elasticsearch.client.indexlifecycle.Phase;
@@ -101,7 +102,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   @Override
   public void createSchemaTemplatesAndPolicies() {
     if (tasklistProperties.getArchiver().isIlmEnabled()) {
-      createIndexLifeCycles();
+      createIndexLifeCyclesIfNotExist();
     }
     createDefaults();
     createTemplates();
@@ -297,6 +298,24 @@ public class ElasticsearchSchemaManager implements SchemaManager {
             .name(getComponentTemplateName())
             .componentTemplate(componentTemplate);
     retryElasticsearchClient.createComponentTemplate(request, overwrite);
+  }
+
+  public void createIndexLifeCyclesIfNotExist() {
+    // Only manage the retention policy when the application is configured to do so, and only create
+    // it when it does not already exist, so a restart never overwrites a user-managed or
+    // pre-existing policy. This mirrors ILMPolicyUpdateElasticSearch and keeps
+    // createSchemaTemplatesAndPolicies() safe to run on every startup (#32806).
+    if (!tasklistProperties.getArchiver().isIlmManagePolicy()) {
+      LOGGER.info("ILM policy is not managed by Tasklist, skipping creation.");
+      return;
+    }
+    if (retryElasticsearchClient.getLifeCyclePolicy(
+            new GetLifecyclePolicyRequest(TASKLIST_DELETE_ARCHIVED_INDICES))
+        != null) {
+      LOGGER.info("{} ILM policy already exists.", TASKLIST_DELETE_ARCHIVED_INDICES);
+      return;
+    }
+    createIndexLifeCycles();
   }
 
   public void createIndexLifeCycles() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -100,12 +100,17 @@ public class OpenSearchSchemaManager implements SchemaManager {
 
   @Override
   public void createSchema() {
+    createSchemaTemplatesAndPolicies();
+    createIndices();
+  }
+
+  @Override
+  public void createSchemaTemplatesAndPolicies() {
     if (tasklistProperties.getArchiver().isIlmEnabled()) {
       createIndexLifeCyclesIfNotExist();
     }
     createDefaults();
     createTemplates();
-    createIndices();
   }
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -383,6 +383,14 @@ public class OpenSearchSchemaManager implements SchemaManager {
   }
 
   public void createIndexLifeCyclesIfNotExist() {
+    // Only manage the retention policy when the application is configured to do so, so a restart
+    // never recreates a policy a user chose to manage themselves. It is already created only when
+    // missing, so an existing policy is never overwritten. This keeps
+    // createSchemaTemplatesAndPolicies() safe to run on every startup (#32806).
+    if (!tasklistProperties.getArchiver().isIlmManagePolicy()) {
+      LOGGER.info("ISM policy is not managed by Tasklist, skipping creation.");
+      return;
+    }
     if (retryOpenSearchClient.getLifecyclePolicy(TASKLIST_DELETE_ARCHIVED_INDICES).isPresent()) {
       LOGGER.info("{} ISM policy already exists", TASKLIST_DELETE_ARCHIVED_INDICES);
       return;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
@@ -18,6 +18,26 @@ public interface SchemaManager {
 
   void createSchema();
 
+  /**
+   * Creates the ILM/ISM retention policies, the component template and the index templates that
+   * make up the schema, but not the data indices themselves.
+   *
+   * <p>Index templates and ILM/ISM policies are not included in Elasticsearch/OpenSearch snapshots.
+   * After restoring a backup into an empty cluster the restored indices exist while the templates
+   * and policies are missing; without them the archiver would later create indices with an
+   * incorrect structure. This method (re)creates any missing templates and policies. Templates are
+   * created idempotently: existing ones are left untouched (created with {@code overwrite=false}).
+   *
+   * <p>This is only ever invoked when schema creation is enabled ({@code createSchema=true}), i.e.
+   * when the application is permitted to manage the schema and its retention policies. Guarding on
+   * that flag is what makes touching ILM/ISM safe here: it avoids altering (or failing to alter,
+   * for lack of permissions) a pre-existing retention configuration on restart (see <a
+   * href="https://github.com/camunda/camunda/issues/28571">#28571</a>).
+   *
+   * @see <a href="https://github.com/camunda/camunda/issues/32806">#32806</a>
+   */
+  void createSchemaTemplatesAndPolicies();
+
   IndexMapping getExpectedIndexFields(IndexDescriptor indexDescriptor);
 
   Map<String, IndexMapping> getIndexMappings(String s) throws IOException;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
@@ -20,13 +20,18 @@ public interface SchemaManager {
 
   /**
    * Creates the ILM/ISM retention policies, the component template and the index templates that
-   * make up the schema, but not the data indices themselves.
+   * make up the schema. Creating an index template also bootstraps its initial backing index, so
+   * some indices are created as a side effect; this method does not, however, run the separate step
+   * that creates the remaining plain (non-template) indices.
    *
    * <p>Index templates and ILM/ISM policies are not included in Elasticsearch/OpenSearch snapshots.
    * After restoring a backup into an empty cluster the restored indices exist while the templates
    * and policies are missing; without them the archiver would later create indices with an
-   * incorrect structure. This method (re)creates any missing templates and policies. Templates are
-   * created idempotently: existing ones are left untouched (created with {@code overwrite=false}).
+   * incorrect structure. This method (re)creates any missing templates and policies. It is
+   * idempotent: existing templates are left untouched (created with {@code overwrite=false}) and
+   * the retention policy is created only when it does not already exist and only when the
+   * application is configured to manage it ({@code ilmManagePolicy}), so a restart never overwrites
+   * a pre-existing or user-managed one.
    *
    * <p>This is only ever invoked when schema creation is enabled ({@code createSchema=true}), i.e.
    * when the application is permitted to manage the schema and its retention policies. Guarding on

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManagerTest.java
@@ -10,18 +10,22 @@ package io.camunda.tasklist.schema.manager;
 import static io.camunda.tasklist.property.TasklistProperties.ELASTIC_SEARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.tasklist.es.RetryElasticsearchClient;
+import io.camunda.tasklist.property.ArchiverProperties;
 import io.camunda.tasklist.property.TasklistElasticsearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.schema.templates.TaskTemplate;
+import java.util.List;
 import org.elasticsearch.client.indices.PutComposableIndexTemplateRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
@@ -31,6 +35,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ElasticsearchSchemaManagerTest {
@@ -74,5 +79,24 @@ class ElasticsearchSchemaManagerTest {
                 .get();
     final var expectedPriority = priority != null ? Long.valueOf(priority) : null;
     assertThat(indexTemplate.priority()).isEqualTo(expectedPriority);
+  }
+
+  @Test
+  void createSchemaTemplatesAndPoliciesShouldCreateComponentAndIndexTemplates() {
+    // given
+    // index templates and ILM policies are not part of a backup, so they must be (re)created on
+    // startup even when the schema (indices) already exists after a restore (#32806)
+    when(tasklistProperties.getArchiver()).thenReturn(mock(ArchiverProperties.class));
+    ReflectionTestUtils.setField(
+        elasticsearchSchemaManager, "templateDescriptors", List.of(taskTemplate));
+    ReflectionTestUtils.setField(elasticsearchSchemaManager, "indexDescriptors", List.of());
+
+    // when
+    elasticsearchSchemaManager.createSchemaTemplatesAndPolicies();
+
+    // then
+    verify(retryElasticsearchClient).createComponentTemplate(any(), eq(false));
+    verify(retryElasticsearchClient)
+        .createTemplate(any(PutComposableIndexTemplateRequest.class), eq(false));
   }
 }

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManagerTest.java
@@ -9,17 +9,21 @@ package io.camunda.tasklist.schema.manager;
 
 import static io.camunda.tasklist.property.TasklistProperties.OPEN_SEARCH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.os.RetryOpenSearchClient;
+import io.camunda.tasklist.property.ArchiverProperties;
 import io.camunda.tasklist.property.TasklistOpenSearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.schema.templates.TaskTemplate;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +42,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class OpenSearchSchemaManagerTest {
@@ -102,6 +107,24 @@ class OpenSearchSchemaManagerTest {
     verify(retryOpenSearchClient).createTemplate(requestCaptor.capture(), eq(false));
     final var request = requestCaptor.getValue();
     assertThat(request.priority()).isEqualTo(priority);
+  }
+
+  @Test
+  void createSchemaTemplatesAndPoliciesShouldCreateComponentAndIndexTemplates() {
+    // given
+    // index templates and ISM policies are not part of a backup, so they must be (re)created on
+    // startup even when the schema (indices) already exists after a restore (#32806)
+    when(tasklistProperties.getArchiver()).thenReturn(mock(ArchiverProperties.class));
+    ReflectionTestUtils.setField(
+        openSearchSchemaManager, "templateDescriptors", List.of(taskTemplate));
+    ReflectionTestUtils.setField(openSearchSchemaManager, "indexDescriptors", List.of());
+
+    // when
+    openSearchSchemaManager.createSchemaTemplatesAndPolicies();
+
+    // then
+    verify(retryOpenSearchClient).createComponentTemplate(any(), eq(false));
+    verify(retryOpenSearchClient).createTemplate(any(PutIndexTemplateRequest.class), eq(false));
   }
 
   private void validateMappings(final TypeMapping mapping, final String fileName)

--- a/tasklist/qa/backup-restore-tests/pom.xml
+++ b/tasklist/qa/backup-restore-tests/pom.xml
@@ -205,6 +205,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.qa.backup;
 
 import static io.camunda.tasklist.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.tasklist.util.CollectionUtil.asMap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
@@ -22,16 +23,27 @@ import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.io.IOException;
 import java.util.List;
 import org.apache.http.HttpHost;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indexlifecycle.DeleteLifecyclePolicyRequest;
+import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
+import org.elasticsearch.client.indices.DeleteComposableIndexTemplateRequest;
+import org.elasticsearch.client.indices.GetComponentTemplatesRequest;
+import org.elasticsearch.client.indices.GetComposableIndexTemplateRequest;
 import org.elasticsearch.repositories.fs.FsRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
@@ -55,6 +67,9 @@ public class BackupRestoreTest {
   public static final String VERSION = "current-test";
   public static final String REPOSITORY_NAME = "testRepository";
   public static final Long BACKUP_ID = 123L;
+  public static final String TASKLIST_INDEX_PREFIX = "tasklist";
+  public static final String TASKLIST_TEMPLATE = "tasklist_template";
+  public static final String TASKLIST_DELETE_ARCHIVED_INDICES = "tasklist_delete_archived_indices";
   private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreTest.class);
   private static final String TASKLIST_TEST_DOCKER_IMAGE = "localhost:5000/camunda/tasklist";
 
@@ -66,6 +81,10 @@ public class BackupRestoreTest {
 
   private ZeebeClient zeebeClient;
 
+  // Low-level OpenSearch REST client, used to query/delete the ISM policy (which the typed client
+  // does not expose). Created together with the OpenSearch client and closed on teardown.
+  private org.opensearch.client.RestClient osRestClient;
+
   private final TestContainerUtil testContainerUtil = new TestContainerUtil();
   private BackupRestoreTestContext testContext;
   private List<String> snapshots;
@@ -75,8 +94,48 @@ public class BackupRestoreTest {
     testContext = new BackupRestoreTestContext().setZeebeIndexPrefix(ZEEBE_INDEX_PREFIX);
   }
 
-  @Test
-  public void testBackupRestore() throws Exception {
+  @AfterEach
+  public void tearDown() {
+    // Each parameterized run spins up its own containers; stop them so the two scenarios don't run
+    // their (heavyweight) database/Zeebe/Tasklist containers side by side. Stopping is best effort:
+    // a failure here must not mask the actual test outcome.
+    stopQuietly("Tasklist", this::stopTasklist);
+    stopQuietly("Zeebe", () -> testContainerUtil.stopZeebeAndTasklist(testContext));
+    if (TestUtil.isOpenSearch()) {
+      stopQuietly("OpenSearch", testContainerUtil::stopOpenSearch);
+      stopQuietly(
+          "OpenSearch REST client",
+          () -> {
+            if (osRestClient != null) {
+              osRestClient.close();
+            }
+          });
+    } else {
+      stopQuietly("Elasticsearch", testContainerUtil::stopElasticsearch);
+    }
+    stopQuietly(
+        "Zeebe client",
+        () -> {
+          if (zeebeClient != null) {
+            zeebeClient.close();
+          }
+        });
+  }
+
+  /**
+   * The global cluster state carries the index templates and the component template (for both
+   * Elasticsearch and OpenSearch) as well as the Elasticsearch ILM policy. Restoring a snapshot
+   * <em>with</em> global state therefore brings those back, whereas restoring <em>without</em>
+   * global state only brings back the indices, leaving the templates and policy to be recreated by
+   * Tasklist on startup (https://github.com/camunda/camunda/issues/32806).
+   *
+   * <p>OpenSearch ISM policies are stored in a system index rather than in the cluster metadata, so
+   * they are never part of the restored global state and are always recreated by Tasklist on
+   * startup.
+   */
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testBackupRestore(final boolean restoreGlobalState) throws Exception {
     startAllApps();
     backupRestoreDataGenerator.createData(testContext);
     backupRestoreDataGenerator.assertData();
@@ -85,8 +144,37 @@ public class BackupRestoreTest {
     backupRestoreDataGenerator.assertDataAfterChange();
     stopTasklist();
     deleteTasklistIndices();
-    restoreBackup();
+    deleteTemplatesAndPolicy();
+    restoreBackup(restoreGlobalState);
+
+    if (restoreGlobalState) {
+      // Index templates and the component template are part of the cluster global state (for both
+      // ES and OS), so restoring it brings them back with the snapshot.
+      assertIndexTemplatesPresent();
+      assertComponentTemplatePresent();
+      // ES stores ILM policies in the cluster global state, so they are restored too. OpenSearch
+      // ISM policies live in a system index rather than the cluster metadata, so they are NOT part
+      // of the restored global state and are instead recreated by Tasklist on startup (asserted
+      // after startTasklist below).
+      if (!TestUtil.isOpenSearch()) {
+        assertRetentionPolicyPresent();
+      }
+    } else {
+      // Without the global state, none of these are restored; they must be recreated by Tasklist on
+      // startup (https://github.com/camunda/camunda/issues/32806).
+      assertIndexTemplatesAbsent();
+      assertComponentTemplateAbsent();
+      assertRetentionPolicyAbsent();
+    }
+
     startTasklist();
+
+    // In both cases the schema must be complete once Tasklist has started: the templates and
+    // retention policy were either restored from the global state or recreated on schema startup.
+    assertIndexTemplatesPresent();
+    assertComponentTemplatePresent();
+    assertRetentionPolicyPresent();
+
     backupRestoreDataGenerator.assertData();
   }
 
@@ -95,6 +183,212 @@ public class BackupRestoreTest {
     tasklistAPICaller.assertBackupState();
     return backupResponse.getScheduledSnapshots();
   }
+
+  // ---------------------------------------------------------------------------------------------
+  // Assertions: index templates / component template / retention policy (ILM on ES, ISM on OS)
+  // ---------------------------------------------------------------------------------------------
+
+  private void assertIndexTemplatesPresent() throws IOException {
+    assertThat(indexTemplatesExist())
+        .as("Index templates '%s*' should be present", TASKLIST_INDEX_PREFIX)
+        .isTrue();
+    LOGGER.info("************ Index templates present ************");
+  }
+
+  private void assertIndexTemplatesAbsent() throws IOException {
+    assertThat(indexTemplatesExist())
+        .as("Index templates '%s*' should be absent before Tasklist startup", TASKLIST_INDEX_PREFIX)
+        .isFalse();
+    LOGGER.info("************ Index templates absent ************");
+  }
+
+  private boolean indexTemplatesExist() throws IOException {
+    if (TestUtil.isOpenSearch()) {
+      return testContext
+          .getOsClient()
+          .indices()
+          .existsIndexTemplate(it -> it.name(TASKLIST_INDEX_PREFIX + "*"))
+          .value();
+    }
+    try {
+      return !testContext
+          .getEsClient()
+          .indices()
+          .getIndexTemplate(
+              new GetComposableIndexTemplateRequest(TASKLIST_INDEX_PREFIX + "*"),
+              RequestOptions.DEFAULT)
+          .getIndexTemplates()
+          .isEmpty();
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private void assertComponentTemplatePresent() throws IOException {
+    assertThat(componentTemplateExists())
+        .as("Component template '%s' should be present", TASKLIST_TEMPLATE)
+        .isTrue();
+    LOGGER.info("************ Component template present ************");
+  }
+
+  private void assertComponentTemplateAbsent() throws IOException {
+    assertThat(componentTemplateExists())
+        .as("Component template '%s' should be absent before Tasklist startup", TASKLIST_TEMPLATE)
+        .isFalse();
+    LOGGER.info("************ Component template absent ************");
+  }
+
+  private boolean componentTemplateExists() throws IOException {
+    if (TestUtil.isOpenSearch()) {
+      return testContext
+          .getOsClient()
+          .cluster()
+          .existsComponentTemplate(r -> r.name(TASKLIST_TEMPLATE))
+          .value();
+    }
+    try {
+      return testContext
+              .getEsClient()
+              .cluster()
+              .getComponentTemplate(
+                  new GetComponentTemplatesRequest(TASKLIST_TEMPLATE), RequestOptions.DEFAULT)
+              .getComponentTemplates()
+              .get(TASKLIST_TEMPLATE)
+          != null;
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private void assertRetentionPolicyPresent() throws IOException {
+    assertThat(retentionPolicyExists())
+        .as("Retention policy '%s' should be present", TASKLIST_DELETE_ARCHIVED_INDICES)
+        .isTrue();
+    LOGGER.info("************ Retention policy present ************");
+  }
+
+  private void assertRetentionPolicyAbsent() throws IOException {
+    assertThat(retentionPolicyExists())
+        .as(
+            "Retention policy '%s' should be absent before Tasklist startup",
+            TASKLIST_DELETE_ARCHIVED_INDICES)
+        .isFalse();
+    LOGGER.info("************ Retention policy absent ************");
+  }
+
+  private boolean retentionPolicyExists() throws IOException {
+    if (TestUtil.isOpenSearch()) {
+      final Request request =
+          new Request("GET", "/_plugins/_ism/policies/" + TASKLIST_DELETE_ARCHIVED_INDICES);
+      try {
+        final Response response = osRestClient.performRequest(request);
+        return response.getStatusLine().getStatusCode() == 200;
+      } catch (final ResponseException e) {
+        if (e.getResponse().getStatusLine().getStatusCode() == 404) {
+          return false;
+        }
+        throw e;
+      }
+    }
+    try {
+      return testContext
+              .getEsClient()
+              .indexLifecycle()
+              .getLifecyclePolicy(
+                  new GetLifecyclePolicyRequest(TASKLIST_DELETE_ARCHIVED_INDICES),
+                  RequestOptions.DEFAULT)
+              .getPolicies()
+              .get(TASKLIST_DELETE_ARCHIVED_INDICES)
+          != null;
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() == 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Deletion of templates + retention policy (to simulate a restore into a fresh cluster)
+  // ---------------------------------------------------------------------------------------------
+
+  private void deleteTemplatesAndPolicy() throws IOException {
+    if (TestUtil.isOpenSearch()) {
+      deleteOsTemplatesAndPolicy();
+    } else {
+      deleteElsTemplatesAndPolicy();
+    }
+  }
+
+  private void deleteElsTemplatesAndPolicy() throws IOException {
+    final RestHighLevelClient esClient = testContext.getEsClient();
+    try {
+      esClient
+          .indices()
+          .deleteIndexTemplate(
+              new DeleteComposableIndexTemplateRequest(TASKLIST_INDEX_PREFIX + "*"),
+              RequestOptions.DEFAULT);
+    } catch (final ElasticsearchStatusException e) {
+      if (e.status().getStatus() != 404) {
+        throw e;
+      }
+    }
+    esClient
+        .getLowLevelClient()
+        .performRequest(
+            new org.elasticsearch.client.Request(
+                "DELETE", "/_component_template/" + TASKLIST_TEMPLATE));
+    esClient
+        .indexLifecycle()
+        .deleteLifecyclePolicy(
+            new DeleteLifecyclePolicyRequest(TASKLIST_DELETE_ARCHIVED_INDICES),
+            RequestOptions.DEFAULT);
+    LOGGER.info(
+        "************ Tasklist ElasticSearch templates and ILM policy deleted ************");
+  }
+
+  private void deleteOsTemplatesAndPolicy() throws IOException {
+    final OpenSearchClient osClient = testContext.getOsClient();
+    osClient
+        .indices()
+        .getIndexTemplate(it -> it.name(TASKLIST_INDEX_PREFIX + "*"))
+        .indexTemplates()
+        .forEach(
+            t -> {
+              try {
+                osClient.indices().deleteIndexTemplate(d -> d.name(t.name()));
+              } catch (final IOException e) {
+                throw new TasklistRuntimeException(
+                    "Exception occurred while deleting index template " + t.name(), e);
+              }
+            });
+    try {
+      osClient.cluster().deleteComponentTemplate(d -> d.name(TASKLIST_TEMPLATE));
+    } catch (final OpenSearchException e) {
+      if (e.status() != 404) {
+        throw e;
+      }
+    }
+    try {
+      osRestClient.performRequest(
+          new Request("DELETE", "/_plugins/_ism/policies/" + TASKLIST_DELETE_ARCHIVED_INDICES));
+    } catch (final ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() != 404) {
+        throw e;
+      }
+    }
+    LOGGER.info("************ Tasklist OpenSearch templates and ISM policy deleted ************");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Application / container lifecycle
+  // ---------------------------------------------------------------------------------------------
 
   private void startAllApps() throws IOException {
     if (TestUtil.isOpenSearch()) {
@@ -108,6 +402,7 @@ public class BackupRestoreTest {
             .createTasklistContainer(TASKLIST_TEST_DOCKER_IMAGE, VERSION, testContext)
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .withEnv("CAMUNDA_TASKLIST_BACKUP_REPOSITORYNAME", REPOSITORY_NAME)
+            .withEnv("CAMUNDA_TASKLIST_ARCHIVER_ILMENABLED", "true")
             .withEnv(
                 "CAMUNDA_TASKLIST_DATABASE",
                 TestUtil.isOpenSearch() ? "opensearch" : "elasticsearch")
@@ -148,6 +443,10 @@ public class BackupRestoreTest {
     final OpenSearchClient osClient = createOsClient();
     testContainerUtil.checkOpenSearchHealth(osClient);
     testContext.setOsClient(osClient);
+    osRestClient =
+        org.opensearch.client.RestClient.builder(
+                new HttpHost(testContext.getExternalOsHost(), testContext.getExternalOsPort()))
+            .build();
     createOsSnapshotRepository(testContext);
 
     testContainerUtil.startZeebe(
@@ -162,19 +461,22 @@ public class BackupRestoreTest {
   }
 
   private void stopTasklist() {
-    tasklistContainer.stop();
-    LOGGER.info("************ Tasklist stopped  ************");
-  }
-
-  private void restoreBackup() {
-    if (TestUtil.isOpenSearch()) {
-      restoreOsBackup();
-    } else {
-      restoreElsBackup();
+    if (tasklistContainer != null) {
+      tasklistContainer.stop();
+      LOGGER.info("************ Tasklist stopped  ************");
     }
   }
 
-  private void restoreElsBackup() {
+  private void restoreBackup(final boolean restoreGlobalState) {
+    if (TestUtil.isOpenSearch()) {
+      restoreOsBackup(restoreGlobalState);
+    } else {
+      restoreElsBackup(restoreGlobalState);
+    }
+    LOGGER.info("************ Backup restored (globalState={}) ************", restoreGlobalState);
+  }
+
+  private void restoreElsBackup(final boolean restoreGlobalState) {
     snapshots.forEach(
         snapshot -> {
           try {
@@ -182,7 +484,9 @@ public class BackupRestoreTest {
                 .getEsClient()
                 .snapshot()
                 .restore(
-                    new RestoreSnapshotRequest(REPOSITORY_NAME, snapshot).waitForCompletion(true),
+                    new RestoreSnapshotRequest(REPOSITORY_NAME, snapshot)
+                        .waitForCompletion(true)
+                        .includeGlobalState(restoreGlobalState),
                     RequestOptions.DEFAULT);
           } catch (final IOException e) {
             throw new TasklistRuntimeException(
@@ -191,7 +495,7 @@ public class BackupRestoreTest {
         });
   }
 
-  private void restoreOsBackup() {
+  private void restoreOsBackup(final boolean restoreGlobalState) {
     snapshots.forEach(
         snapshot -> {
           try {
@@ -199,7 +503,11 @@ public class BackupRestoreTest {
                 .getOsClient()
                 .snapshot()
                 .restore(
-                    r -> r.repository(REPOSITORY_NAME).snapshot(snapshot).waitForCompletion(true));
+                    r ->
+                        r.repository(REPOSITORY_NAME)
+                            .snapshot(snapshot)
+                            .waitForCompletion(true)
+                            .includeGlobalState(restoreGlobalState));
           } catch (final IOException | OpenSearchException e) {
             throw new TasklistRuntimeException(
                 "Exception occurred while restoring the backup: " + e.getMessage(), e);
@@ -282,6 +590,19 @@ public class BackupRestoreTest {
             .usePlaintext();
     zeebeClient = builder.build();
     return zeebeClient;
+  }
+
+  private void stopQuietly(final String name, final ThrowingRunnable action) {
+    try {
+      action.run();
+    } catch (final Exception e) {
+      LOGGER.warn("Failed to stop {} during teardown: {}", name, e.getMessage());
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
   }
 }
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -577,4 +577,10 @@ public class TestContainerUtil {
       elsContainer.stop();
     }
   }
+
+  public void stopOpenSearch() {
+    if (osContainer != null) {
+      osContainer.stop();
+    }
+  }
 }


### PR DESCRIPTION
## Description

Backport-equivalent, for versions **< 8.8**, of the fix done for newer versions in #40675 / #47007.

**Problem.** Index templates and ILM/ISM retention policies are not included in Elasticsearch/OpenSearch snapshots — they are part of the cluster global state, not of the index snapshots. After restoring a backup into an empty cluster, the restored **indices** exist (so `schemaExists()` returns `true` and the schema is considered complete), but the **templates** and **retention policies** are missing. The archiver then creates new indices with an incorrect structure.

**Fix.** On startup, when the schema already exists but schema creation is enabled, Operate and Tasklist now (re)create any missing component/index templates and ILM/ISM retention policies through a new `SchemaManager#createSchemaTemplatesAndPolicies()`, invoked from the `schemaExists()` branch of `SchemaStartup`.

- Templates are created idempotently (`overwrite=false`), so existing templates are left untouched.
- Touching ILM/ISM is deliberately guarded by the `createSchema` flag. This branch only runs when the application is configured (and permitted) to manage the schema, so a restart never alters a pre-existing retention configuration when the app lacks permission to manage it (see #28571).
- `createSchema()` is refactored to delegate to `createSchemaTemplatesAndPolicies()` + `createIndices()`, keeping the fresh-install path unchanged.

Applies to both **Operate** and **Tasklist**, for **Elasticsearch** and **OpenSearch**.

### Tests

- Unit tests for the Tasklist ES/OS schema managers assert `createSchemaTemplatesAndPolicies()` creates the component + index templates.
- Operate `SchemaStartupIT` regression: a template deleted while the schema still "exists" is recreated on the next startup.
- The Operate and Tasklist **backup-restore integration tests** now run with **and without** the cluster global state:
  - **with** global state → templates + component template (and, for ES, the ILM policy) are restored by the snapshot itself;
  - **without** global state → they are absent after restore and must be recreated by the app on startup.
  - OpenSearch ISM policies live in a system index rather than the cluster metadata, so they are never part of the restored global state and are always recreated on startup — the tests model this explicitly.

## Related issues

closes #32806
relates to #28571
