### PR TITLE
ci: dump docker logs on Optimize E2E Cloud job failure

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -611,6 +611,12 @@ jobs:
         with:
           name: logs
           path: ./optimize/client/build/*.log
+      - name: Docker log dump
+        uses: ./.github/actions/docker-logs
+        if: always()
+        continue-on-error: true
+        with:
+          archive_name: optimize-e2e-cloud-docker-logs
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

`Optimize / E2E Cloud` (`e2e-cloud-test` in `ci-optimize.yml`) uploads the Optimize backend app log on failure, but never captures Elasticsearch container logs — the `docker-logs` composite action exists in this same workflow file and is already used by sibling jobs (`optimize-e2e-smoke`, `optimize-it-elasticsearch`, `optimize-it-opensearch`), it was just never wired into this job.

This surfaced during [INC-6717](https://camunda.slack.com/archives/C0BLEPDUCKA): the job hung for 10 minutes during Optimize schema initialization and timed out with no ES-side diagnostics available — only the backend app log, which stopped mid-request. Related: INC-6719 shows a 40% intermittent failure rate for this same job in the merge queue to main.

This PR only adds the missing observability step so the next occurrence is actually diagnosable. It does not attempt a root-cause fix — the ES-side stall itself needs the docker logs to investigate further.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Related to INC-6717 / INC-6719