### PR TITLE
feat: add possibility to switch priority in /cluster/partition-distribution

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
@@ -38,10 +39,10 @@ import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.Error;
 import io.camunda.zeebe.management.cluster.MessageCorrelationHashMod;
-import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
 import io.camunda.zeebe.management.cluster.RoutingState;
+import io.camunda.zeebe.management.cluster.UpdatePartitionDistributionRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -479,14 +480,22 @@ public class ClusterEndpoint {
 
   @PutMapping(path = "/partition-distribution", consumes = "application/json")
   public ResponseEntity<?> updatePartitionDistribution(
-      @RequestBody final PartitionDistributionConfig partitionDistributionConfig,
+      @RequestBody final UpdatePartitionDistributionRequest request,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
     try {
-      final var internalConfig =
-          ClusterApiUtils.toPartitionDistributorConfig(partitionDistributionConfig);
-      final var updateRequest = new UpdatePartitionDistributorConfigRequest(internalConfig, dryRun);
-      return ClusterApiUtils.mapOperationResponse(
-          requestSender.updatePartitionDistribution(updateRequest).join());
+      final var config = Optional.ofNullable(request.getConfig());
+      final var zonePriorities = Optional.ofNullable(request.getZonePriorities()).orElse(List.of());
+      if (config.isPresent() == !zonePriorities.isEmpty()) {
+        return invalidRequest("Exactly one of config and zonePriorities must be set.");
+      }
+      final var result =
+          config.isPresent()
+              ? requestSender.updatePartitionDistribution(
+                  new UpdatePartitionDistributorConfigRequest(
+                      ClusterApiUtils.toPartitionDistributorConfig(config.get()), dryRun))
+              : requestSender.updateZonePriorities(
+                  new UpdateZonePrioritiesRequest(zonePriorities, dryRun));
+      return ClusterApiUtils.mapOperationResponse(result.join());
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -483,16 +483,18 @@ public class ClusterEndpoint {
       @RequestBody final UpdatePartitionDistributionRequest request,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
     try {
-      final var config = Optional.ofNullable(request.getConfig());
+      final var partitionDistributionConfig = Optional.ofNullable(request.getConfig());
       final var zonePriorities = Optional.ofNullable(request.getZonePriorities()).orElse(List.of());
-      if (config.isPresent() == !zonePriorities.isEmpty()) {
+      if (partitionDistributionConfig.isPresent() == !zonePriorities.isEmpty()) {
         return invalidRequest("Exactly one of config and zonePriorities must be set.");
       }
       final var result =
-          config.isPresent()
+          partitionDistributionConfig.isPresent()
               ? requestSender.updatePartitionDistribution(
                   new UpdatePartitionDistributorConfigRequest(
-                      ClusterApiUtils.toPartitionDistributorConfig(config.get()), dryRun))
+                      ClusterApiUtils.toPartitionDistributorConfig(
+                          partitionDistributionConfig.get()),
+                      dryRun))
               : requestSender.updateZonePriorities(
                   new UpdateZonePrioritiesRequest(zonePriorities, dryRun));
       return ClusterApiUtils.mapOperationResponse(result.join());

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -187,18 +187,27 @@ paths:
   /partition-distribution:
     put:
       summary:
-        Update the partition distribution configuration. The new configuration is persisted and applied immediately
-        by computing the necessary partition join, leave, and priority-reconfiguration operations. When migrating
-        a bare or partially zoned cluster to zone-aware (see `PUT /cluster/zones`), list zones in the order they
-        should receive the existing (bare) nodes — the first zone in the list receives node 0, the second zone
-        node 1, and so on, wrapping around by zone count. This order only matters for that one-time migration;
-        once all zones are migrated, every other API addresses zones by name.
+        Update the partition distribution configuration. Exactly one of `config` and `zonePriorities` must be set.
+
+        Setting `config` persists a new configuration and applies it immediately by computing the necessary
+        partition join, leave, and priority-reconfiguration operations. When migrating a bare or partially zoned
+        cluster to zone-aware (see `PUT /cluster/zones`), list zones in `config.zones` in the order they should
+        receive the existing (bare) nodes — the first zone receives node 0, the second node 1, and so on, wrapping
+        around by zone count. This order only matters for that one-time migration; once all zones are migrated,
+        every other API addresses zones by name.
+
+        Setting `zonePriorities` re-orders the zones' priorities on a fully zone-aware cluster. The
+        priorities values are reused and they are just reassigned to a different zone based on the order of the zones in the
+        request. The first zone gets the highest existing priority value, the second zone the next highest, and so on. No new
+        priority values are introduced. This only updates the priorities; it does not itself move partition
+        leaders. Leaders move to the newly-preferred zone on the next election (e.g. triggered by a separate
+        rebalance). It must list exactly the currently configured zones; idempotent.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "components.yaml#/schemas/PartitionDistributionConfig"
+              $ref: "components.yaml#/schemas/UpdatePartitionDistributionRequest"
       parameters:
         - $ref: '#/components/parameters/DryRunParameter'
       responses:

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -149,6 +149,25 @@ schemas:
       partitionDistribution:
         $ref: "components.yaml#/schemas/PartitionDistributionConfig"
 
+  UpdatePartitionDistributionRequest:
+    description: >
+      Request body for `PUT /cluster/partition-distribution`. Exactly one of `config` and
+      `zonePriorities` must be set.
+    type: object
+    properties:
+      config:
+        $ref: "components.yaml#/schemas/PartitionDistributionConfig"
+      zonePriorities:
+        type: array
+        minItems: 1
+        items:
+          type: string
+        description: >
+          Leader switchover: desired zone order for Raft leader-election priority, highest first.
+          Must list exactly the currently configured zones. The existing priority values are kept
+          and re-assigned in this order. Mutually exclusive with `config`.
+        example: ["zone-a", "zone-b"]
+
   PartitionDistributionConfig:
     description: The partition distributor configuration agreed on by the cluster.
     type: object

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -12,12 +12,19 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
+import io.camunda.zeebe.management.cluster.UpdatePartitionDistributionRequest;
+import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -138,6 +145,98 @@ final class ClusterEndpointTest {
 
       // then
       verify(sender).modeChange(new ModeChangeRequest(Mode.RECOVERING, true));
+    }
+  }
+
+  @Nested
+  class UpdatePartitionDistributionEndpoint {
+
+    private static PartitionDistributionConfig zoneAwareConfig() {
+      return new PartitionDistributionConfig()
+          .type(TypeEnum.ZONE_AWARE)
+          .zones(List.of(new ZoneSpec().name("zone-a").numberOfReplicas(1).priority(100)));
+    }
+
+    @Test
+    void shouldSendPartitionDistributionRequestWhenConfigSet() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      final var config = zoneAwareConfig();
+      final var expected =
+          new UpdatePartitionDistributorConfigRequest(
+              ClusterApiUtils.toPartitionDistributorConfig(config), false);
+      when(sender.updatePartitionDistribution(expected))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  Either.right(
+                      new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of()))));
+
+      // when
+      final var response =
+          endpoint.updatePartitionDistribution(
+              new UpdatePartitionDistributionRequest().config(config), false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(202);
+      verify(sender).updatePartitionDistribution(expected);
+    }
+
+    @Test
+    void shouldSendZonePrioritiesRequestWhenZonePrioritiesSet() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      final var zoneOrder = List.of("zone-b", "zone-a");
+      final var expected = new UpdateZonePrioritiesRequest(zoneOrder, true);
+      when(sender.updateZonePriorities(expected))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  Either.right(
+                      new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of()))));
+
+      // when - dryRun flag is forwarded
+      final var response =
+          endpoint.updatePartitionDistribution(
+              new UpdatePartitionDistributionRequest().zonePriorities(zoneOrder), true);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(202);
+      verify(sender).updateZonePriorities(expected);
+    }
+
+    @Test
+    void shouldRejectWhenBothConfigAndZonePrioritiesSet() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response =
+          endpoint.updatePartitionDistribution(
+              new UpdatePartitionDistributionRequest()
+                  .config(zoneAwareConfig())
+                  .zonePriorities(List.of("zone-a")),
+              false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
+    }
+
+    @Test
+    void shouldRejectWhenNeitherConfigNorZonePrioritiesSet() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+
+      // when
+      final var response =
+          endpoint.updatePartitionDistribution(new UpdatePartitionDistributionRequest(), false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(400);
+      verifyNoInteractions(sender);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
@@ -83,6 +84,9 @@ public interface ClusterConfigurationManagementApi {
       ForceZoneRemoveRequest forceZoneRemoveRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> addZone(AddZoneRequest addZoneRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> updateZonePriorities(
+      UpdateZonePrioritiesRequest updateZonePrioritiesRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
       ExporterDisableRequest exporterDisableRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -137,6 +137,14 @@ public sealed interface ClusterConfigurationManagementRequest {
       String zoneId, int numberOfReplicas, int priority, Set<MemberId> brokers, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
+  /**
+   * Re-orders the Raft leader-election priorities of the persisted {@code ZoneAwareConfig}: the
+   * existing priority values are kept and re-assigned to zones by {@code zoneOrder} (highest
+   * first).
+   */
+  record UpdateZonePrioritiesRequest(List<String> zoneOrder, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record ExporterDisableRequest(String exporterId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -288,6 +289,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.ADD_ZONE.topic(),
         request,
         serializer::encodeAddZoneRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      updateZonePriorities(final UpdateZonePrioritiesRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.UPDATE_ZONE_PRIORITIES.topic(),
+        request,
+        serializer::encodeUpdateZonePrioritiesRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
@@ -223,6 +224,14 @@ public final class ClusterConfigurationManagementRequestsHandler
             addZoneRequest.numberOfReplicas(),
             addZoneRequest.priority(),
             addZoneRequest.brokers()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> updateZonePriorities(
+      final UpdateZonePrioritiesRequest updateZonePrioritiesRequest) {
+    return handleRequest(
+        updateZonePrioritiesRequest.dryRun(),
+        new UpdateZonePrioritiesTransformer(updateZonePrioritiesRequest.zoneOrder()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -58,6 +58,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerRestoreHandler();
     registerForceRemoveZoneHandler();
     registerAddZoneHandler();
+    registerUpdateZonePrioritiesHandler();
   }
 
   @Override
@@ -267,6 +268,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.ADD_ZONE.topic(),
         serializer::decodeAddZoneRequest,
         request -> mapResponse(clusterConfigurationManagementApi.addZone(request)),
+        this::encodeResponse);
+  }
+
+  private void registerUpdateZonePrioritiesHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.UPDATE_ZONE_PRIORITIES.topic(),
+        serializer::decodeUpdateZonePrioritiesRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.updateZonePriorities(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -30,7 +30,8 @@ public enum ClusterConfigurationRequestTopics {
   RESTORE("cluster-restore"),
   ZONE_MIGRATION("topology-cluster-zone-migration"),
   ADD_ZONE("topology-add-zone"),
-  FORCE_REMOVE_ZONE("topology-force-remove-zone");
+  FORCE_REMOVE_ZONE("topology-force-remove-zone"),
+  UPDATE_ZONE_PRIORITIES("topology-update-zone-priorities");
 
   private final String topic;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
@@ -13,13 +13,12 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.util.CollectionUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * Re-orders the Raft leader-election priorities of a fully zone-aware cluster. The existing set of
@@ -32,10 +31,10 @@ import java.util.stream.IntStream;
  */
 public final class UpdateZonePrioritiesTransformer implements ConfigurationChangeRequest {
 
-  private final List<String> zoneOrder;
+  private final List<String> sortedZoneNames;
 
-  public UpdateZonePrioritiesTransformer(final List<String> zoneOrder) {
-    this.zoneOrder = List.copyOf(zoneOrder);
+  public UpdateZonePrioritiesTransformer(final List<String> sortedZoneNames) {
+    this.sortedZoneNames = List.copyOf(sortedZoneNames);
   }
 
   @Override
@@ -60,10 +59,10 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
     final var currentZones = zoneAwareConfig.zones();
     final var currentNames = currentZones.stream().map(ZoneSpec::name).collect(Collectors.toSet());
 
-    final var requestedSet = new HashSet<>(zoneOrder);
-    if (requestedSet.size() != zoneOrder.size()) {
+    final var requestedSet = new HashSet<>(sortedZoneNames);
+    if (CollectionUtil.containsDuplicates(sortedZoneNames)) {
       return Either.left(
-          new InvalidRequest("Zone priority request contains duplicate zones: " + zoneOrder));
+          new InvalidRequest("Zone priority request contains duplicate zones: " + sortedZoneNames));
     }
     if (!requestedSet.equals(currentNames)) {
       return Either.left(
@@ -71,7 +70,7 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
               "Zone priority request must list exactly the configured zones "
                   + currentNames
                   + ", but got "
-                  + zoneOrder
+                  + sortedZoneNames
                   + "."));
     }
 
@@ -80,12 +79,14 @@ public final class UpdateZonePrioritiesTransformer implements ConfigurationChang
     final var descendingPriorities =
         currentZones.stream().map(ZoneSpec::priority).sorted(Comparator.reverseOrder()).toList();
 
-    final Map<String, ZoneSpec> byName =
-        currentZones.stream().collect(Collectors.toMap(ZoneSpec::name, z -> z));
+    final var sortedZones =
+        sortedZoneNames.stream()
+            .flatMap(name -> currentZones.stream().filter(z -> z.name().equals(name)))
+            .toList();
 
     final var reprioritized =
-        IntStream.range(0, zoneOrder.size())
-            .mapToObj(i -> byName.get(zoneOrder.get(i)).withPriority(descendingPriorities.get(i)))
+        CollectionUtil.zipAsStream(descendingPriorities, sortedZones)
+            .map(t -> t.getRight().withPriority(t.getLeft()))
             .toList();
 
     final var newConfig = new ZoneAwareConfig(reprioritized);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.util.Either;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Re-orders the Raft leader-election priorities of a fully zone-aware cluster. The existing set of
+ * per-zone {@code priority} values is preserved and re-assigned to zones by the request order: the
+ * first zone in {@code zoneOrder} receives the highest existing priority, the next the second
+ * highest, and so on. The change is idempotent — replaying the same order is a no-op.
+ *
+ * <p>Delegates to {@link UpdatePartitionDistributionTransformer} to persist the re-prioritized
+ * {@link ZoneAwareConfig} and emit the partition/priority reconfiguration operations.
+ */
+public final class UpdateZonePrioritiesTransformer implements ConfigurationChangeRequest {
+
+  private final List<String> zoneOrder;
+
+  public UpdateZonePrioritiesTransformer(final List<String> zoneOrder) {
+    this.zoneOrder = List.copyOf(zoneOrder);
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration currentConfiguration) {
+    final var partitionDistributorConfig = currentConfiguration.partitionDistributorConfig();
+    final ZoneAwareConfig zoneAwareConfig;
+    if (partitionDistributorConfig.isPresent()
+        && partitionDistributorConfig.get() instanceof final ZoneAwareConfig cfg) {
+      zoneAwareConfig = cfg;
+    } else {
+      return Either.left(
+          new InvalidRequest(
+              "Updating zone priorities requires a persisted zone-aware partition distribution "
+                  + "config, but was %s."
+                      .formatted(
+                          partitionDistributorConfig
+                              .map(c -> c.getClass().getSimpleName())
+                              .orElse("not set"))));
+    }
+
+    final var currentZones = zoneAwareConfig.zones();
+    final var currentNames = currentZones.stream().map(ZoneSpec::name).collect(Collectors.toSet());
+
+    final var requestedSet = new HashSet<>(zoneOrder);
+    if (requestedSet.size() != zoneOrder.size()) {
+      return Either.left(
+          new InvalidRequest("Zone priority request contains duplicate zones: " + zoneOrder));
+    }
+    if (!requestedSet.equals(currentNames)) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone priority request must list exactly the configured zones "
+                  + currentNames
+                  + ", but got "
+                  + zoneOrder
+                  + "."));
+    }
+
+    // Preserve the existing multiset of priority values, sorted descending, and zip onto the
+    // requested order (index 0 -> highest existing priority).
+    final var descendingPriorities =
+        currentZones.stream().map(ZoneSpec::priority).sorted(Comparator.reverseOrder()).toList();
+
+    final Map<String, ZoneSpec> byName =
+        currentZones.stream().collect(Collectors.toMap(ZoneSpec::name, z -> z));
+
+    final var reprioritized =
+        IntStream.range(0, zoneOrder.size())
+            .mapToObj(i -> byName.get(zoneOrder.get(i)).withPriority(descendingPriorities.get(i)))
+            .toList();
+
+    final var newConfig = new ZoneAwareConfig(reprioritized);
+    return new UpdatePartitionDistributionTransformer(newConfig).operations(currentConfiguration);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -72,6 +73,8 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeForceRemoveZoneRequest(ForceZoneRemoveRequest request);
 
   byte[] encodeAddZoneRequest(AddZoneRequest request);
+
+  byte[] encodeUpdateZonePrioritiesRequest(UpdateZonePrioritiesRequest request);
 
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
@@ -134,6 +137,8 @@ public interface ClusterConfigurationRequestsSerializer {
   ForceZoneRemoveRequest decodeForceRemoveZoneRequest(byte[] bytes);
 
   AddZoneRequest decodeAddZoneRequest(byte[] bytes);
+
+  UpdateZonePrioritiesRequest decodeUpdateZonePrioritiesRequest(byte[] bytes);
 
   byte[] encodeModeChangeRequest(ModeChangeRequest modeChangeRequest);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Requests;
@@ -1153,6 +1154,15 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodeUpdateZonePrioritiesRequest(final UpdateZonePrioritiesRequest request) {
+    return Requests.UpdateZonePrioritiesRequest.newBuilder()
+        .addAllZoneOrder(request.zoneOrder())
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -1507,6 +1517,16 @@ public class ProtoBufSerializer
         proto.getPriority(),
         proto.getBrokersList().stream().map(MemberId::from).collect(Collectors.toSet()),
         proto.getDryRun());
+  }
+
+  @Override
+  public UpdateZonePrioritiesRequest decodeUpdateZonePrioritiesRequest(final byte[] encodedState) {
+    try {
+      final var request = Requests.UpdateZonePrioritiesRequest.parseFrom(encodedState);
+      return new UpdateZonePrioritiesRequest(request.getZoneOrderList(), request.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -87,6 +87,11 @@ message AddZoneRequest {
   bool dryRun = 5;
 }
 
+message UpdateZonePrioritiesRequest {
+  repeated string zoneOrder = 1;
+  bool dryRun = 2;
+}
+
 message ReassignAllPartitionsRequest {
   // The ids of the brokers to which all partitions should be re-distributed
   repeated string memberIds = 1;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
@@ -104,7 +104,7 @@ final class UpdateZonePrioritiesTransformerTest {
     EitherAssert.assertThat(result).isLeft();
     assertThat(result.getLeft())
         .isInstanceOf(InvalidRequest.class)
-        .hasMessageContaining("one priority request contains duplicate zones: [zone-a, zone-a]");
+        .hasMessageContaining("Zone priority request contains duplicate zones: [zone-a, zone-a]");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdateZonePrioritiesTransformerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.ZoneAwarePartitionDistributor;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class UpdateZonePrioritiesTransformerTest {
+
+  private static final DynamicPartitionConfig PARTITION_CONFIG = DynamicPartitionConfig.init();
+
+  private static final List<PartitionId> PARTITION_IDS =
+      IntStream.rangeClosed(1, 2).mapToObj(i -> new PartitionId("temp", i)).toList();
+
+  // Builds a fully zone-aware ClusterConfiguration with one member per zone. Modeled on
+  // ForceRemoveZoneTransformerTest#buildTopology /
+  // UpdatePartitionDistributionTransformerTest#buildTopology.
+  private ClusterConfiguration zoneAwareCluster(final ZoneSpec... zones) {
+    final var config = new ZoneAwareConfig(List.of(zones));
+    final var members =
+        config.zones().stream()
+            .map(zone -> MemberId.from(zone.name(), 0))
+            .collect(java.util.stream.Collectors.toSet());
+    final var distribution =
+        new ZoneAwarePartitionDistributor(config.zones())
+            .distributePartitions(Set.copyOf(members), PARTITION_IDS, config.replicationFactor());
+    final var topology =
+        ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
+    return topology.setPartitionDistributorConfig(config);
+  }
+
+  @Test
+  void shouldSwapPrioritiesByRequestOrderKeepingExistingValues() {
+    // given zone-a=3 (leader), zone-b=1
+    final var config = zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1));
+
+    // when requesting order [zone-b, zone-a]  (zone-b should now be leader)
+    final var result =
+        new UpdateZonePrioritiesTransformer(List.of(ZONE_B, ZONE_A)).operations(config);
+
+    // then the persisted config keeps the SAME priority values {3,1} but re-assigned
+    EitherAssert.assertThat(result).isRight();
+    final var configOp =
+        result.get().stream()
+            .filter(UpdatePartitionDistributorConfigOperation.class::isInstance)
+            .map(UpdatePartitionDistributorConfigOperation.class::cast)
+            .findFirst()
+            .orElseThrow();
+    final var newZones = ((ZoneAwareConfig) configOp.config()).zones();
+    assertThat(newZones)
+        .extracting(ZoneSpec::name, ZoneSpec::priority)
+        .containsExactlyInAnyOrder(
+            org.assertj.core.groups.Tuple.tuple(ZONE_B, 3),
+            org.assertj.core.groups.Tuple.tuple(ZONE_A, 1));
+
+    // and a partition priority-reconfigure operation is emitted so leaders actually move
+    assertThat(result.get()).anyMatch(PartitionReconfigurePriorityOperation.class::isInstance);
+  }
+
+  @Test
+  void shouldRejectWhenRequestZonesDoNotMatchConfiguredZones() {
+    // given
+    final var config = zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1));
+
+    // when a zone is unknown / set mismatch
+    final var result =
+        new UpdateZonePrioritiesTransformer(List.of(ZONE_A, ZONE_C)).operations(config);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining(
+            "Zone priority request must list exactly the configured zones [zone-a, zone-b], but got [zone-a, zone-c]");
+  }
+
+  @Test
+  void shouldRejectDuplicateZoneInRequest() {
+    final var config = zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1));
+    final var result =
+        new UpdateZonePrioritiesTransformer(List.of(ZONE_A, ZONE_A)).operations(config);
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining("one priority request contains duplicate zones: [zone-a, zone-a]");
+  }
+
+  @Test
+  void shouldRejectIncompleteZoneList() {
+    final var config = zoneAwareCluster(new ZoneSpec(ZONE_A, 1, 3), new ZoneSpec(ZONE_B, 1, 1));
+    final var result = new UpdateZonePrioritiesTransformer(List.of(ZONE_A)).operations(config);
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining(
+            "Zone priority request must list exactly the configured zones [zone-a, zone-b], but got [zone-a]");
+  }
+
+  @Test
+  void shouldRejectWhenNotZoneAware() {
+    // given a non-zone-aware cluster (no PartitionDistributorConfig persisted)
+    final var config = ClusterConfiguration.init();
+    final var result = new UpdateZonePrioritiesTransformer(List.of(ZONE_A)).operations(config);
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(InvalidRequest.class)
+        .hasMessageContaining(
+            "Updating zone priorities requires a persisted zone-aware partition distribution config, but was not set");
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -7,8 +7,7 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
-import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.ZONE_A;
-import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.ZONE_B;
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -26,8 +25,11 @@ import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.ZoneSpec;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.actuator.RebalanceActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
@@ -338,6 +340,76 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
         newZoneABroker.close();
       }
     }
+  }
+
+  @Test
+  void shouldSwapZonePrioritiesAndMoveLeaders() {
+    try (final var cluster = createCluster(brokerCount())) {
+      // given - a fully zone-aware cluster where zoneA (priority 100) is the preferred leader zone
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      Awaitility.await()
+          .untilAsserted(
+              () -> {
+                for (int partitionId = 1; partitionId <= partitionCount(); partitionId++) {
+                  assertThat(leaderIsInZone(cluster, ZONES[0], partitionId)).isTrue();
+                }
+              });
+
+      // when - swap the order so zoneB becomes preferred
+      final var response = actuator.updateZonePriorities(List.of(ZONES[1], ZONES[0]), false);
+
+      // then - the change is accepted and plans operations
+      Awaitility.await()
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
+
+      // and - the distribution config now lists zoneB first with the higher priority
+      final var expectedDistribution =
+          new PartitionDistributionConfig()
+              .type(TypeEnum.ZONE_AWARE)
+              .zones(
+                  List.of(
+                      new ZoneSpec().name(ZONE_B).numberOfReplicas(1).priority(100),
+                      new ZoneSpec().name(ZONE_A).numberOfReplicas(2).priority(10)));
+      assertThat(actuator.getTopology().getPartitionDistribution()).isEqualTo(expectedDistribution);
+
+      // and - after a rebalance forces the now-lower-priority zoneA leaders to step down,
+      // partition leaders move to zoneB. A priority change alone does not displace a healthy
+      // sitting leader; the rebalance issues stepDownIfNotPrimary so the highest-priority
+      // (zoneB) node wins re-election. Rebalancing is best-effort, so re-trigger it each poll
+      // until every partition leader has moved.
+      final var rebalanceActuator = RebalanceActuator.of(cluster.availableGateway());
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(1))
+          .untilAsserted(
+              () -> {
+                rebalanceActuator.rebalance();
+                for (int partitionId = 1; partitionId <= partitionCount(); partitionId++) {
+                  assertThat(leaderIsInZone(cluster, ZONE_B, partitionId)).isTrue();
+                }
+              });
+    }
+  }
+
+  /**
+   * Returns whether any broker in the given zone is the leader for the given partition, by querying
+   * each zone broker's partitions actuator directly.
+   */
+  private boolean leaderIsInZone(
+      final TestCluster cluster, final String zone, final int partitionId) {
+    for (int nodeIdx = 0; nodeIdx < brokerCount(); nodeIdx++) {
+      if (!zoneFor(nodeIdx).equals(zone)) {
+        continue;
+      }
+      final var broker = cluster.brokers().get(memberIdForBroker(nodeIdx));
+      final var status = PartitionsActuator.of(broker).query().get(partitionId);
+      if (status != null && "Leader".equalsIgnoreCase(status.role())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Nested

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.RoutingState;
+import io.camunda.zeebe.management.cluster.UpdatePartitionDistributionRequest;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import java.util.List;
@@ -358,8 +359,25 @@ public interface ClusterActuator {
 
   @RequestLine("PUT /partition-distribution?dryRun={dryRun}")
   @Headers({"Content-Type: application/json", "accept: application/json"})
-  PlannedOperationsResponse patchPartitionDistribution(
-      @RequestBody final PartitionDistributionConfig config, @Param boolean dryRun);
+  PlannedOperationsResponse updatePartitionDistribution(
+      @RequestBody final UpdatePartitionDistributionRequest request, @Param boolean dryRun);
+
+  /** Applies a full partition distribution config via {@code PUT /partition-distribution}. */
+  default PlannedOperationsResponse patchPartitionDistribution(
+      final PartitionDistributionConfig config, final boolean dryRun) {
+    return updatePartitionDistribution(
+        new UpdatePartitionDistributionRequest().config(config), dryRun);
+  }
+
+  /**
+   * Performs a leader switchover via {@code PUT /partition-distribution}: re-orders the existing
+   * per-zone priorities by {@code zonePriorities} (highest first).
+   */
+  default PlannedOperationsResponse updateZonePriorities(
+      final List<String> zonePriorities, final boolean dryRun) {
+    return updatePartitionDistribution(
+        new UpdatePartitionDistributionRequest().zonePriorities(zonePriorities), dryRun);
+  }
 
   @RequestLine("PUT /zones?dryRun={dryRun}")
   @Headers({"Content-Type: application/json", "accept: application/json"})

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/CollectionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/CollectionUtil.java
@@ -7,9 +7,15 @@
  */
 package io.camunda.zeebe.util;
 
+import io.camunda.zeebe.util.collection.Tuple;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class CollectionUtil {
   public static <T, V> boolean containsDuplicates(
@@ -27,5 +33,60 @@ public class CollectionUtil {
 
   public static <T> boolean containsDuplicates(final Collection<T> collection) {
     return containsDuplicates(collection, Function.identity());
+  }
+
+  /**
+   * Zips two iterables into a collection of tuples, pairing elements by their iteration order.
+   * Stops as soon as the shorter of the two iterables is exhausted; excess elements of the longer
+   * iterable are ignored.
+   *
+   * @param left the left iterable
+   * @param right the right iterable
+   * @return a collection of tuples, one per pair of elements, in iteration order
+   */
+  public static <T, V> Iterator<Tuple<T, V>> zip(final Iterator<T> left, final Iterator<V> right) {
+    return new Iterator<>() {
+      @Override
+      public boolean hasNext() {
+        return left.hasNext() && right.hasNext();
+      }
+
+      @Override
+      public Tuple<T, V> next() {
+        return new Tuple<>(left.next(), right.next());
+      }
+    };
+  }
+
+  /**
+   * Zips two collections into a stream of tuples, pairing elements by their iteration order. Stops
+   * as soon as the shorter of the two collections is exhausted; excess elements of the longer
+   * collection are ignored.
+   *
+   * @param left the left collection
+   * @param right the right collection
+   * @return a Stream of tuples, one per pair of elements, in iteration order
+   */
+  public static <T, V> Stream<Tuple<T, V>> zipAsStream(
+      final Collection<T> left, final Collection<V> right) {
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(
+            zip(left.iterator(), right.iterator()), Spliterator.ORDERED),
+        false);
+  }
+
+  /**
+   * Zips two iterators into a stream of tuples, pairing elements by their iteration order. Stops as
+   * soon as the shorter of the two iterators is exhausted; excess elements of the longer iterator
+   * are ignored.
+   *
+   * @param left the left iterator
+   * @param right the right iterator
+   * @return a Stream of tuples, one per pair of elements, in iteration order
+   */
+  public static <T, V> Stream<Tuple<T, V>> zipAsStream(
+      final Iterator<T> left, final Iterator<V> right) {
+    return StreamSupport.stream(
+        Spliterators.spliteratorUnknownSize(zip(left, right), Spliterator.ORDERED), false);
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/CollectionUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/CollectionUtilTest.java
@@ -9,41 +9,73 @@ package io.camunda.zeebe.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class CollectionUtilTest {
 
-  @Test
-  void shouldReturnFalseWhenElementsAreUnique() {
-    assertThat(CollectionUtil.containsDuplicates(List.of("a", "b", "c"))).isFalse();
-  }
-
-  @Test
-  void shouldReturnFalseForAnEmptyCollection() {
-    assertThat(CollectionUtil.containsDuplicates(List.of())).isFalse();
-  }
-
-  @Test
-  void shouldReturnTrueWhenElementsAreDuplicated() {
-    assertThat(CollectionUtil.containsDuplicates(List.of("a", "b", "a"))).isTrue();
-  }
-
-  @Test
-  void shouldReturnFalseWhenProjectedValuesAreUnique() {
-    assertThat(
-            CollectionUtil.containsDuplicates(
-                List.of(new Item("a", 1), new Item("b", 1)), Item::name))
-        .isFalse();
-  }
-
-  @Test
-  void shouldReturnTrueWhenProjectedValuesAreDuplicated() {
-    assertThat(
-            CollectionUtil.containsDuplicates(
-                List.of(new Item("a", 1), new Item("a", 2)), Item::name))
-        .isTrue();
-  }
-
   private record Item(String name, int id) {}
+
+  @Nested
+  class Duplicates {
+    @Test
+    void shouldReturnFalseWhenElementsAreUnique() {
+      assertThat(CollectionUtil.containsDuplicates(List.of("a", "b", "c"))).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseForAnEmptyCollection() {
+      assertThat(CollectionUtil.containsDuplicates(List.of())).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenElementsAreDuplicated() {
+      assertThat(CollectionUtil.containsDuplicates(List.of("a", "b", "a"))).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenProjectedValuesAreUnique() {
+      assertThat(
+              CollectionUtil.containsDuplicates(
+                  List.of(new Item("a", 1), new Item("b", 1)), Item::name))
+          .isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueWhenProjectedValuesAreDuplicated() {
+      assertThat(
+              CollectionUtil.containsDuplicates(
+                  List.of(new Item("a", 1), new Item("a", 2)), Item::name))
+          .isTrue();
+    }
+  }
+
+  @Nested
+  class Zip {
+    @Test
+    void shouldZipCollectionsOfEqualSize() {
+      assertThat(CollectionUtil.zipAsStream(List.of("a", "b"), List.of(1, 2)))
+          .containsExactly(new Tuple<>("a", 1), new Tuple<>("b", 2));
+    }
+
+    @Test
+    void shouldZipStoppingAtShorterLeftCollection() {
+      assertThat(CollectionUtil.zipAsStream(List.of("a"), List.of(1, 2)))
+          .containsExactly(new Tuple<>("a", 1));
+    }
+
+    @Test
+    void shouldZipStoppingAtShorterRightCollection() {
+      assertThat(CollectionUtil.zipAsStream(List.of("a", "b"), List.of(1)))
+          .containsExactly(new Tuple<>("a", 1));
+    }
+
+    @Test
+    void shouldZipReturnEmptyWhenEitherCollectionIsEmpty() {
+      assertThat(CollectionUtil.zipAsStream(List.of(), List.of(1, 2))).isEmpty();
+      assertThat(CollectionUtil.zipAsStream(List.of("a", "b"), List.of())).isEmpty();
+    }
+  }
 }


### PR DESCRIPTION
## Description
Adds a new field to the request in `PUT /cluster/partition-distribution` named `zonePriorities`.
This field is exclusive with the existing `config`, allowing the user to use one or the other. 

Using `zonePriorities` the user just changes the priorities inside the cluster using the order of the zones.
So for example this request (assuming zoneA was primary):
```
PUT /partition-distribution { "zonePriorities" : ["zoneB", "zoneA"]}
```
makes `zoneB` "primary", by using the value of the priority that was held by zoneA. At the same time zoneA gets the priority from zoneB.

Internally, this is mapped to a different request, transformer etc.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51613 
