### PR TITLE
fix: page data-layer-medic user group instead of literal team tag

### DIFF
--- a/.github/workflows/data-layer-nightly-tests.yml
+++ b/.github/workflows/data-layer-nightly-tests.yml
@@ -204,7 +204,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "@camunda/data-layer Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                    "text": "<!subteam^S08P2CSC06S|data-layer-medic> Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]


### PR DESCRIPTION
Use the Data Layer medic tag rather than team. Change to user group ID as previous tag was not working as expected