### PR TITLE
feat: add gcp store type to Secrets configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -231,8 +231,10 @@ public class Secrets {
   }
 
   /**
-   * Configuration for a GCP Secret Manager store. Authentication is always identity-based (GCP
-   * Application Default Credentials chain): no static credentials are accepted here by design.
+   * Configuration for a GCP Secret Manager store. Authentication uses the GCP Application Default
+   * Credentials (ADC) chain (e.g. a service-account key file referenced by {@code
+   * GOOGLE_APPLICATION_CREDENTIALS}, gcloud user credentials, or the attached service account via
+   * the compute metadata server). This config does not accept explicit credentials fields.
    */
   public static class GcpSecretManagerStore {
 
@@ -331,10 +333,10 @@ public class Secrets {
      * length is checked together with the container id (the only id fully known at config time);
      * per-reference ids in flat mode are formed at runtime and validated there.
      *
-     * @throws IllegalArgumentException if project-id or container-secret-id is set but blank, if
-     *     path-prefix or container-secret-id contains characters outside {@code [a-zA-Z0-9_-]}, or
-     *     if the effective container secret id (path-prefix + container-secret-id) exceeds 255
-     *     characters
+     * @throws IllegalArgumentException if project-id, container-secret-id, or endpoint is set but
+     *     blank, if path-prefix or container-secret-id contains characters outside {@code
+     *     [a-zA-Z0-9_-]}, or if the effective container secret id (path-prefix +
+     *     container-secret-id) exceeds 255 characters
      */
     void validate(final String storeId) {
       if (projectId != null && projectId.isBlank()) {
@@ -344,6 +346,10 @@ public class Secrets {
       if (containerSecretId != null && containerSecretId.isBlank()) {
         throw new IllegalArgumentException(
             "camunda.secrets.stores.gcp." + storeId + ".container-secret-id must not be blank");
+      }
+      if (endpoint != null && endpoint.isBlank()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.gcp." + storeId + ".endpoint must not be blank");
       }
       if (pathPrefix != null && !SECRET_ID_PATTERN.matcher(pathPrefix).matches()) {
         throw new IllegalArgumentException(

--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -9,6 +9,7 @@ package io.camunda.configuration;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -25,6 +26,10 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
  *   <li>{@code camunda.secrets.stores.aws.<id>.batch-enabled}
  *   <li>{@code camunda.secrets.stores.aws.<id>.batch-size}
  *   <li>{@code camunda.secrets.stores.aws.<id>.container-secret-id}
+ *   <li>{@code camunda.secrets.stores.gcp.<id>.project-id}
+ *   <li>{@code camunda.secrets.stores.gcp.<id>.path-prefix}
+ *   <li>{@code camunda.secrets.stores.gcp.<id>.endpoint}
+ *   <li>{@code camunda.secrets.stores.gcp.<id>.container-secret-id}
  * </ul>
  *
  * <p>Secrets configuration is overridable per physical tenant via {@code
@@ -47,6 +52,7 @@ public class Secrets {
 
     private Map<String, FileStore> file = new LinkedHashMap<>();
     private Map<String, AwsSecretsManagerStore> aws = new LinkedHashMap<>();
+    private Map<String, GcpSecretManagerStore> gcp = new LinkedHashMap<>();
 
     public Map<String, FileStore> getFile() {
       return file;
@@ -69,6 +75,20 @@ public class Secrets {
 
     public void setAws(final Map<String, AwsSecretsManagerStore> aws) {
       this.aws = aws;
+    }
+
+    /**
+     * @throws IllegalArgumentException if any store sets a blank project-id/container-secret-id, a
+     *     path-prefix or container-secret-id with characters outside {@code [a-zA-Z0-9_-]}, or an
+     *     effective container secret id longer than 255 characters (GCP secret-id rules)
+     */
+    public Map<String, GcpSecretManagerStore> getGcp() {
+      gcp.forEach((id, store) -> store.validate(id));
+      return gcp;
+    }
+
+    public void setGcp(final Map<String, GcpSecretManagerStore> gcp) {
+      this.gcp = gcp;
     }
   }
 
@@ -206,6 +226,156 @@ public class Secrets {
                 + storeId
                 + ".batch-enabled and .container-secret-id are mutually exclusive, but both were "
                 + "configured");
+      }
+    }
+  }
+
+  /**
+   * Configuration for a GCP Secret Manager store. Authentication is always identity-based (GCP
+   * Application Default Credentials chain): no static credentials are accepted here by design.
+   */
+  public static class GcpSecretManagerStore {
+
+    /**
+     * GCP secret ids allow only these characters, and are capped at 255 characters. Both {@link
+     * #pathPrefix} (which is prepended to form ids) and {@link #containerSecretId} (which is itself
+     * an id) must respect this, otherwise every lookup would target an id GCP rejects.
+     */
+    private static final Pattern SECRET_ID_PATTERN = Pattern.compile("[a-zA-Z0-9_-]*");
+
+    private static final int MAX_SECRET_ID_LENGTH = 255;
+
+    /**
+     * GCP project id owning the secrets. Optional: when omitted the client resolves it from the
+     * environment ({@code GOOGLE_CLOUD_PROJECT}) or the compute metadata server, via the
+     * Application Default Credentials chain — mirroring how {@link AwsSecretsManagerStore#region}
+     * is resolved for AWS. If set it must not be blank.
+     */
+    private @Nullable String projectId;
+
+    /**
+     * Optional prefix prepended, with no separator inserted, to every reference name to form the
+     * GCP secret id (e.g. {@code camunda-} plus reference {@code db-password} resolves to secret id
+     * {@code camunda-db-password}; include the trailing separator here if one is wanted). When
+     * omitted, references map to bare secret ids. Applies to {@link #containerSecretId} as well,
+     * since that is itself resolved as a GCP secret id.
+     *
+     * <p>Note GCP secret ids only allow {@code [a-zA-Z0-9_-]} and are capped at 255 characters, so
+     * an AWS-style {@code camunda/} prefix (with a slash) would produce invalid ids; use e.g.
+     * {@code camunda-} instead.
+     */
+    private @Nullable String pathPrefix;
+
+    /**
+     * Optional Secret Manager endpoint override (e.g. a regional endpoint such as {@code
+     * secretmanager.europe-west1.rep.googleapis.com:443}, or a Private Service Connect endpoint).
+     * Unlike the AWS SDK, the GCP client libraries do not honour an endpoint override via
+     * environment variable, so it is exposed here as first-class config; it also doubles as the
+     * hook for pointing at an emulator in tests. When omitted, the default global endpoint is used.
+     */
+    private @Nullable String endpoint;
+
+    /**
+     * Opt-in: instead of one GCP secret per reference, treat every reference as a JSON key inside
+     * this one named secret (e.g. {@code app-config}). If set it must not be blank.
+     *
+     * <p>The named secret's value must be a flat JSON object mapping each reference name to a JSON
+     * string value (e.g. {@code {"db-password": "s3cr3t"}}); nested objects/arrays are not
+     * supported, and a non-object value makes the store unusable.
+     */
+    private @Nullable String containerSecretId;
+
+    public @Nullable String getProjectId() {
+      return projectId;
+    }
+
+    public void setProjectId(final @Nullable String projectId) {
+      this.projectId = projectId;
+    }
+
+    public @Nullable String getPathPrefix() {
+      return pathPrefix;
+    }
+
+    public void setPathPrefix(final @Nullable String pathPrefix) {
+      this.pathPrefix = pathPrefix;
+    }
+
+    public @Nullable String getEndpoint() {
+      return endpoint;
+    }
+
+    public void setEndpoint(final @Nullable String endpoint) {
+      this.endpoint = endpoint;
+    }
+
+    public @Nullable String getContainerSecretId() {
+      return containerSecretId;
+    }
+
+    public void setContainerSecretId(final @Nullable String containerSecretId) {
+      this.containerSecretId = containerSecretId;
+    }
+
+    /**
+     * Only present-value checks live here (blank, GCP-secret-id charset, and length), so the
+     * validating {@link Stores#getGcp()} stays safe to call from the physical-tenant overlay: a
+     * transiently-inherited-then-missing field is {@code null}, which is skipped. Required-field
+     * presence and connectivity are enforced by the GCP store implementation instead (mirroring how
+     * AWS defers those to {@code AwsSecretsManagerStoreConfig} plus its startup connectivity
+     * probe), not by this config layer.
+     *
+     * <p>{@code path-prefix} and {@code container-secret-id} are validated against the GCP
+     * secret-id rules ({@code [a-zA-Z0-9_-]}, max 255 chars) because both feed into secret ids: a
+     * bad prefix would corrupt every id, and the container-secret-id is itself an id. The prefix's
+     * length is checked together with the container id (the only id fully known at config time);
+     * per-reference ids in flat mode are formed at runtime and validated there.
+     *
+     * @throws IllegalArgumentException if project-id or container-secret-id is set but blank, if
+     *     path-prefix or container-secret-id contains characters outside {@code [a-zA-Z0-9_-]}, or
+     *     if the effective container secret id (path-prefix + container-secret-id) exceeds 255
+     *     characters
+     */
+    void validate(final String storeId) {
+      if (projectId != null && projectId.isBlank()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.gcp." + storeId + ".project-id must not be blank");
+      }
+      if (containerSecretId != null && containerSecretId.isBlank()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.gcp." + storeId + ".container-secret-id must not be blank");
+      }
+      if (pathPrefix != null && !SECRET_ID_PATTERN.matcher(pathPrefix).matches()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.gcp."
+                + storeId
+                + ".path-prefix must contain only [a-zA-Z0-9_-] to form valid GCP secret ids, but "
+                + "was '"
+                + pathPrefix
+                + "'");
+      }
+      if (containerSecretId != null && !SECRET_ID_PATTERN.matcher(containerSecretId).matches()) {
+        throw new IllegalArgumentException(
+            "camunda.secrets.stores.gcp."
+                + storeId
+                + ".container-secret-id must contain only [a-zA-Z0-9_-] to be a valid GCP secret "
+                + "id, but was '"
+                + containerSecretId
+                + "'");
+      }
+      if (containerSecretId != null) {
+        final int fullLength =
+            (pathPrefix == null ? 0 : pathPrefix.length()) + containerSecretId.length();
+        if (fullLength > MAX_SECRET_ID_LENGTH) {
+          throw new IllegalArgumentException(
+              "camunda.secrets.stores.gcp."
+                  + storeId
+                  + " effective container secret id (path-prefix + container-secret-id) must be at "
+                  + "most "
+                  + MAX_SECRET_ID_LENGTH
+                  + " characters, but was "
+                  + fullLength);
+        }
       }
     }
   }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
@@ -11,15 +11,16 @@ import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Secrets;
 import io.camunda.configuration.Secrets.AwsSecretsManagerStore;
 import io.camunda.configuration.Secrets.FileStore;
+import io.camunda.configuration.Secrets.GcpSecretManagerStore;
 import io.camunda.configuration.physicaltenants.MapOverlaySpec.MapDescriptor;
 import java.util.List;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Per-tenant {@link Secrets} resolution: registers the {@code stores.file} and {@code stores.aws}
- * named maps so that {@link PhysicalTenantMapOverlay} deep-merges them per physical tenant (the
- * generic two-bind has a defect that drops unmentioned root entries when a tenant overrides only
- * some map keys).
+ * Per-tenant {@link Secrets} resolution: registers the {@code stores.file}, {@code stores.aws} and
+ * {@code stores.gcp} named maps so that {@link PhysicalTenantMapOverlay} deep-merges them per
+ * physical tenant (the generic two-bind has a defect that drops unmentioned root entries when a
+ * tenant overrides only some map keys).
  */
 @NullMarked
 final class PhysicalTenantSecretConfigurations {
@@ -32,7 +33,9 @@ final class PhysicalTenantSecretConfigurations {
           List.of(
               new MapDescriptor<>("stores.file", FileStore.class, s -> s.getStores().getFile()),
               new MapDescriptor<>(
-                  "stores.aws", AwsSecretsManagerStore.class, s -> s.getStores().getAws())),
+                  "stores.aws", AwsSecretsManagerStore.class, s -> s.getStores().getAws()),
+              new MapDescriptor<>(
+                  "stores.gcp", GcpSecretManagerStore.class, s -> s.getStores().getGcp())),
           MapOverlaySpec.noHook(),
           Camunda::setSecrets);
 

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -400,6 +400,29 @@ class SecretsTest {
   }
 
   @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.gcp.blank.endpoint= "})
+  class WithBlankGcpEndpoint {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBlankGcpEndpoint(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectBlankEndpoint() {
+      // given endpoint is set to a blank string (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("endpoint must not be blank");
+    }
+  }
+
+  @Nested
   @TestPropertySource(properties = {"camunda.secrets.stores.gcp.blank.container-secret-id= "})
   class WithBlankGcpContainerSecretId {
     private final UnifiedConfiguration unifiedConfiguration;

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -282,4 +282,328 @@ class SecretsTest {
       assertThat(secrets.getStores().getAws()).isEmpty();
     }
   }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.gcp.gcp-prod.project-id=my-gcp-project",
+        "camunda.secrets.stores.gcp.gcp-prod.path-prefix=camunda-",
+        "camunda.secrets.stores.gcp.gcp-prod.endpoint=secretmanager.example.com:443",
+        "camunda.secrets.stores.gcp.gcp-minimal.project-id=minimal-project"
+      })
+  class WithGcpStoreConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpStoreConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindGcpStoreProperties() {
+      // given the camunda.secrets.stores.gcp.gcp-prod.* properties are set
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the named store is present and its fields are bound
+      assertThat(secrets.getStores().getGcp().get("gcp-prod"))
+          .satisfies(
+              store -> {
+                assertThat(store.getProjectId()).isEqualTo("my-gcp-project");
+                assertThat(store.getPathPrefix()).isEqualTo("camunda-");
+                assertThat(store.getEndpoint()).isEqualTo("secretmanager.example.com:443");
+              });
+    }
+
+    @Test
+    void shouldDefaultContainerSecretIdToNull() {
+      // given container-secret-id is not set for gcp-prod (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then it defaults to the flat one-secret-per-reference mode
+      assertThat(secrets.getStores().getGcp().get("gcp-prod").getContainerSecretId()).isNull();
+    }
+
+    @Test
+    void shouldBindMultipleStoresKeyedById() {
+      // given two gcp stores are configured (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then both store ids are present
+      assertThat(secrets.getStores().getGcp()).containsKeys("gcp-prod", "gcp-minimal");
+    }
+
+    @Test
+    void shouldAllowOptionalPathPrefixAndEndpoint() {
+      // given gcp-minimal has only project-id set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then project-id is bound while the optional fields stay null
+      assertThat(secrets.getStores().getGcp().get("gcp-minimal"))
+          .satisfies(
+              store -> {
+                assertThat(store.getProjectId()).isEqualTo("minimal-project");
+                assertThat(store.getPathPrefix()).isNull();
+                assertThat(store.getEndpoint()).isNull();
+              });
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.secrets.stores.gcp.bundled.project-id=my-gcp-project",
+        "camunda.secrets.stores.gcp.bundled.container-secret-id=app-config"
+      })
+  class WithGcpContainerSecretIdConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpContainerSecretIdConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindContainerSecretId() {
+      // given container-secret-id is set (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then it is bound onto the named store
+      assertThat(secrets.getStores().getGcp().get("bundled").getContainerSecretId())
+          .isEqualTo("app-config");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.gcp.blank.project-id= "})
+  class WithBlankGcpProjectId {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBlankGcpProjectId(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectBlankProjectId() {
+      // given project-id is set to a blank string (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("project-id must not be blank");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.gcp.blank.container-secret-id= "})
+  class WithBlankGcpContainerSecretId {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithBlankGcpContainerSecretId(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectBlankContainerSecretId() {
+      // given container-secret-id is set to a blank string (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("container-secret-id must not be blank");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.gcp.no-project.path-prefix=camunda-"})
+  class WithGcpStoreWithoutProjectId {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpStoreWithoutProjectId(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldAllowOmittedProjectId() {
+      // given a gcp store with no project-id set (see @TestPropertySource): project-id is optional
+      // and resolved from the environment/metadata via Application Default Credentials
+      // when the unified configuration is bound and the validating getter is read
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the store binds without throwing and project-id stays null
+      assertThat(secrets.getStores().getGcp().get("no-project").getProjectId()).isNull();
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.secrets.stores.gcp.badprefix.path-prefix=camunda/"})
+  class WithGcpPathPrefixContainingInvalidChars {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpPathPrefixContainingInvalidChars(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectPathPrefixWithCharsOutsideSecretIdCharset() {
+      // given path-prefix contains a slash, invalid in a GCP secret id (see @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("path-prefix must contain only [a-zA-Z0-9_-]");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {"camunda.secrets.stores.gcp.badcontainer.container-secret-id=app/config"})
+  class WithGcpContainerSecretIdContainingInvalidChars {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpContainerSecretIdContainingInvalidChars(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectContainerSecretIdWithCharsOutsideSecretIdCharset() {
+      // given container-secret-id contains a slash, invalid in a GCP secret id
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("container-secret-id must contain only [a-zA-Z0-9_-]");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // 256 'a's (4 x 64), one over the 255 GCP secret-id cap
+        "camunda.secrets.stores.gcp.toolong.container-secret-id="
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      })
+  class WithGcpEffectiveContainerSecretIdTooLong {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpEffectiveContainerSecretIdTooLong(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectEffectiveContainerSecretIdOver255Chars() {
+      // given a 256-char container-secret-id, over the 255 GCP secret-id cap
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("must be at most 255 characters");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // path-prefix (64) + container-secret-id (192) = 256, one over the 255 cap, while each
+        // part alone is within it: exercises the combined "effective" length check
+        "camunda.secrets.stores.gcp.combined.path-prefix="
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "camunda.secrets.stores.gcp.combined.container-secret-id="
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      })
+  class WithGcpEffectiveContainerSecretIdTooLongViaPrefix {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpEffectiveContainerSecretIdTooLongViaPrefix(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldRejectWhenPathPrefixPlusContainerSecretIdExceeds255Chars() {
+      // given path-prefix + container-secret-id sum to 256, though neither alone exceeds 255
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+      final Secrets.Stores stores = secrets.getStores();
+
+      // then reading the store map throws on the combined length
+      assertThatThrownBy(stores::getGcp)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("must be at most 255 characters");
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // path-prefix (63) + container-secret-id (192) = 255, exactly at the cap: must bind cleanly
+        "camunda.secrets.stores.gcp.atlimit.path-prefix="
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "camunda.secrets.stores.gcp.atlimit.container-secret-id="
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      })
+  class WithGcpEffectiveContainerSecretIdAtLimit {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithGcpEffectiveContainerSecretIdAtLimit(
+        @Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldAllowEffectiveContainerSecretIdOfExactly255Chars() {
+      // given path-prefix + container-secret-id sum to exactly 255, the GCP secret-id cap
+      // when the unified configuration is bound and the validating getter is read
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the store binds without throwing
+      assertThat(secrets.getStores().getGcp().get("atlimit").getContainerSecretId()).hasSize(192);
+    }
+  }
+
+  @Nested
+  class WithoutGcpStoreConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithoutGcpStoreConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldDefaultToEmptyGcpMap() {
+      // given no camunda.secrets.* property is set
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the gcp map is empty
+      assertThat(secrets.getStores().getGcp()).isEmpty();
+    }
+  }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
@@ -283,4 +283,84 @@ class PhysicalTenantSecretsOverlayTest {
                 .getPathPrefix())
         .isEqualTo("camunda/");
   }
+
+  @Test
+  void shouldOverlayGcpStorePerTenant() {
+    // given a root gcp store and a tenant that overrides its path-prefix
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.gcp.shared.project-id", "my-gcp-project",
+                "camunda.secrets.stores.gcp.shared.path-prefix", "camunda-",
+                "camunda.physical-tenants.tenanta.secrets.stores.gcp.shared.path-prefix",
+                    "tenanta-")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta gets its own path-prefix and the synthesized default keeps the root one
+    assertThat(
+            resolver
+                .forPhysicalTenant("tenanta")
+                .getSecrets()
+                .getStores()
+                .getGcp()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("tenanta-");
+    assertThat(
+            resolver
+                .forPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getSecrets()
+                .getStores()
+                .getGcp()
+                .get("shared")
+                .getPathPrefix())
+        .isEqualTo("camunda-");
+  }
+
+  @Test
+  void shouldInheritRootGcpStoreWhenTenantHasNoSecretsOverride() {
+    // given only a root gcp store; the tenant overrides no secrets field
+    setProperties(
+        new HashMap<>(Map.of("camunda.secrets.stores.gcp.shared.project-id", "my-gcp-project")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta inherits the root store (non-overridden -> seeded from root bind)
+    assertThat(
+            resolver
+                .forPhysicalTenant("tenanta")
+                .getSecrets()
+                .getStores()
+                .getGcp()
+                .get("shared")
+                .getProjectId())
+        .isEqualTo("my-gcp-project");
+  }
+
+  @Test
+  void shouldOverrideOnlyTheFieldTenantSetsForGcpStore() {
+    // given root sets both project-id and path-prefix; tenant overrides only path-prefix
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.gcp.shared.project-id", "my-gcp-project",
+                "camunda.secrets.stores.gcp.shared.path-prefix", "camunda-",
+                "camunda.physical-tenants.tenanta.secrets.stores.gcp.shared.path-prefix",
+                    "tenanta-")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta's path-prefix is overridden but project-id survives the deep merge from root
+    final var store =
+        resolver.forPhysicalTenant("tenanta").getSecrets().getStores().getGcp().get("shared");
+    assertThat(store.getPathPrefix()).isEqualTo("tenanta-");
+    assertThat(store.getProjectId()).isEqualTo("my-gcp-project");
+  }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -331,6 +331,7 @@ processing.scheduled-tasks-check-interval
 processing.skip-positions
 secrets.stores.aws
 secrets.stores.file
+secrets.stores.gcp
 security.authentication
 security.authentication.authentication-refresh-interval
 security.authentication.oidc.additional-jwk-set-uris


### PR DESCRIPTION
## Description

Adds a `gcp` store type to the unified `camunda.secrets.stores` configuration, mirroring the existing `file` and `aws` store types. **Configuration only** — no resolver implementation yet; the GCP Secret Manager store lands in a follow-up PR, the same staged approach used for AWS.

New `Secrets.GcpSecretManagerStore`, bound under `camunda.secrets.stores.gcp.<id>.*`:

| Property | Required | Purpose |
|---|---|---|
| `project-id` | no | GCP project owning the secrets; when omitted, resolved from the environment (`GOOGLE_CLOUD_PROJECT`) or the metadata server via Application Default Credentials — mirroring how AWS `region` is resolved. Must not be blank if set. |
| `path-prefix` | no | prepended (raw, no separator inserted) to each reference to form the secret id; applies to `container-secret-id` too |
| `endpoint` | no | Secret Manager endpoint override for a regional or Private Service Connect endpoint (the GCP client libraries, unlike the AWS SDK, do not honour an endpoint override via env var); also doubles as the emulator hook in tests |
| `container-secret-id` | no | opt into treating every reference as a JSON key inside one named secret, instead of one secret per reference |

- Authentication is identity-based by design (GCP Application Default Credentials chain); no static credentials are accepted in config — consistent with the `aws` store.
- Overridable per physical tenant via `camunda.physical-tenants.<id>.secrets.stores.gcp.*`, reusing the deep-merge overlay already registered for `stores.file`/`stores.aws` (one extra `MapDescriptor`).
- Regenerates the physical-tenant overridable-properties golden to include `secrets.stores.gcp`.

### Validation

`Stores#getGcp()` validates each store on read (mirroring `getAws()`). All checks are **present-value only** (a `null`/transiently-missing field is skipped), so the validating getter stays safe to call from the physical-tenant overlay mid-merge:

- `project-id` and `container-secret-id`, if set, must not be blank;
- `path-prefix` and `container-secret-id` must match the GCP secret-id charset `[a-zA-Z0-9_-]` (so an AWS-style `camunda/` prefix is rejected — GCP disallows the slash);
- the effective container secret id (`path-prefix` + `container-secret-id`) must not exceed the 255-character GCP secret-id cap.

## Related issues

closes #56578
