### PR TITLE
style: Remove unused private fields flagged by new UnusedPrivateFie…

### DIFF
--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/annotation/AnnotationUtilTest.java
@@ -194,8 +194,6 @@ public class AnnotationUtilTest {
     }
 
     private static final class VariablesType {
-      private String hello;
-      private String world;
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/BatchOperationImpl.java
@@ -41,7 +41,6 @@ public class BatchOperationImpl implements BatchOperation {
   private final Integer operationsTotalCount;
   private final Integer operationsFailedCount;
   private final Integer operationsCompletedCount;
-  private final List<Long> keys = new ArrayList<>();
   private final List<BatchOperationError> errors = new ArrayList<>();
 
   public BatchOperationImpl(final BatchOperationCreatedResult item) {

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -77,7 +77,6 @@ public class Metrics {
       TAG_VALUE_SUCCEEDED = "succeeded",
       TAG_VALUE_FAILED = "failed";
   private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
-  private Timer importBatchTimer;
   @Autowired private MeterRegistry registry;
 
   /**

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
@@ -58,8 +58,6 @@ import org.springframework.core.env.Environment;
 
 public class ConfigurationService {
 
-  private static final String ERROR_NO_ENGINE_WITH_ALIAS = "No Engine configured with alias ";
-
   // @formatter:off
   private static final TypeRef<List<String>> LIST_OF_STRINGS_TYPE_REF = new TypeRef<>() {};
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(ConfigurationService.class);
@@ -76,8 +74,6 @@ public class ConfigurationService {
   private Long initialBackoff;
   private Long maximumBackoff;
   // engine import settings
-  private Integer engineConnectTimeout;
-  private Integer engineReadTimeout;
   private Integer currentTimeBackoffMilliseconds;
   private Integer engineImportProcessInstanceMaxPageSize;
   private Integer engineImportVariableInstanceMaxPageSize;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auditlog/AuditLogAgentIT.java
@@ -42,7 +42,6 @@ public class AuditLogAgentIT {
           .withAuthenticatedAccess();
 
   private static final String AGENT_ELEMENT_ID = "test_agent_ahsp";
-  private static CamundaClient adminClient;
 
   @BeforeAll
   static void setup(@Authenticated(DEFAULT_USERNAME) final CamundaClient client) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -523,7 +523,6 @@ final class ElasticsearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
-    private final int position = 1;
 
     @BeforeEach
     void initExporter() {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -522,7 +522,6 @@ final class ElasticsearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
-    private final int position = 1;
 
     @BeforeEach
     void initExporter() {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -601,7 +601,6 @@ final class OpensearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
-    private final int position = 1;
 
     @BeforeEach
     void initExporter() {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -600,7 +600,6 @@ final class OpensearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
-    private final int position = 1;
 
     @BeforeEach
     void initExporter() {


### PR DESCRIPTION
 Issue #59705

**Description:**

Removes a few unused private fields flagged by a new checkstyle check `UnusedPrivateFieldCheck` currently in review upstream: <https://github.com/checkstyle/checkstyle/pull/19816>.

Diff report showing violations found in this repo: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/71d22e5_2026072652/reports/diff/camunda/index.html

**About the check:** 
it flags private fields that are declared but never referenced anywhere in the file. It supports two properties to reduce false positives:

**`ignoreAnnotationCanonicalNames `:** a list of annotation canonical `or shortnames` a field is skipped if it or its enclosing class, carries one of these annotations. Useful for fields populated via reflection-based frameworks `Lombok, Spring @Autowired/@Value, Mockito @Mock/@InjectMocks, JPA, DI, etc.` ` Defaults to java.io.Serial.`
**`ignoredFieldNames:`**  a list of literal field names to always skip regardless of usage or annotations. Useful for long-standing name-based conventions the compiler/runtime relies on, such as `serialVersionUID` which predates the @Serial annotation. Defaults to serialVersionUID.

Each field removed in this PR was manually verified as genuinely unused before removal. Fields used via reflection or test annotations `e.g. @UserDefinition` were left untouched, since those are false positives for the check as currently configured  this project's checkstyle config would need `@UserDefinition` and similar annotations added to `ignoreAnnotationCanonicalNames` to suppress them cleanly if this check is adopted here.

 Happy to adjust if any of these are intentional. Feedback on the check itself false positives, edge cases, or naming conventions this project relies on is very welcome, and will help shape it before its finalized upstream.



