### PR TITLE
fix: skip web-session write until search schema is initialized

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactory.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.DocumentBasedWriteClient;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.clients.PersistentWebSessionSearchImpl;
 import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.PersistentWebSessionIndexDescriptor;
 import java.util.LinkedHashMap;
@@ -33,14 +34,17 @@ public final class PhysicalTenantScopedPersistentWebSessionClientFactory {
 
   /**
    * Builds a provider for Elasticsearch/OpenSearch: one {@link PersistentWebSessionSearchImpl} per
-   * physical tenant from that tenant's document search client and index descriptors.
+   * physical tenant from that tenant's document search client and index descriptors, each guarded
+   * by {@link SchemaGatedPersistentWebSessionClient} against writing before that tenant's schema is
+   * initialized (issue #58509).
    *
    * @throws IllegalStateException if a tenant has no {@link IndexDescriptors}, or its search client
    *     does not also implement {@link DocumentBasedWriteClient}
    */
   public static PhysicalTenantScopedPersistentWebSessionClient fromDocumentSearchClients(
       final Map<String, DocumentBasedSearchClient> physicalTenantDocumentSearchClients,
-      final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors) {
+      final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors,
+      final SchemaManagerContainer schemaManagerContainer) {
     final var byTenant = new LinkedHashMap<String, PersistentWebSessionClient>();
     physicalTenantDocumentSearchClients.forEach(
         (tenantId, client) -> {
@@ -57,8 +61,12 @@ public final class PhysicalTenantScopedPersistentWebSessionClientFactory {
                     + client.getClass().getName());
           }
           final var descriptor = descriptors.get(PersistentWebSessionIndexDescriptor.class);
+          final PersistentWebSessionClient searchClient =
+              new PersistentWebSessionSearchImpl(client, writeClient, descriptor);
           byTenant.put(
-              tenantId, new PersistentWebSessionSearchImpl(client, writeClient, descriptor));
+              tenantId,
+              new SchemaGatedPersistentWebSessionClient(
+                  searchClient, tenantId, () -> schemaManagerContainer.isInitialized(tenantId)));
         });
     return new PhysicalTenantScopedPersistentWebSessionClient(Map.copyOf(byTenant));
   }

--- a/dist/src/main/java/io/camunda/application/commons/identity/SchemaGatedPersistentWebSessionClient.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/SchemaGatedPersistentWebSessionClient.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import io.camunda.search.clients.PersistentWebSessionClient;
+import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.query.SearchQueryResult;
+import java.util.function.BooleanSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Skips {@link #upsertPersistentWebSession} while the physical tenant's search schema is not yet
+ * initialized, instead of delegating straight through to Elasticsearch/OpenSearch (issue #58509).
+ *
+ * <p>Before the schema manager has created the {@code web-session} index, a write reaches ES/OS's
+ * {@code auto_create_index} and fabricates a poison index with no alias and the wrong dynamic
+ * mappings; {@code IndexSchemaValidator} then hard-fails on every subsequent startup, crash-looping
+ * the gateway. Callers already tolerate a lost session write the same way they tolerate one lost to
+ * a transient ES/OS outage (retry-then-swallow-with-WARN in {@code SessionStoreAdapter}), so
+ * skipping here is a safe degrade, not a new failure mode.
+ *
+ * <p>Reads and deletes are never gated: {@code get}/{@code getAll} don't write, and ES/OS delete
+ * uses internal versioning that does not trigger {@code auto_create_index}.
+ */
+final class SchemaGatedPersistentWebSessionClient implements PersistentWebSessionClient {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SchemaGatedPersistentWebSessionClient.class);
+
+  private final PersistentWebSessionClient delegate;
+  private final String physicalTenantId;
+  private final BooleanSupplier isSchemaInitialized;
+
+  SchemaGatedPersistentWebSessionClient(
+      final PersistentWebSessionClient delegate,
+      final String physicalTenantId,
+      final BooleanSupplier isSchemaInitialized) {
+    this.delegate = delegate;
+    this.physicalTenantId = physicalTenantId;
+    this.isSchemaInitialized = isSchemaInitialized;
+  }
+
+  @Override
+  public PersistentWebSessionEntity getPersistentWebSession(final String sessionId) {
+    return delegate.getPersistentWebSession(sessionId);
+  }
+
+  @Override
+  public void upsertPersistentWebSession(
+      final PersistentWebSessionEntity persistentWebSessionEntity) {
+    if (!isSchemaInitialized.getAsBoolean()) {
+      LOGGER.warn(
+          "Skipping a persistent web session upsert on physical tenant '{}': "
+              + "search schema is not initialized yet",
+          physicalTenantId);
+      return;
+    }
+    delegate.upsertPersistentWebSession(persistentWebSessionEntity);
+  }
+
+  @Override
+  public void deletePersistentWebSession(final String sessionId) {
+    delegate.deletePersistentWebSession(sessionId);
+  }
+
+  @Override
+  public SearchQueryResult<PersistentWebSessionEntity> getAllPersistentWebSessions() {
+    return delegate.getAllPersistentWebSessions();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -17,6 +17,7 @@ import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.security.core.port.out.SessionStorePort;
 import io.camunda.security.spring.annotation.ConditionalOnPersistentWebSessionEnabled;
 import io.camunda.security.spring.session.WebSessionAttributeConverter;
@@ -89,9 +90,12 @@ public class WebSessionRepositoryConfiguration {
   })
   public PhysicalTenantScoped<PersistentWebSessionClient> persistentWebSessionClientProviderSearch(
       final Map<String, DocumentBasedSearchClient> physicalTenantDocumentSearchClients,
-      final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors) {
+      final Map<String, IndexDescriptors> physicalTenantScopedIndexDescriptors,
+      final SchemaManagerContainer schemaManagerContainer) {
     return PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
-        physicalTenantDocumentSearchClients, physicalTenantScopedIndexDescriptors);
+        physicalTenantDocumentSearchClients,
+        physicalTenantScopedIndexDescriptors,
+        schemaManagerContainer);
   }
 
   @Bean("persistentWebSessionClientProvider")

--- a/dist/src/test/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactoryTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/PhysicalTenantScopedPersistentWebSessionClientFactoryTest.java
@@ -10,6 +10,8 @@ package io.camunda.application.commons.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -18,6 +20,8 @@ import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedWriteClient;
 import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
+import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -60,7 +64,9 @@ class PhysicalTenantScopedPersistentWebSessionClientFactoryTest {
     // when
     final PhysicalTenantScopedPersistentWebSessionClient provider =
         PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
-            Map.of("t1", searchClient), Map.of("t1", descriptors));
+            Map.of("t1", searchClient),
+            Map.of("t1", descriptors),
+            mock(SchemaManagerContainer.class));
 
     // then
     assertThat(provider.withPhysicalTenant("t1")).isNotNull();
@@ -78,7 +84,9 @@ class PhysicalTenantScopedPersistentWebSessionClientFactoryTest {
     assertThatThrownBy(
             () ->
                 PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
-                    Map.of("missing-pt", searchClient), Map.of()))
+                    Map.of("missing-pt", searchClient),
+                    Map.of(),
+                    mock(SchemaManagerContainer.class)))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("missing-pt");
   }
@@ -93,9 +101,44 @@ class PhysicalTenantScopedPersistentWebSessionClientFactoryTest {
     assertThatThrownBy(
             () ->
                 PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
-                    Map.of("t1", readOnlyClient), Map.of("t1", descriptors)))
+                    Map.of("t1", readOnlyClient),
+                    Map.of("t1", descriptors),
+                    mock(SchemaManagerContainer.class)))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("t1")
         .hasMessageContaining("DocumentBasedWriteClient");
+  }
+
+  @Test
+  void shouldSkipWriteForTenantWhoseSchemaIsNotInitialized() {
+    // given — t1 ready, t2 not; the guard must consult isInitialized per-tenant, not globally
+    final var readyClient =
+        mock(
+            DocumentBasedSearchClient.class,
+            withSettings().extraInterfaces(DocumentBasedWriteClient.class));
+    final var notReadyClient =
+        mock(
+            DocumentBasedSearchClient.class,
+            withSettings().extraInterfaces(DocumentBasedWriteClient.class));
+    final var descriptors = new IndexDescriptors("test", /* isElasticsearch= */ true);
+    final var schemaManagerContainer = mock(SchemaManagerContainer.class);
+    when(schemaManagerContainer.isInitialized("t1")).thenReturn(true);
+    when(schemaManagerContainer.isInitialized("t2")).thenReturn(false);
+
+    final var provider =
+        PhysicalTenantScopedPersistentWebSessionClientFactory.fromDocumentSearchClients(
+            Map.of("t1", readyClient, "t2", notReadyClient),
+            Map.of("t1", descriptors, "t2", descriptors),
+            schemaManagerContainer);
+    final var session = new PersistentWebSessionEntity("session-1", 1L, 1L, 1800L, Map.of());
+
+    // when
+    provider.withPhysicalTenant("t1").upsertPersistentWebSession(session);
+    provider.withPhysicalTenant("t2").upsertPersistentWebSession(session);
+
+    // then
+    verify((DocumentBasedWriteClient) readyClient).index(org.mockito.ArgumentMatchers.any());
+    verify((DocumentBasedWriteClient) notReadyClient, never())
+        .index(org.mockito.ArgumentMatchers.any());
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/identity/SchemaGatedPersistentWebSessionClientTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/SchemaGatedPersistentWebSessionClientTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.PersistentWebSessionClient;
+import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.query.SearchQueryResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SchemaGatedPersistentWebSessionClientTest {
+
+  private final PersistentWebSessionClient delegate = mock(PersistentWebSessionClient.class);
+
+  @Test
+  void shouldSkipUpsertWhenSchemaNotInitialized() {
+    // given
+    final var client = new SchemaGatedPersistentWebSessionClient(delegate, "pt-1", () -> false);
+    final var session = session("session-1");
+
+    // when
+    client.upsertPersistentWebSession(session);
+
+    // then
+    verify(delegate, never()).upsertPersistentWebSession(session);
+  }
+
+  @Test
+  void shouldDelegateUpsertWhenSchemaInitialized() {
+    // given
+    final var client = new SchemaGatedPersistentWebSessionClient(delegate, "pt-1", () -> true);
+    final var session = session("session-1");
+
+    // when
+    client.upsertPersistentWebSession(session);
+
+    // then
+    verify(delegate).upsertPersistentWebSession(session);
+  }
+
+  @Test
+  void shouldAlwaysDelegateGet() {
+    // given
+    final var client = new SchemaGatedPersistentWebSessionClient(delegate, "pt-1", () -> false);
+    final var session = session("session-1");
+    when(delegate.getPersistentWebSession("session-1")).thenReturn(session);
+
+    // when
+    final var result = client.getPersistentWebSession("session-1");
+
+    // then
+    assertThat(result).isEqualTo(session);
+  }
+
+  @Test
+  void shouldAlwaysDelegateDelete() {
+    // given
+    final var client = new SchemaGatedPersistentWebSessionClient(delegate, "pt-1", () -> false);
+
+    // when
+    client.deletePersistentWebSession("session-1");
+
+    // then
+    verify(delegate).deletePersistentWebSession("session-1");
+  }
+
+  @Test
+  void shouldAlwaysDelegateGetAll() {
+    // given
+    final var client = new SchemaGatedPersistentWebSessionClient(delegate, "pt-1", () -> false);
+    final SearchQueryResult<PersistentWebSessionEntity> expected =
+        SearchQueryResult.of(b -> b.items(List.of(session("session-1"))));
+    when(delegate.getAllPersistentWebSessions()).thenReturn(expected);
+
+    // when
+    final var result = client.getAllPersistentWebSessions();
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  private static PersistentWebSessionEntity session(final String id) {
+    return new PersistentWebSessionEntity(id, 1L, 1L, 1800L, Map.of());
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
@@ -10,6 +10,8 @@ package io.camunda.application.commons.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -22,6 +24,8 @@ import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedWriteClient;
 import io.camunda.search.clients.PhysicalTenantScopedPersistentWebSessionClient;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.schema.SchemaManagerContainer;
 import io.camunda.security.core.port.out.SessionStorePort;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -133,6 +137,7 @@ class WebSessionRepositoryConfigurationTest {
             Map.class,
             () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, descriptors))
         .withBean(PhysicalTenantIds.class, () -> PhysicalTenantIds.DEFAULT)
+        .withBean(SchemaManagerContainer.class, () -> mock(SchemaManagerContainer.class))
         .withUserConfiguration(WebSessionRepositoryConfiguration.class)
         .withPropertyValues(
             "camunda.data.secondary-storage.type=elasticsearch",
@@ -150,6 +155,51 @@ class WebSessionRepositoryConfigurationTest {
                   .isNotNull();
               assertThatThrownBy(() -> provider.withPhysicalTenant("unknown-pt"))
                   .isInstanceOf(IllegalStateException.class);
+            });
+  }
+
+  @Test
+  void shouldGateWriteWhenSchemaManagerContainerBeanReportsTenantNotInitialized() {
+    // given — a SchemaManagerContainer bean is present and reports the tenant as not initialized
+    final var searchClient =
+        mock(
+            DocumentBasedSearchClient.class,
+            withSettings().extraInterfaces(DocumentBasedWriteClient.class));
+    final var descriptors = new IndexDescriptors("test", /* isElasticsearch= */ true);
+    final var schemaManagerContainer = mock(SchemaManagerContainer.class);
+    when(schemaManagerContainer.isInitialized(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .thenReturn(false);
+
+    new WebApplicationContextRunner()
+        .withBean(ConnectConfiguration.class, ConnectConfiguration::new)
+        .withBean(
+            "physicalTenantDocumentSearchClients",
+            Map.class,
+            () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, searchClient))
+        .withBean(
+            "physicalTenantScopedIndexDescriptors",
+            Map.class,
+            () -> Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, descriptors))
+        .withBean(PhysicalTenantIds.class, () -> PhysicalTenantIds.DEFAULT)
+        .withBean(SchemaManagerContainer.class, () -> schemaManagerContainer)
+        .withUserConfiguration(WebSessionRepositoryConfiguration.class)
+        .withPropertyValues(
+            "camunda.data.secondary-storage.type=elasticsearch",
+            "camunda.security.session.persistent.enabled=true")
+        .run(
+            ctx -> {
+              final var provider =
+                  ctx.getBean(PhysicalTenantScopedPersistentWebSessionClient.class);
+              final var client =
+                  provider.withPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+
+              // when
+              client.upsertPersistentWebSession(
+                  new PersistentWebSessionEntity("session-1", 1L, 1L, 1800L, Map.of()));
+
+              // then — the write never reached the underlying write client
+              verify((DocumentBasedWriteClient) searchClient, never())
+                  .index(org.mockito.ArgumentMatchers.any());
             });
   }
 }


### PR DESCRIPTION
## Why

The gateway can end up in a permanent crash-loop because the `camunda-web-session` index exists in Elasticsearch in a malformed state: no alias and auto-inferred mappings that don't match what the schema expects. The schema validator rejects that index on every startup, so the gateway never comes up again until the index is deleted manually.

The likely root cause, reconstructed from logs: during startup there is a short window in which the gateway can accept HTTP requests before the search schema has been initialized (observed when a pod was terminated while schema initialization was still waiting on a temporarily unreachable Elasticsearch — the web server briefly serves during the graceful shutdown). If a request lands in that window, Spring Security persists a web session, and that write reaches Elasticsearch before the schema manager has created the web-session index. Elasticsearch's `auto_create_index` then silently creates the index itself — malformed — and it is never repaired afterwards.

## What

The web-session write is the only write that can race schema creation this way, so this PR gates exactly that write: on the Elasticsearch/OpenSearch backend, the session write is skipped (with a warning) until the schema manager reports the schema initialized. 
~~skipped session write degrades the same way as one lost to a transient Elasticsearch outage, which the session layer already tolerates by design.~~
Reads and deletes are unaffected, and so is the RDBMS backend.

## Alternatives considered

- **Rejecting requests at the HTTP layer until storage is ready** — touches more layers, protects only one entry point, and needs a serving-readiness signal that doesn't exist yet (#58299); that is future feature work rather than this bug fix.
- **Checking index/alias existence in Elasticsearch before each write** — costs an extra round-trip and requires metadata privileges the application user may not have on hardened deployments.
- **Writing through the index alias with `require_alias`** — not viable; our index aliases are deliberately created non-writable.
- **Disabling `auto_create_index` on the cluster** — valid defense-in-depth, but an infrastructure concern outside the application.
- **Repairing the malformed index in the schema manager** — healing rather than prevention

Closes #58509
