### PR TITLE
deps: bump react-router-dom to 7.18.1 (stable/8.9)

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -22,7 +22,7 @@
         "react-dom": "18.3.1",
         "react-hook-form": "7.71.2",
         "react-i18next": "16.5.8",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "react-transition-group": "4.4.5",
         "styled-components": "6.4.1",
         "zod": "4.3.6"
@@ -6309,9 +6309,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6331,12 +6331,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6620,6 +6620,21 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rollup-plugin-license/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rollup-plugin-license/node_modules/spdx-expression-parse": {

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -32,7 +32,7 @@
     "react-dom": "18.3.1",
     "react-hook-form": "7.71.2",
     "react-i18next": "16.5.8",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "react-transition-group": "4.4.5",
     "styled-components": "6.4.1",
     "zod": "4.3.6"

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -42,7 +42,7 @@
         "react-error-boundary": "6.1.1",
         "react-final-form": "7.0.0",
         "react-final-form-arrays": "4.0.0",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "react-transition-group": "4.4.5",
         "styled-components": "6.4.1",
         "tiny-svg": "4.1.4",
@@ -8772,9 +8772,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -8794,12 +8794,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -38,7 +38,7 @@
     "react-error-boundary": "6.1.1",
     "react-final-form": "7.0.0",
     "react-final-form-arrays": "4.0.0",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "react-transition-group": "4.4.5",
     "styled-components": "6.4.1",
     "tiny-svg": "4.1.4",

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -37,7 +37,7 @@
         "react-final-form": "7.0.0",
         "react-final-form-arrays": "4.0.0",
         "react-i18next": "16.5.4",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "react-transition-group": "4.4.5",
         "sass": "1.97.3",
         "styled-components": "6.4.1",
@@ -9232,9 +9232,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9254,12 +9254,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -33,7 +33,7 @@
     "react-final-form": "7.0.0",
     "react-final-form-arrays": "4.0.0",
     "react-i18next": "16.5.4",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "react-transition-group": "4.4.5",
     "sass": "1.97.3",
     "styled-components": "6.4.1",


### PR DESCRIPTION
## Description

Bumps `react-router-dom` from `7.16.0` to `7.18.1` in the identity, operate and tasklist frontends to resolve the transitive `react-router@7.16.0` vulnerabilities flagged by Snyk in CI:

- [HIGH] Cross-site Scripting (XSS) — `SNYK-JS-REACTROUTER-18313128`
- [HIGH] Inefficient Algorithmic Complexity — `SNYK-JS-REACTROUTER-18313148`
- [HIGH] Open Redirect — `SNYK-JS-REACTROUTER-18313144`

All three are fixed in `react-router@7.18.0`. `7.18.1` matches the version already shipping on `main`, so no separate main fix or backport is involved — `main` is not affected.

This PR targets `stable/8.9` directly; a sibling PR does the same for `stable/8.8`. `stable/8.7` is on the react-router v6/early-v7 line (not 7.16.0) and is out of scope for this finding.

## Checklist

- [x] Version pinned exactly (no caret), matching repo convention
- [x] Lockfiles regenerated via `npm install --save-exact --package-lock-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)