### PR TITLE
deps: bump react-router-dom to 7.18.1 (stable/8.8)

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -18,7 +18,7 @@
         "react-dom": "18.3.1",
         "react-hook-form": "7.61.1",
         "react-i18next": "15.6.1",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "react-transition-group": "4.4.5",
         "styled-components": "^6.4.1"
       },
@@ -5988,9 +5988,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6010,12 +6010,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -28,7 +28,7 @@
     "react-dom": "18.3.1",
     "react-hook-form": "7.61.1",
     "react-i18next": "15.6.1",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "react-transition-group": "4.4.5",
     "styled-components": "^6.4.1"
   },

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -41,7 +41,7 @@
         "react-error-boundary": "6.0.3",
         "react-final-form": "6.5.9",
         "react-final-form-arrays": "3.1.4",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "react-transition-group": "4.4.5",
         "styled-components": "6.4.1",
         "tiny-svg": "4.1.4"
@@ -9946,9 +9946,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9968,12 +9968,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -37,7 +37,7 @@
     "react-error-boundary": "6.0.3",
     "react-final-form": "6.5.9",
     "react-final-form-arrays": "3.1.4",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "react-transition-group": "4.4.5",
     "styled-components": "6.4.1",
     "tiny-svg": "4.1.4"

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -37,7 +37,7 @@
         "react-final-form": "7.0.1",
         "react-final-form-arrays": "4.0.0",
         "react-i18next": "15.6.1",
-        "react-router-dom": "7.16.0",
+        "react-router-dom": "7.18.1",
         "react-transition-group": "4.4.5",
         "sass": "1.89.2",
         "styled-components": "6.4.1",
@@ -9522,9 +9522,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9544,12 +9544,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -33,7 +33,7 @@
     "react-final-form": "7.0.1",
     "react-final-form-arrays": "4.0.0",
     "react-i18next": "15.6.1",
-    "react-router-dom": "7.16.0",
+    "react-router-dom": "7.18.1",
     "react-transition-group": "4.4.5",
     "sass": "1.89.2",
     "styled-components": "6.4.1",


### PR DESCRIPTION
## Description

Bumps `react-router-dom` from `7.16.0` to `7.18.1` in the identity, operate and tasklist frontends to resolve the transitive `react-router@7.16.0` vulnerabilities flagged by Snyk in CI (the `identity-frontend@8.8.6-SNAPSHOT` failure):

- [HIGH] Cross-site Scripting (XSS) — `SNYK-JS-REACTROUTER-18313128`
- [HIGH] Inefficient Algorithmic Complexity — `SNYK-JS-REACTROUTER-18313148`
- [HIGH] Open Redirect — `SNYK-JS-REACTROUTER-18313144`

All three are fixed in `react-router@7.18.0`. `7.18.1` matches the version already shipping on `main`, so no separate main fix or backport is involved — `main` is not affected.

This PR targets `stable/8.8` directly; a sibling PR does the same for `stable/8.9`. `stable/8.7` is on the react-router v6/early-v7 line (not 7.16.0) and is out of scope for this finding.

## Checklist

- [x] Version pinned exactly (no caret), matching repo convention
- [x] Lockfiles regenerated via `npm install --save-exact --package-lock-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)