### PR TITLE
fix: api docs should not be physical tenant aware

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -138,6 +138,30 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-common</artifactId>
+      <exclusions>
+        <!-- pulls in log4j-to-slf4j, which conflicts with log4j-slf4j2-impl on the classpath -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+      <exclusions>
+        <!-- pulls in log4j-to-slf4j, which conflicts with log4j-slf4j2-impl on the classpath -->
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-gateway-mcp</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import static io.camunda.spring.utils.PhysicalTenantContext.PHYSICAL_TENANT_URI_PREFIX;
+
+import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.providers.SpringWebProvider;
+import org.springdoc.webmvc.core.providers.SpringWebMvcProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.accept.ApiVersionStrategy;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+
+/**
+ * Supplies our own {@link SpringWebProvider} bean so springdoc's auto-configured default (also
+ * {@code @ConditionalOnMissingBean SpringWebProvider}) backs off — user {@code @Configuration}
+ * beans are registered before auto-configuration's conditions are evaluated, so ours wins. See
+ * {@link PhysicalTenantAwareSpringWebMvcProvider} for why this is needed.
+ */
+@Configuration
+@ConditionalOnRestGatewayEnabled
+@ConditionalOnProperty(
+    name = "camunda.rest.swagger.enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+class PhysicalTenantSpringWebProviderConfiguration {
+
+  @Bean
+  SpringWebProvider springWebProvider(final Optional<ApiVersionStrategy> apiVersionStrategyOptional) {
+    return new PhysicalTenantAwareSpringWebMvcProvider(apiVersionStrategyOptional);
+  }
+
+  /**
+   * Springdoc's {@link SpringWebMvcProvider#findPathPrefix} scans every registered pattern,
+   * request-independent, for the first one ending in the api-docs path — so it can land on {@code
+   * PhysicalTenantRequestMappingHandlerMapping}'s auto-enrolled {@code
+   * /physical-tenants/{physicalTenantId}/v3/api-docs} sibling instead of the real mapping,
+   * depending on Spring's handler-method registration order, which isn't stable across restarts.
+   * That leaks the unresolved {@code {physicalTenantId}} placeholder into swagger-initializer.js
+   * and self-referential server URLs, and can crash {@code OpenApiWebMvcResource#getServerUrl}.
+   * Skipping PT-prefixed candidates here makes the result deterministic.
+   */
+  private static final class PhysicalTenantAwareSpringWebMvcProvider extends SpringWebMvcProvider {
+
+    PhysicalTenantAwareSpringWebMvcProvider(
+        final Optional<ApiVersionStrategy> apiVersionStrategyOptional) {
+      super(apiVersionStrategyOptional);
+    }
+
+    @Override
+    public String findPathPrefix(final SpringDocConfigProperties springDocConfigProperties) {
+      final Map<RequestMappingInfo, HandlerMethod> map = getHandlerMethods();
+      final String apiDocsPath = springDocConfigProperties.getApiDocs().getPath();
+      final String physicalTenantApiDocsPath = PHYSICAL_TENANT_URI_PREFIX + apiDocsPath;
+
+      for (final Entry<RequestMappingInfo, HandlerMethod> entry : map.entrySet()) {
+        final Set<String> patterns = getActivePatterns(entry.getKey());
+        if (CollectionUtils.isEmpty(patterns)) {
+          continue;
+        }
+        for (final String operationPath : patterns) {
+          if (operationPath.endsWith(physicalTenantApiDocsPath)) {
+            return operationPath.replace(physicalTenantApiDocsPath, "");
+          }
+          if (operationPath.endsWith(apiDocsPath)) {
+            return operationPath.replace(apiDocsPath, "");
+          }
+        }
+      }
+      return "";
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfiguration.java
@@ -17,9 +17,9 @@ import java.util.Set;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.SpringWebProvider;
 import org.springdoc.webmvc.core.providers.SpringWebMvcProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.accept.ApiVersionStrategy;
 import org.springframework.web.method.HandlerMethod;
@@ -33,13 +33,10 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
  */
 @Configuration
 @ConditionalOnRestGatewayEnabled
-@ConditionalOnProperty(
-    name = "camunda.rest.swagger.enabled",
-    havingValue = "true",
-    matchIfMissing = true)
 class PhysicalTenantSpringWebProviderConfiguration {
 
   @Bean
+  @Lazy(false)
   SpringWebProvider springWebProvider(
       final Optional<ApiVersionStrategy> apiVersionStrategyOptional) {
     return new PhysicalTenantAwareSpringWebMvcProvider(apiVersionStrategyOptional);

--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfiguration.java
@@ -40,7 +40,8 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 class PhysicalTenantSpringWebProviderConfiguration {
 
   @Bean
-  SpringWebProvider springWebProvider(final Optional<ApiVersionStrategy> apiVersionStrategyOptional) {
+  SpringWebProvider springWebProvider(
+      final Optional<ApiVersionStrategy> apiVersionStrategyOptional) {
     return new PhysicalTenantAwareSpringWebMvcProvider(apiVersionStrategyOptional);
   }
 
@@ -54,7 +55,7 @@ class PhysicalTenantSpringWebProviderConfiguration {
    * and self-referential server URLs, and can crash {@code OpenApiWebMvcResource#getServerUrl}.
    * Skipping PT-prefixed candidates here makes the result deterministic.
    */
-  private static final class PhysicalTenantAwareSpringWebMvcProvider extends SpringWebMvcProvider {
+  static final class PhysicalTenantAwareSpringWebMvcProvider extends SpringWebMvcProvider {
 
     PhysicalTenantAwareSpringWebMvcProvider(
         final Optional<ApiVersionStrategy> apiVersionStrategyOptional) {

--- a/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfigurationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.pt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.commons.pt.PhysicalTenantSpringWebProviderConfiguration.PhysicalTenantAwareSpringWebMvcProvider;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo.BuilderConfiguration;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+class PhysicalTenantSpringWebProviderConfigurationTest {
+
+  private static final String BARE_PATTERN = "/v3/api-docs";
+  private static final String PHYSICAL_TENANT_PATTERN =
+      "/physical-tenants/{physicalTenantId}/v3/api-docs";
+
+  @Test
+  void shouldResolveEmptyPrefixWhenBarePatternRegisteredFirst() {
+    // given
+    final var provider = providerWith(BARE_PATTERN, PHYSICAL_TENANT_PATTERN);
+
+    // when
+    final String prefix = provider.findPathPrefix(apiDocsConfig());
+
+    // then
+    assertThat(prefix).isEmpty();
+  }
+
+  @Test
+  void shouldResolveEmptyPrefixWhenPhysicalTenantPatternRegisteredFirst() {
+    // given
+    final var provider = providerWith(PHYSICAL_TENANT_PATTERN, BARE_PATTERN);
+
+    // when
+    final String prefix = provider.findPathPrefix(apiDocsConfig());
+
+    // then
+    assertThat(prefix).isEmpty();
+  }
+
+  /**
+   * Builds a provider backed by a single mocked {@link RequestMappingHandlerMapping} whose {@code
+   * getHandlerMethods()} returns the given patterns as an insertion-ordered map — {@code patterns}'
+   * order stands in for the registration order that {@code findPathPrefix} used to depend on.
+   */
+  private static PhysicalTenantAwareSpringWebMvcProvider providerWith(final String... patterns) {
+    final Map<RequestMappingInfo, HandlerMethod> handlerMethods = new LinkedHashMap<>();
+    for (final String pattern : patterns) {
+      handlerMethods.put(requestMappingInfo(pattern), handlerMethod());
+    }
+
+    final RequestMappingHandlerMapping mapping = mock(RequestMappingHandlerMapping.class);
+    when(mapping.getHandlerMethods()).thenReturn(handlerMethods);
+
+    final ApplicationContext applicationContext = mock(ApplicationContext.class);
+    when(applicationContext.getBeansOfType(RequestMappingHandlerMapping.class))
+        .thenReturn(Map.of("requestMappingHandlerMapping", mapping));
+
+    final var provider = new PhysicalTenantAwareSpringWebMvcProvider(Optional.empty());
+    provider.setApplicationContext(applicationContext);
+    return provider;
+  }
+
+  private static SpringDocConfigProperties apiDocsConfig() {
+    final SpringDocConfigProperties config = new SpringDocConfigProperties();
+    config.getApiDocs().setPath(BARE_PATTERN);
+    return config;
+  }
+
+  private static RequestMappingInfo requestMappingInfo(final String pattern) {
+    final BuilderConfiguration configuration = new BuilderConfiguration();
+    configuration.setPatternParser(new PathPatternParser());
+    return RequestMappingInfo.paths(pattern).options(configuration).build();
+  }
+
+  private static HandlerMethod handlerMethod() {
+    try {
+      final Method method = FixtureController.class.getDeclaredMethod("handle");
+      return new HandlerMethod(new FixtureController(), method);
+    } catch (final NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static final class FixtureController {
+    @SuppressWarnings("unused") // resolved reflectively in handlerMethod()
+    public void handle() {}
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantSpringWebProviderConfigurationTest.java
@@ -14,9 +14,14 @@ import static org.mockito.Mockito.when;
 import io.camunda.application.commons.pt.PhysicalTenantSpringWebProviderConfiguration.PhysicalTenantAwareSpringWebMvcProvider;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.method.HandlerMethod;
@@ -31,10 +36,17 @@ class PhysicalTenantSpringWebProviderConfigurationTest {
   private static final String PHYSICAL_TENANT_PATTERN =
       "/physical-tenants/{physicalTenantId}/v3/api-docs";
 
-  @Test
-  void shouldResolveEmptyPrefixWhenBarePatternRegisteredFirst() {
+  static Stream<Arguments> registrationOrders() {
+    return Stream.of(
+        Arguments.of(List.of(BARE_PATTERN, PHYSICAL_TENANT_PATTERN)),
+        Arguments.of(List.of(PHYSICAL_TENANT_PATTERN, BARE_PATTERN)));
+  }
+
+  @ParameterizedTest(name = "[{index}] registration order: {0}")
+  @MethodSource("registrationOrders")
+  void shouldResolveEmptyPrefixRegardlessOfRegistrationOrder(final List<String> patterns) {
     // given
-    final var provider = providerWith(BARE_PATTERN, PHYSICAL_TENANT_PATTERN);
+    final var provider = providerWith(patterns.toArray(String[]::new));
 
     // when
     final String prefix = provider.findPathPrefix(apiDocsConfig());
@@ -44,15 +56,19 @@ class PhysicalTenantSpringWebProviderConfigurationTest {
   }
 
   @Test
-  void shouldResolveEmptyPrefixWhenPhysicalTenantPatternRegisteredFirst() {
+  void shouldResolveGenuineNonEmptyPrefixForCustomBasePath() {
+    // Guards the inherited (non-PT) behaviour springdoc's original findPathPrefix provides: a
+    // real custom base path in front of the api-docs mapping must still resolve, not just the
+    // PT-prefixed case this override specifically targets.
+
     // given
-    final var provider = providerWith(PHYSICAL_TENANT_PATTERN, BARE_PATTERN);
+    final var provider = providerWith("/api" + BARE_PATTERN);
 
     // when
     final String prefix = provider.findPathPrefix(apiDocsConfig());
 
     // then
-    assertThat(prefix).isEmpty();
+    assertThat(prefix).isEqualTo("/api");
   }
 
   /**

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2186,6 +2186,12 @@
 
       <dependency>
         <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+        <version>${version.springdoc}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         <version>${version.springdoc}</version>
       </dependency>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/swagger.spec.ts
@@ -33,8 +33,7 @@ test.beforeEach(async ({context}) => {
 });
 
 test.describe('Swagger UI Tests', () => {
-  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
-  test.skip('Swagger UI is accessible and presents the API list', async ({
+  test('Swagger UI is accessible and presents the API list', async ({
     swaggerPage,
   }) => {
     await swaggerPage.gotoSwaggerUI();
@@ -48,8 +47,7 @@ test.describe('Swagger UI Tests', () => {
     await expect(swaggerPage.firstApiTag).toBeVisible({timeout: 60_000});
   });
 
-  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
-  test.skip('Grouped OpenAPI spec returns valid JSON without external file refs', async ({
+  test('Grouped OpenAPI spec returns valid JSON without external file refs', async ({
     request,
     swaggerPage,
   }) => {
@@ -87,8 +85,7 @@ test.describe('Swagger UI Tests', () => {
     expect(externalFileRefs).toEqual([]);
   });
 
-  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
-  test.skip('CSRF token is filled in and Swagger UI is accessible with CSRF token', async ({
+  test('CSRF token is filled in and Swagger UI is accessible with CSRF token', async ({
     loginPage,
     operateHomePage,
     page,
@@ -122,8 +119,7 @@ test.describe('Swagger UI Tests', () => {
     expect(curlCommandText).toMatch(/x-csrf-token\s*:\s*(?!null\b)\S+/i);
   });
 
-  // Skipped due to bug #57502: https://github.com/camunda/camunda/issues/57502
-  test.skip('CSRF token is NOT filled in and Swagger UI is accessible', async ({
+  test('CSRF token is NOT filled in and Swagger UI is accessible', async ({
     swaggerPage,
   }) => {
     // go to swagger UI


### PR DESCRIPTION
## Description

### Root cause

🪲 springdoc bug on `3.0.3`: When I added a GetMapping for /v3/api-docs, it caused an exception. [#2341](https://github.com/springdoc/springdoc-openapi/issues/2341)

`OpenApiWebMvcResource.class`

``` java
    protected String getServerUrl(HttpServletRequest request, String apiDocsUrl) {
        String requestUrl = this.decode(request.getRequestURL().toString());
        Optional<SpringWebProvider> springWebProviderOptional = this.springDocProviders.getSpringWebProvider();
        String prefix = "";
        if (springWebProviderOptional.isPresent()) {
            prefix = ((SpringWebProvider)springWebProviderOptional.get()).findPathPrefix(this.springDocConfigProperties);
        }

        return requestUrl.substring(0, requestUrl.length() - apiDocsUrl.length() - prefix.length());
    }
 ```

`SpringWebMvcProvider.class`

``` java
  public String findPathPrefix(SpringDocConfigProperties springDocConfigProperties) {
        Map<RequestMappingInfo, HandlerMethod> map = this.getHandlerMethods();

        for(Map.Entry<RequestMappingInfo, HandlerMethod> entry : map.entrySet()) {
            RequestMappingInfo requestMappingInfo = (RequestMappingInfo)entry.getKey();
            Set<String> patterns = this.getActivePatterns(requestMappingInfo);
            if (!CollectionUtils.isEmpty(patterns)) {
                for(String operationPath : patterns) {
                    if (operationPath.endsWith(springDocConfigProperties.getApiDocs().getPath())) {
                        return operationPath.replace(springDocConfigProperties.getApiDocs().getPath(), "");
                    }
                }
            }
        }

        return "";
    }
```

#### Breakdown -- Why this was an issue

1. `PhysicalTenantRequestMappingHandlerMapping` registered both `/v3/api-docs` and `/physical-tenants/{physicalTenantId}/v3/api-docs` for the same controller method.
2. `springDocConfigProperties.getApiDocs().getPath()` always returns `/v3/api-docs` — both registered patterns end with this same suffix.
3. `findPathPrefix` picks the first registered pattern it finds ending in that suffix, and iteration order over registered mappings isn't guaranteed stable across restarts — so it could non-deterministically pick either one.

#### Fix

Override `findPathPrefix` to also explicitly match the PT-prefixed variant `PHYSICAL_TENANT_URI_PREFIX + apiDocsPath` and strip it in full, so hitting either pattern resolves to the same correct (empty) prefix, regardless of which one is found first.

## Related issues

closes #57710
closes #57502