### PR TITLE
test: add negative authorization tests (403/401) for v2 job API

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-permission-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-permission-api-tests.spec.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {
+  assertForbiddenRequest,
+  assertStatusCode,
+  assertUnauthorizedRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {
+  activateJobToObtainAValidJobKey,
+  createUser,
+  grantUserResourceAuthorization,
+  setupProcessInstanceForTests,
+} from '@requestHelpers';
+import {searchJobKey} from '../../../../utils/requestHelpers/job-requestHelpers';
+
+// Job command endpoints (complete/fail/throw-error/update) require
+// permission UPDATE_PROCESS_INSTANCE on resource PROCESS_DEFINITION and are
+// hard-rejected with 403 FORBIDDEN when the caller lacks it.
+// See engine authorization tests JobComplete/Fail/UpdateAuthorizationTest.
+const JOB_UPDATE_FORBIDDEN_DETAIL =
+  "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'";
+
+const runSuffix = randomUUID().slice(0, 8);
+const processId = `jobApiProcess-permission-${runSuffix}`;
+const taskType = `jobApiTaskType-permission-${runSuffix}`;
+
+/* eslint-disable playwright/expect-expect */
+test.describe.serial('Job Permission API', () => {
+  const {state, beforeAll, beforeEach, afterEach} =
+    setupProcessInstanceForTests('job_api_process', {
+      processName: processId,
+      substitutions: {jobApiProcess: processId, jobApiTaskType: taskType},
+    });
+
+  let restrictedUser: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let restrictedToken: string;
+
+  test.beforeAll(async ({request}) => {
+    // given: a deployed job process and an authenticated user that only holds
+    // READ on RESOURCE (no PROCESS_DEFINITION permissions) — i.e. can call the
+    // API but is not authorized for job operations.
+    await beforeAll();
+
+    restrictedUser = await createUser(request);
+    await grantUserResourceAuthorization(request, restrictedUser);
+    restrictedToken = encode(
+      `${restrictedUser.username}:${restrictedUser.password}`,
+    );
+  });
+
+  test.beforeEach(beforeEach);
+
+  test.afterEach(afterEach);
+
+  test.afterAll(async ({request}) => {
+    await cleanupUsers(request, [restrictedUser.username]);
+  });
+
+  test('Complete job - forbidden without UPDATE_PROCESS_INSTANCE', async ({
+    request,
+  }) => {
+    // given: a valid, activated job (activated by the admin worker)
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
+
+    // when/then: the restricted user attempts to complete it -> 403
+    await expect(async () => {
+      const res = await request.post(buildUrl(`/jobs/${jobKey}/completion`), {
+        headers: jsonHeaders(restrictedToken),
+        data: {},
+      });
+      await assertForbiddenRequest(res, JOB_UPDATE_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Fail job - forbidden without UPDATE_PROCESS_INSTANCE', async ({
+    request,
+  }) => {
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl(`/jobs/${jobKey}/failure`), {
+        headers: jsonHeaders(restrictedToken),
+        data: {retries: 0, errorMessage: 'Simulated failure'},
+      });
+      await assertForbiddenRequest(res, JOB_UPDATE_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Throw job error - forbidden without UPDATE_PROCESS_INSTANCE', async ({
+    request,
+  }) => {
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
+
+    await expect(async () => {
+      const res = await request.post(buildUrl(`/jobs/${jobKey}/error`), {
+        headers: jsonHeaders(restrictedToken),
+        data: {errorCode: 'ERROR_CODE_1'},
+      });
+      await assertForbiddenRequest(res, JOB_UPDATE_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update job - forbidden without UPDATE_PROCESS_INSTANCE', async ({
+    request,
+  }) => {
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
+
+    await expect(async () => {
+      const res = await request.patch(buildUrl(`/jobs/${jobKey}`), {
+        headers: jsonHeaders(restrictedToken),
+        data: {changeset: {retries: 1, timeout: 9000}},
+      });
+      await assertForbiddenRequest(res, JOB_UPDATE_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search jobs - filters out unauthorized results', async ({request}) => {
+    // Job search requires READ_PROCESS_INSTANCE on PROCESS_DEFINITION, but per
+    // the REST API docs unauthorized results are *filtered* (not rejected).
+    // given: the admin can see the instance's job (i.e. it is indexed)
+    const processInstanceKey = state['processInstanceKey'] as string;
+    await searchJobKey(request, processInstanceKey);
+
+    // when: the restricted user searches with the same filter
+    const res = await request.post(buildUrl('/jobs/search'), {
+      headers: jsonHeaders(restrictedToken),
+      data: {filter: {processInstanceKey}},
+    });
+
+    // then: the request succeeds but the unauthorized job is filtered out
+    await assertStatusCode(res, 200);
+    const json = await res.json();
+    expect(json.items).toHaveLength(0);
+  });
+
+  test('Complete job - unauthorized without authentication', async ({
+    request,
+  }) => {
+    const jobKey = await activateJobToObtainAValidJobKey(request, taskType);
+
+    const res = await request.post(buildUrl(`/jobs/${jobKey}/completion`), {
+      headers: jsonHeaders(''),
+      data: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+
+  test('Search jobs - unauthorized without authentication', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl('/jobs/search'), {
+      headers: jsonHeaders(''),
+      data: {},
+    });
+    await assertUnauthorizedRequest(res);
+  });
+});


### PR DESCRIPTION
## Description

Extends Iteration 2 negative-testing & error-handling coverage for the **V2 Orchestration Cluster REST API**, starting with the **Job** endpoints (reference slice of the 8-category effort).

Adds a dedicated permission spec `tests/api/v2/job/job-permission-api-tests.spec.ts` that exercises a **restricted (authenticated but under-authorized) user** against each job endpoint and asserts the API fails safely and consistently:

- `complete` / `fail` / `throw-error` / `update` → **403 FORBIDDEN** (missing `UPDATE_PROCESS_INSTANCE` on `PROCESS_DEFINITION`; exact `detail` asserted as a stable substring).
- `search` → **200 with unauthorized results filtered out** (per the endpoint's "Required permissions" note in the REST API docs — filter, not reject).
- unauthenticated request → **401**.

Follows the existing `user-task-permission-api-tests.spec.ts` exemplar and reuses shared helpers only (`utils/http.ts`, `@requestHelpers`: `createUser`, `grantUserResourceAuthorization`, `activateJobToObtainAValidJobKey`, `searchJobKey`, `setupProcessInstanceForTests`). No shared files or config changed — the spec auto-runs in the existing `api-tests` project.

## Checklist

- [ ] Enable backports when necessary — **N/A** (test-only addition, `main` only).
- [x] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the on-demand workflow before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

### Test results
- Validated locally against the Standalone Elasticsearch environment — **all 7 new tests pass**.
- On-demand workflow run against this branch: https://github.com/camunda/camunda/actions/runs/30249836871

## Related issues

closes camunda/team-test-automation#150
Part of camunda/team-test-automation#37 · tracked under camunda/team-qa-engineering#514