### PR TITLE
fix: scope /me authorizedComponents per physical tenant

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/service/AuthorizedComponentsAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/AuthorizedComponentsAdapter.java
@@ -13,6 +13,7 @@ import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.core.authz.ResourceAccessProvider;
 import io.camunda.security.core.port.out.AuthorizedComponentsPort;
 import io.camunda.spring.utils.ConditionalOnSecondaryStorageEnabled;
+import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -22,9 +23,10 @@ import org.springframework.stereotype.Service;
  * resource-access framework that holds that data still lives in OC; this adapter bridges the gap
  * until {@code ResourceAccessProvider} itself migrates.
  *
- * <p>Resolves {@code COMPONENT_ACCESS_AUTHORIZATION} via the host's {@link ResourceAccessProvider}
- * and renames the {@code identity} resource id to {@code admin} — a long-standing OC-side alias
- * preserved here so the {@code /v2/authentication/me} response shape does not change.
+ * <p>Resolves {@code COMPONENT_ACCESS_AUTHORIZATION} via the {@link ResourceAccessProvider} scoped
+ * to the request's physical tenant and renames the {@code identity} resource id to {@code admin} —
+ * a long-standing OC-side alias preserved here so the {@code /v2/authentication/me} response shape
+ * does not change.
  *
  * <p>{@code @ConditionalOnSecondaryStorageEnabled} matches the gate on the resource-access stack
  * itself: without secondary storage there is no authorization data to query.
@@ -33,17 +35,19 @@ import org.springframework.stereotype.Service;
 @ConditionalOnSecondaryStorageEnabled
 public final class AuthorizedComponentsAdapter implements AuthorizedComponentsPort {
 
-  private final ResourceAccessProvider resourceAccessProvider;
+  private final PhysicalTenantResourceAccessProvider resourceAccessProvider;
 
-  public AuthorizedComponentsAdapter(final ResourceAccessProvider resourceAccessProvider) {
+  public AuthorizedComponentsAdapter(
+      final PhysicalTenantResourceAccessProvider resourceAccessProvider) {
     this.resourceAccessProvider = resourceAccessProvider;
   }
 
   @Override
   public List<String> resolve(final CamundaAuthentication authentication) {
     final var componentAccess =
-        resourceAccessProvider.resolveResourceAccess(
-            authentication, COMPONENT_ACCESS_AUTHORIZATION);
+        resourceAccessProvider
+            .withPhysicalTenant(PhysicalTenantContext.currentOrNull())
+            .resolveResourceAccess(authentication, COMPONENT_ACCESS_AUTHORIZATION);
     if (!componentAccess.allowed()) {
       return List.of();
     }

--- a/authentication/src/main/java/io/camunda/authentication/service/AuthorizedComponentsAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/AuthorizedComponentsAdapter.java
@@ -46,7 +46,7 @@ public final class AuthorizedComponentsAdapter implements AuthorizedComponentsPo
   public List<String> resolve(final CamundaAuthentication authentication) {
     final var componentAccess =
         resourceAccessProvider
-            .withPhysicalTenant(PhysicalTenantContext.currentOrNull())
+            .withPhysicalTenant(PhysicalTenantContext.current())
             .resolveResourceAccess(authentication, COMPONENT_ACCESS_AUTHORIZATION);
     if (!componentAccess.allowed()) {
       return List.of();

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -88,7 +88,7 @@ public class BasicCamundaUserService implements CamundaUserPort {
   protected List<String> getAuthorizedComponents(final CamundaAuthentication authentication) {
     final var componentAccess =
         resourceAccessProvider
-            .withPhysicalTenant(PhysicalTenantContext.currentOrNull())
+            .withPhysicalTenant(PhysicalTenantContext.current())
             .resolveResourceAccess(authentication, COMPONENT_ACCESS_AUTHORIZATION);
     if (!componentAccess.allowed()) {
       return List.of();

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -14,7 +14,6 @@ import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.user.CamundaUserDTO;
-import io.camunda.security.core.authz.ResourceAccessProvider;
 import io.camunda.security.core.port.in.CamundaUserPort;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
 import io.camunda.service.registry.ServiceRegistry;
@@ -33,12 +32,12 @@ import org.springframework.stereotype.Service;
 public class BasicCamundaUserService implements CamundaUserPort {
 
   private final CamundaAuthenticationProvider authenticationProvider;
-  private final ResourceAccessProvider resourceAccessProvider;
+  private final PhysicalTenantResourceAccessProvider resourceAccessProvider;
   private final ServiceRegistry serviceRegistry;
 
   public BasicCamundaUserService(
       final CamundaAuthenticationProvider authenticationProvider,
-      final ResourceAccessProvider resourceAccessProvider,
+      final PhysicalTenantResourceAccessProvider resourceAccessProvider,
       final ServiceRegistry serviceRegistry) {
     this.authenticationProvider = authenticationProvider;
     this.resourceAccessProvider = resourceAccessProvider;
@@ -88,8 +87,9 @@ public class BasicCamundaUserService implements CamundaUserPort {
 
   protected List<String> getAuthorizedComponents(final CamundaAuthentication authentication) {
     final var componentAccess =
-        resourceAccessProvider.resolveResourceAccess(
-            authentication, COMPONENT_ACCESS_AUTHORIZATION);
+        resourceAccessProvider
+            .withPhysicalTenant(PhysicalTenantContext.currentOrNull())
+            .resolveResourceAccess(authentication, COMPONENT_ACCESS_AUTHORIZATION);
     if (!componentAccess.allowed()) {
       return List.of();
     }

--- a/authentication/src/main/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import io.camunda.search.clients.tenant.PhysicalTenantScoped;
+import io.camunda.security.core.authz.ResourceAccessProvider;
+import java.util.Map;
+
+/**
+ * Provides the {@link ResourceAccessProvider} scoped to a given physical tenant, mirroring {@code
+ * AuthorizationCheckerProvider} and the way {@code SearchClientsProxy} is scoped via {@link
+ * PhysicalTenantScoped}.
+ *
+ * <p>The consolidated-webapp {@code /v2/authentication/me} handlers ({@code
+ * BasicCamundaUserService} and {@code AuthorizedComponentsAdapter}) resolve a user's {@code
+ * COMPONENT ACCESS} authorizations by querying a {@link ResourceAccessProvider} directly, bypassing
+ * the request-path {@code ResourceAccessController}. They obtain their provider through {@link
+ * #withPhysicalTenant(String)} so the lookup reads that tenant's own authorization storage,
+ * consistent with how the same authorizations are enforced on API requests.
+ *
+ * <p>Each per-tenant provider is backed by that tenant's own {@code AuthorizationReader}. When a
+ * tenant has no dedicated provider -- it is absent from the map, or the physical tenant could not
+ * be resolved off a request thread ({@code null}) -- {@code withPhysicalTenant} falls back to
+ * {@code defaultProvider}, the root-scoped bean.
+ */
+public record PhysicalTenantResourceAccessProvider(
+    ResourceAccessProvider defaultProvider,
+    Map<String, ResourceAccessProvider> providersByPhysicalTenant)
+    implements PhysicalTenantScoped<ResourceAccessProvider> {
+
+  @Override
+  public ResourceAccessProvider withPhysicalTenant(final String physicalTenantId) {
+    if (physicalTenantId == null) {
+      return defaultProvider;
+    }
+    return providersByPhysicalTenant.getOrDefault(physicalTenantId, defaultProvider);
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProvider.java
@@ -23,21 +23,28 @@ import java.util.Map;
  * #withPhysicalTenant(String)} so the lookup reads that tenant's own authorization storage,
  * consistent with how the same authorizations are enforced on API requests.
  *
- * <p>Each per-tenant provider is backed by that tenant's own {@code AuthorizationReader}. When a
- * tenant has no dedicated provider -- it is absent from the map, or the physical tenant could not
- * be resolved off a request thread ({@code null}) -- {@code withPhysicalTenant} falls back to
- * {@code defaultProvider}, the root-scoped bean.
+ * <p>Every configured physical tenant (including the default one) has its own provider, backed by
+ * that tenant's own {@code AuthorizationReader}. {@link #withPhysicalTenant(String)} <b>fails hard
+ * when no provider is registered for the requested tenant</b> rather than falling back to a shared
+ * default: silently resolving against another tenant's authorization storage would break tenant
+ * isolation, so an unknown (or unresolved) physical tenant is treated as a configuration error.
  */
 public record PhysicalTenantResourceAccessProvider(
-    ResourceAccessProvider defaultProvider,
     Map<String, ResourceAccessProvider> providersByPhysicalTenant)
     implements PhysicalTenantScoped<ResourceAccessProvider> {
 
   @Override
   public ResourceAccessProvider withPhysicalTenant(final String physicalTenantId) {
-    if (physicalTenantId == null) {
-      return defaultProvider;
+    final var provider =
+        physicalTenantId == null ? null : providersByPhysicalTenant.get(physicalTenantId);
+    if (provider == null) {
+      throw new IllegalStateException(
+          "No ResourceAccessProvider registered for physical tenant '"
+              + physicalTenantId
+              + "'; refusing to fall back to a shared default, as resolving authorizations against "
+              + "another tenant's storage would break tenant isolation. This indicates a "
+              + "configuration issue: the physical tenant is unknown or has no authorization source.");
     }
-    return providersByPhysicalTenant.getOrDefault(physicalTenantId, defaultProvider);
+    return provider;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -9,6 +9,7 @@ package io.camunda.authentication.config.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.service.NoDBMembershipService;
+import io.camunda.authentication.service.PhysicalTenantResourceAccessProvider;
 import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -52,6 +53,12 @@ public class OidcFlowTestContext {
   @Bean
   public ResourceAccessProvider createResourceAccessProvider() {
     return new DisabledResourceAccessProvider();
+  }
+
+  @Bean
+  public PhysicalTenantResourceAccessProvider physicalTenantResourceAccessProvider(
+      final ResourceAccessProvider resourceAccessProvider) {
+    return new PhysicalTenantResourceAccessProvider(resourceAccessProvider, Map.of());
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/OidcFlowTestContext.java
@@ -10,6 +10,7 @@ package io.camunda.authentication.config.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.service.NoDBMembershipService;
 import io.camunda.authentication.service.PhysicalTenantResourceAccessProvider;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.api.model.CamundaAuthentication;
@@ -58,7 +59,8 @@ public class OidcFlowTestContext {
   @Bean
   public PhysicalTenantResourceAccessProvider physicalTenantResourceAccessProvider(
       final ResourceAccessProvider resourceAccessProvider) {
-    return new PhysicalTenantResourceAccessProvider(resourceAccessProvider, Map.of());
+    return new PhysicalTenantResourceAccessProvider(
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, resourceAccessProvider));
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -134,7 +134,8 @@ public class WebSecurityConfigTestContext {
   @Bean
   public PhysicalTenantResourceAccessProvider physicalTenantResourceAccessProvider(
       final ResourceAccessProvider resourceAccessProvider) {
-    return new PhysicalTenantResourceAccessProvider(resourceAccessProvider, Map.of());
+    return new PhysicalTenantResourceAccessProvider(
+        Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, resourceAccessProvider));
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/WebSecurityConfigTestContext.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.config.BasicAuthBeansConfiguration;
 import io.camunda.authentication.config.OidcOverrideBeansConfiguration;
 import io.camunda.authentication.config.WebSecurityConfig;
+import io.camunda.authentication.service.PhysicalTenantResourceAccessProvider;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.search.clients.auth.DisabledResourceAccessProvider;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
@@ -29,6 +30,7 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.registry.DefaultServiceRegistry;
 import io.camunda.service.registry.ServiceRegistry;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -127,6 +129,12 @@ public class WebSecurityConfigTestContext {
   @Bean
   public ResourceAccessProvider createResourceAccessProvider() {
     return new DisabledResourceAccessProvider();
+  }
+
+  @Bean
+  public PhysicalTenantResourceAccessProvider physicalTenantResourceAccessProvider(
+      final ResourceAccessProvider resourceAccessProvider) {
+    return new PhysicalTenantResourceAccessProvider(resourceAccessProvider, Map.of());
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -76,7 +76,11 @@ public class BasicCamundaUserServiceTest {
 
     final var scopedResourceAccessProvider =
         new PhysicalTenantResourceAccessProvider(
-            resourceAccessProvider, Map.of(TENANT_A, tenantAResourceAccessProvider));
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                resourceAccessProvider,
+                TENANT_A,
+                tenantAResourceAccessProvider));
 
     basicCamundaUserService =
         new BasicCamundaUserService(

--- a/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/BasicCamundaUserServiceTest.java
@@ -26,6 +26,7 @@ import io.camunda.service.UserServices;
 import io.camunda.service.registry.DefaultServiceRegistry;
 import io.camunda.spring.utils.PhysicalTenantContext;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,7 @@ public class BasicCamundaUserServiceTest {
 
   @Mock private CamundaAuthenticationProvider authenticationProvider;
   @Mock private ResourceAccessProvider resourceAccessProvider;
+  @Mock private ResourceAccessProvider tenantAResourceAccessProvider;
   @Mock private UserServices userServices;
   @Mock private UserServices tenantAUserServices;
   @Mock private CamundaAuthentication authentication;
@@ -51,6 +53,9 @@ public class BasicCamundaUserServiceTest {
     MockitoAnnotations.openMocks(this).close();
 
     when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION)))
+        .thenReturn(ResourceAccess.allowed(COMPONENT_ACCESS_AUTHORIZATION));
+    when(tenantAResourceAccessProvider.resolveResourceAccess(
             eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION)))
         .thenReturn(ResourceAccess.allowed(COMPONENT_ACCESS_AUTHORIZATION));
 
@@ -69,9 +74,13 @@ public class BasicCamundaUserServiceTest {
                 b.userServices(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, userServices)
                     .userServices(TENANT_A, tenantAUserServices));
 
+    final var scopedResourceAccessProvider =
+        new PhysicalTenantResourceAccessProvider(
+            resourceAccessProvider, Map.of(TENANT_A, tenantAResourceAccessProvider));
+
     basicCamundaUserService =
         new BasicCamundaUserService(
-            authenticationProvider, resourceAccessProvider, serviceRegistry);
+            authenticationProvider, scopedResourceAccessProvider, serviceRegistry);
 
     RequestContextHolder.setRequestAttributes(
         new ServletRequestAttributes(new MockHttpServletRequest()));
@@ -232,5 +241,34 @@ public class BasicCamundaUserServiceTest {
 
     // then — resolved via the tenant-A user services, not the default
     assertThat(currentUser.displayName()).isEqualTo("Tenant A User");
+  }
+
+  @Test
+  void shouldRouteAuthorizedComponentsToRequestPhysicalTenant() {
+    // given a request scoped to a non-default physical tenant, whose authorization storage grants
+    // a different component than the default (root) storage
+    final var request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, TENANT_A);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    final var tenantAUser = mock(UserEntity.class);
+    when(tenantAUser.name()).thenReturn("Tenant A User");
+    when(tenantAUser.email()).thenReturn("foo@bar.com");
+    when(tenantAUserServices.getUser(eq("foo@bar.com"), any())).thenReturn(tenantAUser);
+    when(resourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION)))
+        .thenReturn(
+            ResourceAccess.allowed(
+                withRequiredAuthorization(COMPONENT_ACCESS_AUTHORIZATION, "operate")));
+    when(tenantAResourceAccessProvider.resolveResourceAccess(
+            eq(authentication), eq(COMPONENT_ACCESS_AUTHORIZATION)))
+        .thenReturn(
+            ResourceAccess.allowed(
+                withRequiredAuthorization(COMPONENT_ACCESS_AUTHORIZATION, "tasklist")));
+
+    // when
+    final var currentUser = basicCamundaUserService.getCurrentUser();
+
+    // then — resolved against tenant-A authorization storage, not the default
+    assertThat(currentUser.authorizedComponents()).containsExactly("tasklist");
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProviderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.core.authz.ResourceAccessProvider;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PhysicalTenantResourceAccessProviderTest {
+
+  @Mock private ResourceAccessProvider defaultProvider;
+  @Mock private ResourceAccessProvider tenantAProvider;
+
+  @Test
+  void shouldReturnTenantProviderForKnownTenant() {
+    // given
+    final var provider =
+        new PhysicalTenantResourceAccessProvider(
+            defaultProvider, Map.of("tenanta", tenantAProvider));
+
+    // when / then
+    assertThat(provider.withPhysicalTenant("tenanta")).isSameAs(tenantAProvider);
+  }
+
+  @Test
+  void shouldFallBackToDefaultProviderForUnknownTenant() {
+    // given
+    final var provider =
+        new PhysicalTenantResourceAccessProvider(
+            defaultProvider, Map.of("tenanta", tenantAProvider));
+
+    // when / then
+    assertThat(provider.withPhysicalTenant("tenantb")).isSameAs(defaultProvider);
+  }
+
+  @Test
+  void shouldFallBackToDefaultProviderForNullTenant() {
+    // given
+    final var provider =
+        new PhysicalTenantResourceAccessProvider(
+            defaultProvider, Map.of("tenanta", tenantAProvider));
+
+    // when / then — currentOrNull() may yield null off a request thread
+    assertThat(provider.withPhysicalTenant(null)).isSameAs(defaultProvider);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProviderTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/service/PhysicalTenantResourceAccessProviderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.security.core.authz.ResourceAccessProvider;
 import java.util.Map;
@@ -19,39 +20,38 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PhysicalTenantResourceAccessProviderTest {
 
-  @Mock private ResourceAccessProvider defaultProvider;
   @Mock private ResourceAccessProvider tenantAProvider;
 
   @Test
   void shouldReturnTenantProviderForKnownTenant() {
     // given
     final var provider =
-        new PhysicalTenantResourceAccessProvider(
-            defaultProvider, Map.of("tenanta", tenantAProvider));
+        new PhysicalTenantResourceAccessProvider(Map.of("tenanta", tenantAProvider));
 
     // when / then
     assertThat(provider.withPhysicalTenant("tenanta")).isSameAs(tenantAProvider);
   }
 
   @Test
-  void shouldFallBackToDefaultProviderForUnknownTenant() {
+  void shouldFailHardForUnknownTenant() {
     // given
     final var provider =
-        new PhysicalTenantResourceAccessProvider(
-            defaultProvider, Map.of("tenanta", tenantAProvider));
+        new PhysicalTenantResourceAccessProvider(Map.of("tenanta", tenantAProvider));
 
-    // when / then
-    assertThat(provider.withPhysicalTenant("tenantb")).isSameAs(defaultProvider);
+    // when / then — no silent fallback: an unknown tenant would break isolation, so fail hard
+    assertThatThrownBy(() -> provider.withPhysicalTenant("tenantb"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("tenantb");
   }
 
   @Test
-  void shouldFallBackToDefaultProviderForNullTenant() {
+  void shouldFailHardForNullTenant() {
     // given
     final var provider =
-        new PhysicalTenantResourceAccessProvider(
-            defaultProvider, Map.of("tenanta", tenantAProvider));
+        new PhysicalTenantResourceAccessProvider(Map.of("tenanta", tenantAProvider));
 
-    // when / then — currentOrNull() may yield null off a request thread
-    assertThat(provider.withPhysicalTenant(null)).isSameAs(defaultProvider);
+    // when / then — an unresolved physical tenant (null) is a configuration error, not a default
+    assertThatThrownBy(() -> provider.withPhysicalTenant(null))
+        .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -92,12 +92,15 @@ public class ResourceAccessControllerConfiguration {
    * {@code /v2/authentication/me} handlers to resolve {@code COMPONENT ACCESS} against the tenant
    * the request is scoped to (rather than the root-bound {@link #resourceAccessProvider} bean).
    *
+   * <p>One entry per configured physical tenant (including the default one); there is deliberately
+   * no shared-default fallback, so an unknown tenant fails hard rather than silently resolving
+   * against the wrong tenant's storage.
+   *
    * <p>Storage-agnostic: the per-tenant provider is built the same way for every secondary-storage
    * type, so unlike {@link PhysicalTenantResourceAccessControllers} it needs no storage-type split.
    */
   @Bean
   public PhysicalTenantResourceAccessProvider physicalTenantResourceAccessProvider(
-      final ResourceAccessProvider resourceAccessProvider,
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
       final PhysicalTenantSecurityProperties physicalTenantSecurityProperties) {
     final Map<String, ResourceAccessProvider> providers = new LinkedHashMap<>();
@@ -109,7 +112,7 @@ public class ResourceAccessControllerConfiguration {
                   physicalTenantSecurityProperties.propertiesByPhysicalTenant().get(tenantId);
               providers.put(tenantId, resourceAccessProviderFor(searchClientReaders, cslProps));
             });
-    return new PhysicalTenantResourceAccessProvider(resourceAccessProvider, Map.copyOf(providers));
+    return new PhysicalTenantResourceAccessProvider(Map.copyOf(providers));
   }
 
   private static ResourceAccessProvider resourceAccessProviderFor(

--- a/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/ResourceAccessControllerConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.search;
 
 import io.camunda.application.commons.security.PhysicalTenantSecurityProperties;
+import io.camunda.authentication.service.PhysicalTenantResourceAccessProvider;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.db.rdbms.read.security.RdbmsResourceAccessController;
@@ -19,6 +20,7 @@ import io.camunda.search.clients.auth.DisabledTenantAccessProvider;
 import io.camunda.search.clients.auth.DocumentBasedResourceAccessController;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.reader.PhysicalTenantSearchClientReaders;
+import io.camunda.search.clients.reader.SearchClientReaders;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.core.authz.ResourceAccessController;
 import io.camunda.security.core.authz.ResourceAccessProvider;
@@ -85,6 +87,40 @@ public class ResourceAccessControllerConfiguration {
         RdbmsResourceAccessController::new);
   }
 
+  /**
+   * The {@link ResourceAccessProvider} scoped per physical tenant, consumed by the consolidated
+   * {@code /v2/authentication/me} handlers to resolve {@code COMPONENT ACCESS} against the tenant
+   * the request is scoped to (rather than the root-bound {@link #resourceAccessProvider} bean).
+   *
+   * <p>Storage-agnostic: the per-tenant provider is built the same way for every secondary-storage
+   * type, so unlike {@link PhysicalTenantResourceAccessControllers} it needs no storage-type split.
+   */
+  @Bean
+  public PhysicalTenantResourceAccessProvider physicalTenantResourceAccessProvider(
+      final ResourceAccessProvider resourceAccessProvider,
+      final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
+      final PhysicalTenantSecurityProperties physicalTenantSecurityProperties) {
+    final Map<String, ResourceAccessProvider> providers = new LinkedHashMap<>();
+    physicalTenantSearchClientReaders
+        .readersByPhysicalTenant()
+        .forEach(
+            (tenantId, searchClientReaders) -> {
+              final var cslProps =
+                  physicalTenantSecurityProperties.propertiesByPhysicalTenant().get(tenantId);
+              providers.put(tenantId, resourceAccessProviderFor(searchClientReaders, cslProps));
+            });
+    return new PhysicalTenantResourceAccessProvider(resourceAccessProvider, Map.copyOf(providers));
+  }
+
+  private static ResourceAccessProvider resourceAccessProviderFor(
+      final SearchClientReaders searchClientReaders,
+      final CamundaSecurityLibraryProperties cslProps) {
+    final var checker = AuthorizationCheckerFactory.forPhysicalTenant(searchClientReaders);
+    return cslProps.getAuthorizations().isEnabled()
+        ? new DefaultResourceAccessProvider(checker)
+        : new DisabledResourceAccessProvider();
+  }
+
   private static PhysicalTenantResourceAccessControllers buildPerTenantControllers(
       final PhysicalTenantSearchClientReaders physicalTenantSearchClientReaders,
       final PhysicalTenantSecurityProperties physicalTenantSecurityProperties,
@@ -98,12 +134,8 @@ public class ResourceAccessControllerConfiguration {
             (tenantId, searchClientReaders) -> {
               final var cslProps =
                   physicalTenantSecurityProperties.propertiesByPhysicalTenant().get(tenantId);
-              final var checker =
-                  AuthorizationCheckerFactory.forPhysicalTenant(searchClientReaders);
               final ResourceAccessProvider provider =
-                  cslProps.getAuthorizations().isEnabled()
-                      ? new DefaultResourceAccessProvider(checker)
-                      : new DisabledResourceAccessProvider();
+                  resourceAccessProviderFor(searchClientReaders, cslProps);
               final ResourceAccessController resourceAccessController =
                   controllerFactory.apply(provider, tenantAccessProvider);
               controllers.put(

--- a/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -195,11 +196,12 @@ public class ResourceAccessControllerConfigurationTest {
                 final var provider = context.getBean(PhysicalTenantResourceAccessProvider.class);
                 assertThat(provider.providersByPhysicalTenant())
                     .containsOnlyKeys("tenanta", "tenantb");
-                // each tenant resolves to its own provider, absent tenants fall back to the default
+                // each tenant resolves to its own provider; an unknown tenant fails hard rather
+                // than silently falling back (which would break tenant isolation)
                 assertThat(provider.withPhysicalTenant("tenanta"))
                     .isSameAs(provider.providersByPhysicalTenant().get("tenanta"));
-                assertThat(provider.withPhysicalTenant("absent"))
-                    .isSameAs(provider.defaultProvider());
+                assertThatThrownBy(() -> provider.withPhysicalTenant("absent"))
+                    .isInstanceOf(IllegalStateException.class);
               });
     }
   }

--- a/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/search/ResourceAccessControllerConfigurationTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.application.commons.security.CamundaSecurityConfiguration;
 import io.camunda.application.commons.security.PhysicalTenantSecurityProperties;
+import io.camunda.authentication.service.PhysicalTenantResourceAccessProvider;
 import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.search.clients.auth.DefaultTenantAccessProvider;
@@ -182,6 +183,23 @@ public class ResourceAccessControllerConfigurationTest {
                     .containsOnlyKeys("tenanta", "tenantb");
                 assertThat(controllers.controllersByPhysicalTenant().values())
                     .allSatisfy(c -> assertThat(c).isInstanceOf(ResourceAccessController.class));
+              });
+    }
+
+    @Test
+    void shouldContainScopedResourceAccessProviderForEachPhysicalTenant() {
+      twoTenantRunner("elasticsearch")
+          .run(
+              context -> {
+                assertThat(context).hasSingleBean(PhysicalTenantResourceAccessProvider.class);
+                final var provider = context.getBean(PhysicalTenantResourceAccessProvider.class);
+                assertThat(provider.providersByPhysicalTenant())
+                    .containsOnlyKeys("tenanta", "tenantb");
+                // each tenant resolves to its own provider, absent tenants fall back to the default
+                assertThat(provider.withPhysicalTenant("tenanta"))
+                    .isSameAs(provider.providersByPhysicalTenant().get("tenanta"));
+                assertThat(provider.withPhysicalTenant("absent"))
+                    .isSameAs(provider.defaultProvider());
               });
     }
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -207,12 +207,6 @@ class ApplicationAuthorizationIT {
   }
 
   @Test
-  @DisabledIfSystemProperty(
-      named = "test.integration.camunda.physical-tenant",
-      matches = ".+",
-      disabledReason =
-          "authorizedComponents is resolved against root storage under a physical tenant, "
-              + "see https://github.com/camunda/camunda/issues/58393")
   void meContainsComponentUserSpecificAuthorizations(
       @Authenticated(RESTRICTED) final CamundaClient restrictedClient)
       throws IOException, URISyntaxException, InterruptedException {


### PR DESCRIPTION
## Description

Under a physical tenant, `GET /v2/authentication/me` returned an empty `authorizedComponents` list even when the user held `COMPONENT ACCESS` authorizations in that tenant — while the very same authorizations are enforced correctly on API requests.

The `/me` handlers resolved the component list through the single, root-bound `ResourceAccessProvider` bean, whereas the user lookup (`serviceRegistry.userServices(current())`) and request-path enforcement (per-PT `ResourceAccessController`s) are already physical-tenant scoped. So the component list was read from root storage, where the physical tenant's authorizations do not live.

Two handlers shared this bug: `BasicCamundaUserService` (basic auth) and `AuthorizedComponentsAdapter` (the OIDC bridge for CSL's `AuthorizedComponentsPort`). The issue only surfaced the basic-auth path; both are fixed here.

## Approach

Same pattern as #58635, applied at the `ResourceAccessProvider` layer:

- New `PhysicalTenantResourceAccessProvider` — a `PhysicalTenantScoped<ResourceAccessProvider>` holding one provider per configured physical tenant (including the default), each built from that tenant's own `AuthorizationReader`. Built in `ResourceAccessControllerConfiguration`, which is gated on secondary storage being enabled, so the map is always populated.
- **No silent default fallback.** `withPhysicalTenant(id)` fails hard (throws `IllegalStateException`) for an unknown or unresolved (`null`) physical tenant, rather than resolving against another tenant's storage — that would reintroduce the very isolation leak this PR fixes. A tenant present in the resolver but missing from the map is treated as a configuration error. (Updated after review — an earlier revision fell back to a default; see the thread.)
- Both `/me` handlers resolve the provider via `PhysicalTenantContext.current()` (a physical tenant is mandatory here, consistent with the user lookup), not `currentOrNull()`.
- Scoping at the `ResourceAccessProvider` layer (not the bare `AuthorizationChecker`) preserves the per-tenant authorizations-enabled/disabled decision: a tenant with authorizations disabled keeps its `DisabledResourceAccessProvider` (wildcard) semantics.

## Testing

- `PhysicalTenantResourceAccessProviderTest` — resolution for a known tenant; fail-hard for an unknown tenant and for `null`.
- `BasicCamundaUserServiceTest` — new case asserting `/me` resolves component access against the request's PT storage, not the default.
- `ResourceAccessControllerConfigurationTest` — the scoped bean is wired with one provider per PT and fails hard for an unknown tenant.
- Re-enables `ApplicationAuthorizationIT#meContainsComponentUserSpecificAuthorizations` under physical tenants (previously excluded). Runs in the *Physical Tenant Acceptance Tests* CI job — not runnable locally without an ES + PT harness.

Closes #58393

🤖 Generated with [Claude Code](https://claude.com/claude-code)