### PR TITLE
ci: Make it possible to manually select the target branch to run the FE SBOM scan

### DIFF
--- a/.github/actions/frontend-sbom-snyk/action.yml
+++ b/.github/actions/frontend-sbom-snyk/action.yml
@@ -87,29 +87,6 @@ runs:
         test -f "${{ inputs.sbom-file }}"
         printf 'Using SBOM for %s: %s\n' "${{ inputs.project-name }}" "${{ inputs.sbom-file }}"
 
-    - name: Normalize CycloneDX specVersion for Snyk compatibility
-      shell: bash
-      run: |
-        # Snyk's `sbom test` CLI only decodes CycloneDX 1.4/1.5/1.6
-        # (https://docs.snyk.io/developer-tools/snyk-cli/commands/sbom-test). SBOM generators
-        # (e.g. rollup-plugin-sbom v4+) can default to newer spec versions Snyk can't parse yet.
-        # Normalize the emitted specVersion here, centrally, instead of relying on every
-        # frontend's own build config to pin it.
-        sbomFile="${{ inputs.sbom-file }}"
-        specVersion="$(jq -r '.specVersion' "${sbomFile}")"
-
-        case "${specVersion}" in
-          1.4 | 1.5 | 1.6)
-            printf 'SBOM specVersion %s is already Snyk-compatible for %s, leaving as-is.\n' "${specVersion}" "${{ inputs.project-name }}"
-            ;;
-          *)
-            printf 'SBOM specVersion %s for %s is not supported by Snyk (needs 1.4/1.5/1.6); rewriting to 1.6.\n' "${specVersion}" "${{ inputs.project-name }}"
-            echo "::warning title=SBOM specVersion normalized::${{ inputs.project-name }} generated CycloneDX specVersion ${specVersion}, which Snyk's sbom test does not support (needs 1.4/1.5/1.6). Rewriting to 1.6 — check if the SBOM generator's default changed again."
-            jq '.specVersion = "1.6"' "${sbomFile}" > "${sbomFile}.tmp"
-            mv "${sbomFile}.tmp" "${sbomFile}"
-            ;;
-        esac
-
     - name: Scan SBOM with Snyk
       shell: bash
       env:

--- a/.github/workflows/frontend-sbom-snyk-nightly.yml
+++ b/.github/workflows/frontend-sbom-snyk-nightly.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Snyk token from Vault
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Snyk token from Vault
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Snyk token from Vault
@@ -184,7 +184,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: "Parse pom.xml for versions"
@@ -243,7 +243,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
         with:
-          ref: ${{ inputs.branch || github.ref }}
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Slack token from Vault

--- a/.github/workflows/frontend-sbom-snyk-nightly.yml
+++ b/.github/workflows/frontend-sbom-snyk-nightly.yml
@@ -8,7 +8,13 @@ name: Frontend SBOM Snyk Nightly
 on:
   schedule:
     - cron: '0 3 * * *' # 03:00 UTC daily
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to scan
+        required: true
+        default: main
+        type: string
 
 defaults:
   run:
@@ -36,6 +42,8 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@0c642f6720ab5e9931633fd93b49ac8c767c34e3 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Snyk token from Vault
@@ -80,6 +88,8 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@0c642f6720ab5e9931633fd93b49ac8c767c34e3 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Snyk token from Vault
@@ -125,6 +135,8 @@ jobs:
       - uses: camunda/infra-global-github-actions/start-build-monitor@0c642f6720ab5e9931633fd93b49ac8c767c34e3 # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Snyk token from Vault
@@ -171,6 +183,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: "Parse pom.xml for versions"
@@ -228,6 +242,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1
+        with:
+          ref: ${{ inputs.branch || github.ref }}
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - name: Import Slack token from Vault

--- a/identity/client/vite.config.ts
+++ b/identity/client/vite.config.ts
@@ -33,7 +33,15 @@ const plugins: PluginOption[] = [
 export default defineConfig(
   ({ mode }): UserConfig => ({
     base: "",
-    plugins: mode === "sbom" ? [...plugins, sbom()] : plugins,
+    plugins:
+      mode === "sbom"
+        ? [
+            ...plugins,
+            sbom({
+              specVersion: "1.6",
+            }),
+          ]
+        : plugins,
     resolve: {
       tsconfigPaths: true,
     },

--- a/operate/client/vite.config.ts
+++ b/operate/client/vite.config.ts
@@ -38,7 +38,15 @@ function getReporters(): Pick<
 
 export default defineConfig(({mode}) => ({
   base: mode === 'production' ? './' : undefined,
-  plugins: mode === 'sbom' ? [...plugins, sbom()] : plugins,
+  plugins:
+    mode === 'sbom'
+      ? [
+          ...plugins,
+          sbom({
+            specVersion: '1.6',
+          }),
+        ]
+      : plugins,
   preview: {
     port: 3003,
     open: false,

--- a/optimize/client/vite.config.ts
+++ b/optimize/client/vite.config.ts
@@ -54,7 +54,7 @@ export default defineConfig(({mode}) => ({
       },
     },
   },
-  plugins: mode === 'sbom' ? [...plugins, sbom() as PluginOption] : plugins,
+  plugins: mode === 'sbom' ? [...plugins, sbom({specVersion: '1.6'}) as PluginOption] : plugins,
   optimizeDeps: {
     force: true,
     rolldownOptions: {

--- a/tasklist/client/vite.config.ts
+++ b/tasklist/client/vite.config.ts
@@ -20,7 +20,7 @@ const outDir = 'build';
 
 export default defineConfig(({mode}) => ({
   base: mode === 'production' ? './' : undefined,
-  plugins: mode === 'sbom' ? [...plugins, sbom()] : plugins,
+  plugins: mode === 'sbom' ? [...plugins, sbom({specVersion: '1.6'})] : plugins,
   preview: {
     port: 3003,
     open: false,

--- a/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/vite.config.ts
@@ -54,7 +54,7 @@ const config = defineConfig(({mode}) => ({
 			'#/admin': path.resolve(__dirname, './src/admin'),
 		},
 	},
-	plugins: mode === 'sbom' ? [...basePlugins, sbom()] : basePlugins,
+	plugins: mode === 'sbom' ? [...basePlugins, sbom({specVersion: '1.6'})] : basePlugins,
 	server: {
 		port: 3000,
 		open: true,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Make it possible to manually select the target branch to run the FE SBOM scan so it's easier debug and fix CVEs
Also replaces the custom script to convert the CycloneDX version instead of just pinning the versions