### PR TITLE
fix: fail hard on unknown physical tenant in AuthorizationCheckerProvider

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/AuthorizationCheckerProvider.java
@@ -21,10 +21,14 @@ import java.util.Map;
  * sharing the single default-tenant-pinned bean.
  *
  * <p>Each per-tenant checker is backed by that tenant's own {@link
- * io.camunda.search.clients.reader.AuthorizationReader}. When there is no dedicated checker for a
- * tenant -- either because secondary storage is disabled (there is exactly one authorization source
- * cluster-wide) or because a tenant is absent from the map -- {@code withPhysicalTenant} falls back
- * to {@code defaultChecker}.
+ * io.camunda.search.clients.reader.AuthorizationReader}.
+ *
+ * <p>When secondary storage is disabled there are no per-tenant checkers at all ({@code
+ * checkersByPhysicalTenant} is empty) and there is exactly one authorization source cluster-wide,
+ * so {@code withPhysicalTenant} resolves every tenant to {@code defaultChecker}. Once per-tenant
+ * checkers exist, however, an unknown physical tenant is <b>a configuration error rather than a
+ * default</b>: {@code withPhysicalTenant} fails hard instead of silently resolving against another
+ * tenant's authorization storage (which would break tenant isolation).
  */
 public record AuthorizationCheckerProvider(
     AuthorizationChecker defaultChecker, Map<String, AuthorizationChecker> checkersByPhysicalTenant)
@@ -32,6 +36,20 @@ public record AuthorizationCheckerProvider(
 
   @Override
   public AuthorizationChecker withPhysicalTenant(final String physicalTenantId) {
-    return checkersByPhysicalTenant.getOrDefault(physicalTenantId, defaultChecker);
+    if (checkersByPhysicalTenant.isEmpty()) {
+      // secondary storage disabled: one authorization source cluster-wide, no per-tenant checkers
+      return defaultChecker;
+    }
+    final var checker =
+        physicalTenantId == null ? null : checkersByPhysicalTenant.get(physicalTenantId);
+    if (checker == null) {
+      throw new IllegalStateException(
+          "No AuthorizationChecker registered for physical tenant '"
+              + physicalTenantId
+              + "'; refusing to fall back to a shared default, as resolving authorizations against "
+              + "another tenant's storage would break tenant isolation. This indicates a "
+              + "configuration issue: the physical tenant is unknown or has no authorization source.");
+    }
+    return checker;
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/service/CamundaServicesConfigurationTest.java
@@ -187,39 +187,22 @@ class CamundaServicesConfigurationTest {
   }
 
   @Test
-  void shouldFallBackToSharedAuthorizationCheckerForTenantMissingFromPerTenantCheckers() {
-    // given: the provider only has a per-tenant checker for tenantA -- tenantB is missing, e.g.
-    // config drift between PhysicalTenantResolver and the per-tenant checkers.
+  void shouldFailHardWhenAPhysicalTenantIsMissingFromPerTenantCheckers() {
+    // given: config drift -- both tenants exist in the resolver, but the provider only has a
+    // per-tenant checker for tenantA (tenantB is missing). tenantB must not silently resolve
+    // against another tenant's authorization storage.
     final var checkerA = mock(AuthorizationChecker.class);
-    when(checkerA.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Set.of(PermissionType.CREATE));
-    when(sharedAuthorizationChecker.collectPermissionTypes(any(), any(), any()))
-        .thenReturn(Set.of(PermissionType.CREATE));
-    final var registry =
-        buildRegistry(
-            twoTenants(),
-            new AuthorizationCheckerProvider(
-                sharedAuthorizationChecker, Map.of(TENANT_A, checkerA)));
 
-    // when / then: tenantA uses its own checker, present in the map.
-    assertThat(
-            registry
-                .documentServices(TENANT_A)
-                .createDocumentBatch(List.of(), authentication)
-                .join())
-        .isEmpty();
-    verify(checkerA).collectPermissionTypes(any(), any(), any());
-    verifyNoInteractions(sharedAuthorizationChecker);
-
-    // when / then: tenantB, missing from the map, falls back to the shared checker without
-    // NPE-ing, instead of failing the whole tenant.
-    assertThat(
-            registry
-                .documentServices(TENANT_B)
-                .createDocumentBatch(List.of(), authentication)
-                .join())
-        .isEmpty();
-    verify(sharedAuthorizationChecker).collectPermissionTypes(any(), any(), any());
+    // when / then: wiring the registry fails hard for the missing tenant rather than falling back
+    // to the shared default checker.
+    assertThatThrownBy(
+            () ->
+                buildRegistry(
+                    twoTenants(),
+                    new AuthorizationCheckerProvider(
+                        sharedAuthorizationChecker, Map.of(TENANT_A, checkerA))))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining(TENANT_B);
   }
 
   private static Map<String, Camunda> twoTenants() {


### PR DESCRIPTION
## Description

Follow-up to #58635, applying the same fail-hard fix landed for the `/me` resource-access provider in #58754 (see [this review comment](https://github.com/camunda/camunda/pull/58754#discussion_r3655951704)).

`AuthorizationCheckerProvider.withPhysicalTenant` used `getOrDefault(physicalTenantId, defaultChecker)`, silently falling back to the shared, default-tenant-pinned checker for any physical tenant absent from the per-tenant map. Once per-tenant checkers exist, that resolves a request's authorization against **another tenant's** storage — the same isolation leak. A tenant present in `PhysicalTenantResolver` but missing from the checker map is configuration drift, not an expected default.

## Change

- When the per-tenant map is populated, an unknown (or `null`) physical tenant throws `IllegalStateException` rather than falling back.
- The genuine no-per-tenant-checkers case is preserved: when secondary storage is disabled the map is empty and there is exactly one authorization source cluster-wide, so every tenant still resolves to `defaultChecker`. This empty-map carve-out is the one deliberate difference from #58754's `PhysicalTenantResourceAccessProvider` (which is gated on secondary storage being enabled, so its map is always populated and it has no default at all).

## Testing

`CamundaServicesConfigurationTest`: the config-drift case now asserts the registry fails hard while wiring the tenant missing from the checker map; the empty-map (secondary-storage-disabled) fallback case is unchanged.

## Audit

While here I checked the other per-physical-tenant scoping seams for the same smell:
- `PhysicalTenantScopedPersistentWebSessionClient.withPhysicalTenant` — already fails hard. ✅
- `ServiceRegistry` accessors — already throw `IllegalArgumentException` for an unknown tenant. ✅
- `SecretStoreRegistries.forPhysicalTenant` — returns an empty registry (`NO_STORES`), i.e. a per-tenant "no stores configured" default, not another tenant's data, so no cross-tenant leak. Left as-is.

## Related

- Follow-up to #58635; sibling of #58754

🤖 Generated with [Claude Code](https://claude.com/claude-code)