### PR TITLE
feat: expose each partition's desired leader in the topology

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.SortedMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
@@ -421,6 +422,19 @@ public record CurrentClusterConfiguration(
 
   public @Nullable PartitionGroupConfiguration partitionGroup(final String groupId) {
     return partitionGroups.get(groupId);
+  }
+
+  /**
+   * Returns the desired leader of every partition in the cluster, grouped by partition group id.
+   * Partition ids are unique only within a group, so the outer group-id key is required to
+   * disambiguate them. See {@link PartitionGroupConfiguration#desiredLeaders()} for how the
+   * per-group leaders are derived.
+   *
+   * @return the desired leaders per group, keyed by group id then by partition id
+   */
+  public Map<String, SortedMap<Integer, MemberId>> desiredLeaders() {
+    return partitionGroups.entrySet().stream()
+        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().desiredLeaders()));
   }
 
   private static PhasedChangeState toPhasedChangeState(final ClusterConfiguration legacy) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import com.google.common.collect.ImmutableSortedMap;
 import io.atomix.cluster.MemberId;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -339,6 +341,46 @@ public record PartitionGroupConfiguration(
 
   public @Nullable BrokerPartitionState getMember(final MemberId memberId) {
     return members.get(memberId);
+  }
+
+  /**
+   * Returns the <em>desired leader</em> of the given partition within this group (the broker that
+   * replicates the partition with the highest {@link PartitionState#priority() priority}).
+   *
+   * @param partitionId the partition id, unique only within this group
+   * @return the desired leader, or empty if no broker in this group replicates the partition
+   */
+  public Optional<MemberId> getDesiredLeader(final int partitionId) {
+    return members.entrySet().stream()
+        .map(
+            entry -> {
+              final PartitionState partition = entry.getValue().getPartition(partitionId);
+              return partition == null ? null : Map.entry(entry.getKey(), partition);
+            })
+        .filter(Objects::nonNull)
+        .max(
+            Comparator.<Entry<MemberId, PartitionState>>comparingInt(
+                    entry -> entry.getValue().priority())
+                .thenComparing(Entry::getKey, MemberId.ID_COMPARATOR.reversed()))
+        .map(Entry::getKey);
+  }
+
+  /**
+   * Returns the desired leader of every partition in this group, keyed by partition id. A partition
+   * is present iff at least one broker in the group replicates it.
+   *
+   * @return the desired leaders, keyed by partition id in ascending order
+   */
+  public SortedMap<Integer, MemberId> desiredLeaders() {
+    final SortedMap<Integer, MemberId> leaders = new TreeMap<>();
+    members.values().stream()
+        .flatMap(broker -> broker.partitions().keySet().stream())
+        .distinct()
+        .forEach(
+            partitionId ->
+                getDesiredLeader(partitionId)
+                    .ifPresent(leader -> leaders.put(partitionId, leader)));
+    return leaders;
   }
 
   private PartitionGroupConfiguration withMembers(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -52,6 +52,14 @@ class CurrentClusterConfigurationTest {
         1, Instant.EPOCH, Map.of(partitionId, partition()), Mode.PROCESSING);
   }
 
+  private static BrokerPartitionState brokerPartition(final int partitionId, final int priority) {
+    return new BrokerPartitionState(
+        1,
+        Instant.EPOCH,
+        Map.of(partitionId, PartitionState.active(priority, DynamicPartitionConfig.init())),
+        Mode.PROCESSING);
+  }
+
   private static PartitionGroupConfiguration group(
       final long version, final Map<MemberId, BrokerPartitionState> members) {
     return new PartitionGroupConfiguration(
@@ -808,6 +816,47 @@ class CurrentClusterConfigurationTest {
       assertThatThrownBy(
               () -> new CurrentClusterConfiguration(0, GlobalConfiguration.init(), Map.of(), null))
           .isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class DesiredLeaders {
+
+    @Test
+    void shouldExposeDesiredLeaderPerGroupAndPartition() {
+      // given
+      final var groupA =
+          group(
+              1,
+              Map.of(
+                  MEMBER_0, brokerPartition(1, 1),
+                  MEMBER_1, brokerPartition(1, 3)));
+      final var groupB =
+          group(
+              1,
+              Map.of(
+                  MEMBER_0, brokerPartition(1, 5),
+                  MEMBER_1, brokerPartition(1, 2)));
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("group-a", groupA, "group-b", groupB),
+              PhasedChangeState.empty());
+
+      // when / then
+      final var desiredLeaders = config.desiredLeaders();
+      assertThat(desiredLeaders).containsOnlyKeys("group-a", "group-b");
+      assertThat(desiredLeaders.get("group-a")).containsExactly(Map.entry(1, MEMBER_1));
+      assertThat(desiredLeaders.get("group-b")).containsExactly(Map.entry(1, MEMBER_0));
+    }
+
+    @Test
+    void shouldReturnEmptyMapWhenNoGroups() {
+      // given
+      final var config = config(global(1, Map.of()), Map.of(), PhasedChangeState.empty());
+
+      // when / then
+      assertThat(config.desiredLeaders()).isEmpty();
     }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -25,6 +25,7 @@ class PartitionGroupConfigurationTest {
 
   private static final MemberId MEMBER_0 = MemberId.from("0");
   private static final MemberId MEMBER_1 = MemberId.from("1");
+  private static final MemberId MEMBER_2 = MemberId.from("2");
 
   private static PartitionState partition(final int priority) {
     return PartitionState.active(priority, DynamicPartitionConfig.init());
@@ -36,6 +37,13 @@ class PartitionGroupConfigurationTest {
       partitions.put(id, partition(1));
     }
     return new BrokerPartitionState(version, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  private static BrokerPartitionState brokerWithPriorities(
+      final Map<Integer, Integer> partitionPriorities) {
+    final Map<Integer, PartitionState> partitions = new HashMap<>();
+    partitionPriorities.forEach((id, priority) -> partitions.put(id, partition(priority)));
+    return new BrokerPartitionState(1, Instant.EPOCH, partitions, Mode.PROCESSING);
   }
 
   private static PartitionGroupConfiguration group(
@@ -554,6 +562,72 @@ class PartitionGroupConfigurationTest {
 
       // when / then
       assertThat(config.cancelPendingChanges()).isSameAs(config);
+    }
+  }
+
+  @Nested
+  class DesiredLeader {
+
+    @Test
+    void shouldReturnHighestPriorityBrokerAsDesiredLeader() {
+      // given
+      final var config =
+          group(
+              1,
+              Map.of(
+                  MEMBER_0, brokerWithPriorities(Map.of(1, 1)),
+                  MEMBER_1, brokerWithPriorities(Map.of(1, 3)),
+                  MEMBER_2, brokerWithPriorities(Map.of(1, 2))));
+
+      // when / then
+      assertThat(config.getDesiredLeader(1)).contains(MEMBER_1);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoBrokerReplicatesPartition() {
+      // given
+      final var config = group(1, Map.of(MEMBER_0, brokerWithPriorities(Map.of(1, 1))));
+
+      // when / then
+      assertThat(config.getDesiredLeader(2)).isEmpty();
+    }
+
+    @Test
+    void shouldBreakPriorityTiesDeterministicallyByMemberId() {
+      // given
+      final var config =
+          group(
+              1,
+              Map.of(
+                  MEMBER_1, brokerWithPriorities(Map.of(1, 5)),
+                  MEMBER_0, brokerWithPriorities(Map.of(1, 5))));
+
+      // when / then
+      assertThat(config.getDesiredLeader(1)).contains(MEMBER_0);
+    }
+
+    @Test
+    void shouldDeriveDesiredLeaderPerPartition() {
+      // given
+      final var config =
+          group(
+              1,
+              Map.of(
+                  MEMBER_0, brokerWithPriorities(Map.of(1, 3, 2, 1)),
+                  MEMBER_1, brokerWithPriorities(Map.of(1, 1, 2, 3))));
+
+      // when / then
+      assertThat(config.desiredLeaders())
+          .containsExactly(Map.entry(1, MEMBER_0), Map.entry(2, MEMBER_1));
+    }
+
+    @Test
+    void shouldReturnEmptyDesiredLeadersWhenGroupHasNoPartitions() {
+      // given
+      final var config = group(1, Map.of());
+
+      // when / then
+      assertThat(config.desiredLeaders()).isEmpty();
     }
   }
 }


### PR DESCRIPTION
Allow retrieving the highest-priority replica per partition via the new group-based configuration.

In order to read this as part of the new coordinator to be built for Coordinated Leadership Transfer, we'll require the pending work to integrate the new config mechanism more broadly (https://github.com/camunda/camunda/issues/56018). Until then, the legacy config already exposes the information we need (`ClusterConfiguration.getPrimaryMemberForPartition()`).

Closes #56761.