### PR TITLE
ci(optimize): validate base image digest resolves before merge

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -131,6 +131,15 @@ outputs:
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
       }}
+  optimize-dockerfile-changes:
+    description: Output whether Optimize's Dockerfile-only tooling checks (hadolint, base image validation) should be run based on GitHub event and files changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-common.outputs.dockerfile-change == 'true'
+      }}
   camunda-docker-tests:
     description: Output whether Camunda Docker tests should be run based on GitHub event and files changed
     value: >-

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -16,6 +16,11 @@ on:
         description: "Set to true if Optimize back-end code was changed"
         type: boolean
         required: true
+      runDockerfileChecks:
+        description: "Set to true if optimize.Dockerfile was changed"
+        type: boolean
+        required: false
+        default: true
       use-shared-distball:
         description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
         type: boolean
@@ -31,6 +36,11 @@ on:
         description: "Set to true if Optimize back-end code was changed"
         type: boolean
         required: true
+      runDockerfileChecks:
+        description: "Set to true if optimize.Dockerfile was changed"
+        type: boolean
+        required: false
+        default: true
       use-shared-distball:
         description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
         type: boolean
@@ -312,7 +322,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   hadolint:
-    if: inputs.runBeTests
+    if: inputs.runDockerfileChecks
     name: "Tool / Dockerfile / Hadolint"
     runs-on: ubuntu-latest
     permissions: { }  # GITHUB_TOKEN unused in this job

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -355,6 +355,61 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  validate-base-image:
+    if: inputs.runDockerfileChecks
+    name: "Tool / Dockerfile / Validate Base Image"
+    runs-on: ubuntu-latest
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    timeout-minutes: 5
+    env:
+      TEST_TYPE: Tool
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          [
+            "optimize.Dockerfile",
+          ]
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@0c642f6720ab5e9931633fd93b49ac8c767c34e3 # main
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+      - name: Check for Fork
+        uses: ./.github/actions/is-fork
+        id: is-fork
+      - if: steps.is-fork.outputs.is-fork != 'true'
+        uses: ./.github/actions/setup-build
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      # Same class of check as camunda.Dockerfile gets in the docker-checks job
+      # (.github/workflows/ci.yml) via a full build; here it's a metadata-only resolve since
+      # this job never builds the image. Minimus "-dev" tags are floating and old digests get
+      # GC'd fast, so a digest pinned by Renovate can go stale before it's ever built - which for
+      # optimize.Dockerfile only happens post-merge (deploy-optimize-docker-snapshot runs only on
+      # push to main/stable, never on pull_request). Catch that here instead of on main.
+      - name: Validate base image digest is resolvable
+        if: steps.is-fork.outputs.is-fork != 'true'
+        run: |
+          set -euo pipefail
+          base_image=$(grep -m1 '^ARG BASE_IMAGE=' ${{ matrix.dockerfile }} | cut -d'"' -f2)
+          base_digest=$(grep -m1 '^ARG BASE_DIGEST=' ${{ matrix.dockerfile }} | cut -d'"' -f2)
+          echo "Resolving ${base_image}@${base_digest}"
+          docker manifest inspect "${base_image}@${base_digest}" > /dev/null
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "validate-base-image/${{ matrix.dockerfile }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   optimize-e2e-smoke:
     name: "E2E / Self-Managed (Smoke)"
     if: inputs.runFeTests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
       optimize-frontend-changes: ${{ steps.filter.outputs.optimize-frontend-changes }}
       optimize-backend-changes: ${{ steps.filter.outputs.optimize-backend-changes }}
+      optimize-dockerfile-changes: ${{ steps.filter.outputs.optimize-dockerfile-changes }}
       protobuf-changes: ${{ steps.filter.outputs.protobuf-changes }}
       openapi-changes: ${{ steps.filter.outputs.openapi-changes }}
       stable-branch-changes: ${{ steps.filter.outputs.stable-branch-changes }}
@@ -2104,7 +2105,7 @@ jobs:
       use-shared-distball: true
 
   optimize-ci:
-    if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' }}
+    if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
     name: "Optimize"
     needs: [ detect-changes, build-distball ]
     uses: ./.github/workflows/ci-optimize.yml
@@ -2115,6 +2116,7 @@ jobs:
     with:
       runFeTests: ${{ needs.detect-changes.outputs.optimize-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
+      runDockerfileChecks: ${{ needs.detect-changes.outputs.optimize-dockerfile-changes == 'true' }}
       use-shared-distball: true
 
   zeebe-ci:


### PR DESCRIPTION
## Summary

- `optimize.Dockerfile`'s pinned Minimus `BASE_IMAGE`/`BASE_DIGEST` (bumped by Renovate) was never resolved by any `pull_request` check — `hadolint` only lints syntax, and the job that actually builds this Dockerfile (`deploy-optimize-docker-snapshot` in `ci.yml`) only runs post-merge on `push` to `main`/`stable/*`.
- Minimus `-dev` tags are floating; old digests get GC'd fast, so a digest valid when Renovate pinned it can go stale before the post-merge build ever runs. This happened for real: https://github.com/camunda/camunda/actions/runs/30186066059/job/89752567290 — triggered incident `#inc-6736-unsuccessful-job-ci-deploy-optimize-docker-snapshot-on-main`, self-healed via Renovate's next digest-bump commit.
- Adds a new `validate-base-image` job to `ci-optimize.yml` that does a metadata-only `docker manifest inspect ${BASE_IMAGE}@${BASE_DIGEST}` — no build, no buildx/qemu — so a bad digest fails the merge-queue check instead of only surfacing after landing on `main`.
- Kept as its own job rather than a step in `hadolint`: a registry-resolve failure isn't a lint failure, and `hadolint` currently needs zero secrets/permissions. Bolting Vault/Minimus login onto it would misattribute failures in the Job Trends dashboard (grouped by job name).
- Mirrors the same class of check `camunda.Dockerfile` already gets via a full build in the `docker-checks` job (`.github/workflows/ci.yml`), just without paying for a full build since this job never builds the image otherwise.

Closes #58771

## Test plan

- [ ] CI green on this PR (the new `validate-base-image` job itself is the test — it resolves the currently-valid digest and should pass)
- [ ] Sanity-check failure mode locally: point `BASE_DIGEST` at a bogus sha256 temporarily and confirm `docker manifest inspect` fails fast with a clear error, then revert before merge