### PR TITLE
feat: attribute failed CI jobs to the code owner of the failing tests

### DIFF
--- a/.ci/scripts/ci/observe-build-status/resolve-failing-test-owner.sh
+++ b/.ci/scripts/ci/observe-build-status/resolve-failing-test-owner.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Resolves the owning GitHub team for the failing test classes of the current job,
+# using `.codeowners` as the source of truth (via codeowners-cli).
+#
+# This powers code-ownership-based alert attribution for auto-created CI incidents:
+# instead of always attributing a red job to its static `TEST_OWNER`, we attribute it
+# to the team that actually owns the failing tests whenever that is unambiguous.
+#
+# Strict attribution rule (see docs/monorepo-docs/ci.md, "Automatic Alert Attribution"):
+#   Prints the resolved owner on stdout ONLY when there is at least one failing test
+#   class AND every failing test class resolves to the same non-empty owner. In every
+#   other case (no failing test class, an unresolvable test class, or mixed ownership
+#   across the failing tests) it prints nothing, so the caller falls back to the job's
+#   static `TEST_OWNER`. This avoids confidently misrouting an incident to the wrong team.
+#
+# Requires: codeowners-cli on PATH, python3, jq and git. Must be run from the repository
+# root, with the test reports (TEST-*.xml) present on disk.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+
+# Reuse the FQCN -> source file -> codeowners team resolvers.
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/.ci/scripts/ci/setup-medic-lookup.sh"
+
+# Collect the distinct test classes that actually failed. The JUnit parser tags
+# flaky-but-passed retries as "flaky" and drops the passing occurrence, so filtering
+# on "failure"/"error" here excludes flaky, skipped and passing tests.
+mapfile -t failing_classes < <(
+  find . -iname 'TEST-*.xml' \
+    | python3 "${SCRIPT_DIR}/junit-test-results-to-jsonl.py" \
+    | jq -r 'select(.test_status == "failure" or .test_status == "error") | .test_class_name' \
+    | sort -u
+)
+
+# No failing test class (e.g. compile, setup or infrastructure failure) -> no attribution.
+if [[ "${#failing_classes[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+resolved_owner=""
+for fqcn in "${failing_classes[@]}"; do
+  [[ -z "${fqcn}" ]] && continue
+
+  source_file="$(resolve_test_source_file "${fqcn}")"
+  owner="$(resolve_codeowners_team "${source_file}")"
+
+  # Strict: any failing class we cannot attribute forces a fallback to the job owner.
+  if [[ -z "${owner}" ]]; then
+    exit 0
+  fi
+
+  if [[ -z "${resolved_owner}" ]]; then
+    resolved_owner="${owner}"
+  elif [[ "${resolved_owner}" != "${owner}" ]]; then
+    # Mixed ownership across the failing tests -> fall back to the job owner.
+    exit 0
+  fi
+done
+
+echo "${resolved_owner}"

--- a/.ci/scripts/ci/observe-build-status/resolve-failing-test-owner.sh
+++ b/.ci/scripts/ci/observe-build-status/resolve-failing-test-owner.sh
@@ -13,13 +13,17 @@
 #   across the failing tests) it prints nothing, so the caller falls back to the job's
 #   static `TEST_OWNER`. This avoids confidently misrouting an incident to the wrong team.
 #
-# Requires: codeowners-cli on PATH, python3, jq and git. Must be run from the repository
-# root, with the test reports (TEST-*.xml) present on disk.
+# Requires: codeowners-cli on PATH, python3, jq and git. The test reports (TEST-*.xml)
+# must be present on disk. The script resolves the repository root itself and scans from
+# there, so it is independent of the caller's working directory.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+
+# Scan from the repository root regardless of the caller's CWD, so reports are not missed.
+cd "${REPO_ROOT}"
 
 # Reuse the FQCN -> source file -> codeowners team resolvers.
 # shellcheck source=/dev/null

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -94,6 +94,27 @@ runs:
         test_results_file_path: "${{ steps.get-detailed-junit-tests.outputs.test_results_file }}"
         job_name_override: "${{ inputs.job_name }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+    ############ Resolve code owner of the failing tests (attribution) ############
+    # Only for failed jobs, only when no explicit owner was passed, and only when we
+    # are actually going to submit (secrets present). This keeps the overhead off the
+    # green path entirely.
+    - name: Setup codeowners-cli
+      if: ${{ inputs.build_status == 'failure' && inputs.user_description == '' && steps.secrets.outputs.gcloud_sa_key != '' }}
+      uses: ./.github/actions/codeowners-setup-cli
+
+    - name: Resolve code owner of failing tests
+      id: resolve-owner
+      if: ${{ inputs.build_status == 'failure' && inputs.user_description == '' && steps.secrets.outputs.gcloud_sa_key != '' }}
+      shell: bash
+      run: |
+        # Never fail the build over analytics attribution; on any hiccup fall back to TEST_OWNER.
+        resolved_owner="$(bash .ci/scripts/ci/observe-build-status/resolve-failing-test-owner.sh || true)"
+        if [[ -n "${resolved_owner}" ]]; then
+          echo "Resolved failing-test code owner: ${resolved_owner}"
+        else
+          echo "No single code owner resolved for the failing tests; falling back to the job owner (TEST_OWNER)."
+        fi
+        echo "resolved_owner=${resolved_owner}" >> "$GITHUB_OUTPUT"
    ######################## Report build result #############################
     - uses: camunda/infra-global-github-actions/submit-build-status@main
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
@@ -102,5 +123,5 @@ runs:
         build_status: "${{ inputs.build_status }}"
         build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
         user_reason: "${{ inputs.user_reason }}"
-        user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
+        user_description: "${{ inputs.user_description != '' && inputs.user_description || (steps.resolve-owner.outputs.resolved_owner != '' && steps.resolve-owner.outputs.resolved_owner || env.TEST_OWNER) }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -99,6 +99,9 @@ runs:
     # are actually going to submit (secrets present). This keeps the overhead off the
     # green path entirely.
     - name: Setup codeowners-cli
+      # Attribution is best-effort: a download/cache failure here must never fail the
+      # action, otherwise it could drop the CI Analytics submission for the failing job.
+      continue-on-error: true
       if: ${{ inputs.build_status == 'failure' && inputs.user_description == '' && steps.secrets.outputs.gcloud_sa_key != '' }}
       uses: ./.github/actions/codeowners-setup-cli
 

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -227,6 +227,16 @@ The [`observe-build-status` action](#metrics-collection) reads this env var as t
 
 See [Metrics Collection](#metrics-collection) for the concrete `env:` snippet, including how to override per-job and how to wire matrix-driven values.
 
+##### Code-ownership-based attribution for failed jobs
+
+`TEST_OWNER` is a static, job-level label, so a job that runs tests belonging to several teams attributes all of its failures to a single owner. To route auto-created incidents to the team that actually owns the failing code, the `observe-build-status` action resolves the owner of the failing test classes from `.codeowners` when a job **fails**:
+
+1. It collects the distinct test classes that failed (from the `TEST-*.xml` reports), excluding skipped, passing and flaky-but-passed retries.
+2. Each failing class is mapped to its source file and then to its owning team via `codeowners-cli` (reusing the resolvers in `.ci/scripts/ci/setup-medic-lookup.sh`).
+3. A **strict** rule decides the submitted owner: the resolved code owner is used as `user_description` only when there is at least one failing test class **and** every failing class resolves to the **same** non-empty owner. If any failing class cannot be attributed (e.g. a compile/setup failure with no test class, or a test whose source file cannot be located) or the failing tests span **multiple** owners, it falls back to the job's `TEST_OWNER`.
+
+This keeps the job owner as a safe default — an ambiguous or unattributable failure is never confidently misrouted to the wrong team — while single-team failures are attributed to their real code owner. An explicitly provided `user_description` input still takes precedence over both. Resolution runs only on failed jobs, so the green path is unaffected.
+
 ### Legacy CI
 
 "Legacy CI" is a name for CI tests that has not been migrated to the Unified CI. Legacy tests do not meet the [inclusion criteria for Unified CI](#workflow-inclusion-criteria), such as running under 10 minutes.


### PR DESCRIPTION
## Description

Auto-created CI incidents are routed to a responsible team via the `user_description` field that `observe-build-status` submits to CI Analytics. Today that value defaults to the **static, job-level `TEST_OWNER`**, so a job running tests owned by several teams attributes *all* of its failures to a single owner — regardless of which test actually broke (e.g. `zeebe-shared-integration` lumps many teams under `@camunda/engineering-operations`).

This PR makes attribution reflect the **code ownership of the failing tests** (Option B from the design discussion):

On **job failure**, `observe-build-status` now:
1. Collects the distinct test classes that actually failed from the `TEST-*.xml` reports (excluding skipped, passing, and flaky-but-passed retries).
2. Resolves each failing class to its owning team via `.codeowners` / `codeowners-cli`, reusing the existing resolvers in `.ci/scripts/ci/setup-medic-lookup.sh`.
3. Applies a **strict rule**: the resolved code owner is submitted as `user_description` only when there is at least one failing test class **and** every failing class resolves to the **same** non-empty owner. Otherwise it falls back to the job's `TEST_OWNER`.

Fallback (i.e. keep the existing job-owner behaviour) happens when:
- there is no failing test class (compile / `@BeforeAll` / setup / infra failures);
- any failing class cannot be attributed (source file not locatable, e.g. some parametrized/dynamically-generated tests);
- the failing tests span **multiple** owners (mixed ownership).

Precedence is `explicit user_description input` → `resolved code owner` → `TEST_OWNER`.

### Why strict + fallback

Under the current incident model, incidents are grouped by base-branch + GHA job name, so there is exactly **one owner per incident**. When failures are ambiguous or span teams, guessing a "dominant" owner risks confidently misrouting an incident to the wrong team — which costs a medic's time and erodes trust in the automation. Falling back to the job owner in those cases is strictly no worse than today, while single-team failures now reach their real code owner.

### Scope / cost

- Resolution runs **only on failed jobs** and only when no explicit `user_description` was passed and analytics secrets are present, so the green path is completely unaffected.
- No changes to external infra (BigQuery schema, Grafana alerts, incident.io grouping) — this reuses the existing `user_description` field. Per-test incident *grouping* (Option A) would require those and is out of scope here.

### Changes

- `.ci/scripts/ci/observe-build-status/resolve-failing-test-owner.sh` — new script implementing the strict resolution rule.
- `.github/actions/observe-build-status/action.yml` — set up `codeowners-cli` and run the resolver on failure; feed the result into `user_description`.
- `docs/monorepo-docs/ci.md` — document the code-ownership-based attribution under "Automatic Alert Attribution".

## Checklist

- [ ] Enable backports when necessary ([for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes)).

## Related issues

<!-- No tracked issue yet; opened from a design discussion. -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01MeFyJH6i5YHzAGN9zUxp8n)_