### PR TITLE
feat: add `nodeId` label for brokers

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.gateway.RestApiCompositeFilter;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
 import io.camunda.zeebe.util.MemberIdUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.Filter;
 import java.time.Duration;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -62,6 +64,19 @@ public class BrokerBasedConfiguration {
 
   public BrokerCfg config() {
     return properties;
+  }
+
+  /**
+   * Adds a {@code nodeId} common tag to all metrics, set to the broker's member id ({@code
+   * $zone_$nodeId}, or the bare {@code $nodeId} when no zone is configured). This gives a stable,
+   * human-readable node identity in monitoring that is independent of the scrape-time {@code pod}
+   * (Kubernetes) or {@code taskId} (ECS) label, and encodes the zone when one is set.
+   */
+  @Bean
+  public MeterRegistryCustomizer<MeterRegistry> nodeIdMeterRegistryCustomizer() {
+    final var cluster = properties.getCluster();
+    final var nodeId = MemberIdUtil.memberIdString(cluster.getZone(), cluster.getNodeId());
+    return registry -> registry.config().commonTags("nodeId", nodeId);
   }
 
   public WorkingDirectory workingDirectory() {

--- a/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/configuration/BrokerBasedConfiguration.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.gateway.RestApiCompositeFilter;
 import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
 import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
 import io.camunda.zeebe.util.MemberIdUtil;
-import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.Filter;
 import java.time.Duration;
 import java.util.List;
@@ -30,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
-import org.springframework.boot.micrometer.metrics.autoconfigure.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -64,19 +62,6 @@ public class BrokerBasedConfiguration {
 
   public BrokerCfg config() {
     return properties;
-  }
-
-  /**
-   * Adds a {@code nodeId} common tag to all metrics, set to the broker's member id ({@code
-   * $zone_$nodeId}, or the bare {@code $nodeId} when no zone is configured). This gives a stable,
-   * human-readable node identity in monitoring that is independent of the scrape-time {@code pod}
-   * (Kubernetes) or {@code taskId} (ECS) label, and encodes the zone when one is set.
-   */
-  @Bean
-  public MeterRegistryCustomizer<MeterRegistry> nodeIdMeterRegistryCustomizer() {
-    final var cluster = properties.getCluster();
-    final var nodeId = MemberIdUtil.memberIdString(cluster.getZone(), cluster.getNodeId());
-    return registry -> registry.config().commonTags("nodeId", nodeId);
   }
 
   public WorkingDirectory workingDirectory() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenerCfg;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenersCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
+import io.camunda.zeebe.broker.system.monitoring.BrokerRootMetrics;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.engine.processing.globallistener.GlobalListenerValidator;
@@ -64,6 +65,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.TlsConfigUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -166,7 +168,10 @@ public final class SystemContext {
     this.scheduler = scheduler;
     this.cluster = cluster;
     this.brokerClient = brokerClient;
-    this.meterRegistry = meterRegistry;
+    this.meterRegistry =
+        MicrometerUtil.wrap(
+            meterRegistry, BrokerRootMetrics.rootTags(brokerCfg.getCluster().getMemberId()));
+
     this.physicalTenantContexts = Map.copyOf(physicalTenantContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.broker.Broker.LOG;
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 import static io.camunda.zeebe.util.StringUtil.sanitizeList;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.broker.system.configuration.partitioning.ZoneAwareCfg;
@@ -186,6 +187,10 @@ public final class ClusterCfg implements ConfigurationEntry {
 
   public void setNodeId(final Integer nodeId) {
     this.nodeId = nodeId;
+  }
+
+  public MemberId getMemberId() {
+    return MemberId.from(getZone(), getNodeId());
   }
 
   public int getPartitionsCount() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerRootMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerRootMetrics.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import io.atomix.cluster.MemberId;
+import io.micrometer.core.instrument.Tags;
+
+public class BrokerRootMetrics {
+  public static final String NODE_ID = "nodeId";
+
+  public static Tags rootTags(final MemberId memberId) {
+    return Tags.of(BrokerRootMetrics.NODE_ID, memberId.toString());
+  }
+}


### PR DESCRIPTION
## Description
In this PR zone related labels are added to the global `MeterRegistry` via a `MeterRegistryCustomizer`:
- `nodeId` for brokers such as `1` or `eu-west-1_`

Grafana changes will be added in a followup PR

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates  #57612
