### PR TITLE
ci: do not cancel concurrent docs deploys on `main`

### DIFF
--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -10,10 +10,11 @@ on:
       - main
   workflow_dispatch: {}
 
-# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Commplete builds for every commit needed for confidenence
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: false
   group: ${{ github.workflow }}-${{ github.ref }}
+
 
 defaults:
   run:


### PR DESCRIPTION
## Description

Cancelling GHA runs due to concurrency leads to unsuccessul builds on `main`, which we alert on since we want to achieve fully green checks. This workflow runs on GH-hosted runners so no costs -> let's run builds til completion

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) - only on `main`
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to INC-6720
