### PR TITLE
ci: load-test: align build timeouts for load test images

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -475,7 +475,7 @@ jobs:
     name: Build Starter and Worker
     if: ${{ inputs.reuse-tag == '' || inputs.orchestration-tag != '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     needs: calculate-image-tag
     permissions:
       contents: 'read'

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -143,7 +143,7 @@ jobs:
     needs: test-data
     if: ${{ inputs.reuse-tag == '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -424,11 +424,11 @@ jobs:
     permissions:
       contents: read
     with:
-      base_group_name: deploy-load-test-images
+      base_group_name: build-load-test-images
 
-  deploy-load-test-images:
-    name: Deploy load test images
-    timeout-minutes: 5
+  build-load-test-images:
+    name: Build load test Starter and Worker
+    timeout-minutes: 20
     needs: [ test-summary, utils-get-snapshot-docker-tag, utils-get-concurrency-group-for-load-test ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))


### PR DESCRIPTION
## Description

In 54cd1ee we increase the `jib:build` timeout to mitigate the impact of timeouts while pushing Docker images to Harbor. While we increased the timeouts for the image push themselves, the GitHub Actions jobs were not aligned and the job is now failing before we managed to push the Docker images: https://github.com/camunda/camunda/actions/runs/30256788496/job/89949750404
<img width="1006" height="281" alt="image" src="https://github.com/user-attachments/assets/4916ea60-a09a-4987-9705-f58f62c504c8" />


* Increase/align build timeouts to 20 minutes
  * Build timeout was increased in 54cd1ee5ceef3705b1bb6a8f726cab67608e8b65 but we are now hitting the job timeout
  * 20 minutes should be plenty enough to build the images and push them, while absorbing any very high latency on Harbor (if any)
* Align jobs names between the workflows

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://app.incident.io/camunda/incidents/6761
