### PR TITLE
fix: JSON-encode Slack payload in Statistics Weekly failed-tests job

### DIFF
--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -140,7 +140,7 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "${{ steps.message.outputs.MESSAGE }}"
+                  text: ${{ toJSON(steps.message.outputs.MESSAGE) }}
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

The `failed-tests` job of the **Statistics Weekly** workflow interpolated the BigQuery-derived message directly into a double-quoted Slack payload field:

```yaml
text: "${{ steps.message.outputs.MESSAGE }}"
```

`slackapi/slack-github-action` parses that field with `JSON.parse`, so any double quote in the message terminates the JSON string and the whole payload fails to parse — `Invalid input! Failed to parse contents of the provided payload`.

The bug was **latent**: it only triggers when a top-5 failing test name contains a quote. Scheduled runs stayed green through 2026-07-13, then failed on 07-20 and 07-27 — not because of a code change on our side, but because parameterized `TopologyControllerTest` cases with names like `... baseUrl = "/v1/topology"` entered the top-5 list and broke every scheduled run. (The action version is identical across the pass→fail boundary; the v4 bump in between was reverted for an unrelated reason.)

The fix wraps the message in `toJSON()`, which emits a correctly escaped JSON string literal robust to any character in the test names. This matches the sibling `ci-slo` job, which has always used `toJSON()` and never hit this failure.

Failing run: https://github.com/camunda/camunda/actions/runs/30244901675/job/89909692194

## Validation

- `actionlint` — clean
- `conftest` (`--rego-version v0`) — 35/35 checks pass (only the pre-existing print-metadata warning, unrelated to this change)
- Behavioral repro: reconstructed the exact multi-line message from the failing run; the old `text: "..."` form fails to parse at the embedded double quote (reproducing the CI error), the `toJSON(...)` form parses cleanly.

## Backporting

Not backported — the `schedule` trigger only fires from the default branch (`main`), so the same broken form on `stable/*` is dormant and cannot manifest there.

## Related issues

n/a — CI workflow fix