### PR TITLE
fix: reduce RocksDB MANIFEST rollover threshold

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -161,7 +161,7 @@ public final class ZeebeRocksDbFactory<
             .setAvoidFlushDuringRecovery(true)
             // limit the size of the manifest (logs all operations), otherwise it will grow
             // unbounded
-            .setMaxManifestFileSize(256 * 1024 * 1024L)
+            .setMaxManifestFileSize(32 * 1024 * 1024L)
             // keep 1 hour of logs - completely arbitrary. we should keep what we think would be
             // a good balance between useful for performance and small for replication
             .setLogFileTimeToRoll(Duration.ofMinutes(30).toSeconds())


### PR DESCRIPTION
Reduce the rollover threshold from 256MiB to 32MiB, to limit unnecessary growth of this file and associated memory usage.

Per https://github.com/facebook/rocksdb/blob/v10.10.1/include/rocksdb/options.h#L978 this isn't actually a hard limit (if the MANIFEST file _needs_ to exceed this it will), but rather a minimum for considering rollover.

Closes #58623.