### PR TITLE
feat: add dynamic retrieval of ECS task id from metadata endpoint

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
+++ b/configuration/src/main/java/io/camunda/configuration/NodeIdProvider.java
@@ -121,6 +121,12 @@ public class NodeIdProvider {
     private Optional<String> taskId = Optional.empty();
 
     /**
+     * If no taskId is explicitly configured, resolve it from the ECS task metadata endpoint. When
+     * disabled, a random taskId is generated instead of querying ECS.
+     */
+    private boolean resolveTaskId = true;
+
+    /**
      * Configure URL endpoint for the store. If no endpoint is provided, it will be determined based
      * on the configured region.
      */
@@ -220,6 +226,8 @@ public class NodeIdProvider {
           + '\''
           + ", apiCallTimeout="
           + apiCallTimeout
+          + ", resolveTaskId="
+          + resolveTaskId
           + '}';
     }
 
@@ -237,6 +245,14 @@ public class NodeIdProvider {
 
     public void setTaskId(final String taskId) {
       this.taskId = Optional.ofNullable(taskId);
+    }
+
+    public boolean isResolveTaskId() {
+      return resolveTaskId;
+    }
+
+    public void setResolveTaskId(final boolean resolveTaskId) {
+      this.resolveTaskId = resolveTaskId;
     }
 
     public Duration getLeaseAcquireMaxDelay() {

--- a/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/ClusterNodeIdProviderTest.java
@@ -46,7 +46,8 @@ public class ClusterNodeIdProviderTest {
         assertThat(cluster.getNodeIdProvider().s3())
             .returns("bucketExample", S3::getBucketName)
             .returns(Duration.ofSeconds(10), S3::getLeaseDuration)
-            .returns(Duration.ofMinutes(2), S3::getExpiredLeaseThreshold);
+            .returns(Duration.ofMinutes(2), S3::getExpiredLeaseThreshold)
+            .returns(true, S3::isResolveTaskId);
       }
     }
 
@@ -62,6 +63,7 @@ public class ClusterNodeIdProviderTest {
           "camunda.cluster.node-id-provider.s3.accessKey=myAccessKey",
           "camunda.cluster.node-id-provider.s3.secretKey=mySecretKey",
           "camunda.cluster.node-id-provider.s3.expired-lease-threshold=PT5m",
+          "camunda.cluster.node-id-provider.s3.resolve-task-id=false",
         })
     class WithAllProperties {
 
@@ -83,7 +85,8 @@ public class ClusterNodeIdProviderTest {
             .returns(Optional.of("us-east-1"), S3::getRegion)
             .returns(Optional.of("myAccessKey"), S3::getAccessKey)
             .returns(Optional.of("mySecretKey"), S3::getSecretKey)
-            .returns(Duration.ofMinutes(5), S3::getExpiredLeaseThreshold);
+            .returns(Duration.ofMinutes(5), S3::getExpiredLeaseThreshold)
+            .returns(false, S3::isResolveTaskId);
 
         assertThatThrownBy(cluster::getNodeId).isInstanceOf(IllegalStateException.class);
       }

--- a/dist/src/main/java/io/camunda/zeebe/broker/ECSTaskIdResolver.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/ECSTaskIdResolver.java
@@ -34,6 +34,14 @@ final class ECSTaskIdResolver {
 
   private ECSTaskIdResolver() {}
 
+  static Optional<String> resolve(final boolean resolveTaskId) {
+    return resolveTaskId ? resolve() : Optional.empty();
+  }
+
+  static Optional<String> resolve(final boolean resolveTaskId, final String metadataUri) {
+    return resolveTaskId ? resolve(metadataUri) : Optional.empty();
+  }
+
   static Optional<String> resolve() {
     final var metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI_V4");
     if (metadataUri == null || metadataUri.isBlank()) {

--- a/dist/src/main/java/io/camunda/zeebe/broker/ECSTaskIdResolver.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/ECSTaskIdResolver.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves the current node's task id from the ECS task metadata endpoint (v4), if the process is
+ * running as an ECS task. See <a
+ * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html">...</a>.
+ *
+ * <p>The endpoint is eventually consistent during task startup: it can refuse connections, return a
+ * 5xx, or return a 200 with the {@code TaskARN} field not yet populated. AWS guidance is to treat
+ * these as transient and retry with bounded exponential backoff. A 404 is not transient (wrong
+ * launch type or agent version) so we stop immediately.
+ */
+final class ECSTaskIdResolver {
+  private static final Logger LOG = LoggerFactory.getLogger(ECSTaskIdResolver.class);
+  private static final long RETRY_BUDGET_MILLIS = 15_000;
+  private static final long INITIAL_BACKOFF_MILLIS = 100;
+  private static final long MAX_BACKOFF_MILLIS = 2_000;
+
+  private ECSTaskIdResolver() {}
+
+  static Optional<String> resolve() {
+    final var metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI_V4");
+    if (metadataUri == null || metadataUri.isBlank()) {
+      LOG.info("Expected env var ECS_CONTAINER_METADATA_URI_V4 to be defined, but it wasn't");
+      return Optional.empty();
+    }
+    return resolve(metadataUri);
+  }
+
+  static Optional<String> resolve(final String metadataUri) {
+    return resolve(metadataUri, RETRY_BUDGET_MILLIS, INITIAL_BACKOFF_MILLIS);
+  }
+
+  static Optional<String> resolve(
+      final String metadataUri, final long retryBudgetMillis, final long initialBackoffMillis) {
+    final long deadlineMillis = System.currentTimeMillis() + retryBudgetMillis;
+    long backoffMillis = initialBackoffMillis;
+    while (true) {
+      final var attempt = tryResolve(metadataUri);
+      if (attempt.taskId().isPresent() || !attempt.retryable()) {
+        return attempt.taskId();
+      }
+      final long remaining = deadlineMillis - System.currentTimeMillis();
+      if (remaining <= 0) {
+        LOG.warn("Gave up fetching ECS task ID after {}ms", retryBudgetMillis);
+        return Optional.empty();
+      }
+      try {
+        Thread.sleep(Math.min(backoffMillis, remaining));
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return Optional.empty();
+      }
+      backoffMillis = Math.min(backoffMillis * 2, MAX_BACKOFF_MILLIS);
+    }
+  }
+
+  private static AttemptResult tryResolve(final String metadataUri) {
+    HttpURLConnection connection = null;
+    try {
+      connection = (HttpURLConnection) URI.create(metadataUri + "/task").toURL().openConnection();
+      connection.setConnectTimeout(2_000);
+      connection.setReadTimeout(2_000);
+      final int status = connection.getResponseCode();
+      if (status == HttpURLConnection.HTTP_NOT_FOUND) {
+        LOG.warn(
+            "ECS metadata endpoint returned 404; likely an unsupported launch type or agent version");
+        return AttemptResult.giveUp();
+      }
+      if (status >= 500) {
+        LOG.debug("ECS metadata endpoint returned {}, will retry", status);
+        return AttemptResult.retry();
+      }
+      if (status != HttpURLConnection.HTTP_OK) {
+        LOG.warn("ECS metadata endpoint returned unexpected status {}", status);
+        return AttemptResult.giveUp();
+      }
+      try (final var in = connection.getInputStream()) {
+        final var taskId =
+            new ObjectMapper()
+                .readTree(in)
+                .path("TaskARN")
+                .asOptional()
+                .map(JsonNode::asText)
+                .map(taskArn -> taskArn.substring(taskArn.lastIndexOf('/') + 1));
+        if (taskId.isEmpty()) {
+          LOG.debug("ECS metadata response missing TaskARN, will retry");
+          return AttemptResult.retry();
+        }
+        return new AttemptResult(taskId, false);
+      }
+    } catch (final IOException | RuntimeException e) {
+      LOG.debug("Failed to reach ECS metadata endpoint, will retry", e);
+      return AttemptResult.retry();
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+
+  private record AttemptResult(Optional<String> taskId, boolean retryable) {
+    static AttemptResult retry() {
+      return new AttemptResult(Optional.empty(), true);
+    }
+
+    static AttemptResult giveUp() {
+      return new AttemptResult(Optional.empty(), false);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfiguration.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.broker;
 
-import static io.camunda.zeebe.broker.NodeIProviderConfigurationUtils.fromBrokerCopier;
-import static io.camunda.zeebe.broker.NodeIProviderConfigurationUtils.getNodeIdProvider;
-import static io.camunda.zeebe.broker.NodeIProviderConfigurationUtils.getS3NodeIdRepository;
+import static io.camunda.zeebe.broker.NodeIdProviderConfigurationUtils.fromBrokerCopier;
+import static io.camunda.zeebe.broker.NodeIdProviderConfigurationUtils.getNodeIdProvider;
+import static io.camunda.zeebe.broker.NodeIdProviderConfigurationUtils.getS3NodeIdRepository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.atomix.cluster.AtomixCluster;

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
@@ -68,16 +69,7 @@ public class NodeIdProviderConfigurationUtils {
               throw new IllegalStateException(
                   "DynamicNodeIdProvider configured to use S3: missing s3 node id repository");
             }
-            final var taskId =
-                config
-                    .getTaskId()
-                    .or(ECSTaskIdResolver::resolve)
-                    .orElseGet(
-                        () -> {
-                          LOG.info(
-                              "Generating taskId as none was configured and it could not be fetched from ECS metadata API");
-                          return UUID.randomUUID().toString();
-                        });
+            final var taskId = resolveTaskId(config);
             log.debug("Node configured with taskId {}", taskId);
             yield new RepositoryNodeIdProvider(
                 nodeIdRepository.get(),
@@ -108,6 +100,23 @@ public class NodeIdProviderConfigurationUtils {
     }
     nodeIdProvider.initialize(brokerCount).join();
     return nodeIdProvider;
+  }
+
+  static String resolveTaskId(final S3 config) {
+    return resolveTaskId(config, ECSTaskIdResolver::resolve);
+  }
+
+  static String resolveTaskId(
+      final S3 config, final Function<Boolean, Optional<String>> ecsResolver) {
+    return config
+        .getTaskId()
+        .or(() -> ecsResolver.apply(config.isResolveTaskId()))
+        .orElseGet(
+            () -> {
+              LOG.info(
+                  "Generating taskId as none was configured and it could not be fetched from ECS metadata API");
+              return UUID.randomUUID().toString();
+            });
   }
 
   private static S3ClientConfig makeS3ClientConfig(final S3 s3) {

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.configuration.Cluster;
 import io.camunda.configuration.NodeIdProvider.S3;
 import io.camunda.configuration.Partitioning.Scheme;
@@ -73,7 +71,7 @@ public class NodeIdProviderConfigurationUtils {
             final var taskId =
                 config
                     .getTaskId()
-                    .or(NodeIdProviderConfigurationUtils::getCurrentECSTaskId)
+                    .or(ECSTaskIdResolver::resolve)
                     .orElseGet(
                         () -> {
                           LOG.info(
@@ -110,39 +108,6 @@ public class NodeIdProviderConfigurationUtils {
     }
     nodeIdProvider.initialize(brokerCount).join();
     return nodeIdProvider;
-  }
-
-  /**
-   * Derives the current node's task id from the ECS task metadata endpoint (v4), if the process is
-   * running as an ECS task. See <a
-   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html">...</a>.
-   */
-  static Optional<String> getCurrentECSTaskId() {
-    final var metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI_V4");
-    if (metadataUri == null || metadataUri.isBlank()) {
-      LOG.info("Expected env var ECS_CONTAINER_METADATA_URI_V4 to be defined, but it wasn't");
-      return Optional.empty();
-    }
-    return getCurrentECSTaskId(metadataUri);
-  }
-
-  static Optional<String> getCurrentECSTaskId(final String metadataUri) {
-    try {
-      final var connection = URI.create(metadataUri + "/task").toURL().openConnection();
-      connection.setConnectTimeout(2_000);
-      connection.setReadTimeout(2_000);
-      try (final var in = connection.getInputStream()) {
-        return new ObjectMapper()
-            .readTree(in)
-            .path("TaskARN")
-            .asOptional()
-            .map(JsonNode::asText)
-            .map(taskArn -> taskArn.substring(taskArn.lastIndexOf('/') + 1));
-      }
-    } catch (final IOException | RuntimeException e) {
-      LOG.warn("Failed to get current ECS task ID", e);
-      return Optional.empty();
-    }
   }
 
   private static S3ClientConfig makeS3ClientConfig(final S3 s3) {

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.configuration.Cluster;
 import io.camunda.configuration.NodeIdProvider.S3;
 import io.camunda.configuration.Partitioning.Scheme;
@@ -24,6 +26,7 @@ import java.time.Clock;
 import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 
 /**
@@ -31,7 +34,9 @@ import software.amazon.awssdk.regions.Region;
  *
  * <p>Used by both the broker and the restore application.
  */
-public class NodeIProviderConfigurationUtils {
+public class NodeIdProviderConfigurationUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(NodeIdProviderConfigurationUtils.class);
+
   public static S3NodeIdRepository getS3NodeIdRepository(final Cluster cluster) {
     return switch (cluster.getNodeIdProvider().getType()) {
       case FIXED -> null;

--- a/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtils.java
@@ -70,7 +70,16 @@ public class NodeIdProviderConfigurationUtils {
               throw new IllegalStateException(
                   "DynamicNodeIdProvider configured to use S3: missing s3 node id repository");
             }
-            final var taskId = config.getTaskId().orElse(UUID.randomUUID().toString());
+            final var taskId =
+                config
+                    .getTaskId()
+                    .or(NodeIdProviderConfigurationUtils::getCurrentECSTaskId)
+                    .orElseGet(
+                        () -> {
+                          LOG.info(
+                              "Generating taskId as none was configured and it could not be fetched from ECS metadata API");
+                          return UUID.randomUUID().toString();
+                        });
             log.debug("Node configured with taskId {}", taskId);
             yield new RepositoryNodeIdProvider(
                 nodeIdRepository.get(),
@@ -101,6 +110,39 @@ public class NodeIdProviderConfigurationUtils {
     }
     nodeIdProvider.initialize(brokerCount).join();
     return nodeIdProvider;
+  }
+
+  /**
+   * Derives the current node's task id from the ECS task metadata endpoint (v4), if the process is
+   * running as an ECS task. See <a
+   * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html">...</a>.
+   */
+  static Optional<String> getCurrentECSTaskId() {
+    final var metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI_V4");
+    if (metadataUri == null || metadataUri.isBlank()) {
+      LOG.info("Expected env var ECS_CONTAINER_METADATA_URI_V4 to be defined, but it wasn't");
+      return Optional.empty();
+    }
+    return getCurrentECSTaskId(metadataUri);
+  }
+
+  static Optional<String> getCurrentECSTaskId(final String metadataUri) {
+    try {
+      final var connection = URI.create(metadataUri + "/task").toURL().openConnection();
+      connection.setConnectTimeout(2_000);
+      connection.setReadTimeout(2_000);
+      try (final var in = connection.getInputStream()) {
+        return new ObjectMapper()
+            .readTree(in)
+            .path("TaskARN")
+            .asOptional()
+            .map(JsonNode::asText)
+            .map(taskArn -> taskArn.substring(taskArn.lastIndexOf('/') + 1));
+      }
+    } catch (final IOException | RuntimeException e) {
+      LOG.warn("Failed to get current ECS task ID", e);
+      return Optional.empty();
+    }
   }
 
   private static S3ClientConfig makeS3ClientConfig(final S3 s3) {

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreNodeIdProviderConfiguration.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.zeebe.restore;
 
-import static io.camunda.zeebe.broker.NodeIProviderConfigurationUtils.fromBrokerCopier;
-import static io.camunda.zeebe.broker.NodeIProviderConfigurationUtils.getNodeIdProvider;
-import static io.camunda.zeebe.broker.NodeIProviderConfigurationUtils.getS3NodeIdRepository;
+import static io.camunda.zeebe.broker.NodeIdProviderConfigurationUtils.fromBrokerCopier;
+import static io.camunda.zeebe.broker.NodeIdProviderConfigurationUtils.getNodeIdProvider;
+import static io.camunda.zeebe.broker.NodeIdProviderConfigurationUtils.getS3NodeIdRepository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.atomix.cluster.MemberId;

--- a/dist/src/test/java/io/camunda/zeebe/broker/ECSTaskIdResolverTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/ECSTaskIdResolverTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-final class NodeIdProviderConfigurationUtilsTest {
+final class ECSTaskIdResolverTest {
 
   private HttpServer server;
 
@@ -49,14 +49,14 @@ final class NodeIdProviderConfigurationUtilsTest {
     final var metadataUri = "http://localhost:" + server.getAddress().getPort();
 
     // when
-    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+    final var taskId = ECSTaskIdResolver.resolve(metadataUri);
 
     // then
     assertThat(taskId).contains("abcdef1234567890");
   }
 
   @Test
-  void shouldReturnEmptyWhenMetadataEndpointReturnsError() {
+  void shouldGiveUpWhenMetadataEndpointKeepsReturningServerError() {
     // given
     server.createContext(
         "/task",
@@ -67,14 +67,35 @@ final class NodeIdProviderConfigurationUtilsTest {
     final var metadataUri = "http://localhost:" + server.getAddress().getPort();
 
     // when
-    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+    final var taskId = ECSTaskIdResolver.resolve(metadataUri, 200, 10);
 
     // then
     assertThat(taskId).isEmpty();
   }
 
   @Test
-  void shouldReturnEmptyWhenMetadataEndpointReturnsUnexpectedBody() {
+  void shouldStopImmediatelyWhenMetadataEndpointReturnsNotFound() {
+    // given
+    final var attempts = new java.util.concurrent.atomic.AtomicInteger();
+    server.createContext(
+        "/task",
+        exchange -> {
+          attempts.incrementAndGet();
+          exchange.sendResponseHeaders(404, -1);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when
+    final var taskId = ECSTaskIdResolver.resolve(metadataUri, 5_000, 10);
+
+    // then
+    assertThat(taskId).isEmpty();
+    assertThat(attempts.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldGiveUpWhenMetadataEndpointKeepsReturningIncompleteBody() {
     // given
     server.createContext(
         "/task",
@@ -87,10 +108,40 @@ final class NodeIdProviderConfigurationUtilsTest {
     final var metadataUri = "http://localhost:" + server.getAddress().getPort();
 
     // when
-    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+    final var taskId = ECSTaskIdResolver.resolve(metadataUri, 200, 10);
 
     // then
     assertThat(taskId).isEmpty();
+  }
+
+  @Test
+  void shouldRetryUntilMetadataEndpointReturnsTaskId() {
+    // given
+    final var attempts = new java.util.concurrent.atomic.AtomicInteger();
+    server.createContext(
+        "/task",
+        exchange -> {
+          if (attempts.incrementAndGet() < 3) {
+            exchange.sendResponseHeaders(500, -1);
+            exchange.close();
+            return;
+          }
+          final var body =
+              """
+              {"TaskARN": "arn:aws:ecs:eu-central-1:123456789012:task/my-cluster/abcdef1234567890"}"""
+                  .getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when
+    final var taskId = ECSTaskIdResolver.resolve(metadataUri, 5_000, 10);
+
+    // then
+    assertThat(taskId).contains("abcdef1234567890");
+    assertThat(attempts.get()).isEqualTo(3);
   }
 
   @Test
@@ -100,7 +151,7 @@ final class NodeIdProviderConfigurationUtilsTest {
     final var metadataUri = "http://localhost:" + server.getAddress().getPort();
 
     // when
-    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+    final var taskId = ECSTaskIdResolver.resolve(metadataUri, 200, 10);
 
     // then
     assertThat(taskId).isEmpty();

--- a/dist/src/test/java/io/camunda/zeebe/broker/ECSTaskIdResolverTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/ECSTaskIdResolverTest.java
@@ -145,6 +145,55 @@ final class ECSTaskIdResolverTest {
   }
 
   @Test
+  void shouldNotQueryMetadataWhenResolveDisabled() {
+    // given a metadata endpoint that would return a valid task id
+    final var attempts = new java.util.concurrent.atomic.AtomicInteger();
+    server.createContext(
+        "/task",
+        exchange -> {
+          attempts.incrementAndGet();
+          final var body =
+              """
+              {"TaskARN": "arn:aws:ecs:eu-central-1:123456789012:task/my-cluster/abcdef1234567890"}"""
+                  .getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when resolution is disabled
+    final var taskId = ECSTaskIdResolver.resolve(false, metadataUri);
+
+    // then it returns empty without contacting the endpoint
+    assertThat(taskId).isEmpty();
+    assertThat(attempts.get()).isZero();
+  }
+
+  @Test
+  void shouldQueryMetadataWhenResolveEnabled() {
+    // given
+    server.createContext(
+        "/task",
+        exchange -> {
+          final var body =
+              """
+              {"TaskARN": "arn:aws:ecs:eu-central-1:123456789012:task/my-cluster/abcdef1234567890"}"""
+                  .getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when resolution is enabled
+    final var taskId = ECSTaskIdResolver.resolve(true, metadataUri);
+
+    // then
+    assertThat(taskId).contains("abcdef1234567890");
+  }
+
+  @Test
   void shouldReturnEmptyWhenMetadataEndpointIsUnreachable() {
     // given
     server.stop(0);

--- a/dist/src/test/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.NodeIdProvider.S3;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+final class NodeIdProviderConfigurationUtilsTest {
+
+  @Test
+  void shouldUseConfiguredTaskIdWithoutQueryingEcs() {
+    // given
+    final var config = new S3();
+    config.setTaskId("configured-task-id");
+    config.setResolveTaskId(true);
+    final var captured = new AtomicReference<Boolean>();
+    final Function<Boolean, Optional<String>> resolver =
+        flag -> {
+          captured.set(flag);
+          return Optional.of("ecs-task-id");
+        };
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.resolveTaskId(config, resolver);
+
+    // then the configured id wins and the resolver is never consulted
+    assertThat(taskId).isEqualTo("configured-task-id");
+    assertThat(captured).hasValue(null);
+  }
+
+  @Test
+  void shouldPassResolveEnabledFlagToResolverAndUseItsResult() {
+    // given
+    final var config = new S3();
+    config.setResolveTaskId(true);
+    final var captured = new AtomicReference<Boolean>();
+    final Function<Boolean, Optional<String>> resolver =
+        flag -> {
+          captured.set(flag);
+          return Optional.of("ecs-task-id");
+        };
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.resolveTaskId(config, resolver);
+
+    // then the flag is forwarded and the resolved id is used
+    assertThat(captured).hasValue(true);
+    assertThat(taskId).isEqualTo("ecs-task-id");
+  }
+
+  @Test
+  void shouldPassResolveDisabledFlagToResolverAndGenerateRandomTaskId() {
+    // given
+    final var config = new S3();
+    config.setResolveTaskId(false);
+    final var captured = new AtomicReference<Boolean>();
+    final Function<Boolean, Optional<String>> resolver =
+        flag -> {
+          captured.set(flag);
+          return Optional.empty();
+        };
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.resolveTaskId(config, resolver);
+
+    // then the disabled flag is forwarded and a random UUID is generated
+    assertThat(captured).hasValue(false);
+    assertThat(UUID.fromString(taskId)).isNotNull();
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/NodeIdProviderConfigurationUtilsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class NodeIdProviderConfigurationUtilsTest {
+
+  private HttpServer server;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+    server.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  void shouldReturnTaskIdFromMetadataEndpoint() {
+    // given
+    server.createContext(
+        "/task",
+        exchange -> {
+          final var body =
+              """
+              {"TaskARN": "arn:aws:ecs:eu-central-1:123456789012:task/my-cluster/abcdef1234567890"}"""
+                  .getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+
+    // then
+    assertThat(taskId).contains("abcdef1234567890");
+  }
+
+  @Test
+  void shouldReturnEmptyWhenMetadataEndpointReturnsError() {
+    // given
+    server.createContext(
+        "/task",
+        exchange -> {
+          exchange.sendResponseHeaders(500, -1);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+
+    // then
+    assertThat(taskId).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenMetadataEndpointReturnsUnexpectedBody() {
+    // given
+    server.createContext(
+        "/task",
+        exchange -> {
+          final var body = "{}".getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(200, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+
+    // then
+    assertThat(taskId).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenMetadataEndpointIsUnreachable() {
+    // given
+    server.stop(0);
+    final var metadataUri = "http://localhost:" + server.getAddress().getPort();
+
+    // when
+    final var taskId = NodeIdProviderConfigurationUtils.getCurrentECSTaskId(metadataUri);
+
+    // then
+    assertThat(taskId).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description
On startup, we perform a GET at the metadata v4 endpoint to fetch the ARN. The last part of the arn is the taskId of the current task. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
