### PR TITLE
ci: prevent fe sbom slack notification on workflow_dispatch

### DIFF
--- a/.github/workflows/frontend-sbom-snyk-nightly.yml
+++ b/.github/workflows/frontend-sbom-snyk-nightly.yml
@@ -238,7 +238,7 @@ jobs:
       - operate-fe-sbom-snyk
       - tasklist-fe-sbom-snyk
       - optimize-fe-sbom-snyk
-    if: always() && contains(needs.*.result, 'failure')
+    if: always() && github.event_name != 'workflow_dispatch' && contains(needs.*.result, 'failure')
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         timeout-minutes: 1


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Small follow up from https://github.com/camunda/camunda/pull/58767

This PR prevents the Slack notification when manually running the action
