### PR TITLE
feat: report commit SHA in GCP serviceContext.version

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/logging/StackdriverResolver.java
+++ b/dist/src/main/java/io/camunda/application/commons/logging/StackdriverResolver.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application.commons.logging;
 
+import java.io.IOException;
+import java.util.Properties;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.layout.template.json.resolver.EventResolver;
@@ -26,6 +28,21 @@ import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
 public final class StackdriverResolver implements EventResolver {
   private static final String ERROR_TYPE =
       "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent";
+
+  /**
+   * The abbreviated commit id of the build, read once from the {@code git.properties} that the
+   * git-commit-id Maven plugin writes onto the classpath. Empty when the metadata is unavailable.
+   */
+  private static final String COMMIT_ID = readCommitId();
+
+  /**
+   * Reports the commit id as the service version. Error Reporting uses {@code
+   * serviceContext.version} to attribute an error to a build, and a release version such as {@code
+   * 8.10.0-SNAPSHOT} is a moving target — the same tag is rebuilt from many commits — whereas the
+   * commit id identifies the revision exactly.
+   */
+  private static final EventResolver SERVICE_VERSION_RESOLVER =
+      (value, jsonWriter) -> jsonWriter.writeString(COMMIT_ID);
 
   private static final EventResolver TYPE_RESOLVER =
       new EventResolver() {
@@ -78,8 +95,22 @@ public final class StackdriverResolver implements EventResolver {
     return switch (fieldName) {
       case "type" -> TYPE_RESOLVER;
       case "reportLocation" -> REPORT_LOCATION_RESOLVER;
+      case "serviceVersion" -> SERVICE_VERSION_RESOLVER;
       default -> throw new IllegalArgumentException("unknown field: " + config);
     };
+  }
+
+  private static String readCommitId() {
+    final var properties = new Properties();
+    try (final var input =
+        StackdriverResolver.class.getClassLoader().getResourceAsStream("git.properties")) {
+      if (input != null) {
+        properties.load(input);
+      }
+    } catch (final IOException e) {
+      // best-effort: report an empty version if the build metadata cannot be read
+    }
+    return properties.getProperty("git.commit.id.abbrev", "");
   }
 
   @Override

--- a/dist/src/main/resources/logging/StackdriverLayout.json
+++ b/dist/src/main/resources/logging/StackdriverLayout.json
@@ -60,7 +60,10 @@
   },
   "serviceContext": {
     "service": "${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}",
-    "version": "${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}"
+    "version": {
+      "$resolver": "stackdriver",
+      "field": "serviceVersion"
+    }
   },
   "@type": {
     "$resolver": "stackdriver",

--- a/dist/src/test/java/io/camunda/application/commons/logging/StackdriverLayoutTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/logging/StackdriverLayoutTest.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ResourceBundle;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
@@ -31,6 +32,12 @@ final class StackdriverLayoutTest {
   private static final StackTraceElement DUMMY_LOCATION =
       new StackTraceElement("Foo", "Bar", "Foo.java", 1);
   private static final String LOG_MESSAGE = "Hello World!";
+
+  // The layout reports the build's commit id as the service version, read from the git.properties
+  // that the git-commit-id Maven plugin writes onto the classpath. It differs per build, so it is
+  // resolved here rather than hard-coded.
+  private static final String EXPECTED_SERVICE_VERSION =
+      ResourceBundle.getBundle("git").getString("git.commit.id.abbrev");
 
   private Logger logger;
   private ListAppender appender;
@@ -167,14 +174,15 @@ final class StackdriverLayoutTest {
         "function":"Foo.Bar"},%s\
         "threadContext":{"id":%d,"name":"%s","priority":%d},\
         "loggerName":"io.camunda.application.commons.logging.StackdriverLayoutTest",\
-        "serviceContext":{"service":"","version":""}}""",
+        "serviceContext":{"service":"","version":"%s"}}""",
             message.getInstant().getEpochSecond(),
             message.getInstant().getNanoOfSecond(),
             expectedSeverity,
             expectedContext == null ? "" : expectedContext + ",",
             message.getThreadId(),
             message.getThreadName(),
-            message.getThreadPriority());
+            message.getThreadPriority(),
+            EXPECTED_SERVICE_VERSION);
   }
 
   private void assertMessageMatchesWithReportLocation() {
@@ -190,14 +198,15 @@ final class StackdriverLayoutTest {
         "function":"Foo.Bar"},\
         "threadContext":{"id":%d,"name":"%s","priority":%d},\
         "loggerName":"io.camunda.application.commons.logging.StackdriverLayoutTest",\
-        "serviceContext":{"service":"","version":""},\
+        "serviceContext":{"service":"","version":"%s"},\
         "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
         "reportLocation":{"filePath":"Foo.java","functionName":"Bar","lineNumber":1}}""",
             message.getInstant().getEpochSecond(),
             message.getInstant().getNanoOfSecond(),
             message.getThreadId(),
             message.getThreadName(),
-            message.getThreadPriority());
+            message.getThreadPriority(),
+            EXPECTED_SERVICE_VERSION);
   }
 
   private void assertMessageMatchesWithException(final RuntimeException exception) {
@@ -216,7 +225,7 @@ final class StackdriverLayoutTest {
         "function":"Foo.Bar"},\
         "threadContext":{"id":%d,"name":"%s","priority":%d},\
         "loggerName":"io.camunda.application.commons.logging.StackdriverLayoutTest",\
-        "serviceContext":{"service":"","version":""},\
+        "serviceContext":{"service":"","version":"%s"},\
         "@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",\
         "exception":"""
                         .formatted(
@@ -224,7 +233,8 @@ final class StackdriverLayoutTest {
                             message.getInstant().getNanoOfSecond(),
                             message.getThreadId(),
                             message.getThreadName(),
-                            message.getThreadPriority()))
+                            message.getThreadPriority(),
+                            EXPECTED_SERVICE_VERSION))
                 + ".+\"}")
         .contains(exception.getMessage());
   }


### PR DESCRIPTION
## Description

Our GCP Stackdriver log layout (`dist/src/main/resources/logging/StackdriverLayout.json`) populates `serviceContext.version`, which GCP Error Reporting uses to attribute a logged error to a build. It was fed from the `*_LOG_STACKDRIVER_SERVICEVERSION` env vars, which deployment tooling sets to the image tag — a moving target for snapshot lines such as `8.10.0-SNAPSHOT`, since the same tag is rebuilt from many commits and so can't identify the revision an error came from.

This reports the abbreviated commit SHA instead. It's already written to `git.properties` on the classpath at build time by the `git-commit-id-maven-plugin`, so the existing `stackdriver` resolver just reads it once and serves it as the service version:

```json
"version": {
  "$resolver": "stackdriver",
  "field": "serviceVersion"
}
```

Resolving it through the existing resolver rather than a `${...}` lookup in the template is deliberate, and keeps it off the logging hot path: `JsonTemplateLayout` re-substitutes template string **values** on every log event (`EventResolverStringSubstitutor.isStable()` is hard-coded `false`), whereas `$resolver` entries are constructed once when the template is parsed. A `${...}` form would have re-resolved the constant SHA per log line; this way the per-event cost is a single `writeString` of a cached field. It also means no new Log4j2 plugin — the resolver already registered for `@type`/`reportLocation` gains one more field.

**Behavior change worth noting:** the `*_LOG_STACKDRIVER_SERVICEVERSION` env vars are no longer read by this layout, so a version configured by deployment tooling is now ignored in favour of the SHA.

Scope note: this changes the main distribution layout (`dist`). The sibling layouts for Optimize (`optimize/backend/.../OptimizeStackdriverLayout.json`) and load tests use different mechanisms and are left alone; `optimize-backend` isn't on `dist`'s classpath, so extending this to them is separate work rather than a one-liner.

### Testing
- The existing `StackdriverLayoutTest` golden-master asserts the emitted `serviceContext.version`, resolving the expected SHA from the same `git.properties`.
- Full `dist` module suite green (492 tests).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

<!-- No tracking issue; opened from an investigation into GCP logging. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)