### PR TITLE
pg/55939-per-tenant-mode-change

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.shared.management;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
@@ -74,7 +75,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestControllerEndpoint(id = "cluster")
 public class ClusterEndpoint {
   private static final Set<String> ALLOWED_QUERY_PARAMETERS =
-      Set.of("dryRun", "force", "replicationFactor", "mode");
+      Set.of("dryRun", "force", "replicationFactor", "mode", "physicalTenantId");
 
   private final ClusterConfigurationManagementRequestSender requestSender;
 
@@ -559,13 +560,18 @@ public class ClusterEndpoint {
    * endpoint will be accessible through the Management REST API.
    *
    * @param mode The requested {@link Mode} to transition the member to
+   * @param physicalTenantId The physical tenant to target; defaults to {@link
+   *     PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} if not provided
    * @param dryRun Whether to perform a dry run of the mode change
    * @return The operations to transition the member to the requested mode
    */
   @PatchMapping(path = "/mode")
   public ResponseEntity<?> updateMode(
-      @RequestParam final Mode mode, @RequestParam(defaultValue = "false") final boolean dryRun) {
-    final var request = new ModeChangeRequest(mode, dryRun);
+      @RequestParam final Mode mode,
+      @RequestParam(defaultValue = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+          final String physicalTenantId,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+    final var request = new ModeChangeRequest(physicalTenantId, mode, dryRun);
     return ClusterApiUtils.mapOperationResponse(requestSender.modeChange(request).join());
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.shared.management;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.MemberId;
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddZoneRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
@@ -21,14 +20,12 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceZoneRemoveRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
-import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
@@ -75,7 +72,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestControllerEndpoint(id = "cluster")
 public class ClusterEndpoint {
   private static final Set<String> ALLOWED_QUERY_PARAMETERS =
-      Set.of("dryRun", "force", "replicationFactor", "mode", "physicalTenantId");
+      Set.of("dryRun", "force", "replicationFactor");
 
   private final ClusterConfigurationManagementRequestSender requestSender;
 
@@ -553,26 +550,6 @@ public class ClusterEndpoint {
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }
-  }
-
-  /**
-   * This endpoint is to be used internally and as a testing tool. The complete mode transition
-   * endpoint will be accessible through the Management REST API.
-   *
-   * @param mode The requested {@link Mode} to transition the member to
-   * @param physicalTenantId The physical tenant to target; defaults to {@link
-   *     PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID} if not provided
-   * @param dryRun Whether to perform a dry run of the mode change
-   * @return The operations to transition the member to the requested mode
-   */
-  @PatchMapping(path = "/mode")
-  public ResponseEntity<?> updateMode(
-      @RequestParam final Mode mode,
-      @RequestParam(defaultValue = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
-          final String physicalTenantId,
-      @RequestParam(defaultValue = "false") final boolean dryRun) {
-    final var request = new ModeChangeRequest(physicalTenantId, mode, dryRun);
-    return ClusterApiUtils.mapOperationResponse(requestSender.modeChange(request).join());
   }
 
   /**

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -286,34 +286,6 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
-  /mode:
-    patch:
-      summary: Change cluster mode
-      description: Transitions the physical tenant's partitions between processing and recovery
-        mode. This is a non-blocking operation - the request is acknowledged once the change
-        has been accepted, before the transition itself has completed. Entering recovery mode
-        deactivates all partitions of the target physical tenant so that only a restricted set
-        of read-only operations remains available; exiting recovery mode returns it to normal
-        processing.
-      parameters:
-        - $ref: '#/components/parameters/ModeParameter'
-        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
-        - $ref: '#/components/parameters/DryRunParameter'
-      responses:
-        '202':
-          $ref: '#/components/responses/ModeChangeResponse'
-        '400':
-          $ref: 'components.yaml#/responses/InvalidRequest'
-        '409':
-          $ref: 'components.yaml#/responses/ConcurrentChangeError'
-        '500':
-          $ref: 'components.yaml#/responses/InternalError'
-        '502':
-          $ref: 'components.yaml#/responses/GatewayError'
-        '504':
-          $ref: 'components.yaml#/responses/TimeoutError'
-
-
   /zones:
     put:
       summary:
@@ -392,25 +364,6 @@ components:
       schema:
         type: integer
         format: int32
-    ModeParameter:
-      name: mode
-      description: The target cluster mode.
-      in: query
-      style: form
-      required: true
-      schema:
-        $ref: 'components.yaml#/schemas/Mode'
-    PhysicalTenantIdParameter:
-      name: physicalTenantId
-      description: The physical tenant to target. Defaults to the default physical tenant if not
-        specified.
-      in: query
-      style: form
-      required: false
-      schema:
-        type: string
-        default: default
-
   responses:
     AddBrokersResponse:
       description: Request to add a new broker is accepted.
@@ -453,10 +406,3 @@ components:
         application/json:
           schema:
             $ref: "components.yaml#/schemas/GetTopologyResponse"
-
-    ModeChangeResponse:
-      description: Request to change cluster mode is accepted.
-      content:
-        application/json:
-          schema:
-            $ref: "components.yaml#/schemas/PlannedOperationsResponse"

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -286,6 +286,34 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /mode:
+    patch:
+      summary: Change cluster mode
+      description: Transitions the physical tenant's partitions between processing and recovery
+        mode. This is a non-blocking operation - the request is acknowledged once the change
+        has been accepted, before the transition itself has completed. Entering recovery mode
+        deactivates all partitions of the target physical tenant so that only a restricted set
+        of read-only operations remains available; exiting recovery mode returns it to normal
+        processing.
+      parameters:
+        - $ref: '#/components/parameters/ModeParameter'
+        - $ref: '#/components/parameters/PhysicalTenantIdParameter'
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          $ref: '#/components/responses/ModeChangeResponse'
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
+
   /zones:
     put:
       summary:
@@ -364,6 +392,24 @@ components:
       schema:
         type: integer
         format: int32
+    ModeParameter:
+      name: mode
+      description: The target cluster mode.
+      in: query
+      style: form
+      required: true
+      schema:
+        $ref: 'components.yaml#/schemas/Mode'
+    PhysicalTenantIdParameter:
+      name: physicalTenantId
+      description: The physical tenant to target. Defaults to the default physical tenant if not
+        specified.
+      in: query
+      style: form
+      required: false
+      schema:
+        type: string
+        default: default
 
   responses:
     AddBrokersResponse:
@@ -407,3 +453,10 @@ components:
         application/json:
           schema:
             $ref: "components.yaml#/schemas/GetTopologyResponse"
+
+    ModeChangeResponse:
+      description: Request to change cluster mode is accepted.
+      content:
+        application/json:
+          schema:
+            $ref: "components.yaml#/schemas/PlannedOperationsResponse"

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -569,6 +569,14 @@ schemas:
       - LEAVING
       - RECOVERING
 
+  Mode:
+    title: Mode
+    description: The operating mode of a cluster's partitions
+    type: string
+    enum:
+      - PROCESSING
+      - RECOVERING
+
   TopologyVersion:
     title: TopologyVersion
     description: The version of the topology

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -569,14 +569,6 @@ schemas:
       - LEAVING
       - RECOVERING
 
-  Mode:
-    title: Mode
-    description: The operating mode of a cluster's partitions
-    type: string
-    enum:
-      - PROCESSING
-      - RECOVERING
-
   TopologyVersion:
     title: TopologyVersion
     description: The version of the topology

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
@@ -101,15 +102,39 @@ final class ClusterEndpointTest {
       final var endpoint = new ClusterEndpoint(sender);
       final var changeResponse =
           new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(new ModeChangeRequest(Mode.RECOVERING, false)))
+      when(sender.modeChange(
+              new ModeChangeRequest(
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, false)))
           .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
 
       // when
-      final var response = endpoint.updateMode(Mode.RECOVERING, false);
+      final var response =
+          endpoint.updateMode(Mode.RECOVERING, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, false);
 
       // then
       assertThat(response.getStatusCode().value()).isEqualTo(202);
-      verify(sender).modeChange(new ModeChangeRequest(Mode.RECOVERING, false));
+      verify(sender)
+          .modeChange(
+              new ModeChangeRequest(
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, false));
+    }
+
+    @Test
+    void shouldRequestModeChangeForGivenPhysicalTenant() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      final var changeResponse =
+          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
+      when(sender.modeChange(new ModeChangeRequest("tenant-a", Mode.RECOVERING, false)))
+          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
+
+      // when
+      final var response = endpoint.updateMode(Mode.RECOVERING, "tenant-a", false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(202);
+      verify(sender).modeChange(new ModeChangeRequest("tenant-a", Mode.RECOVERING, false));
     }
 
     @Test
@@ -119,15 +144,21 @@ final class ClusterEndpointTest {
       final var endpoint = new ClusterEndpoint(sender);
       final var changeResponse =
           new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(new ModeChangeRequest(Mode.PROCESSING, false)))
+      when(sender.modeChange(
+              new ModeChangeRequest(
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.PROCESSING, false)))
           .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
 
       // when
-      final var response = endpoint.updateMode(Mode.PROCESSING, false);
+      final var response =
+          endpoint.updateMode(Mode.PROCESSING, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, false);
 
       // then
       assertThat(response.getStatusCode().value()).isEqualTo(202);
-      verify(sender).modeChange(new ModeChangeRequest(Mode.PROCESSING, false));
+      verify(sender)
+          .modeChange(
+              new ModeChangeRequest(
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.PROCESSING, false));
     }
 
     @Test
@@ -137,14 +168,19 @@ final class ClusterEndpointTest {
       final var endpoint = new ClusterEndpoint(sender);
       final var changeResponse =
           new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(new ModeChangeRequest(Mode.RECOVERING, true)))
+      when(sender.modeChange(
+              new ModeChangeRequest(
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, true)))
           .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
 
       // when
-      endpoint.updateMode(Mode.RECOVERING, true);
+      endpoint.updateMode(Mode.RECOVERING, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, true);
 
       // then
-      verify(sender).modeChange(new ModeChangeRequest(Mode.RECOVERING, true));
+      verify(sender)
+          .modeChange(
+              new ModeChangeRequest(
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, true));
     }
   }
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -15,13 +15,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateZonePrioritiesRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
-import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
 import io.camunda.zeebe.management.cluster.UpdatePartitionDistributionRequest;
@@ -80,108 +77,6 @@ final class ClusterEndpointTest {
 
   private ClusterEndpoint createEndpoint() {
     return new ClusterEndpoint(mock(ClusterConfigurationManagementRequestSender.class));
-  }
-
-  @Nested
-  class ModeChangeEndpoint {
-    @Test
-    void shouldAllowModeQueryParameter() {
-      // given
-      final var endpoint = createEndpoint();
-      final var request = mock(HttpServletRequest.class);
-      when(request.getParameterMap()).thenReturn(Map.of("mode", new String[] {"RECOVERING"}));
-
-      // when - then
-      assertThatCode(() -> endpoint.validateRequestParameters(request)).doesNotThrowAnyException();
-    }
-
-    @Test
-    void shouldRequestModeChangeToRecovering() {
-      // given
-      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
-      final var endpoint = new ClusterEndpoint(sender);
-      final var changeResponse =
-          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(
-              new ModeChangeRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, false)))
-          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
-
-      // when
-      final var response =
-          endpoint.updateMode(Mode.RECOVERING, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, false);
-
-      // then
-      assertThat(response.getStatusCode().value()).isEqualTo(202);
-      verify(sender)
-          .modeChange(
-              new ModeChangeRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, false));
-    }
-
-    @Test
-    void shouldRequestModeChangeForGivenPhysicalTenant() {
-      // given
-      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
-      final var endpoint = new ClusterEndpoint(sender);
-      final var changeResponse =
-          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(new ModeChangeRequest("tenant-a", Mode.RECOVERING, false)))
-          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
-
-      // when
-      final var response = endpoint.updateMode(Mode.RECOVERING, "tenant-a", false);
-
-      // then
-      assertThat(response.getStatusCode().value()).isEqualTo(202);
-      verify(sender).modeChange(new ModeChangeRequest("tenant-a", Mode.RECOVERING, false));
-    }
-
-    @Test
-    void shouldRequestModeChangeToProcessing() {
-      // given
-      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
-      final var endpoint = new ClusterEndpoint(sender);
-      final var changeResponse =
-          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(
-              new ModeChangeRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.PROCESSING, false)))
-          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
-
-      // when
-      final var response =
-          endpoint.updateMode(Mode.PROCESSING, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, false);
-
-      // then
-      assertThat(response.getStatusCode().value()).isEqualTo(202);
-      verify(sender)
-          .modeChange(
-              new ModeChangeRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.PROCESSING, false));
-    }
-
-    @Test
-    void shouldPassDryRunFlagOnModeChange() {
-      // given
-      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
-      final var endpoint = new ClusterEndpoint(sender);
-      final var changeResponse =
-          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
-      when(sender.modeChange(
-              new ModeChangeRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, true)))
-          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
-
-      // when
-      endpoint.updateMode(Mode.RECOVERING, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, true);
-
-      // then
-      verify(sender)
-          .modeChange(
-              new ModeChangeRequest(
-                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Mode.RECOVERING, true));
-    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -165,15 +165,17 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
-  record ModeChangeRequest(Mode mode, boolean dryRun)
+  record ModeChangeRequest(String physicalTenantId, Mode mode, boolean dryRun)
       implements ClusterConfigurationManagementRequest {
 
-    public static ModeChangeRequest recovering(final boolean dryRun) {
-      return new ModeChangeRequest(Mode.RECOVERING, dryRun);
+    public static ModeChangeRequest recovering(
+        final String physicalTenantId, final boolean dryRun) {
+      return new ModeChangeRequest(physicalTenantId, Mode.RECOVERING, dryRun);
     }
 
-    public static ModeChangeRequest processing(final boolean dryRun) {
-      return new ModeChangeRequest(Mode.PROCESSING, dryRun);
+    public static ModeChangeRequest processing(
+        final String physicalTenantId, final boolean dryRun) {
+      return new ModeChangeRequest(physicalTenantId, Mode.PROCESSING, dryRun);
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -263,7 +263,9 @@ public final class ClusterConfigurationManagementRequestsHandler
   public ActorFuture<ClusterConfigurationChangeResponse> modeChange(
       final ModeChangeRequest modeChangeRequest) {
     return handleRequest(
-        modeChangeRequest.dryRun(), new ModeChangeRequestTransformer(modeChangeRequest.mode()));
+        modeChangeRequest.dryRun(),
+        new ModeChangeRequestTransformer(
+            modeChangeRequest.physicalTenantId(), modeChangeRequest.mode()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformer.java
@@ -21,9 +21,11 @@ import java.util.Map.Entry;
 
 public final class ModeChangeRequestTransformer implements ConfigurationChangeRequest {
 
+  private final String physicalTenantId;
   private final Mode mode;
 
-  public ModeChangeRequestTransformer(final Mode mode) {
+  public ModeChangeRequestTransformer(final String physicalTenantId, final Mode mode) {
+    this.physicalTenantId = physicalTenantId;
     this.mode = mode;
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1552,6 +1552,7 @@ public class ProtoBufSerializer
     return Requests.ModeChangeRequest.newBuilder()
         .setMode(toProtoRequestMode(modeChangeRequest.mode()))
         .setDryRun(modeChangeRequest.dryRun())
+        .setPhysicalTenantId(modeChangeRequest.physicalTenantId())
         .build()
         .toByteArray();
   }
@@ -1560,7 +1561,8 @@ public class ProtoBufSerializer
   public ModeChangeRequest decodeModeChangeRequest(final byte[] encodedRequest) {
     try {
       final var request = Requests.ModeChangeRequest.parseFrom(encodedRequest);
-      return new ModeChangeRequest(toMode(request.getMode()), request.getDryRun());
+      return new ModeChangeRequest(
+          request.getPhysicalTenantId(), toMode(request.getMode()), request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -128,6 +128,7 @@ message ExportingStateChangeRequest {
 message ModeChangeRequest {
   Mode mode = 1;
   bool dryRun = 2;
+  string physicalTenantId = 3;
 }
 
 message CancelTopologyChangeRequest {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/NewModelManagementApiEndpointsTest.java
@@ -490,7 +490,11 @@ final class NewModelManagementApiEndpointsTest {
                     Map.of(1, PartitionState.active(1, partitionConfig)))));
 
     // when — switch to recovery mode
-    handler.modeChange(new ModeChangeRequest(Mode.RECOVERING, false)).join();
+    handler
+        .modeChange(
+            new ModeChangeRequest(
+                CurrentClusterConfiguration.DEFAULT_GROUP, Mode.RECOVERING, false))
+        .join();
 
     // then — the plan is applied and the local member is now in recovery mode
     final var config = manager.getMultiConfiguration().join();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ModeChangeRequestTransformerTest.java
@@ -27,7 +27,7 @@ final class ModeChangeRequestTransformerTest {
   @Test
   void shouldGenerateRecoveringOperationsForAllActiveMembers() {
     // given
-    final var transformer = new ModeChangeRequestTransformer(Mode.RECOVERING);
+    final var transformer = new ModeChangeRequestTransformer("default", Mode.RECOVERING);
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()))
@@ -52,7 +52,7 @@ final class ModeChangeRequestTransformerTest {
   @Test
   void shouldGenerateProcessingOperationsForAllRecoveringMembers() {
     // given
-    final var transformer = new ModeChangeRequestTransformer(Mode.PROCESSING);
+    final var transformer = new ModeChangeRequestTransformer("default", Mode.PROCESSING);
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering())
@@ -78,7 +78,7 @@ final class ModeChangeRequestTransformerTest {
   @Test
   void shouldOnlyTargetActiveMembersWhenEnteringRecovery() {
     // given — id0 active, id1 already recovering
-    final var transformer = new ModeChangeRequestTransformer(Mode.RECOVERING);
+    final var transformer = new ModeChangeRequestTransformer("default", Mode.RECOVERING);
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()))
@@ -98,7 +98,7 @@ final class ModeChangeRequestTransformerTest {
   @Test
   void shouldOnlyTargetRecoveringMembersWhenExitingRecovery() {
     // given — id0 still active, id1 recovering
-    final var transformer = new ModeChangeRequestTransformer(Mode.PROCESSING);
+    final var transformer = new ModeChangeRequestTransformer("default", Mode.PROCESSING);
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()))
@@ -118,7 +118,7 @@ final class ModeChangeRequestTransformerTest {
   @Test
   void shouldSucceedWithNoOperationsWhenEnteringRecoveryAndNoActiveMembers() {
     // given — all members already recovering, so the request is a no-op
-    final var transformer = new ModeChangeRequestTransformer(Mode.RECOVERING);
+    final var transformer = new ModeChangeRequestTransformer("default", Mode.RECOVERING);
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering());
@@ -134,7 +134,7 @@ final class ModeChangeRequestTransformerTest {
   @Test
   void shouldSucceedWithNoOperationsWhenExitingRecoveryAndNoRecoveringMembers() {
     // given — all members active, so the request is a no-op
-    final var transformer = new ModeChangeRequestTransformer(Mode.PROCESSING);
+    final var transformer = new ModeChangeRequestTransformer("default", Mode.PROCESSING);
     final var clusterConfiguration =
         ClusterConfiguration.init().addMember(id0, MemberState.initializeAsActive(Map.of()));
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -74,24 +74,8 @@ paths:
         mode returns the cluster to normal processing. Returns the planned cluster change so its
         progress can be monitored via the topology.
       parameters:
-        - name: mode
-          in: query
-          required: true
-          description: The target cluster mode.
-          schema:
-            type: string
-            enum:
-              - PROCESSING
-              - RECOVERING
-        - name: dryRun
-          in: query
-          required: false
-          description: >-
-            If true, the requested change is only validated and the resulting plan is returned,
-            without applying it to the cluster.
-          schema:
-            type: boolean
-            default: false
+        - $ref: '#/components/parameters/ModeParameter'
+        - $ref: '#/components/parameters/DryRunParameter'
       responses:
         "200":
           description: The mode change request was accepted; returns the planned cluster changes.
@@ -149,7 +133,33 @@ paths:
 ## Schema definitions
 
 components:
+  parameters:
+    ModeParameter:
+      name: mode
+      in: query
+      required: true
+      description: The target cluster mode.
+      schema:
+        $ref: '#/components/schemas/Mode'
+    DryRunParameter:
+      name: dryRun
+      in: query
+      required: false
+      description: >-
+        If true, the requested change is only validated and the resulting plan is returned,
+        without applying it to the cluster.
+      schema:
+        type: boolean
+        default: false
+
   schemas:
+    Mode:
+      description: The operating mode of a cluster's partitions.
+      type: string
+      enum:
+        - PROCESSING
+        - RECOVERING
+
     TopologyResponse:
       description: The response of a topology request.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -66,7 +66,7 @@ public final class RecoveryController {
     return RequestExecutor.executeServiceMethod(
         () ->
             clusterConfigurationRequestSender
-                .modeChange(new ModeChangeRequest(mode, dryRun))
+                .modeChange(new ModeChangeRequest(physicalTenantId, mode, dryRun))
                 .thenApply(RecoveryController::unwrapOrThrow),
         RecoveryController::toClusterModeChangeResponse,
         HttpStatus.OK);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -59,7 +59,7 @@ public class RecoveryControllerTest extends RestControllerTest {
             List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING)));
     Mockito.when(
             clusterConfigurationRequestSender.modeChange(
-                new ModeChangeRequest(Mode.RECOVERING, false)))
+                new ModeChangeRequest("default", Mode.RECOVERING, false)))
         .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
 
     final var expectedResponse =
@@ -92,7 +92,7 @@ public class RecoveryControllerTest extends RestControllerTest {
     // given
     Mockito.when(
             clusterConfigurationRequestSender.modeChange(
-                new ModeChangeRequest(Mode.RECOVERING, false)))
+                new ModeChangeRequest("default", Mode.RECOVERING, false)))
         .thenReturn(
             CompletableFuture.completedFuture(
                 Either.left(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRdbmsRangeRestoreIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRdbmsRangeRestoreIT.java
@@ -72,9 +72,11 @@ final class InProcessRdbmsRangeRestoreIT extends RdbmsRangeRestoreTestBase {
 
   private ClusterActuator enterRecovering() {
     final var clusterActuator = ClusterActuator.of(broker);
-    final var toRecovering = clusterActuator.updateMode("RECOVERING", false);
-    awaitChangeCompletes(
-        clusterActuator, toRecovering.getChangeId(), "broker transitions to RECOVERING");
+    final long toRecovering;
+    try (final var client = broker.newClientBuilder().build()) {
+      toRecovering = InProcessRestoreTestUtil.changeMode(client, "RECOVERING", false);
+    }
+    awaitChangeCompletes(clusterActuator, toRecovering, "broker transitions to RECOVERING");
     return clusterActuator;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreAcceptance.java
@@ -61,9 +61,9 @@ public interface InProcessRestoreAcceptance {
       final var backupActuator = BackupActuator.of(cluster.availableGateway());
       takeBackup(backupActuator, BACKUP_ID);
 
-      // when -- the cluster is put into RECOVERING mode
+      // when -- the cluster is put into RECOVERING mode over the cluster's REST endpoint
       final var clusterActuator = ClusterActuator.of(cluster.availableGateway());
-      final var toRecovering = clusterActuator.updateMode("RECOVERING", false);
+      final var toRecovering = InProcessRestoreTestUtil.changeMode(client, "RECOVERING", false);
       Awaitility.await("cluster transitions to RECOVERING")
           .timeout(Duration.ofSeconds(60))
           .untilAsserted(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreRetryOnCorruptionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreRetryOnCorruptionIT.java
@@ -89,13 +89,13 @@ final class InProcessRestoreRetryOnCorruptionIT {
 
       // when - the broker is put into RECOVERING mode and a restore is triggered
       final var clusterActuator = ClusterActuator.of(broker);
-      final var toRecovering = clusterActuator.updateMode("RECOVERING", false);
+      final var toRecovering = InProcessRestoreTestUtil.changeMode(client, "RECOVERING", false);
       Awaitility.await("broker transitions to RECOVERING")
           .timeout(Duration.ofSeconds(60))
           .untilAsserted(
               () ->
                   ClusterActuatorAssert.assertThat(clusterActuator)
-                      .hasCompletedChanges(toRecovering.getChangeId())
+                      .hasCompletedChanges(toRecovering)
                       .doesNotHavePendingChanges());
       final var changeId = InProcessRestoreTestUtil.triggerRestore(client, BACKUP_ID);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
@@ -33,9 +33,11 @@ import org.awaitility.Awaitility;
 /**
  * Shared helpers for the in-process restore tests ({@link InProcessRestoreAcceptance}, {@link
  * InProcessRestoreRetryOnCorruptionIT} and {@link InProcessRdbmsRangeRestoreIT}), which all trigger
- * a restore over the cluster's REST endpoint while a broker is in {@code RECOVERING} mode.
+ * a restore over the cluster's REST endpoint while a broker is in {@code RECOVERING} mode. Also
+ * exposes {@link #changeMode} for triggering a cluster mode change over {@code v2/mode}, reused by
+ * {@code ModeChangeAcceptanceIT} outside this package.
  */
-final class InProcessRestoreTestUtil {
+public final class InProcessRestoreTestUtil {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
@@ -84,6 +86,32 @@ final class InProcessRestoreTestUtil {
       return OBJECT_MAPPER.readTree(response.body()).get("changeId").asLong();
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to parse restore REST response", e);
+    }
+  }
+
+  /**
+   * Triggers a cluster mode change to the given mode over {@code v2/mode}, asserting the request is
+   * accepted (200), and returns the id of the cluster configuration change it started.
+   */
+  public static long changeMode(
+      final CamundaClient client, final String mode, final boolean dryRun) {
+    try {
+      final var uri =
+          URI.create(
+              "%sv2/mode?mode=%s&dryRun=%s"
+                  .formatted(client.getConfiguration().getRestAddress(), mode, dryRun));
+      final var request =
+          HttpRequest.newBuilder(uri).method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
+      final var response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      assertThat(response.statusCode())
+          .describedAs("mode change REST response: %s".formatted(response.body()))
+          .isEqualTo(200);
+      return OBJECT_MAPPER.readTree(response.body()).get("changeId").asLong();
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to trigger mode change via REST endpoint", e);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while triggering mode change via REST endpoint", e);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/InProcessRestoreTestUtil.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.protocol.rest.ClusterModeChangeResponse;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
@@ -40,14 +41,13 @@ import org.awaitility.Awaitility;
 public final class InProcessRestoreTestUtil {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
 
   private InProcessRestoreTestUtil() {}
 
   /** POSTs a restore request with the given body to {@code v2/restore} and returns the response. */
   static HttpResponse<String> sendRestoreRequest(
       final CamundaClient client, final Map<String, Object> body) {
-    try {
+    try (final var httpClient = HttpClient.newHttpClient()) {
       final var uri =
           URI.create(
               "%sv2/restore?dryRun=false".formatted(client.getConfiguration().getRestAddress()));
@@ -56,7 +56,7 @@ public final class InProcessRestoreTestUtil {
               .header("Content-Type", "application/json")
               .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(body)))
               .build();
-      return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to trigger restore via REST endpoint", e);
     } catch (final InterruptedException e) {
@@ -83,7 +83,8 @@ public final class InProcessRestoreTestUtil {
         .describedAs("restore REST response: %s".formatted(response.body()))
         .isEqualTo(202);
     try {
-      return OBJECT_MAPPER.readTree(response.body()).get("changeId").asLong();
+      return Long.parseLong(
+          OBJECT_MAPPER.readValue(response.body(), ClusterModeChangeResponse.class).getChangeId());
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to parse restore REST response", e);
     }
@@ -95,18 +96,19 @@ public final class InProcessRestoreTestUtil {
    */
   public static long changeMode(
       final CamundaClient client, final String mode, final boolean dryRun) {
-    try {
+    try (final var httpClient = HttpClient.newHttpClient()) {
       final var uri =
           URI.create(
               "%sv2/mode?mode=%s&dryRun=%s"
                   .formatted(client.getConfiguration().getRestAddress(), mode, dryRun));
       final var request =
           HttpRequest.newBuilder(uri).method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
-      final var response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      final var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
       assertThat(response.statusCode())
           .describedAs("mode change REST response: %s".formatted(response.body()))
           .isEqualTo(200);
-      return OBJECT_MAPPER.readTree(response.body()).get("changeId").asLong();
+      return Long.parseLong(
+          OBJECT_MAPPER.readValue(response.body(), ClusterModeChangeResponse.class).getChangeId());
     } catch (final IOException e) {
       throw new UncheckedIOException("Failed to trigger mode change via REST endpoint", e);
     } catch (final InterruptedException e) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RecoveryModeBackupAccessIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RecoveryModeBackupAccessIT.java
@@ -127,7 +127,10 @@ final class RecoveryModeBackupAccessIT {
     assertThat(backupsBeforeRecovery).isNotEmpty();
 
     // when — transition the cluster to RECOVERING mode
-    final var toRecovering = clusterActuator.updateMode("RECOVERING", false);
+    final long toRecovering;
+    try (final var client = cluster.newClientBuilder().build()) {
+      toRecovering = InProcessRestoreTestUtil.changeMode(client, "RECOVERING", false);
+    }
     Awaitility.await("cluster transitions to RECOVERING")
         .timeout(Duration.ofSeconds(60))
         .untilAsserted(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
@@ -10,20 +10,15 @@ package io.camunda.zeebe.it.cluster.clustering.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.zeebe.it.cluster.backup.InProcessRestoreTestUtil;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -31,9 +26,8 @@ import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @ZeebeIntegration
 @Timeout(value = 60, unit = TimeUnit.SECONDS)
@@ -52,8 +46,6 @@ final class ModeChangeAcceptanceIT {
           .build();
 
   private static final String JOB_TYPE = "job";
-  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @AutoClose CamundaClient camundaClient;
 
   @BeforeEach
@@ -61,9 +53,8 @@ final class ModeChangeAcceptanceIT {
     camundaClient = cluster.availableGateway().newClientBuilder().preferRestOverGrpc(false).build();
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"ACTUATOR", "REST"})
-  void shouldCycleBetweenRecoveryAndProcessing(final String trigger) {
+  @Test
+  void shouldCycleBetweenRecoveryAndProcessing() {
     // given
     final var processId = "mode-change-test-process";
     Utils.deployProcessModel(camundaClient, JOB_TYPE, processId);
@@ -71,7 +62,8 @@ final class ModeChangeAcceptanceIT {
 
     for (int i = 0; i < 3; i++) {
       // when - transition to RECOVERING
-      final var toRecovering = triggerModeChange(trigger, actuator, "RECOVERING");
+      final var toRecovering =
+          InProcessRestoreTestUtil.changeMode(camundaClient, "RECOVERING", false);
       Awaitility.await("Cluster transitions to RECOVERING (iteration " + i + ")")
           .timeout(Duration.ofMinutes(2))
           .untilAsserted(
@@ -102,7 +94,8 @@ final class ModeChangeAcceptanceIT {
               });
 
       // when - transition back to PROCESSING
-      final var toProcessing = triggerModeChange(trigger, actuator, "PROCESSING");
+      final var toProcessing =
+          InProcessRestoreTestUtil.changeMode(camundaClient, "PROCESSING", false);
       Awaitility.await("Cluster transitions to PROCESSING (iteration " + i + ")")
           .timeout(Duration.ofMinutes(2))
           .untilAsserted(
@@ -135,33 +128,6 @@ final class ModeChangeAcceptanceIT {
                         state ->
                             state == io.camunda.zeebe.management.cluster.PartitionStateCode.ACTIVE);
               });
-    }
-  }
-
-  private long triggerModeChange(
-      final String trigger, final ClusterActuator actuator, final String mode) {
-    if ("ACTUATOR".equals(trigger)) {
-      return actuator.updateMode(mode, false).getChangeId();
-    } else {
-      return triggerModeChangeViaRestEndpoint(mode);
-    }
-  }
-
-  private long triggerModeChangeViaRestEndpoint(final String mode) {
-    try {
-      final var uri =
-          URI.create(
-              "%sv2/mode?mode=%s&dryRun=%s"
-                  .formatted(camundaClient.getConfiguration().getRestAddress(), mode, false));
-      final var request =
-          HttpRequest.newBuilder(uri).method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
-      final var response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
-      assertThat(response.statusCode())
-          .describedAs("REST mode change response: %s".formatted(response.body()))
-          .isEqualTo(200);
-      return OBJECT_MAPPER.readTree(response.body()).get("changeId").asLong();
-    } catch (final IOException | InterruptedException e) {
-      throw new RuntimeException("Failed to trigger mode change via REST endpoint", e);
     }
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -405,17 +405,6 @@ public interface ClusterActuator {
   PlannedOperationsResponse addZone(
       @Param final String zoneId, @RequestBody final AddZoneRequest request, @Param boolean dryRun);
 
-  /**
-   * Requests a cluster mode change.
-   *
-   * @param mode the target mode, e.g. {@code "RECOVERING"} or {@code "PROCESSING"}
-   * @param dryRun if true, changes are not applied but only simulated
-   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
-   */
-  @RequestLine("PATCH /mode?mode={mode}&dryRun={dryRun}")
-  @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PlannedOperationsResponse updateMode(@Param final String mode, @Param boolean dryRun);
-
   // -- BrokerId dispatch methods (default) --
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Write the `physicalTenantId` in the mode transition requests both for the API. As a placeholder for the future per tenant configuration change request.

The mode change actuator endpoint is now completely dropped with the tests aligned to use the REST mode change approach.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55939
