### PR TITLE
ci: capture container and elasticsearch logs in OC API nightly

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -214,6 +214,32 @@ jobs:
           npm run test -- --project=api-tests
         working-directory: qa/c8-orchestration-cluster-e2e-test-suite
 
+      # Capture the container logs (incl. camunda.log = the exporter log) and
+      # Elasticsearch state after the tests run, regardless of outcome. These
+      # are not otherwise available in the step log or artifacts, so exporter-
+      # side failures — e.g. a handler throwing during bulk flush, which halts
+      # indexing and makes v2 search/get return empty/404 — can be diagnosed
+      # from the exporter log + ES index doc counts rather than test symptoms.
+      - name: Capture container and Elasticsearch logs
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p container-logs
+          for c in $(docker ps --format '{{.Names}}'); do
+            docker logs --timestamps "$c" > "container-logs/${c}.log" 2>&1 || true
+          done
+          docker ps -a > container-logs/docker-ps.txt 2>&1 || true
+          {
+            echo "### _cluster/health"
+            curl -s 'http://localhost:9200/_cluster/health?pretty' || true
+            echo "### _cat/indices"
+            curl -s 'http://localhost:9200/_cat/indices?v&s=index' || true
+          } > container-logs/elasticsearch-state.txt 2>&1 || true
+          curl -s 'http://localhost:9600/actuator/prometheus' 2>/dev/null \
+            | grep -iE 'export|backpressure|flush|zeebe_stream_processor' \
+            > container-logs/camunda-exporter-metrics.txt 2>&1 || true
+        working-directory: qa/c8-orchestration-cluster-e2e-test-suite/config
+
       - name: Publish test results to TestRail
         if: always()
         shell: bash
@@ -262,6 +288,15 @@ jobs:
           name: test-results-nightly-api-${{ steps.sanitize.outputs.safe_branch }}-${{ inputs.camunda_mode }}
           path: qa/c8-orchestration-cluster-e2e-test-suite/test-results/**
           if-no-files-found: ignore
+          retention-days: 5
+
+      - name: Upload container logs to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: container-logs-nightly-api-${{ steps.sanitize.outputs.safe_branch }}-${{ inputs.camunda_mode }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/config/container-logs/**
+          if-no-files-found: warn
           retention-days: 5
 
       - name: Observe build status

--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -225,7 +225,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p container-logs
-          for c in $(docker ps --format '{{.Names}}'); do
+          for c in $(docker ps --format '{{.Names}}' 2>/dev/null || true); do
             docker logs --timestamps "$c" > "container-logs/${c}.log" 2>&1 || true
           done
           docker ps -a > container-logs/docker-ps.txt 2>&1 || true


### PR DESCRIPTION
## Description

Adds an always-run step to the reusable OC API-tests workflow that captures the **Camunda container log** (which carries the `CamundaExporter` log), the **Elasticsearch** log, `_cat/indices` doc counts + cluster health, and exporter/backpressure metrics — and uploads them as an artifact.

## Why

The OC API nightly (ES) failures surface as v2 `*/search` returning empty results and `GET /{key}` returning `404` for freshly-written data. The root cause is on the exporter / secondary-storage side, but the Camunda container log is **not** in the GitHub step log or the existing artifacts (`json-report`, `test-results`), so a red run could not be diagnosed without re-running with manual instrumentation.

This was exactly the gap hit while diagnosing the current failures (a `CamundaExporter` NPE that halts bulk flush — see camunda/camunda#58803): the exporter log had to be captured with a throwaway step. This makes that capture permanent so the next on-call can diagnose exporter-side failures straight from the failed run.

## What

New `Capture container and Elasticsearch logs` step (`if: always()`):
- `docker logs` for every running container → `camunda.log`, `elasticsearch.log`, etc.
- `docker ps -a`
- ES `_cluster/health` + `_cat/indices?v` (doc counts show whether the exporter actually wrote data)
- exporter/backpressure metrics from `actuator/prometheus`

Uploaded as artifact `container-logs-nightly-api-<branch>-<mode>` (5-day retention).

No behavioral change to the tests themselves.
