### PR TITLE
deps: bump Optimize jetty to 12.0.36 to resolve CVE-2026-10050

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     name: "Lint / Flattened POM Metadata"
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v6

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -45,7 +45,7 @@
     <previous.optimize.opensearch.version>2.9.0</previous.optimize.opensearch.version>
     <awssdk.version>2.28.13</awssdk.version>
 
-    <jetty.version>12.0.33</jetty.version>
+    <jetty.version>12.0.36</jetty.version>
     <jackson.version>2.21.5</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.5</apache.http5-client.version>


### PR DESCRIPTION
Fixes incorrect Digest authentication algorithm (CWE-173) caused by lossy ISO-8859-1 encoding in jetty-security digest hash computation.

Closes https://github.com/camunda/camunda/issues/58811
