### PR TITLE
test: seed operations-panel demo ops on a dedicated instance

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -19,7 +19,6 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForAssertion} from '../../utils/waitForAssertion';
 import {findInstanceWithVariable} from '../../utils/operateDashboardHelper';
-import {undefined} from 'valibot';
 
 let instanceIds: string[] = [];
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -19,7 +19,6 @@ import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForAssertion} from '../../utils/waitForAssertion';
 import {undefined} from 'valibot';
-import { sleep } from 'utils/sleep';
 
 let instanceIds: string[] = [];
 
@@ -139,26 +138,58 @@ test.describe('Dashboard', () => {
     await expect(operateDashboardPage.incidentInstancesBadge).toHaveText(/\d+/);
   };
 
+  const findInstanceWithVariable = async (
+    expectedVariableRegex: RegExp,
+  ): Promise<boolean> => {
+    const viewInstanceLinks = operateDashboardPage.viewInstanceLink();
+    await expect(viewInstanceLinks.first()).toBeVisible();
+
+    const linkCount = await viewInstanceLinks.count();
+    for (let index = 0; index < linkCount; index++) {
+      await operateDashboardPage.viewInstanceLink().nth(index).click();
+
+      const variableVisible = await operateProcessInstancePage
+        .variableCellByName(expectedVariableRegex)
+        .waitFor({state: 'visible', timeout: 10000})
+        .then(() => true)
+        .catch(() => false);
+      if (variableVisible) {
+        return true;
+      }
+
+      await page.goBack();
+      await expect(
+        operateDashboardPage.viewInstanceLink().first(),
+      ).toBeVisible();
+    }
+
+    return false;
+  };
+
   const openIncidentTypeAndVerifyVariable = async (
     incidentTypeRegex: RegExp,
     expectedVariableRegex: RegExp,
   ) => {
-    await ensureDashboardReady();
+    const openGroupedIncidentView = async () => {
+      await ensureDashboardReady();
+      await operateDashboardPage.clickIncidentByType(incidentTypeRegex);
+      await expect(
+        page.getByRole('heading', {name: /process instances/i}),
+      ).toBeVisible();
+    };
 
-    await operateDashboardPage.clickIncidentByType(incidentTypeRegex);
+    await openGroupedIncidentView();
+
+    // Incidents whose messages truncate to the same text share one dashboard
+    // group, so the filtered view can list more than one instance. Retry while
+    // instances import until the one carrying the expected variable is found.
     await waitForAssertion({
       assertion: async () => {
-        await expect(page.getByRole('heading', {name: /process instances/i})).toBeVisible();
+        expect(await findInstanceWithVariable(expectedVariableRegex)).toBe(true);
       },
-      onFailure: async () => {
-        await sleep(250);
-      },
+      onFailure: openGroupedIncidentView,
+      maxRetries: 5,
     });
-    await operateDashboardPage.clickViewInstanceLink();
-
-    await expect(
-      operateProcessInstancePage.variableCellByName(expectedVariableRegex),
-    ).toBeVisible();
   };
 
   await test.step('Select incident type A and verify details', async () => {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/dashboard.spec.ts
@@ -18,6 +18,7 @@ import {waitForProcessInstances} from 'utils/incidentsHelper';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {waitForAssertion} from '../../utils/waitForAssertion';
+import {findInstanceWithVariable} from '../../utils/operateDashboardHelper';
 import {undefined} from 'valibot';
 
 let instanceIds: string[] = [];
@@ -138,34 +139,6 @@ test.describe('Dashboard', () => {
     await expect(operateDashboardPage.incidentInstancesBadge).toHaveText(/\d+/);
   };
 
-  const findInstanceWithVariable = async (
-    expectedVariableRegex: RegExp,
-  ): Promise<boolean> => {
-    const viewInstanceLinks = operateDashboardPage.viewInstanceLink();
-    await expect(viewInstanceLinks.first()).toBeVisible();
-
-    const linkCount = await viewInstanceLinks.count();
-    for (let index = 0; index < linkCount; index++) {
-      await operateDashboardPage.viewInstanceLink().nth(index).click();
-
-      const variableVisible = await operateProcessInstancePage
-        .variableCellByName(expectedVariableRegex)
-        .waitFor({state: 'visible', timeout: 10000})
-        .then(() => true)
-        .catch(() => false);
-      if (variableVisible) {
-        return true;
-      }
-
-      await page.goBack();
-      await expect(
-        operateDashboardPage.viewInstanceLink().first(),
-      ).toBeVisible();
-    }
-
-    return false;
-  };
-
   const openIncidentTypeAndVerifyVariable = async (
     incidentTypeRegex: RegExp,
     expectedVariableRegex: RegExp,
@@ -180,12 +153,16 @@ test.describe('Dashboard', () => {
 
     await openGroupedIncidentView();
 
-    // Incidents whose messages truncate to the same text share one dashboard
-    // group, so the filtered view can list more than one instance. Retry while
-    // instances import until the one carrying the expected variable is found.
     await waitForAssertion({
       assertion: async () => {
-        expect(await findInstanceWithVariable(expectedVariableRegex)).toBe(true);
+        expect(
+          await findInstanceWithVariable(
+            page,
+            operateDashboardPage,
+            operateProcessInstancePage,
+            expectedVariableRegex,
+          ),
+        ).toBe(true);
       },
       onFailure: openGroupedIncidentView,
       maxRetries: 5,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -23,6 +23,7 @@ type ProcessInstance = {
 
 let initialData: {
   singleOperationInstance: ProcessInstance;
+  demoOperationsInstance: ProcessInstance;
   batchOperationInstances: ProcessInstance[];
 };
 
@@ -33,11 +34,16 @@ test.beforeAll(async ({request}) => {
   ]);
 
   const singleInstance = await createSingleInstance('operationsProcessA', 1);
+  const demoInstance = await createSingleInstance('operationsProcessA', 1);
   const batchInstances = await createInstances('operationsProcessB', 1, 10);
 
   initialData = {
     singleOperationInstance: {
       processInstanceKey: singleInstance.processInstanceKey,
+      bpmnProcessId: 'operationsProcessA',
+    },
+    demoOperationsInstance: {
+      processInstanceKey: demoInstance.processInstanceKey,
       bpmnProcessId: 'operationsProcessA',
     },
     batchOperationInstances: batchInstances.map((instance) => ({
@@ -48,7 +54,7 @@ test.beforeAll(async ({request}) => {
   await sleep(2500);
   await createDemoOperations(
     request,
-    initialData.singleOperationInstance.processInstanceKey,
+    initialData.demoOperationsInstance.processInstanceKey,
     51,
   );
   await sleep(500);
@@ -124,7 +130,7 @@ test.describe('Operations', () => {
         operateProcessesPage.getRetryInstanceButton(
           instance.processInstanceKey,
         ),
-      ).toBeVisible({timeout: 120000});
+      ).toBeEnabled({timeout: 120000});
       await operateProcessesPage.clickRetryInstanceButton(
         instance.processInstanceKey,
       );

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/operateDashboardHelper.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/operateDashboardHelper.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, Page} from '@playwright/test';
+import {OperateDashboardPage} from '@pages/OperateDashboardPage';
+import {OperateProcessInstancePage} from '@pages/OperateProcessInstancePage';
+
+// Incidents whose messages truncate to the same text share one dashboard
+// group, so the filtered view can list more than one instance. Open each
+// view-instance link until the one carrying the expected variable is found.
+export async function findInstanceWithVariable(
+  page: Page,
+  operateDashboardPage: OperateDashboardPage,
+  operateProcessInstancePage: OperateProcessInstancePage,
+  expectedVariableRegex: RegExp,
+): Promise<boolean> {
+  const viewInstanceLinks = operateDashboardPage.viewInstanceLink();
+  await expect(viewInstanceLinks.first()).toBeVisible();
+
+  const linkCount = await viewInstanceLinks.count();
+  for (let index = 0; index < linkCount; index++) {
+    await operateDashboardPage.viewInstanceLink().nth(index).click();
+
+    const variableVisible = await operateProcessInstancePage
+      .variableCellByName(expectedVariableRegex)
+      .waitFor({state: 'visible', timeout: 10000})
+      .then(() => true)
+      .catch(() => false);
+    if (variableVisible) {
+      return true;
+    }
+
+    await page.goBack();
+    await expect(operateDashboardPage.viewInstanceLink().first()).toBeVisible();
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Description

Fixes the recurring nightly failure of `operate/operations.spec.ts › Operations › Retry and cancel single instance` on `stable/8.8` (Tasklist v2 mode). Prior fixes to this flow (waiting for the button, scoping the spinner) did not resolve it — this addresses the actual root cause.

### Root cause (evidence-based)

The click targets the **correct** button (`data-testid="retry-operation"`, `aria-label="Retry Instance …"`) — it is not a wrong-element or post-reload issue. The button is rendered **disabled**, and Playwright waits the full 60s for it to become enabled.

Operate disables the per-row Retry button whenever the instance has an active `RESOLVE_INCIDENT` operation:

- `InstanceOperations.tsx`: `disabled: activeOperations.includes('RESOLVE_INCIDENT')`
- `InstancesTable/v2/index.tsx`: `activeOperations` = the instance's operations in `SENT` / `SCHEDULED` / `LOCKED` state.

`beforeAll` seeds **51 `RESOLVE_INCIDENT` demo operations onto the very instance** the retry test later clicks. `operationsProcessA` is `start → unhandled error end event`, so those retries can never clear the incident. The captured API response in the nightly trace shows the instance holding **50 `FAILED` + 1 `SENT`** `RESOLVE_INCIDENT` operations — that single non-terminal `SENT` op keeps the button permanently disabled, so the click always times out. Waiting longer can't help because the op sticks.

The previous fix waited for the button to be **visible**, but it is visible-and-disabled.

### Fix

1. Seed the 51 demo operations on a **dedicated instance** (`demoOperationsInstance`) instead of the retry test's `singleOperationInstance`, so that instance carries no self-inflicted active operation and the Retry button renders enabled.
2. Gate the click on `toBeEnabled` instead of `toBeVisible`.

This does **not** mask anything: the retry-button disable was correct product behavior for a busy instance. The regression coverage for [#42375](https://github.com/camunda/camunda/issues/42375) (a retry appears in the operations panel, a cancel does not) is preserved. The operations panel is global and sorted by `endDate desc`, so the retry created during the test still appears first for the panel assertion; the infinite-scroll test reads the same global panel and still sees the 51 seeded operations.

### Verification

Not run against a live cluster (nightly artifact-only diagnosis). Reasoning verified against the product source and the trace's captured `GET process-instances` response (`50 FAILED + 1 SENT RESOLVE_INCIDENT`). Local `prettier --check` and `eslint` pass on the changed file.

Nightly run: https://github.com/camunda/camunda/actions/runs/30273961677

## Definition of done

- [ ] Not applicable / to be validated by the next nightly run

---

## Additional fix — `dashboard.spec.ts › Navigate to processes view (same truncated error message)`

Surfaced by the on-demand validation run ([30277498045](https://github.com/camunda/camunda/actions/runs/30277498045)). This is a **pre-existing flake unrelated to the operations change** (it also failed on the 07-25 nightly [30138043855](https://github.com/camunda/camunda/actions/runs/30138043855) on plain `stable/8.8`); bundled here at the reviewer's request.

**Root cause:** The two `incidentGeneratorProcess` instances (Type A / Type B) have error messages that truncate to the same text, so Operate groups them under one dashboard incident entry keyed by a shared `incidentErrorHashCode` (`-524097104`, confirmed in the failing trace's filter payload). Clicking the incident filters to **both** instances — the steady state is 2 rows — so `clickViewInstanceLink()` (strict, expects one `/view instance/i` link) failed with a strict-mode violation. It only passed before by racing ahead of the second instance's incident import.

**Fix:** `variableCellByName` reads the instance-detail variables list, so the assertion must open the instance that actually carries the expected variable. Replaced the single strict click with `findInstanceWithVariable`, which opens each view-instance link until the expected incident-type variable is visible, wrapped in `waitForAssertion` to retry while the instances import. This preserves the assertion's intent (the Type A / Type B variable must genuinely be reachable) — no timeout bump, weakened check, or skip. Dropped the now-unused `sleep` import.

---

## Validation

✅ **On-demand run [30281878853](https://github.com/camunda/camunda/actions/runs/30281878853) passed** (rebased on the latest `stable/8.8`): all jobs green — `validate-branch`, API Tests (profiles), **E2E v1**, and **E2E v2** (H2/RDBMS skipped as expected for 8.8). This validates both the operations retry fix and the dashboard grouped-incident fix.

A follow-up commit extracts `findInstanceWithVariable` into `utils/operateDashboardHelper.ts` (pure code move, no behaviour change, verified locally with `tsc`).
