### PR TITLE
Prevent unreadable commit messages from humans and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,15 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 `test`
 
 - Separate behavioral changes from structural/refactoring changes into distinct commits
-- Commit messages should explain *why*, not just *what* changed
+- Write for the reader: the reviewer first, then whoever needs to understand/debug this change later
+- Header: name the effect (the bug prevented or behavior enabled), not the mechanism. Prefer
+  `fix: prevent duplicate job activation under concurrent polling` over `fix: add mutex around job activation`.
 - Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
+- Body: inverted-pyramid — begin with the details that readers care about most, then what only few care
+  about (the problem and its root cause first, then what changed and why — and why this approach over
+  the alternatives). Cut what the diff already shows; never compress the why — it's the one thing the
+  diff can't say. Include background if needed. If long, use headings for structure.
+- Hard-wrap the body at ~72 columns as `git log` does not soft-wrap.
 
 ### Referencing code in issues, PRs, and comments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,9 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 - Header: name the effect (the bug prevented or behavior enabled), not the mechanism. Prefer
   `fix: prevent duplicate job activation under concurrent polling` over `fix: add mutex around job activation`.
 - Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
+- Every commit gets a body — including tests and reverts. A test needs the context for why it's
+  needed and the design rationale behind it; a revert needs the reason. Only a purely mechanical
+  change, like a formatter run, stands on its header alone.
 - Body: inverted-pyramid — the problem and its root cause first, then the approach and why it over
   the alternatives. Summarize the approach; don't restate the diff. Never compress the why — it's the
   one thing the diff can't say. Include background if needed. If long, use headings for structure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,10 +115,9 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 - Header: name the effect (the bug prevented or behavior enabled), not the mechanism. Prefer
   `fix: prevent duplicate job activation under concurrent polling` over `fix: add mutex around job activation`.
 - Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
-- Body: inverted-pyramid — begin with the details that readers care about most, then what only few care
-  about (the problem and its root cause first, then what changed and why — and why this approach over
-  the alternatives). Cut what the diff already shows; never compress the why — it's the one thing the
-  diff can't say. Include background if needed. If long, use headings for structure.
+- Body: inverted-pyramid — the problem and its root cause first, then the approach and why it over
+  the alternatives. Summarize the approach; don't restate the diff. Never compress the why — it's the
+  one thing the diff can't say. Include background if needed. If long, use headings for structure.
 - Hard-wrap the body at ~72 columns as `git log` does not soft-wrap.
 
 ### Referencing code in issues, PRs, and comments


### PR DESCRIPTION
## Description

The commit-message guideline in AGENTS.md only said "explain why" — too thin to stop three recurring failures: commits landing with just a title and no body, AI-written bodies that ignore the reader, and AI-written messages that stay unreadable even when a human dictated the change.

This rewrites the guideline to expect a body on every commit, effect-first headers, and inverted-pyramid bodies that summarize the approach rather than restating the diff, while keeping the why the diff can't say. Informed by these public commit-message writing references:

- https://dhwthompson.com/2019/my-favourite-git-commit
- https://mtlynch.io/no-longer-my-favorite-git-commit/
- https://refactoringenglish.com/excerpts/commit-messages/

The body hard-wrap rule follows Simon Tatham's argument for physical newlines, since `git log` does not soft-wrap:

- https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/commit-messages/

Two things the diff can't show. First, this reaches the commits that matter: 71% of commits on main (356 of the last 500) are preserved branch commits rather than squash-merges, so the message an author writes lands in `git log` verbatim. Of the last 300 commits, 95 landed with no body beyond a link or trailer — 54 renovate bumps, and 41 authored, 17 of those `fix:` or `feat:` where the reasoning matters most. All 41 came through the preserved route; squash-merges always get a body because GitHub prefills it from the pull request.

Second, this is deliberately not enforced by commitlint. `body-empty` stays disabled there: reverts from the GitHub UI, backport cherry-picks and renovate bumps all produce commits no author writes, and gating on a body would push routine pull requests onto the `ci:ignore-commitlint` label and devalue it for the cases it exists for. A body is a strong expectation, not a gate.

## Related issues

None — this is a self-initiated guideline change, not tied to a tracked issue. Also posted to [#team-orchestration-cluster](https://camunda.slack.com/archives/C08F5RD5X8B/p1785165714669169) for broader team visibility and feedback before merging.
